### PR TITLE
Fixed servlet/client incompatibility if parentSpanId is not provided

### DIFF
--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ClientServletCompatibilityTest.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ClientServletCompatibilityTest.java
@@ -1,0 +1,94 @@
+package com.github.kristofa.brave.jersey;
+
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.EndPointSubmitter;
+import com.github.kristofa.brave.ServerTracer;
+import com.github.kristofa.brave.SpanId;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.core.util.StringKeyObjectValueIgnoreCaseMultivaluedMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientServletCompatibilityTest {
+
+    @Mock
+    ClientTracer clientTracer;
+    @Mock
+    ServerTracer serverTracer;
+    @Mock
+    EndPointSubmitter endPointSubmitter;
+    @Mock
+    FilterChain filterChain = mock(FilterChain.class);
+    @InjectMocks
+    JerseyClientTraceFilter clientFilter = new JerseyClientTraceFilter(clientTracer);
+    @InjectMocks
+    ServletTraceFilter servletFilter = new ServletTraceFilter(serverTracer, endPointSubmitter);
+
+    @Mock
+    ClientRequest clientRequest;
+    @Mock
+    HttpServletRequest servletRequest;
+    @Mock
+    ServletResponse servletResponse;
+
+    @Test
+    public void shouldHandleAllProvidedIds() throws Exception {
+        validateUsingSpan(mockSpan(123L, 456L, 789L));
+    }
+
+    @Test
+    public void shouldHandleMissingParentId() throws Exception {
+        validateUsingSpan(mockSpan(123L, 456L, null));
+    }
+
+    private SpanId mockSpan(long traceId, long spanId, Long parentSpanId) {
+        SpanId mockedSpan = mock(SpanId.class);
+        when(mockedSpan.getTraceId()).thenReturn(traceId);
+        when(mockedSpan.getSpanId()).thenReturn(spanId);
+        when(mockedSpan.getParentSpanId()).thenReturn(parentSpanId);
+        return mockedSpan;
+    }
+
+    private void validateUsingSpan(SpanId span) throws Exception {
+        when(clientRequest.getURI()).thenReturn(URI.create("http://testuri.com/path"));
+        when(clientRequest.getHeaders()).thenReturn(new StringKeyObjectValueIgnoreCaseMultivaluedMap());
+        when(clientTracer.startNewSpan(anyString())).thenReturn(span);
+
+        clientFilter.addTracingHeaders(clientRequest, span);
+
+        final MultivaluedMap<String, Object> headers = clientRequest.getHeaders();
+        when(servletRequest.getHeader(anyString())).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] arguments = invocation.getArguments();
+                return headers.getFirst((String) arguments[0]);
+            }
+        });
+        servletFilter.doFilter(servletRequest, servletResponse, filterChain);
+        long traceId = span.getTraceId();
+        long spanId = span.getSpanId();
+        Long parentSpanId = span.getParentSpanId();
+        verify(serverTracer).setStateCurrentTrace(eq(traceId),
+                eq(spanId),
+                eq(parentSpanId),
+                anyString());
+    }
+}

--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilterTest.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilterTest.java
@@ -1,0 +1,67 @@
+package com.github.kristofa.brave.jersey;
+
+import com.github.kristofa.brave.BraveHttpHeaders;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.SpanId;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.core.util.StringKeyObjectValueIgnoreCaseMultivaluedMap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JerseyClientTraceFilterTest {
+
+    @Mock
+    ClientTracer clientTracer;
+    @Mock
+    ClientRequest clientRequest;
+    @InjectMocks
+    JerseyClientTraceFilter jerseyClientTraceFilter = new JerseyClientTraceFilter(clientTracer);
+
+    @Test
+    public void shouldAddAllFields() {
+        when(clientRequest.getHeaders()).thenReturn(new StringKeyObjectValueIgnoreCaseMultivaluedMap());
+        jerseyClientTraceFilter.addTracingHeaders(clientRequest, mockSpan(123L, 456L, 789L));
+        MultivaluedMap<String, Object> headers = clientRequest.getHeaders();
+        Assert.assertEquals("123", headers.getFirst(BraveHttpHeaders.TraceId.getName()));
+        Assert.assertEquals("456", headers.getFirst(BraveHttpHeaders.SpanId.getName()));
+        Assert.assertEquals("789", headers.getFirst(BraveHttpHeaders.ParentSpanId.getName()));
+        Assert.assertEquals("true", headers.getFirst(BraveHttpHeaders.Sampled.getName()));
+    }
+
+    @Test
+    public void shouldNotIncludeMissingParentId() {
+        when(clientRequest.getHeaders()).thenReturn(new StringKeyObjectValueIgnoreCaseMultivaluedMap());
+        jerseyClientTraceFilter.addTracingHeaders(clientRequest, mockSpan(123L, 456L, null));
+        MultivaluedMap<String, Object> headers = clientRequest.getHeaders();
+        Assert.assertEquals("123", headers.getFirst(BraveHttpHeaders.TraceId.getName()));
+        Assert.assertEquals("456", headers.getFirst(BraveHttpHeaders.SpanId.getName()));
+        Assert.assertEquals(null, headers.getFirst(BraveHttpHeaders.ParentSpanId.getName()));
+        Assert.assertEquals("true", headers.getFirst(BraveHttpHeaders.Sampled.getName()));
+    }
+
+    @Test
+    public void shouldSetSampledToFalseIfNull() {
+        when(clientRequest.getHeaders()).thenReturn(new StringKeyObjectValueIgnoreCaseMultivaluedMap());
+        jerseyClientTraceFilter.addTracingHeaders(clientRequest, null);
+        MultivaluedMap<String, Object> headers = clientRequest.getHeaders();
+        Assert.assertEquals("false", headers.getFirst(BraveHttpHeaders.Sampled.getName()));
+    }
+
+    private SpanId mockSpan(long traceId, long spanId, Long parentSpanId) {
+        SpanId mockedSpan = mock(SpanId.class);
+        when(mockedSpan.getTraceId()).thenReturn(traceId);
+        when(mockedSpan.getSpanId()).thenReturn(spanId);
+        when(mockedSpan.getParentSpanId()).thenReturn(parentSpanId);
+        return mockedSpan;
+    }
+}


### PR DESCRIPTION
Stumbled upon this bug when I was trying to instigate some tracing with some client code.  The ParentSpanId is an optional parameter that `JerseyClientTraceFilter` serializes in the headers, either as a String representation of the provided Long, or the String `"null"`.  The `ServletTraceFilter` of a downstream service will attempt to deserialize this parameter, but it expects either a null value (as if the header was not provided) or a String representation of a long.  It does not know how to handle the String `"null"`.

My proposed change includes a ParentSpanId header only if a value is provided, and includes some unit tests around the `JerseyClientTraceFilter` and a compatibility test between the client and servlet filters.
