### PR TITLE
RestEasy implementation now uses brave-client module

### DIFF
--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
@@ -12,6 +12,10 @@ public class ClientRequestHeaders {
     private final static Logger LOGGER = LoggerFactory.getLogger(ClientRequestHeaders.class);
 
     public static void addTracingHeaders(ClientRequestAdapter clientRequestAdapter, SpanId spanId) {
+        addTracingHeaders(clientRequestAdapter, spanId, null);
+    }
+
+    public static void addTracingHeaders(ClientRequestAdapter clientRequestAdapter, SpanId spanId, String spanName) {
         if (spanId != null) {
             LOGGER.debug("Will trace request. Span Id returned from ClientTracer: {}", spanId);
             clientRequestAdapter.addHeader(BraveHttpHeaders.Sampled.getName(), TRUE);
@@ -19,6 +23,9 @@ public class ClientRequestHeaders {
             clientRequestAdapter.addHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(spanId.getSpanId(), 16));
             if (spanId.getParentSpanId() != null) {
                 clientRequestAdapter.addHeader(BraveHttpHeaders.ParentSpanId.getName(), Long.toString(spanId.getParentSpanId(), 16));
+            }
+            if(spanName != null) {
+                clientRequestAdapter.addHeader(BraveHttpHeaders.SpanName.getName(), spanName);
             }
         } else {
             LOGGER.debug("Will not trace request.");

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
@@ -29,7 +29,7 @@ public class ClientRequestInterceptor {
 
     private Optional<String> getServiceName(ClientRequestAdapter clientRequestAdapter, Optional<String> serviceNameOverride) {
         Optional<String> serviceName;
-        if(serviceNameOverride.isPresent()) {
+        if (serviceNameOverride.isPresent()) {
             serviceName = serviceNameOverride;
         } else {
             String path = clientRequestAdapter.getUri().getPath();
@@ -47,14 +47,13 @@ public class ClientRequestInterceptor {
 
     private String getSpanName(ClientRequestAdapter clientRequestAdapter, Optional<String> serviceNameOverride) {
         String spanName;
-        if(serviceNameOverride.isPresent()) {
-            if (clientRequestAdapter.getSpanName().isPresent()) {
-                spanName = clientRequestAdapter.getSpanName().get();
-            } else {
-                spanName = clientRequestAdapter.getUri().getPath();
-            }
+        Optional<String> spanNameFromRequest = clientRequestAdapter.getSpanName();
+        String path = clientRequestAdapter.getUri().getPath();
+        if (spanNameFromRequest.isPresent()) {
+            spanName = spanNameFromRequest.get();
+        } else if (serviceNameOverride.isPresent()) {
+            spanName = path;
         } else {
-            final String path = clientRequestAdapter.getUri().getPath();
             final String[] split = path.split("/");
             if (split.length > 2 && path.startsWith("/")) {
                 // If path starts with '/', then context is between first two '/'. Left over is path for service.

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -31,8 +31,13 @@
   <dependencies>
     <dependency>
         <groupId>com.github.kristofa</groupId>
-        <artifactId>brave-impl</artifactId>
+        <artifactId>brave-client</artifactId>
         <version>2.2.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.1</version>
     </dependency>
     <dependency>
 		<groupId>org.jboss.resteasy</groupId>

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
@@ -143,7 +143,7 @@ public class BravePreProcessInterceptor implements PreProcessInterceptor {
     private Long getFirstLongValueFor(final Entry<String, List<String>> headerEntry) {
 
         final String firstStringValueFor = getFirstStringValueFor(headerEntry);
-        return firstStringValueFor == null ? null : Long.valueOf(firstStringValueFor);
+        return firstStringValueFor == null ? null : Long.valueOf(firstStringValueFor, 16);
 
     }
 

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/RestEasyClientRequestAdapter.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/RestEasyClientRequestAdapter.java
@@ -1,0 +1,46 @@
+package com.github.kristofa.brave.resteasy;
+
+import com.github.kristofa.brave.BraveHttpHeaders;
+import com.github.kristofa.brave.ClientRequestAdapter;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import org.jboss.resteasy.client.ClientRequest;
+
+import java.net.URI;
+
+public class RestEasyClientRequestAdapter implements ClientRequestAdapter {
+    private final ClientRequest clientRequest;
+
+    public RestEasyClientRequestAdapter(ClientRequest clientRequest) {
+        this.clientRequest = clientRequest;
+    }
+
+    @Override
+    public URI getUri() {
+        try {
+            return URI.create(clientRequest.getUri());
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public String getMethod() {
+        return clientRequest.getHttpMethod();
+    }
+
+    @Override
+    public Optional<String> getSpanName() {
+        Optional<String> spanName = Optional.absent();
+        Object spanNameHeader = clientRequest.getHeaders().getFirst(BraveHttpHeaders.SpanName.getName());
+        if (spanNameHeader != null) {
+            spanName = Optional.fromNullable(spanNameHeader.toString());
+        }
+        return spanName;
+    }
+
+    @Override
+    public void addHeader(String header, String value) {
+        clientRequest.header(header, value);
+    }
+}

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/RestEasyClientResponseAdapter.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/RestEasyClientResponseAdapter.java
@@ -1,0 +1,20 @@
+package com.github.kristofa.brave.resteasy;
+
+import com.github.kristofa.brave.ClientResponseAdapter;
+import org.jboss.resteasy.client.ClientResponse;
+
+public class RestEasyClientResponseAdapter implements ClientResponseAdapter {
+    private final ClientResponse clientResponse;
+
+    public RestEasyClientResponseAdapter(ClientResponse clientResponse) {
+        this.clientResponse = clientResponse;
+    }
+
+    @Override
+    public int getStatusCode() {
+        if(clientResponse == null) {
+            return 0;
+        }
+        return clientResponse.getStatus();
+    }
+}

--- a/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptorTest.java
+++ b/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptorTest.java
@@ -1,5 +1,20 @@
 package com.github.kristofa.brave.resteasy;
 
+import com.github.kristofa.brave.BraveHttpHeaders;
+import com.github.kristofa.brave.EndPointSubmitter;
+import com.github.kristofa.brave.ServerTracer;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.client.ClientRequestHeaders;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
+
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -7,23 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.HttpHeaders;
-
-import org.apache.commons.lang3.StringUtils;
-import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
-
-import com.github.kristofa.brave.BraveHttpHeaders;
-import com.github.kristofa.brave.EndPointSubmitter;
-import com.github.kristofa.brave.ServerTracer;
-
 public class BravePreProcessInterceptorTest {
 
-    private final static long TRACE_ID = 10l;
+    private final static long TRACE_ID = -10l;
     private final static long SPAN_ID = 11l;
     private final static long PARENT_SPAN_ID = 12l;
     private static final String PATH = "/PATH";
@@ -68,7 +69,7 @@ public class BravePreProcessInterceptorTest {
     public void testPreProcessEndPointNotSet_TraceHeadersSubmitted() {
 
         when(mockEndPointSubmitter.endPointSubmitted()).thenReturn(false);
-        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, null, true, false);
+        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, null, true);
 
         assertNull(interceptor.preProcess(mockHttpRequest, null));
 
@@ -95,29 +96,7 @@ public class BravePreProcessInterceptorTest {
     @Test
     public void testPreProcessEndPointSet_TraceHeadersSubmitted() {
         when(mockEndPointSubmitter.endPointSubmitted()).thenReturn(true);
-        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, null, true, false);
-
-        assertNull(interceptor.preProcess(mockHttpRequest, null));
-
-        final InOrder inOrder = inOrder(mockEndPointSubmitter, mockServerTracer);
-        inOrder.verify(mockEndPointSubmitter).endPointSubmitted();
-        inOrder.verify(mockServerTracer).clearCurrentSpan();
-        inOrder.verify(mockServerTracer).setStateCurrentTrace(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, PATH);
-        inOrder.verify(mockServerTracer).setServerReceived();
-
-        verify(mockHttpRequest).getPreprocessedPath();
-        verify(mockHttpRequest).getHttpHeaders();
-
-        verifyNoMoreInteractions(mockEndPointSubmitter);
-        verifyNoMoreInteractions(mockServerTracer);
-        verifyNoMoreInteractions(mockHttpRequest);
-        verifyNoMoreInteractions(mockHttpServletRequest);
-    }
-
-    @Test
-    public void testPreProcessEndPointSet_TraceHeadersMixedCase() {
-        when(mockEndPointSubmitter.endPointSubmitted()).thenReturn(true);
-        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, null, true, true);
+        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, null, true);
 
         assertNull(interceptor.preProcess(mockHttpRequest, null));
 
@@ -182,7 +161,7 @@ public class BravePreProcessInterceptorTest {
     @Test
     public void testPreProcessSpanNameDefined() {
         when(mockEndPointSubmitter.endPointSubmitted()).thenReturn(true);
-        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, SPAN_NAME, true, false);
+        mockHttpHeaders(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, SPAN_NAME, true);
 
         assertNull(interceptor.preProcess(mockHttpRequest, null));
 
@@ -201,30 +180,23 @@ public class BravePreProcessInterceptorTest {
     }
 
     private void mockHttpHeaders(final long traceid, final long spanId, final long parentSpanId, final String spanName,
-        final Boolean sampled, final boolean mixLowerAndUpperCase) {
+                                 final Boolean sampled) {
         final HttpHeaders mockHttpHeaders = mock(HttpHeaders.class);
-        final MultivaluedMapImpl<String, String> multivaluedMapImpl = new MultivaluedMapImpl<String, String>();
 
-        if (StringUtils.isNotBlank(spanName)) {
-            multivaluedMapImpl.add(BraveHttpHeaders.SpanName.getName().toLowerCase(), spanName);
-        }
-
-        if (mixLowerAndUpperCase) {
-            multivaluedMapImpl.add(BraveHttpHeaders.TraceId.getName().toLowerCase(), String.valueOf(traceid));
-            multivaluedMapImpl.add(BraveHttpHeaders.SpanId.getName().toUpperCase(), String.valueOf(spanId));
-            multivaluedMapImpl.add(BraveHttpHeaders.ParentSpanId.getName().toLowerCase(), String.valueOf(parentSpanId));
-            if (sampled != null) {
-                multivaluedMapImpl.add(BraveHttpHeaders.Sampled.getName(), sampled.toString().toUpperCase());
-            }
+        ClientRequest clientRequest = new ClientRequest("test");
+        RestEasyClientRequestAdapter request = new RestEasyClientRequestAdapter(clientRequest);
+        SpanId span;
+        if (sampled) {
+            span = mock(SpanId.class);
+            when(span.getTraceId()).thenReturn(traceid);
+            when(span.getSpanId()).thenReturn(spanId);
+            when(span.getParentSpanId()).thenReturn(parentSpanId);
         } else {
-            multivaluedMapImpl.add(BraveHttpHeaders.TraceId.getName(), String.valueOf(traceid));
-            multivaluedMapImpl.add(BraveHttpHeaders.SpanId.getName(), String.valueOf(spanId));
-            multivaluedMapImpl.add(BraveHttpHeaders.ParentSpanId.getName(), String.valueOf(parentSpanId));
-            if (sampled != null) {
-                multivaluedMapImpl.add(BraveHttpHeaders.Sampled.getName(), sampled.toString());
-            }
+            span = null;
         }
-        when(mockHttpHeaders.getRequestHeaders()).thenReturn(multivaluedMapImpl);
+        ClientRequestHeaders.addTracingHeaders(request, span, spanName);
+
+        when(mockHttpHeaders.getRequestHeaders()).thenReturn(clientRequest.getHeaders());
         when(mockHttpRequest.getHttpHeaders()).thenReturn(mockHttpHeaders);
     }
 


### PR DESCRIPTION
After reading the comments on #26, I realized I forgot to modify the RestEasy implementation to use the shared client module.  ~~This pull request includes the hexcode fix in #28 (necesary for tests to pass), but I wanted to get some eyes on this as well.~~  I've rebased this after the pull of #28. 
