### PR TITLE
Span collector metrics

### DIFF
--- a/brave-spancollector-scribe/README.md
+++ b/brave-spancollector-scribe/README.md
@@ -1,10 +1,12 @@
-# brave-spancollector-scribe #
+# brave-spancollector-scribe
 
 SpanCollector that is used to submit spans to a Scribe compatible source.
 This can be Scribe itself or the [Zipkin Collector Service](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector-service)
 or another Scribe compatible source like Flume configured with Scribe source.
 
 ![Scribe SpanCollector overview](https://raw.github.com/wiki/kristofa/brave/ZipkinSpanCollector.png)
+
+## Performance
 
 The `ScribeSpanCollector` is build in such a way that it has no or very minimal impact on your application performance:
 
@@ -15,6 +17,17 @@ This approach has again been chosen to minimize the impact on the application. H
 *    The `SpanProcessingThread` does not submit every individual span immediately to the back-end service. It buffers spans and sends them in batches as much as possible.
 However it makes sure that it does not keeps holding onto spans. If the buffer is not full after 10 seconds it sends the received spans in any case.
 
+## Monitoring
 
-If you use this SpanCollector you can reuse the the Zipkin back-end (zipkin-collector-service, Cassandra back-end store, zipkin-query, zipkin-web).
+Monitor `ScribeSpanCollector`'s performance by providing your implementation of `ScribeCollectorMetricsHandler`. It will
+be notified when a span is accepted for processing and when it gets dropped for any reason, so you can update corresponding
+counters in your metrics tool. When a span gets dropped, the reason is written to the application logs.
+The number of spans sent to the target collector can be calculated by subtracting the dropped count from the accepted count.
+
+Refer to `DropwizardMetricsScribeCollectorMetricsHandlerExample` for an example of how to integrate with 
+[dropwizard metrics](https://github.com/dropwizard/metrics). 
+
+## Zipkin integration
+
+If you use this SpanCollector you can reuse the Zipkin back-end (zipkin-collector-service, Cassandra back-end store, zipkin-query, zipkin-web).
 For information on how to set up the Zipkin backend components see [here](https://github.com/openzipkin/zipkin).

--- a/brave-spancollector-scribe/pom.xml
+++ b/brave-spancollector-scribe/pom.xml
@@ -48,5 +48,11 @@
         <artifactId>log4j-slf4j-impl</artifactId>
         <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>io.dropwizard.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+          <version>3.1.2</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/EmptyScribeCollectorMetricsHandler.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/EmptyScribeCollectorMetricsHandler.java
@@ -1,0 +1,17 @@
+package com.github.kristofa.brave.scribe;
+
+/**
+ * Empty implementation ignoring all events.
+ */
+class EmptyScribeCollectorMetricsHandler implements ScribeCollectorMetricsHandler {
+
+    @Override
+    public void incrementAcceptedSpans(int quantity) {
+
+    }
+
+    @Override
+    public void incrementDroppedSpans(int quantity) {
+
+    }
+}

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeCollectorMetricsHandler.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeCollectorMetricsHandler.java
@@ -1,0 +1,24 @@
+package com.github.kristofa.brave.scribe;
+
+/**
+ * Monitor {@link ScribeSpanCollector} by implementing reactions to these events, e.g. updating suitable metrics.
+ *
+ * See DropwizardMetricsScribeCollectorMetricsHandlerExample in test sources for an example.
+ */
+public interface ScribeCollectorMetricsHandler {
+
+    /**
+     * Called when spans are submitted to {@link ScribeSpanCollector} for processing.
+     *
+     * @param quantity the number of spans accepted.
+     */
+    void incrementAcceptedSpans(int quantity);
+
+    /**
+     * Called when spans become lost for any reason and won't be delivered to the target collector.
+     *
+     * @param quantity the number of spans dropped.
+     */
+    void incrementDroppedSpans(int quantity);
+
+}

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorParams.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorParams.java
@@ -1,5 +1,7 @@
 package com.github.kristofa.brave.scribe;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 /**
  * Optional parameters for {@link ScribeSpanCollector}.
  * <p/>
@@ -13,6 +15,7 @@ package com.github.kristofa.brave.scribe;
  * will be thrown.</li>
  * <li>fail on setup: Indicates if {@link ScribeSpanCollector} should fail on creation when connection with collector can't
  * be established or just log error message.</li>
+ * <li>metrics handler: see {@link ScribeCollectorMetricsHandler}.</li>
  * </ul>
  * 
  * @author kristof
@@ -29,6 +32,7 @@ public class ScribeSpanCollectorParams {
     private int nrOfThreads;
     private int socketTimeout;
     private boolean failOnSetup = true;
+    private ScribeCollectorMetricsHandler metricsHandler = new EmptyScribeCollectorMetricsHandler();
 
     /**
      * Create a new instance with default values.
@@ -138,4 +142,11 @@ public class ScribeSpanCollectorParams {
         return failOnSetup;
     }
 
+    public ScribeCollectorMetricsHandler getMetricsHandler() {
+        return metricsHandler;
+    }
+
+    public void setMetricsHandler(ScribeCollectorMetricsHandler metricsHandler) {
+        this.metricsHandler = checkNotNull(metricsHandler, "Null metricsHandler");
+    }
 }

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/DropwizardMetricsScribeCollectorMetricsHandlerExample.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/DropwizardMetricsScribeCollectorMetricsHandlerExample.java
@@ -1,0 +1,26 @@
+package com.github.kristofa.brave.scribe;
+
+import com.codahale.metrics.MetricRegistry;
+
+class DropwizardMetricsScribeCollectorMetricsHandlerExample implements ScribeCollectorMetricsHandler {
+
+    static final String ACCEPTED_METER = "tracing.collector.scribe.span.accepted";
+    static final String DROPPED_METER = "tracing.collector.scribe.span.dropped";
+
+    private final MetricRegistry registry;
+
+    DropwizardMetricsScribeCollectorMetricsHandlerExample(MetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void incrementAcceptedSpans(int quantity) {
+        registry.meter(ACCEPTED_METER).mark(quantity);
+    }
+
+    @Override
+    public void incrementDroppedSpans(int quantity) {
+        registry.meter(DROPPED_METER).mark(quantity);
+    }
+
+}

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeReceiver.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeReceiver.java
@@ -30,11 +30,7 @@ class ScribeReceiver implements Iface {
 
     private static final Logger LOGGER = Logger.getLogger(ScribeReceiver.class.getName());
     private final BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
-    private final int delayMs;
-
-    public ScribeReceiver(final int delayMs) {
-        this.delayMs = delayMs;
-    }
+    private volatile int delayMs;
 
     public void clearReceivedSpans() {
         spans.clear();
@@ -81,4 +77,11 @@ class ScribeReceiver implements Iface {
         return result;
     }
 
+    public void setDelayMs(int delayMs) {
+        if (delayMs < 0) {
+            throw new IllegalArgumentException("Invalid delay of " + delayMs + " ms");
+        }
+
+        this.delayMs = delayMs;
+    }
 }

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeServer.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeServer.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.scribe;
 
 import com.twitter.zipkin.gen.scribe;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.THsHaServer;
@@ -24,11 +25,7 @@ class ScribeServer {
     private final ScribeReceiver receiver;
 
     public ScribeServer(final int port) throws TTransportException {
-        this(port, -1);
-    }
-
-    public ScribeServer(final int port, final int delayMs) throws TTransportException {
-        receiver = new ScribeReceiver(delayMs);
+        receiver = new ScribeReceiver();
 
         final Processor<Iface> processor = new scribe.Processor<>(receiver);
 
@@ -63,6 +60,14 @@ class ScribeServer {
 
     public List<Span> getReceivedSpans() {
         return receiver.getSpans();
+    }
+
+    public void introduceDelay(int duration, TimeUnit unit) {
+        receiver.setDelayMs((int) TimeUnit.MILLISECONDS.convert(duration, unit));
+    }
+
+    public void clearDelay() {
+        receiver.setDelayMs(0);
     }
 
     public void stop() {

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorMetricsTest.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorMetricsTest.java
@@ -1,0 +1,105 @@
+package com.github.kristofa.brave.scribe;
+
+import com.codahale.metrics.MetricRegistry;
+import com.twitter.zipkin.gen.Span;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.github.kristofa.brave.scribe.DropwizardMetricsScribeCollectorMetricsHandlerExample.ACCEPTED_METER;
+import static com.github.kristofa.brave.scribe.DropwizardMetricsScribeCollectorMetricsHandlerExample.DROPPED_METER;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ScribeSpanCollectorMetricsTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = FreePortProvider.getNewFreePort();
+    private static final Span SPAN = new Span(1, "span name", 2, emptyList(), emptyList());
+
+    private static ScribeServer scribeServer;
+
+    private MetricRegistry metricRegistry = new MetricRegistry();
+
+    @BeforeClass
+    public static void beforeClass() throws TTransportException {
+        scribeServer = new ScribeServer(PORT);
+        scribeServer.start();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        scribeServer.stop();
+    }
+
+    @Before
+    public void setup() {
+        scribeServer.clearReceivedSpans();
+        scribeServer.clearDelay();
+    }
+
+    @Test
+    public void testCollectorMetricsWhenSpansDeliveredSuccessfully() {
+        // given
+        DropwizardMetricsScribeCollectorMetricsHandlerExample eventsHandler = new DropwizardMetricsScribeCollectorMetricsHandlerExample(metricRegistry);
+        ScribeSpanCollectorParams params = new ScribeSpanCollectorParams();
+        params.setMetricsHandler(eventsHandler);
+
+        // when
+        try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector(HOST, PORT, params)) {
+            scribeSpanCollector.collect(SPAN);
+        }
+
+        // then
+        assertEquals(1, metricRegistry.meter(ACCEPTED_METER).getCount());
+        assertEquals(0, metricRegistry.meter(DROPPED_METER).getCount());
+    }
+
+    @Test
+    public void testCollectorMetricsWhenSpansDroppedDueToFullQueue() throws InterruptedException {
+        // given
+        final DropwizardMetricsScribeCollectorMetricsHandlerExample eventsHandler = new DropwizardMetricsScribeCollectorMetricsHandlerExample(metricRegistry);
+        ScribeSpanCollectorParams params = new ScribeSpanCollectorParams();
+        params.setMetricsHandler(eventsHandler);
+        params.setQueueSize(1);
+        params.setBatchSize(1);
+        scribeServer.introduceDelay(500, TimeUnit.MILLISECONDS);
+
+        // when
+        try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector(HOST, PORT, params)) {
+            scribeSpanCollector.collect(SPAN);
+            scribeSpanCollector.collect(SPAN);
+            scribeSpanCollector.collect(SPAN);
+        }
+
+        // then
+        assertEquals(3, metricRegistry.meter(ACCEPTED_METER).getCount());
+        assertTrue(metricRegistry.meter(DROPPED_METER).getCount() > 0);
+        assertEquals(scribeServer.getReceivedSpans().size(),
+                metricRegistry.meter(ACCEPTED_METER).getCount() - metricRegistry.meter(DROPPED_METER).getCount());
+    }
+
+    @Test
+    public void testCollectorMetricsWhenSpansDroppedDueToConnectionFailure() {
+        // given
+        final DropwizardMetricsScribeCollectorMetricsHandlerExample eventsHandler = new DropwizardMetricsScribeCollectorMetricsHandlerExample(metricRegistry);
+        ScribeSpanCollectorParams params = new ScribeSpanCollectorParams();
+        params.setMetricsHandler(eventsHandler);
+        params.setFailOnSetup(false);
+
+        // when
+        try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("invalid-host", PORT, params)) {
+            scribeSpanCollector.collect(SPAN);
+        }
+
+        // then
+        assertEquals(1, metricRegistry.meter(ACCEPTED_METER).getCount());
+        assertEquals(1, metricRegistry.meter(DROPPED_METER).getCount());
+    }
+
+}


### PR DESCRIPTION
Allows to monitor span collector's performance by implementing a single interface. Leaves the developer with free choice of which parameters to monitor, how to call these metrics and which metrics library to use.

What do you think?