### PR TITLE
brave needs httpcore 4.2.3 but received 4.1.3 from thrift

### DIFF
--- a/brave-interfaces/pom.xml
+++ b/brave-interfaces/pom.xml
@@ -30,7 +30,17 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>0.9.0</version>
+	<exclusions>
+	   <exclusion>
+		<artifactId>org.apache.httpcomponents</artifactId>
+		<groupId>httpcore</groupId>
+	    </exclusion>
+	</exclusions>
     </dependency>
+    <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+   </dependency>
   
   </dependencies>
   

--- a/pom.xml
+++ b/pom.xml
@@ -60,15 +60,20 @@
   <dependencyManagement>
   	<dependencies>
   		<dependency>
-    		<groupId>org.springframework</groupId>
+    			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 			<version>${spring.version}</version>
-    	</dependency>
-    	<dependency>
+	    	</dependency>
+    		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
 			<version>${spring.version}</version>
-    	</dependency>
+	    	</dependency>
+		<dependency>
+		        <groupId>org.apache.httpcomponents</groupId>
+		        <artifactId>httpcore</artifactId>
+		        <version>4.3.2</version>
+    		</dependency>
   	</dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Hey Kristof,

When using the new client interceptors I noticed that with having the brave zipkin span collector on the classpath the wrong httpcore dependency got resolved.  I added it to you master pom and excluded it from thrift in the interfaces and included it directly.

Pieter
