### PR TITLE
Avoid string concat in log statements

### DIFF
--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
@@ -67,8 +67,7 @@ public class ServletTraceFilter implements Filter {
             String localAddr = request.getLocalAddr();
             int localPort = request.getLocalPort();
             endPointSubmitter.submit(localAddr, localPort, contextPath);
-            logger.debug("Setting endpoint: addr: " + localAddr + ", port: " + localPort +
-                    ", contextpath: " + contextPath);
+            logger.debug("Setting endpoint: addr: {}, port: {}, contextpath: {}", localAddr, localPort, contextPath);
         }
     }
 

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
@@ -76,7 +76,7 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
 
         final SpanId newSpanId = clientTracer.startNewSpan(spanName);
         if (newSpanId != null) {
-            LOGGER.debug("Will trace request. Span Id returned from ClientTracer: " + newSpanId.toString());
+            LOGGER.debug("Will trace request. Span Id returned from ClientTracer: {}", newSpanId);
             request.header(BraveHttpHeaders.Sampled.getName(), TRUE);
             request.header(BraveHttpHeaders.TraceId.getName(), newSpanId.getTraceId());
             request.header(BraveHttpHeaders.SpanId.getName(), newSpanId.getSpanId());

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
@@ -111,8 +111,7 @@ public class BravePreProcessInterceptor implements PreProcessInterceptor {
             final String localAddr = servletRequest.getLocalAddr();
             final int localPort = servletRequest.getLocalPort();
             final String contextPath = servletRequest.getContextPath();
-            LOGGER.debug("Setting endpoint: addr: " + localAddr + ", port: " + localPort +
-                    ", contextpath: " + contextPath);
+            LOGGER.debug("Setting endpoint: addr: {}, port: {}, contextpath: {}", localAddr, localPort, contextPath);
             endPointSubmitter.submit(localAddr, localPort, contextPath);
         }
     }
