### PR TITLE
Changed header encoding from toHexString() to toString()

### DIFF
--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -70,8 +70,8 @@ public class ITBraveHttpRequestAndResponseInterceptor {
 
         final HttpRequestImpl request = new HttpRequestImpl();
         request.method(Method.GET).path(FULL_PATH)
-            .httpMessageHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(TRACE_ID))
-            .httpMessageHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(SPAN_ID))
+            .httpMessageHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(TRACE_ID, 16))
+            .httpMessageHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(SPAN_ID, 16))
             .httpMessageHeader(BraveHttpHeaders.Sampled.getName(), "true");
         final HttpResponseImpl response = new HttpResponseImpl(200, null, null);
         responseProvider.set(request, response);
@@ -143,8 +143,8 @@ public class ITBraveHttpRequestAndResponseInterceptor {
 
         final HttpRequestImpl request = new HttpRequestImpl();
         request.method(Method.GET).path(FULL_PATH).queryParameter("x", "1").queryParameter("y", "2")
-            .httpMessageHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(TRACE_ID))
-            .httpMessageHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(SPAN_ID))
+            .httpMessageHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(TRACE_ID, 16))
+            .httpMessageHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(SPAN_ID, 16))
             .httpMessageHeader(BraveHttpHeaders.Sampled.getName(), "true");
         final HttpResponseImpl response = new HttpResponseImpl(200, null, null);
         responseProvider.set(request, response);
@@ -181,8 +181,8 @@ public class ITBraveHttpRequestAndResponseInterceptor {
 
         final HttpRequestImpl request = new HttpRequestImpl();
         request.method(Method.GET).path(FULL_PATH)
-                .httpMessageHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(TRACE_ID))
-                .httpMessageHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(SPAN_ID))
+                .httpMessageHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(TRACE_ID, 16))
+                .httpMessageHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(SPAN_ID, 16))
                 .httpMessageHeader(BraveHttpHeaders.Sampled.getName(), "true");
         final HttpResponseImpl response = new HttpResponseImpl(200, null, null);
         responseProvider.set(request, response);

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
@@ -15,10 +15,10 @@ public class ClientRequestHeaders {
         if (spanId != null) {
             LOGGER.debug("Will trace request. Span Id returned from ClientTracer: {}", spanId);
             clientRequestAdapter.addHeader(BraveHttpHeaders.Sampled.getName(), TRUE);
-            clientRequestAdapter.addHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(spanId.getTraceId()));
-            clientRequestAdapter.addHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(spanId.getSpanId()));
+            clientRequestAdapter.addHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(spanId.getTraceId(), 16));
+            clientRequestAdapter.addHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(spanId.getSpanId(), 16));
             if (spanId.getParentSpanId() != null) {
-                clientRequestAdapter.addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toHexString(spanId.getParentSpanId()));
+                clientRequestAdapter.addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toString(spanId.getParentSpanId(), 16));
             }
         } else {
             LOGGER.debug("Will not trace request.");

--- a/brave-client/src/test/java/com/github/kristofa/brave/client/ClientRequestInterceptorTest.java
+++ b/brave-client/src/test/java/com/github/kristofa/brave/client/ClientRequestInterceptorTest.java
@@ -78,9 +78,9 @@ public class ClientRequestInterceptorTest {
 
         inOrder.verify(mockClientTracer).startNewSpan(PATH);
         inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.Sampled.getName(), "true");
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(TRACE_ID));
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(SPAN_ID));
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toHexString(PARENT_SPAN_ID));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(TRACE_ID, 16));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(SPAN_ID, 16));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toString(PARENT_SPAN_ID, 16));
         inOrder.verify(mockClientTracer).setCurrentClientServiceName(CONTEXT);
         inOrder.verify(mockClientTracer).submitBinaryAnnotation("request", METHOD + " " + FULL_PATH);
         inOrder.verify(mockClientTracer).setClientSent();
