### PR TITLE
Adjust log levels to be less severe

### DIFF
--- a/brave-impl/src/main/java/com/github/kristofa/brave/LoggingSpanCollectorImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/LoggingSpanCollectorImpl.java
@@ -48,7 +48,9 @@ public class LoggingSpanCollectorImpl implements SpanCollector {
             }
         }
 
-        getLogger().info(span.toString());
+        if (getLogger().isInfoEnabled()) {
+            getLogger().info(span.toString());
+        }
     }
 
     /**

--- a/brave-tracefilters/src/main/java/com/github/kristofa/brave/tracefilter/ZooKeeperSamplingTraceFilter.java
+++ b/brave-tracefilters/src/main/java/com/github/kristofa/brave/tracefilter/ZooKeeperSamplingTraceFilter.java
@@ -152,7 +152,7 @@ public class ZooKeeperSamplingTraceFilter implements TraceFilter, Watcher {
                 return zkCurator.getData().usingWatcher(this).forPath(znode);
             }
         } catch (final Exception e) {
-            LOGGER.error("Zookeeper exception.", e);
+            LOGGER.warn("Zookeeper exception.", e);
         }
         return null;
     }

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinCollectorClientProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinCollectorClientProvider.java
@@ -69,20 +69,22 @@ class ZipkinCollectorClientProvider implements ThriftClientProvider<ZipkinCollec
      */
     @Override
     public Client exception(final TException exception) {
-        LOGGER.error("Thrift exception.", exception);
         if (exception instanceof TTransportException) {
+            LOGGER.debug("TransportException detected, closing current connection and opening new one", exception);
             // Close existing transport.
             close();
 
             try {
                 setup();
             } catch (final TException e) {
-                LOGGER.error("Trying to reconnect to Thrift server failed.", e);
+                LOGGER.warn("Trying to reconnect to Thrift server failed.", e);
                 return null;
             }
             return client;
+        } else {
+            LOGGER.warn("Thrift exception.", exception);
+            return null;
         }
-        return null;
     }
 
     /**

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
@@ -81,7 +81,7 @@ public class ZipkinSpanCollector implements SpanCollector {
             if (params.failOnSetup()) {
                 throw new IllegalStateException(e);
             } else {
-                LOGGER.error("Connection could not be established during setup.", e);
+                LOGGER.warn("Connection could not be established during setup.", e);
             }
         }
         spanQueue = new ArrayBlockingQueue<Span>(params.getQueueSize());
@@ -110,7 +110,7 @@ public class ZipkinSpanCollector implements SpanCollector {
 
         final boolean offer = spanQueue.offer(span);
         if (!offer) {
-            LOGGER.error("Queue rejected Span, span not submitted: {}", span);
+            LOGGER.warn("Queue rejected Span, span not submitted: {}", span);
         } else {
             final long end = System.currentTimeMillis();
             if (LOGGER.isDebugEnabled()) {
@@ -157,7 +157,7 @@ public class ZipkinSpanCollector implements SpanCollector {
                 final Integer spansProcessed = future.get();
                 LOGGER.info("SpanProcessingThread processed {} spans.", spansProcessed);
             } catch (final Exception e) {
-                LOGGER.error("Exception when getting result of SpanProcessingThread.", e);
+                LOGGER.warn("Exception when getting result of SpanProcessingThread.", e);
             }
         }
         executorService.shutdown();

--- a/flume-zipkin-collector-sink/src/main/java/com/github/kristofa/flume/ZipkinSpanCollectorSink.java
+++ b/flume-zipkin-collector-sink/src/main/java/com/github/kristofa/flume/ZipkinSpanCollectorSink.java
@@ -130,12 +130,12 @@ public class ZipkinSpanCollectorSink extends AbstractSink implements Configurabl
             txn.commit();
         } catch (final TTransportException e) {
             txn.rollback();
-            LOGGER.error("Got a TTransportException. Will close current Transport and create new connection/client.");
+            LOGGER.info("Got a TTransportException. Will close current Transport and create new connection/client.");
             try {
                 connect();
                 LOGGER.info("Reconnect succeeded.");
             } catch (final TTransportException e1) {
-                LOGGER.error("Trying to reconnect failed.", e1);
+                LOGGER.warn("Trying to reconnect failed when recovering from " + e.getMessage(), e1);
                 throw new EventDeliveryException(e1);
             }
         } catch (final Throwable e) {
@@ -186,7 +186,7 @@ public class ZipkinSpanCollectorSink extends AbstractSink implements Configurabl
             transport.open();
             sinkCounter.incrementConnectionCreatedCount();
         } catch (final TTransportException e) {
-            LOGGER.error("Staring ZipkinSpanCollectorSink failed!", e);
+            LOGGER.warn("Staring ZipkinSpanCollectorSink failed!", e);
             sinkCounter.incrementConnectionFailedCount();
             lifeCycleState = LifecycleState.ERROR;
             throw e;

--- a/flume-zipkin-metrics-sink/src/main/java/com/github/kristofa/flume/ZipkinMetricsSink.java
+++ b/flume-zipkin-metrics-sink/src/main/java/com/github/kristofa/flume/ZipkinMetricsSink.java
@@ -96,7 +96,7 @@ public class ZipkinMetricsSink extends AbstractSink implements Configurable {
                     try {
                         process(create(event));
                     } catch (final TException e) {
-                        LOGGER.error("We were unable to build spans from received data...", e);
+                        LOGGER.warn("We were unable to build spans from received data...", e);
                     }
                 }
                 sinkCounter.incrementBatchCompleteCount();
@@ -107,7 +107,7 @@ public class ZipkinMetricsSink extends AbstractSink implements Configurable {
             txn.commit();
         } catch (final IOException e) {
             txn.rollback();
-            LOGGER.error("IOException", e);
+            LOGGER.warn("IOException", e);
         } catch (final Throwable e) {
             txn.rollback();
             throw new EventDeliveryException(e);


### PR DESCRIPTION
In our applications, we noticed a lot of ERROR messages that seemed to signify that something bad was happening with the application, but it was actually coming from the tracing modules, most of which we felt were too highly escalated.  In general, we think that the logging shouldn't go above WARN, so we removed some duplicated messages and downgraded many of the error and "retrying" messages to something less severe.
