### PR TITLE
Issue #85 - Make client conform to Zipkin standard of 0 or 1

### DIFF
--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -31,9 +31,9 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
     @Override
     public void addSpanIdToRequest(@Nullable SpanId spanId) {
         if (spanId == null) {
-            request.addHeader(BraveHttpHeaders.Sampled.getName(), "false");
+            request.addHeader(BraveHttpHeaders.Sampled.getName(), "0");
         } else {
-            request.addHeader(BraveHttpHeaders.Sampled.getName(), "true");
+            request.addHeader(BraveHttpHeaders.Sampled.getName(), "1");
             request.addHeader(BraveHttpHeaders.TraceId.getName(), String.valueOf(spanId.getTraceId()));
             request.addHeader(BraveHttpHeaders.SpanId.getName(), String.valueOf(spanId.getSpanId()));
             if (spanId.getParentSpanId() != null) {

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -21,7 +21,7 @@ public class HttpClientRequestAdapterTest {
     private static final String SPAN_NAME = "span_name";
     private static final long TRACE_ID = 1;
     private static final long SPAN_ID = 2;
-    private static final Long PARENT_SPAN_ID = Long.valueOf(3);
+    private static final Long PARENT_SPAN_ID = 3L;
     private static final String TEST_URI = "http://abc.com/request";
 
     private HttpClientRequestAdapter clientRequestAdapter;
@@ -56,7 +56,7 @@ public class HttpClientRequestAdapterTest {
     @Test
     public void addSpanIdToRequest_NoSpanId() {
         clientRequestAdapter.addSpanIdToRequest(null);
-        verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "false");
+        verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "0");
         verifyNoMoreInteractions(request, serviceNameProvider, spanNameProvider);
     }
 
@@ -64,7 +64,7 @@ public class HttpClientRequestAdapterTest {
     public void addSpanIdToRequest_WithParentSpanId() {
         SpanId id = SpanId.create(TRACE_ID, SPAN_ID, PARENT_SPAN_ID);
         clientRequestAdapter.addSpanIdToRequest(id);
-        verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "true");
+        verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "1");
         verify(request).addHeader(BraveHttpHeaders.TraceId.getName(), String.valueOf(TRACE_ID));
         verify(request).addHeader(BraveHttpHeaders.SpanId.getName(), String.valueOf(SPAN_ID));
         verify(request).addHeader(BraveHttpHeaders.ParentSpanId.getName(), String.valueOf(PARENT_SPAN_ID));
@@ -75,7 +75,7 @@ public class HttpClientRequestAdapterTest {
     public void addSpanIdToRequest_WithoutParentSpanId() {
         SpanId id = SpanId.create(TRACE_ID, SPAN_ID, null);
         clientRequestAdapter.addSpanIdToRequest(id);
-        verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "true");
+        verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "1");
         verify(request).addHeader(BraveHttpHeaders.TraceId.getName(), String.valueOf(TRACE_ID));
         verify(request).addHeader(BraveHttpHeaders.SpanId.getName(), String.valueOf(SPAN_ID));
         verifyNoMoreInteractions(request, serviceNameProvider, spanNameProvider);


### PR DESCRIPTION
This change makes Brave conform to the Zipkin standard of sending 0 or 1 rather than false or true to indicate whether tracing should be enabled or not.

Note that this will be a 'slightly' breaking change in that any downstream service which is on a previous version of Brave will think that the request isn't being traced