### PR TITLE
Allow client span names to be set based on pattern matching.

### DIFF
--- a/brave-client/src/main/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImpl.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImpl.java
@@ -1,0 +1,65 @@
+package com.github.kristofa.brave.client.spanfilter;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Given a list of span name patterns like "/api/{client}/{operation}" or "/api/{version}/{client}/save",
+ * this filter will only allow these span names to be set as the client span name (else "[span name not defined]").
+ */
+public class PatternBasedSpanNameFilterImpl implements SpanNameFilter {
+    @VisibleForTesting
+    static final String DEFAULT_SPAN_NAME = "[span name not defined]";
+
+    private final Iterable<SpanNamePattern> spanNamePatterns;
+    private final String defaultSpanName;
+
+    public PatternBasedSpanNameFilterImpl(Iterable<String> spanNamePatterns) {
+        this(spanNamePatterns, DEFAULT_SPAN_NAME);
+    }
+
+    public PatternBasedSpanNameFilterImpl(Iterable<String> spanNamePatterns, String defaultSpanName) {
+        final List<SpanNamePattern> patternNamePairs = Lists.newArrayList();
+        if (spanNamePatterns != null) {
+            for (String spanNamePattern : spanNamePatterns) {
+                if (spanNamePattern != null) {
+                    patternNamePairs.add(new SpanNamePattern(spanNamePattern));
+                }
+            }
+        }
+
+        this.spanNamePatterns = patternNamePairs;
+        this.defaultSpanName = defaultSpanName;
+    }
+
+    @Override
+    public String filterSpanName(String unfilteredSpanName) {
+        for (SpanNamePattern spanNamePattern : spanNamePatterns) {
+            if (spanNamePattern.matches(unfilteredSpanName)) {
+                return spanNamePattern.getName();
+            }
+        }
+        return defaultSpanName;
+    }
+
+    private static class SpanNamePattern {
+        private final String name;
+        private final Pattern pattern;
+
+        private SpanNamePattern(String name) {
+            this.name = name;
+            this.pattern = Pattern.compile(name.replaceAll("\\{.+?\\}", ".+?"), Pattern.CASE_INSENSITIVE);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean matches(String input) {
+            return pattern.matcher(input).matches();
+        }
+    }
+}

--- a/brave-client/src/test/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImplTest.java
+++ b/brave-client/src/test/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImplTest.java
@@ -1,0 +1,64 @@
+package com.github.kristofa.brave.client.spanfilter;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class PatternBasedSpanNameFilterImplTest {
+
+    @Test
+    public void testMultiplePatterns() throws Exception {
+        final String add = "/api/{something}/{else}/add";
+        final String remove = "/api/{something}/{else}/remove";
+        final String anythingElse = "/api/{anythingelse}";
+        final PatternBasedSpanNameFilterImpl filter
+                = new PatternBasedSpanNameFilterImpl(Lists.newArrayList(add, remove, anythingElse));
+
+        assertEquals(add, filter.filterSpanName("/api/clients/relationships/add"));
+        assertEquals(remove, filter.filterSpanName("/api/science/math/remove"));
+        assertEquals(anythingElse, filter.filterSpanName("/api/set/up/us/the/bomb"));
+    }
+
+    @Test
+    public void testNoMatch() throws Exception {
+        final String add = "/api/{something}/{else}/add";
+        final PatternBasedSpanNameFilterImpl filter
+                = new PatternBasedSpanNameFilterImpl(Lists.newArrayList(add));
+
+        assertEquals(PatternBasedSpanNameFilterImpl.DEFAULT_SPAN_NAME, filter.filterSpanName("/api/nomatch"));
+    }
+
+    @Test
+    public void testHandlesNull() throws Exception {
+        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(null);
+        assertEquals(PatternBasedSpanNameFilterImpl.DEFAULT_SPAN_NAME, filter.filterSpanName("/api/whatever"));
+    }
+
+    @Test
+    public void testHandlesEmpty() throws Exception {
+        final String undef = "UNDEF";
+        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Collections.<String>emptyList(), undef);
+
+        assertEquals(undef, filter.filterSpanName("/api/anything/at/all"));
+    }
+
+    @Test
+    public void testHandlesNullPatterns() throws Exception {
+        final String undef = "not-defined";
+        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Lists.<String>newArrayList(null, null), undef);
+
+        assertEquals(undef, filter.filterSpanName("/api/not-a-match"));
+    }
+
+    @Test
+    public void testCaseInsensitive() throws Exception {
+        final String updatePattern = "/api/{userid}/update";
+        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Lists.newArrayList(updatePattern));
+
+        assertEquals(updatePattern, filter.filterSpanName("/api/12/update"));
+        assertEquals(updatePattern, filter.filterSpanName("/api/12/UPDATE"));
+    }
+}

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
@@ -28,9 +28,13 @@ public class JerseyClientTraceFilter extends ClientFilter {
 
     @Inject
     public JerseyClientTraceFilter(final ClientTracer clientTracer, final Optional<String> serviceName) {
+        this(clientTracer, serviceName, Optional.<SpanNameFilter>absent());
+    }
+
+    public JerseyClientTraceFilter(final ClientTracer clientTracer, final Optional<String> serviceName, final Optional<SpanNameFilter> spanNameFilter) {
         Validate.notNull(clientTracer);
         Validate.notNull(serviceName);
-        final Optional<SpanNameFilter> spanNameFilter = Optional.absent();
+        Validate.notNull(spanNameFilter);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
         this.serviceName = serviceName;

--- a/brave-jersey2/src/main/java/com/github/kristofa/brave/jersey2/BraveClientRequestFilter.java
+++ b/brave-jersey2/src/main/java/com/github/kristofa/brave/jersey2/BraveClientRequestFilter.java
@@ -24,9 +24,13 @@ public class BraveClientRequestFilter implements ClientRequestFilter {
 
     @Inject
     public BraveClientRequestFilter(final ClientTracer clientTracer, final Optional<String> serviceName) {
+        this(clientTracer, serviceName, Optional.<SpanNameFilter>absent());
+    }
+
+    public BraveClientRequestFilter(final ClientTracer clientTracer, final Optional<String> serviceName, final Optional<SpanNameFilter> spanNameFilter) {
         Validate.notNull(clientTracer);
         Validate.notNull(serviceName);
-        final Optional<SpanNameFilter> spanNameFilter = Optional.absent();
+        Validate.notNull(spanNameFilter);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         this.serviceName = serviceName;
     }


### PR DESCRIPTION
For instance, perhaps you want to have your client span names
reported as `/api/{userid}/update` instead of having span names
that contain all user ids.
