### PR TITLE
allow changing the Scribe category

### DIFF
--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
@@ -88,7 +88,7 @@ public class ZipkinSpanCollector implements SpanCollector {
         executorService = Executors.newFixedThreadPool(params.getNrOfThreads());
         for (int i = 1; i <= params.getNrOfThreads(); i++) {
             final SpanProcessingThread spanProcessingThread =
-                new SpanProcessingThread(spanQueue, clientProvider, params.getBatchSize());
+                new SpanProcessingThread(spanQueue, clientProvider, params.getBatchSize(), params.getScribeCategory());
             spanProcessingThreads.add(spanProcessingThread);
             futures.add(executorService.submit(spanProcessingThread));
         }

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollectorParams.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollectorParams.java
@@ -25,12 +25,14 @@ public class ZipkinSpanCollectorParams {
     public int DEFAULT_BATCH_SIZE = 10;
     public int DEFAULT_NR_OF_THREADS = 1;
     public int DEFAULT_SOCKET_TIMEOUT = 5000;
+    public String DEFAULT_SCRIBE_CATEGORY = "zipkin";
 
     private int queueSize;
     private int batchSize;
     private int nrOfThreads;
     private int socketTimeout;
     private boolean failOnSetup = true;
+    private String scribeCategory;
 
     /**
      * Create a new instance with default values.
@@ -40,6 +42,7 @@ public class ZipkinSpanCollectorParams {
         batchSize = DEFAULT_BATCH_SIZE;
         nrOfThreads = DEFAULT_NR_OF_THREADS;
         socketTimeout = DEFAULT_SOCKET_TIMEOUT;
+        scribeCategory = DEFAULT_SCRIBE_CATEGORY;
     }
 
     /**
@@ -140,4 +143,19 @@ public class ZipkinSpanCollectorParams {
         return failOnSetup;
     }
 
+    /**
+     * Gets the Scribe category.
+     * @return Scribe category
+     */
+    public String getScribeCategory() {
+        return scribeCategory;
+    }
+
+    /**
+     * Sets the Scribe category.
+     * @param scribeCategory Scribe category. Default is "zipkin".
+     */
+    public void setScribeCategory(String scribeCategory) {
+        this.scribeCategory = scribeCategory;
+    }
 }


### PR DESCRIPTION
This change lets you call ZipkinSpanCollectorParams.setScribeCategory()
to change the category from the default of "zipkin".

Since the old SpanProcessingThread constructor was public, I overloaded
it so that any direct users of it won't have to change.

This fixes https://github.com/kristofa/brave/issues/12
