### PR TITLE
Support Single-Threaded Functionality

### DIFF
--- a/brave-impl/src/main/java/com/github/kristofa/brave/AbstractAnnotationSubmitter.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/AbstractAnnotationSubmitter.java
@@ -1,7 +1,7 @@
 package com.github.kristofa.brave;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import org.apache.commons.lang3.Validate;
 
@@ -22,7 +22,7 @@ import com.twitter.zipkin.gen.Span;
  */
 abstract class AbstractAnnotationSubmitter implements AnnotationSubmitter {
 
-    private static final String UTF_8 = "UTF-8";
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     /**
      * Gets the span to which to add annotations.
@@ -81,12 +81,8 @@ abstract class AbstractAnnotationSubmitter implements AnnotationSubmitter {
         final Span span = getSpan();
         if (span != null) {
             Validate.notNull(value);
-            try {
-                final ByteBuffer bb = ByteBuffer.wrap(value.getBytes(UTF_8));
-                submitBinaryAnnotation(span, getEndPoint(), key, bb, AnnotationType.STRING);
-            } catch (final UnsupportedEncodingException e) {
-                throw new IllegalStateException(e);
-            }
+            final ByteBuffer bb = ByteBuffer.wrap(value.getBytes(UTF_8));
+            submitBinaryAnnotation(span, getEndPoint(), key, bb, AnnotationType.STRING);
         }
     }
 

--- a/brave-impl/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/Brave.java
@@ -64,7 +64,7 @@ public class Brave {
      * @return {@link ServerTracer} instance.
      */
     public static ServerTracer getServerTracer(final SpanCollector collector, final List<TraceFilter> traceFilters) {
-        return new ServerTracerImpl(SERVER_AND_CLIENT_SPAN_STATE, collector, traceFilters, RANDOM_GENERATOR);
+        return new ServerTracerImpl(SERVER_AND_CLIENT_SPAN_STATE, RANDOM_GENERATOR, collector, traceFilters);
     }
 
     /**

--- a/brave-impl/src/main/java/com/github/kristofa/brave/BraveContext.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/BraveContext.java
@@ -1,0 +1,37 @@
+package com.github.kristofa.brave;
+
+import java.util.List;
+import java.util.Random;
+
+public class BraveContext {
+	private final SimpleServerAndClientSpanStateImpl spanState;
+	
+	private final Random randomGenerator;
+	
+	private final EndPointSubmitter endpointSubmitter;
+	
+	private final AnnotationSubmitter annotationSubmitter;
+	
+	public BraveContext(){
+		spanState = new SimpleServerAndClientSpanStateImpl();
+		randomGenerator   = new Random();
+		endpointSubmitter = new EndPointSubmitterImpl(spanState);
+		annotationSubmitter = new AnnotationSubmitterImpl(spanState);
+	}
+	
+	public EndPointSubmitter getEndPointSubmitter() {
+        return endpointSubmitter;
+    }
+	
+	public ClientTracer getClientTracer(final SpanCollector collector, final List<TraceFilter> traceFilters) {
+        return new ClientTracerImpl(spanState, randomGenerator, collector, traceFilters);
+    }
+	
+	public ServerTracer getServerTracer(final SpanCollector collector, final List<TraceFilter> traceFilters) {
+        return new ServerTracerImpl(spanState, randomGenerator, collector, traceFilters);
+    }
+	
+	public AnnotationSubmitter getServerSpanAnnotationSubmitter() {
+        return annotationSubmitter;
+    }
+}

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ServerTracerImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ServerTracerImpl.java
@@ -30,8 +30,8 @@ class ServerTracerImpl extends AbstractAnnotationSubmitter implements ServerTrac
      * @param spanCollector Span collector.
      * @param traceFilters Trace Filters.
      */
-    ServerTracerImpl(final ServerSpanState state, final SpanCollector spanCollector, final List<TraceFilter> traceFilters,
-        final Random randomGenerator) {
+    ServerTracerImpl(final ServerSpanState state, final Random randomGenerator, final SpanCollector spanCollector,
+    		final List<TraceFilter> traceFilters) {
         Validate.notNull(state);
         Validate.notNull(spanCollector);
         Validate.notNull(traceFilters);

--- a/brave-impl/src/main/java/com/github/kristofa/brave/SimpleServerAndClientSpanStateImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/SimpleServerAndClientSpanStateImpl.java
@@ -1,0 +1,81 @@
+package com.github.kristofa.brave;
+
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+
+class SimpleServerAndClientSpanStateImpl implements ServerAndClientSpanState {
+	
+	private Endpoint endPoint;
+	private Span currentClientSpan;
+	private ServerSpan currentServerSpan;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ServerSpan getCurrentServerSpan() {
+		return currentServerSpan;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setCurrentServerSpan(final ServerSpan span) {
+		currentServerSpan = span;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Endpoint getEndPoint() {
+		return endPoint;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setEndPoint(final Endpoint endPoint) {
+		this.endPoint = endPoint;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Span getCurrentClientSpan() {
+		return currentClientSpan;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setCurrentClientSpan(final Span span) {
+		currentClientSpan = span;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void incrementServerSpanThreadDuration(final long durationMs) {
+		currentServerSpan.incThreadDuration(durationMs);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public long getServerSpanThreadDuration() {
+		return currentServerSpan.getThreadDuration();
+	}
+
+	@Override
+	public Boolean sample() {
+		return currentServerSpan.getSample();
+	}
+
+}

--- a/brave-impl/src/test/java/com/github/kristofa/brave/ServerTracerImplTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/ServerTracerImplTest.java
@@ -60,7 +60,7 @@ public class ServerTracerImplTest {
 
         traceFilters = Arrays.asList(mockTraceFilter1, mockTraceFilter2);
 
-        serverTracer = new ServerTracerImpl(mockServerSpanState, mockSpanCollector, traceFilters, mockRandom) {
+        serverTracer = new ServerTracerImpl(mockServerSpanState, mockRandom,  mockSpanCollector, traceFilters) {
 
             @Override
             long currentTimeMicroseconds() {
@@ -72,22 +72,22 @@ public class ServerTracerImplTest {
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullState() {
-        new ServerTracerImpl(null, mockSpanCollector, traceFilters, mockRandom);
+        new ServerTracerImpl(null, mockRandom, mockSpanCollector, traceFilters);
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullCollector() {
-        new ServerTracerImpl(mockServerSpanState, null, traceFilters, mockRandom);
+        new ServerTracerImpl(mockServerSpanState, mockRandom, null, traceFilters);
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullTraceFilters() {
-        new ServerTracerImpl(mockServerSpanState, mockSpanCollector, null, mockRandom);
+        new ServerTracerImpl(mockServerSpanState, mockRandom, mockSpanCollector, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullRandom() {
-        new ServerTracerImpl(mockServerSpanState, mockSpanCollector, traceFilters, null);
+        new ServerTracerImpl(mockServerSpanState, null, mockSpanCollector, traceFilters);
     }
 
     @Test


### PR DESCRIPTION
Change Summary:
- Added a public BraveContext object that doesn't require a single-threaded environment to function.
- Added a SimpleServerAndClientSpanStateImpl class to facilitate single-threaded context
- Modifed AbstractAnnotationSubmitter to use a java.nio.Charset when calling getBytes to avoid having to catch an UnsupportedEncodingException
- Modified ServerTracerImpl constructor argument order to be consistent with ClientTracerImpl and updated all references.
