### PR TITLE
Fixes accidental builder invisibility

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -62,7 +62,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
          */
         public abstract Builder traceFilters(List<TraceFilter> traceFilters);
 
-        abstract ServerTracer build();
+        public abstract ServerTracer build();
     }
 
     /**


### PR DESCRIPTION
I believe these methods weren't meant to be hidden