### PR TITLE
Fix negative trace ids

### DIFF
--- a/brave-client/pom.xml
+++ b/brave-client/pom.xml
@@ -28,7 +28,7 @@
     <dependencies>
         <dependency>
             <groupId>com.github.kristofa</groupId>
-            <artifactId>brave-interfaces</artifactId>
+            <artifactId>brave-impl</artifactId>
             <version>2.4-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.ClientRequestAdapter;
+import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.SpanId;
 
 public class ClientRequestHeaders {
@@ -18,11 +19,11 @@ public class ClientRequestHeaders {
         if (spanId != null) {
             LOGGER.debug("Will trace request. Span Id returned from ClientTracer: {}", spanId);
             clientRequestAdapter.addHeader(BraveHttpHeaders.Sampled.getName(), TRUE);
-            clientRequestAdapter.addHeader(BraveHttpHeaders.TraceId.getName(), Long.toString(spanId.getTraceId(), 16));
-            clientRequestAdapter.addHeader(BraveHttpHeaders.SpanId.getName(), Long.toString(spanId.getSpanId(), 16));
+            clientRequestAdapter.addHeader(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.getTraceId()));
+            clientRequestAdapter.addHeader(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.getSpanId()));
             if (spanId.getParentSpanId() != null) {
                 clientRequestAdapter.addHeader(BraveHttpHeaders.ParentSpanId.getName(),
-                    Long.toString(spanId.getParentSpanId(), 16));
+                		IdConversion.convertToString(spanId.getParentSpanId()));
             }
             if (spanName != null) {
                 clientRequestAdapter.addHeader(BraveHttpHeaders.SpanName.getName(), spanName);

--- a/brave-impl/pom.xml
+++ b/brave-impl/pom.xml
@@ -37,6 +37,10 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.1</version>
     </dependency>
+    <dependency>
+    	<groupId>com.google.guava</groupId>
+    	<artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
   
   <build>	

--- a/brave-impl/src/main/java/com/github/kristofa/brave/IdConversion.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/IdConversion.java
@@ -1,0 +1,47 @@
+package com.github.kristofa.brave;
+
+import com.google.common.primitives.UnsignedLongs;
+
+/**
+ * Contains conversion utilities for converting trace and span ids from long to string and vice
+ * versa.
+ * <p/>
+ * The string representation is used when transferring trace context from client to server
+ * as http headers.
+ * <p/>
+ * This implementation is expected to be compatible with Zipkin. This is important in case you
+ * mix brave services with zipkin / finagle services.
+ * <p/>
+ * The only difference between the zipkin implementation and this implementation 
+ * is that zipkin prepends '0' characters in case String does not contain 16 characters. 
+ * For example instead of generating String 
+ * "0" for long id 0 it generates "0000000000000000". But zipkin will properly convert String
+ * representations in case they are not prepended with 0's. 
+ * 
+ * @author kristof
+ */
+public class IdConversion {
+	
+	/**
+	 * Converts long trace or span id to String.
+	 * 
+	 * @param id trace, span or parent span id.
+	 * @return String representation.
+	 */
+	public static String convertToString(final long id)
+	{
+		return UnsignedLongs.toString(id, 16);
+	}
+	
+	/**
+	 * Converts String trace or span id to long.
+	 * 
+	 * @param id trace, span or parent span id.
+	 * @return Long representation.
+	 */
+	public static long convertToLong(final String id)
+	{
+		return UnsignedLongs.parseUnsignedLong(id, 16);
+	}
+
+}

--- a/brave-impl/src/test/java/com/github/kristofa/brave/IdConversionTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/IdConversionTest.java
@@ -1,0 +1,55 @@
+package com.github.kristofa.brave;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class IdConversionTest {
+	
+	@Test
+	public void testPositiveId() {
+		final long longId = 8828218016717761634l;
+		// This id was generated using the zipkin code.
+		final String expectedId = "7a842183262a6c62";
+		assertEquals(expectedId, IdConversion.convertToString(longId));
+		assertEquals(longId, IdConversion.convertToLong(expectedId));
+	}
+	
+
+	@Test
+	public void testNegativeId() {
+		final long longId = -4667777584646200191l;
+		// This id was generated using the zipkin code.
+		final String expectedId = "bf38b90488a1e481";
+		assertEquals(expectedId, IdConversion.convertToString(longId));
+		assertEquals(longId, IdConversion.convertToLong(expectedId));
+	}
+	
+	@Test
+	public void testZeroId() {
+		final long longId = 0;
+		// Zipkin prepends 0's but conversion without those zeros also works.
+		final String expectedId = "0";
+		assertEquals(expectedId, IdConversion.convertToString(longId));
+		assertEquals(longId, IdConversion.convertToLong(expectedId));
+	}
+	
+	@Test
+	public void testMinValueId() {
+		final long longId = Long.MIN_VALUE;
+		// This id was generated using the zipkin code.
+		final String expectedId = "8000000000000000";
+		assertEquals(expectedId, IdConversion.convertToString(longId));
+		assertEquals(longId, IdConversion.convertToLong(expectedId));
+	}
+	
+	@Test
+	public void testMaxValueId() {
+		final long longId = Long.MAX_VALUE;
+		// This id was generated using the zipkin code.
+		final String expectedId = "7fffffffffffffff";
+		assertEquals(expectedId, IdConversion.convertToString(longId));
+		assertEquals(longId, IdConversion.convertToLong(expectedId));
+	}
+
+}

--- a/brave-jersey/pom.xml
+++ b/brave-jersey/pom.xml
@@ -27,11 +27,6 @@
     <dependencies>
         <dependency>
             <groupId>com.github.kristofa</groupId>
-            <artifactId>brave-interfaces</artifactId>
-            <version>2.4-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.kristofa</groupId>
             <artifactId>brave-client</artifactId>
             <version>2.4-SNAPSHOT</version>
         </dependency>

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
@@ -2,7 +2,9 @@ package com.github.kristofa.brave.jersey;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.EndPointSubmitter;
+import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.ServerTracer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,6 +12,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.IOException;
 
 /**
@@ -97,7 +100,7 @@ public class ServletTraceFilter implements Filter {
         if (value == null) {
             return null;
         }
-        return Long.parseLong(value, 16);
+        return IdConversion.convertToLong(value);
     }
 
     @Override

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -80,9 +80,16 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
+                	<groupId>org.apache.maven.plugins</groupId>
+                	<artifactId>maven-compiler-plugin</artifactId>
+                	<version>2.5.1</version>
+                	<configuration>
+                   		<source>1.7</source>
+                    	<target>1.7</target>
+                    	<optimize>true</optimize>
+                    	<debug>true</debug>
+                	</configuration>
+       	     	</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>

--- a/brave-jersey2/src/main/java/com/github/kristofa/brave/jersey2/BraveContainerRequestFilter.java
+++ b/brave-jersey2/src/main/java/com/github/kristofa/brave/jersey2/BraveContainerRequestFilter.java
@@ -2,7 +2,9 @@ package com.github.kristofa.brave.jersey2;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.EndPointSubmitter;
+import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.ServerTracer;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +14,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
+
 import java.io.IOException;
 import java.net.URI;
 
@@ -99,6 +102,6 @@ public class BraveContainerRequestFilter implements ContainerRequestFilter {
         if (value == null) {
             return null;
         }
-        return Long.parseLong(value, 16);
+        return IdConversion.convertToLong(value);
     }
 }

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Component;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.EndPointSubmitter;
+import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.ServerTracer;
 import com.twitter.zipkin.gen.Endpoint;
 
@@ -152,7 +153,7 @@ public class BravePreProcessInterceptor implements PreProcessInterceptor {
     private Long getFirstLongValueFor(final Entry<String, List<String>> headerEntry) {
 
         final String firstStringValueFor = getFirstStringValueFor(headerEntry);
-        return firstStringValueFor == null ? null : Long.valueOf(firstStringValueFor, 16);
+        return firstStringValueFor == null ? null : IdConversion.convertToLong(firstStringValueFor);
 
     }
 


### PR DESCRIPTION
Started implementation to make sure `trace ids` and `span ids` that are transferred over http headers are compatible between brave and zipkin / finagle.
There is currently a bug that negative ids are not compatible so mixing brave based services with zipkin / finagle based services would brake traces.
Once implemented it will fix #39 .
