### PR TITLE
Enable customising the client provider on subclasses of the Zipkin span collector

### DIFF
--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SpanProcessingThread.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SpanProcessingThread.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.twitter.zipkin.gen.ZipkinCollector;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -39,7 +40,7 @@ class SpanProcessingThread implements Callable<Integer> {
     private static final int MAX_SUBSEQUENT_EMPTY_BATCHES = 2;
 
     private final BlockingQueue<Span> queue;
-    private final ZipkinCollectorClientProvider clientProvider;
+    private final ThriftClientProvider<ZipkinCollector.Client> clientProvider;
     private final TProtocolFactory protocolFactory;
     private volatile boolean stop = false;
     private int processedSpans = 0;
@@ -53,7 +54,7 @@ class SpanProcessingThread implements Callable<Integer> {
      * @param clientProvider {@link ThriftClientProvider} that provides client used to submit spans to zipkin span collector.
      * @param maxBatchSize Max batch size. Indicates how many spans we submit to collector in 1 go.
      */
-    public SpanProcessingThread(final BlockingQueue<Span> queue, final ZipkinCollectorClientProvider clientProvider,
+    public SpanProcessingThread(final BlockingQueue<Span> queue, final ThriftClientProvider<ZipkinCollector.Client> clientProvider,
         final int maxBatchSize) {
         if (maxBatchSize <= 0) throw new IllegalArgumentException("maxBatchSize must be positive");
         this.queue = checkNotNull(queue, "Null queue");

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollector.java
@@ -19,6 +19,7 @@ import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.ServerTracer;
 import com.github.kristofa.brave.SpanCollector;
 
+import com.twitter.zipkin.gen.ZipkinCollector;
 import org.apache.thrift.TException;
 
 import com.twitter.zipkin.gen.AnnotationType;
@@ -81,7 +82,7 @@ public class ZipkinSpanCollector implements SpanCollector, Closeable {
         for (int i = 1; i <= params.getNrOfThreads(); i++) {
 
             // Creating a client provider for every spanProcessingThread.
-            ZipkinCollectorClientProvider clientProvider = createZipkinCollectorClientProvider(zipkinCollectorHost,
+            ThriftClientProvider<ZipkinCollector.Client> clientProvider = createZipkinCollectorClientProvider(zipkinCollectorHost,
                     zipkinCollectorPort, params);
             final SpanProcessingThread spanProcessingThread = new SpanProcessingThread(spanQueue, clientProvider,
                     params.getBatchSize());
@@ -90,9 +91,9 @@ public class ZipkinSpanCollector implements SpanCollector, Closeable {
         }
     }
 
-    private ZipkinCollectorClientProvider createZipkinCollectorClientProvider(String zipkinCollectorHost,
+    protected ThriftClientProvider<ZipkinCollector.Client> createZipkinCollectorClientProvider(String zipkinCollectorHost,
             int zipkinCollectorPort, ZipkinSpanCollectorParams params) {
-        ZipkinCollectorClientProvider clientProvider = new ZipkinCollectorClientProvider(zipkinCollectorHost,
+        ThriftClientProvider<ZipkinCollector.Client> clientProvider = new ZipkinCollectorClientProvider(zipkinCollectorHost,
                 zipkinCollectorPort, params.getSocketTimeout());
         try {
             clientProvider.setup();


### PR DESCRIPTION
The use case for this is when looking up the Zipkin collector service is more complicated than a static address and port.