### PR TITLE
Don't create new server span objects when not sampling

### DIFF
--- a/brave-impl/src/main/java/com/github/kristofa/brave/ClientTracerImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ClientTracerImpl.java
@@ -33,7 +33,6 @@ class ClientTracerImpl extends AbstractAnnotationSubmitter implements ClientTrac
      * @param spanCollector Will collect the spans.
      * @param traceFilters List of TraceFilters. Will be executed in order. If one returns <code>false</code> there will be
      *            no tracing and next ones will not be executed anymore. So order is important.
-     * @param commonAnnotationSubmitter Common Annotation Submitter.
      */
     ClientTracerImpl(final ServerAndClientSpanState state, final Random randomGenerator, final SpanCollector spanCollector,
         final List<TraceFilter> traceFilters) {
@@ -104,7 +103,7 @@ class ClientTracerImpl extends AbstractAnnotationSubmitter implements ClientTrac
         if (sample == null) {
             // No sample indication is present.
             for (final TraceFilter traceFilter : traceFilters) {
-                if (traceFilter.trace(requestName) == false) {
+                if (!traceFilter.trace(requestName)) {
                     state.setCurrentClientSpan(null);
                     state.setCurrentClientServiceName(null);
                     return null;

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ServerSpanImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ServerSpanImpl.java
@@ -27,7 +27,6 @@ class ServerSpanImpl implements ServerSpan {
      * @param spanId Span id.
      * @param parentSpanId Parent span id, can be <code>null</code>.
      * @param name Span name.
-     * @param sample Indicates if we should sample this span.
      */
     ServerSpanImpl(final long traceId, final long spanId, final Long parentSpanId, final String name) {
 
@@ -43,6 +42,8 @@ class ServerSpanImpl implements ServerSpan {
 
     /**
      * Creates a new empty instance with no Span but with sample indication.
+     *
+     * @param sample Indicates if we should sample this span.
      */
     ServerSpanImpl(final Boolean sample) {
         span = null;

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ServerTracerImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ServerTracerImpl.java
@@ -18,6 +18,8 @@ import com.twitter.zipkin.gen.zipkinCoreConstants;
  */
 class ServerTracerImpl extends AbstractAnnotationSubmitter implements ServerTracer {
 
+    private static final ServerSpanImpl NOT_SAMPLED = new ServerSpanImpl(false);
+
     private final ServerSpanState state;
     private final SpanCollector collector;
     private final List<TraceFilter> traceFilters = new ArrayList<TraceFilter>();
@@ -80,7 +82,7 @@ class ServerTracerImpl extends AbstractAnnotationSubmitter implements ServerTrac
      */
     @Override
     public void setStateNoTracing() {
-        state.setCurrentServerSpan(new ServerSpanImpl(false));
+        state.setCurrentServerSpan(NOT_SAMPLED);
 
     }
 
@@ -92,7 +94,7 @@ class ServerTracerImpl extends AbstractAnnotationSubmitter implements ServerTrac
         Validate.notBlank(spanName, "Span name should not be null.");
         for (final TraceFilter traceFilter : traceFilters) {
             if (traceFilter.trace(spanName) == false) {
-                state.setCurrentServerSpan(new ServerSpanImpl(false));
+                state.setCurrentServerSpan(NOT_SAMPLED);
                 return;
             }
         }


### PR DESCRIPTION
Small performance improvement. When we decide not to sample a new request (whether that's by intention or by failing to pass a trace filter), we should not create a new object every time. It can ramp up GC time on highly loaded servers.
