### PR TITLE
create TransportProvider abstraction and rewrite SpanCollector to use th...

### DIFF
--- a/brave-zipkin-spancollector/pom.xml
+++ b/brave-zipkin-spancollector/pom.xml
@@ -42,6 +42,11 @@
           <artifactId>commons-lang3</artifactId>
           <version>3.3.1</version>
       </dependency>
+      <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.1.3</version>
+      </dependency>
   </dependencies>
   <build>	
   	<plugins>

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/HttpTransportProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/HttpTransportProvider.java
@@ -1,0 +1,138 @@
+package com.github.kristofa.brave.zipkin;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.thrift.transport.THttpClient;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * HTTP implementation. Relies on the {@link org.apache.thrift.transport.THttpClient thrift http transport} internally.
+ *
+ * @author botizac
+ */
+public class HttpTransportProvider implements ZipkinClientTransportProvider {
+
+    /**
+     * Zipkin server http(s) URL. Could point to a specific server or a load balancer.
+     */
+    private String url;
+
+    /**
+     * Http client socket connect timeout, in milliseconds.
+     */
+    private int connectionTimeout;
+
+    /**
+     * Http client socket read timeout, in milliseconds.
+     */
+    private int readTimeout;
+
+    /**
+     * Http client connection pool maximum size.
+     */
+    private int poolSize;
+
+    /**
+     * Is the Zipkin URL using https?
+     */
+    private boolean secure;
+
+    /**
+     * Constructor with default values.
+     *
+     * @param url Zipkin server http url, including the port.
+     */
+    public HttpTransportProvider(String url) {
+        // timeouts both defaulted to 5 seconds.
+        this(url, 5000, 5000, 100);
+    }
+
+    /**
+     * Constructor with default pool size of 100.
+     *
+     * @param url               Zipkin server http url, including the port.
+     * @param connectionTimeout Socket connect timeout, in milliseconds.
+     * @param readTimeout       Socket read timeout, in milliseconds.
+     */
+    public HttpTransportProvider(String url, int connectionTimeout, int readTimeout) {
+        // pool size defaulted to 100.
+        this(url, connectionTimeout, readTimeout, 100);
+    }
+
+    /**
+     * Most comprehensive constructor.
+     *
+     * @param url               Zipkin server http url, including the port
+     * @param connectionTimeout Socket connect timeout in milliseconds.
+     * @param readTimeout       Socket read timeout, in milliseconds
+     * @param poolSize          Connection pool maximum size.
+     */
+    public HttpTransportProvider(String url, int connectionTimeout, int readTimeout, int poolSize) {
+        Validate.isTrue(StringUtils.isNotBlank(url), "No url provided");
+
+        try {
+            final URL zipkinUrl = new URL(url);
+
+            secure = "https".equals(zipkinUrl.getProtocol());
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid zipkin server URL");
+        }
+
+        Validate.isTrue(connectionTimeout > 0, "Connection timeout must be > 0");
+        Validate.isTrue(readTimeout > 0, "Read timeout must be > 0");
+        Validate.isTrue(poolSize > 0, "Pool size must be > 0");
+
+        this.url = url;
+        this.connectionTimeout = connectionTimeout;
+        this.readTimeout = readTimeout;
+        this.poolSize = poolSize;
+    }
+
+    @Override
+    public TTransport getTransport() {
+        THttpClient client;
+        try {
+            client = new THttpClient(url, createClient());
+
+            client.setConnectTimeout(connectionTimeout);
+            client.setReadTimeout(readTimeout);
+        } catch (TTransportException te) {
+            throw new IllegalStateException("Could not create HTTP Transport instance", te);
+        }
+
+        return client;
+    }
+
+    /**
+     * Initialize the underlying http client.
+     *
+     * @return The HTTP Client.
+     */
+    private HttpClient createClient() {
+        ThreadSafeClientConnManager connManager = new ThreadSafeClientConnManager();
+
+        connManager.setMaxTotal(poolSize);
+        connManager.setDefaultMaxPerRoute(poolSize);
+
+        final DefaultHttpClient client = new DefaultHttpClient(connManager);
+
+        // TODO: if using SSL (secure == true), configure key and truststore
+
+
+        // set custom properties as per Thrift recommendations
+        client.getParams().setParameter("http.protocol.version", HttpVersion.HTTP_1_1);
+        client.getParams().setParameter("http.protocol.content-charset", "UTF-8");
+        client.getParams().setBooleanParameter("http.protocol.expect-continue", false);
+        client.getParams().setBooleanParameter("http.connection.stalecheck", false);
+
+        return client;
+    }
+}

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SocketTransportProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SocketTransportProvider.java
@@ -28,6 +28,7 @@ public final class SocketTransportProvider implements ZipkinClientTransportProvi
 
     public SocketTransportProvider(String host, int port) {
         Validate.notEmpty(host);
+        Validate.isTrue(port > 0);
         this.host = host;
         this.port = port;
     }

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SocketTransportProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SocketTransportProvider.java
@@ -1,0 +1,55 @@
+package com.github.kristofa.brave.zipkin;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+
+/**
+ * Default implementation: uses the socket transport from Thrift.
+ *
+ * @author botizac
+ */
+public final class SocketTransportProvider implements ZipkinClientTransportProvider {
+
+    /**
+     * Zipkin server collector host.
+     */
+    private final String host;
+
+    /**
+     * Zipkin server collector port.
+     */
+    private final int port;
+
+    /**
+     * Optional: socket connect timeout.
+     */
+    private int socketTimeout = 0;
+
+    public SocketTransportProvider(String host, int port) {
+        Validate.notEmpty(host);
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Constructor with all required arguments.
+     *
+     * @param host          Zipkin server host/IP
+     * @param port          Zipkin server port
+     * @param socketTimeout Socket timeout
+     */
+    public SocketTransportProvider(String host, int port, int socketTimeout) {
+        this(host, port);
+        this.socketTimeout = socketTimeout;
+    }
+
+    @Override
+    public TTransport getTransport() {
+        if (socketTimeout > 0) {
+            return new TSocket(host, port, socketTimeout);
+        }
+
+        return new TSocket(host, port);
+    }
+}

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinClientTransportProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinClientTransportProvider.java
@@ -1,0 +1,17 @@
+package com.github.kristofa.brave.zipkin;
+
+import org.apache.thrift.transport.TTransport;
+
+/**
+ * Provider of {@link org.apache.thrift.transport.TTransport transport} implementations.
+ *
+ * @author botizac
+ */
+public interface ZipkinClientTransportProvider {
+    /**
+     * Supplies a transport instance. Implementations are free to cache the objects returned or use a prototype approach.
+     *
+     * @return Client side Transport object
+     */
+    TTransport getTransport();
+}

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinCollectorClientProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinCollectorClientProvider.java
@@ -1,46 +1,57 @@
 package com.github.kristofa.brave.zipkin;
 
+import com.twitter.zipkin.gen.ZipkinCollector;
+import com.twitter.zipkin.gen.ZipkinCollector.Client;
 import org.apache.commons.lang.Validate;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFramedTransport;
-import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.twitter.zipkin.gen.ZipkinCollector;
-import com.twitter.zipkin.gen.ZipkinCollector.Client;
-
 /**
  * {@link ThriftClientProvider} for ZipkinCollector.
- * 
+ * <p>
+ * Implementation note: Always uses the {@link org.apache.thrift.transport.TFramedTransport framed transport}.
+ * The underlying transport for that, however, is meant to be configurable. Therefore, the constructor requires
+ * a {@link com.github.kristofa.brave.zipkin.ZipkinClientTransportProvider client transport provider}, which is used
+ * to create the underlying transport implementation.
+ * </p>
+ *
  * @author adriaens
+ * @author cbotiza
  */
 class ZipkinCollectorClientProvider implements ThriftClientProvider<ZipkinCollector.Client> {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(ZipkinCollectorClientProvider.class);
 
-    private final String host;
-    private final int port;
-    private final int timeout;
     private TTransport transport;
     private ZipkinCollector.Client client;
 
     /**
-     * Create a new instance.
-     * 
-     * @param host Host. Should not be empty.
-     * @param port Port.
-     * @param timeout Socket time out in milliseconds.
+     * Provider of underlying Thrift transport.
      */
+    private ZipkinClientTransportProvider transportProvider;
+
+    public ZipkinCollectorClientProvider(final ZipkinClientTransportProvider transportProvider) {
+        Validate.notNull(transportProvider);
+        this.transportProvider = transportProvider;
+    }
+
+    /**
+     * Convenience constructor. Uses the socket implementation as underlying transport.
+     *
+     * @param host    Host. Should not be empty.
+     * @param port    Port.
+     * @param timeout Socket time out in milliseconds.
+     * @deprecated Use the transport based constructor.
+     */
+    @Deprecated
     public ZipkinCollectorClientProvider(final String host, final int port, final int timeout) {
-        Validate.notEmpty(host);
-        this.host = host;
-        this.port = port;
-        this.timeout = timeout;
+        this(new SocketTransportProvider(host, port, timeout));
     }
 
     /**
@@ -48,9 +59,8 @@ class ZipkinCollectorClientProvider implements ThriftClientProvider<ZipkinCollec
      */
     @Override
     public void setup() throws TException {
-        final TSocket socket = new TSocket(host, port);
-        socket.setTimeout(timeout);
-        transport = new TFramedTransport(socket);
+        final TTransport underlying = transportProvider.getTransport();
+        transport = new TFramedTransport(underlying);
         final TProtocol protocol = new TBinaryProtocol(transport);
         client = new ZipkinCollector.Client(protocol);
         transport.open();

--- a/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/HttpTransportProviderTest.java
+++ b/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/HttpTransportProviderTest.java
@@ -1,0 +1,33 @@
+package com.github.kristofa.brave.zipkin;
+
+import org.apache.thrift.transport.THttpClient;
+import org.apache.thrift.transport.TTransport;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author botizac
+ */
+public class HttpTransportProviderTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongUrl() {
+        new HttpTransportProvider("http8080");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingUrl() {
+        new HttpTransportProvider(" ");
+    }
+
+    @Test
+    public void testGetTransport() {
+        HttpTransportProvider transportProvider = new HttpTransportProvider("http://collector.zipkin.com", 3000, 3000);
+
+        TTransport transport = transportProvider.getTransport();
+
+        assertTrue(transport instanceof THttpClient);
+
+    }
+}

--- a/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/SocketTransportProviderTest.java
+++ b/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/SocketTransportProviderTest.java
@@ -1,0 +1,35 @@
+package com.github.kristofa.brave.zipkin;
+
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author botizac
+ */
+public class SocketTransportProviderTest {
+
+    @Test
+    public void testGetTransport() {
+        SocketTransportProvider transportProvider = new SocketTransportProvider("collector.zipkin.com", 9160);
+
+        TTransport transport = transportProvider.getTransport();
+
+        assertTrue(transport instanceof TSocket);
+
+        //not much we can test without connecting...
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongHost() {
+        new SocketTransportProvider("", 1000);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongPort() {
+        new SocketTransportProvider("collector.zipkin.com", -1);
+    }
+}


### PR DESCRIPTION
I created the ClientTransportProvider abstraction and default, socket based implementation.
Deprecated the socket specific constructor (although the implementations are still valid).
The broader goal is to be able to provide alternative transports, such HTTP/Thrift

Please review. I will soon provide the HTTP transport implementation