@@ -124,7 +123,7 @@ public class BravePreProcessInterceptor implements PreProcessInterceptor {
         final TraceData traceData = new TraceData();
 
         for (final Entry<String, List<String>> headerEntry : requestHeaders.entrySet()) {
-            LOGGER.debug(headerEntry.getKey() + "=" + headerEntry.getValue());
+            LOGGER.debug("{}={}", headerEntry.getKey(), headerEntry.getValue());
             if (BraveHttpHeaders.TraceId.getName().equalsIgnoreCase(headerEntry.getKey())) {
                 traceData.setTraceId(getFirstLongValueFor(headerEntry));
             } else if (BraveHttpHeaders.SpanId.getName().equalsIgnoreCase(headerEntry.getKey())) {

--- a/brave-tracefilters/src/main/java/com/github/kristofa/brave/tracefilter/ZooKeeperSamplingTraceFilter.java
+++ b/brave-tracefilters/src/main/java/com/github/kristofa/brave/tracefilter/ZooKeeperSamplingTraceFilter.java
@@ -112,7 +112,7 @@ public class ZooKeeperSamplingTraceFilter implements TraceFilter, Watcher {
 
             if (sampleRateZNode.equals(path)) {
                 sampleRate = getSampleRate();
-                LOGGER.info("SampleRate znode [" + sampleRateZNode + "] changed. New value: " + sampleRate);
+                LOGGER.info("SampleRate znode [{}] changed. New value: {}", sampleRateZNode, sampleRate);
             }
         }
     }

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
@@ -110,7 +110,7 @@ public class ZipkinSpanCollector implements SpanCollector {
 
         final boolean offer = spanQueue.offer(span);
         if (!offer) {
-            LOGGER.error("Queue rejected Span, span not submitted: " + span);
+            LOGGER.error("Queue rejected Span, span not submitted: {}", span);
         } else {
             final long end = System.currentTimeMillis();
             if (LOGGER.isDebugEnabled()) {
@@ -155,7 +155,7 @@ public class ZipkinSpanCollector implements SpanCollector {
         for (final Future<Integer> future : futures) {
             try {
                 final Integer spansProcessed = future.get();
-                LOGGER.info("SpanProcessingThread processed " + spansProcessed + " spans.");
+                LOGGER.info("SpanProcessingThread processed {} spans.", spansProcessed);
             } catch (final Exception e) {
                 LOGGER.error("Exception when getting result of SpanProcessingThread.", e);
             }

--- a/flume-zipkin-collector-sink/src/main/java/com/github/kristofa/flume/ZipkinSpanCollectorSink.java
+++ b/flume-zipkin-collector-sink/src/main/java/com/github/kristofa/flume/ZipkinSpanCollectorSink.java
@@ -155,8 +155,7 @@ public class ZipkinSpanCollectorSink extends AbstractSink implements Configurabl
             sinkCounter = new SinkCounter(getName());
         }
 
-        LOGGER.info("Configuring ZipkinSpanCollectorSink. hostname: " + hostName + ", port: " + port + ", batchsize: "
-            + batchSize);
+        LOGGER.info("Configuring ZipkinSpanCollectorSink. hostname: {}, port: {}, batchsize: {}", hostName, port, batchSize);
     }
 
     private LogEntry create(final Event event) {

--- a/flume-zipkin-metrics-sink/src/main/java/com/github/kristofa/flume/MetricReporterBuilder.java
+++ b/flume-zipkin-metrics-sink/src/main/java/com/github/kristofa/flume/MetricReporterBuilder.java
@@ -64,26 +64,26 @@ class MetricReporterBuilder {
             throw new IllegalStateException(GRAPHITE_HOST + " and " + GRAPHITE_PORT + " properties are mandatory.");
         }
 
-        LOGGER.info("Graphite host: " + graphiteHost);
-        LOGGER.info("Graphite port: " + graphitePort);
+        LOGGER.info("Graphite host: {}", graphiteHost);
+        LOGGER.info("Graphite port: {}", graphitePort);
 
         metricPrefix = context.getString(METRIC_PREFIX);
         pollTimeMinutes = context.getInteger(POLL_TIME, 1);
-        LOGGER.info("Reporter poll time in minutes: " + pollTimeMinutes);
+        LOGGER.info("Reporter poll time in minutes: {}", pollTimeMinutes);
 
         final String reservoir = context.getString(METRICS_RESERVOIR, DEFAULT_RESERVOIR);
 
         if (UNIFORM_RESERVOIR.equals(reservoir)) {
-            LOGGER.info("Reservoir: " + UNIFORM_RESERVOIR);
+            LOGGER.info("Reservoir: {}", UNIFORM_RESERVOIR);
             initializeUniformHistogramBuilder(context);
         } else if (EXPONENTIALLY_DECAYING_RESERVOIR.equals(reservoir)) {
-            LOGGER.info("Reservoir: " + EXPONENTIALLY_DECAYING_RESERVOIR);
+            LOGGER.info("Reservoir: {}", EXPONENTIALLY_DECAYING_RESERVOIR);
             initializeExponentiallyDecayingReservoir(context);
         } else if (SLIDING_TIME_WINDOW_RESERVOIR.equals(reservoir)) {
-            LOGGER.info("Reservoir: " + SLIDING_TIME_WINDOW_RESERVOIR);
+            LOGGER.info("Reservoir: {}", SLIDING_TIME_WINDOW_RESERVOIR);
             initializeSlidingTimeWindowReservoir(context);
         } else if (SLIDING_WINDOW_RESERVOIR.equals(reservoir)) {
-            LOGGER.info("Reservoir: " + SLIDING_WINDOW_RESERVOIR);
+            LOGGER.info("Reservoir: {}", SLIDING_WINDOW_RESERVOIR);
             initializeSlidingWindowReservoir(context);
         } else {
             throw new IllegalStateException("Invalid value for reservoir: " + reservoir);
@@ -109,7 +109,7 @@ class MetricReporterBuilder {
             GraphiteReporter.forRegistry(metricRegistry).convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS).filter(MetricFilter.ALL);
         if (StringUtils.isNotBlank(metricPrefix)) {
-            LOGGER.info("Metric prefix: " + metricPrefix);
+            LOGGER.info("Metric prefix: {}", metricPrefix);
             builder.prefixedWith(metricPrefix);
         }
 

--- a/flume-zipkin-metrics-sink/src/main/java/com/github/kristofa/flume/ZipkinMetricsSink.java
+++ b/flume-zipkin-metrics-sink/src/main/java/com/github/kristofa/flume/ZipkinMetricsSink.java
@@ -130,7 +130,7 @@ public class ZipkinMetricsSink extends AbstractSink implements Configurable {
             sinkCounter = new SinkCounter(getName());
         }
 
-        LOGGER.info("batchsize: " + batchSize);
+        LOGGER.info("batchsize: {}", batchSize);
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,17 +93,17 @@
 	<dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.5</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.5</version>
     </dependency>
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>1.6.1</version>
+        <version>1.7.5</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
Update to Slf4j 1.7 to allow varargs, otherwise we have to do new Object[] {} to have more than 2 parameters in the log statement.