@@ -101,8 +101,8 @@ public class ClientRequestInterceptorTest {
 
         inOrder.verify(mockClientTracer).startNewSpan(PATH);
         inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.Sampled.getName(), "true");
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(TRACE_ID));
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(SPAN_ID));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(TRACE_ID, 16));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(SPAN_ID, 16));
         inOrder.verify(mockClientTracer).setCurrentClientServiceName(CONTEXT);
         inOrder.verify(mockClientTracer).submitBinaryAnnotation("request", METHOD + " " + FULL_PATH);
         inOrder.verify(mockClientTracer).setClientSent();
@@ -123,9 +123,9 @@ public class ClientRequestInterceptorTest {
 
         inOrder.verify(mockClientTracer).startNewSpan(FULL_PATH);
         inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.Sampled.getName(), "true");
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.TraceId.getName(), Long.toHexString(TRACE_ID));
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.SpanId.getName(), Long.toHexString(SPAN_ID));
-        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toHexString(PARENT_SPAN_ID));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(TRACE_ID, 16));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(SPAN_ID, 16));
+        inOrder.verify(clientRequestAdapter).addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toString(PARENT_SPAN_ID, 16));
         inOrder.verify(mockClientTracer).setCurrentClientServiceName(SERVICE_NAME);
         inOrder.verify(mockClientTracer).submitBinaryAnnotation("request", METHOD + " " + FULL_PATH);
         inOrder.verify(mockClientTracer).setClientSent();

--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ClientServletCompatibilityTest.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ClientServletCompatibilityTest.java
@@ -57,12 +57,12 @@ public class ClientServletCompatibilityTest {
 
     @Test
     public void shouldHandleAllProvidedIds() throws Exception {
-        validateUsingSpan(mockSpan(123L, 456L, 789L));
+        validateUsingSpan(mockSpan(-123L, 456L, 789L));
     }
 
     @Test
     public void shouldHandleMissingParentId() throws Exception {
-        validateUsingSpan(mockSpan(123L, 456L, null));
+        validateUsingSpan(mockSpan(-123L, 456L, null));
     }
 
     private SpanId mockSpan(long traceId, long spanId, Long parentSpanId) {

--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ServletTraceFilterTest.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ServletTraceFilterTest.java
@@ -72,9 +72,9 @@ public class ServletTraceFilterTest {
     public void shouldGetTraceDataFromHeaders() throws Exception {
         when(endPointSubmitter.endPointSubmitted()).thenReturn(true);
 
-        when(servletRequest.getHeader(BraveHttpHeaders.TraceId.getName())).thenReturn(Long.toHexString(TRACE_ID));
-        when(servletRequest.getHeader(BraveHttpHeaders.SpanId.getName())).thenReturn(Long.toHexString(SPAN_ID));
-        when(servletRequest.getHeader(BraveHttpHeaders.ParentSpanId.getName())).thenReturn(Long.toHexString(PARENT_SPAN_ID));
+        when(servletRequest.getHeader(BraveHttpHeaders.TraceId.getName())).thenReturn(Long.toString(TRACE_ID, 16));
+        when(servletRequest.getHeader(BraveHttpHeaders.SpanId.getName())).thenReturn(Long.toString(SPAN_ID, 16));
+        when(servletRequest.getHeader(BraveHttpHeaders.ParentSpanId.getName())).thenReturn(Long.toString(PARENT_SPAN_ID, 16));
         when(servletRequest.getHeader(BraveHttpHeaders.Sampled.getName())).thenReturn(String.valueOf(SAMPLED_TRUE));
         when(servletRequest.getHeader(BraveHttpHeaders.SpanName.getName())).thenReturn(SPAN_NAME);
 


### PR DESCRIPTION
We started noticing some NumberFormatExceptions showing up in our local development after pulling the changes from #26.  Digging into it, it looks like we have some weirdness in Java to thank for that.  Looking at the definition of [Long.toHexString()](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#toHexString%28long%29), it makes an assumption that the long value provided is nonnegative, which isn't something we can guarantee.  When a negative number is provided, the resulting encoded hex is generates too large of a number when parsed by [Long.parseLong()](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29).  Instead, it seems like we should use an overload of [Long.toString()](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#toString%28long,%20int%29), specifying the radix of 16.  I've updated a test to cover this corner case.
