### PR TITLE
Adds LocalTracer, designed for in-process activity that explains latency

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -14,6 +14,7 @@ public class Brave {
 
     private final ServerTracer serverTracer;
     private final ClientTracer clientTracer;
+    private final LocalTracer localTracer;
     private final ServerRequestInterceptor serverRequestInterceptor;
     private final ServerResponseInterceptor serverResponseInterceptor;
     private final ClientRequestInterceptor clientRequestInterceptor;
@@ -129,6 +130,15 @@ public class Brave {
     }
 
     /**
+     * Returns a tracer used to log in-process activity.
+     *
+     * @since 3.2
+     */
+    public LocalTracer localTracer() {
+        return localTracer;
+    }
+
+    /**
      * Server Tracer.
      * <p>
      * It is advised that you use ServerRequestInterceptor and ServerResponseInterceptor instead.
@@ -199,6 +209,7 @@ public class Brave {
                 .state(builder.state)
                 .traceFilters(builder.traceFilters).build();
 
+        localTracer = LocalTracer.create(clientTracer, builder.spanCollector, builder.state);
         serverRequestInterceptor = new ServerRequestInterceptor(serverTracer);
         serverResponseInterceptor = new ServerResponseInterceptor(serverTracer);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer);

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -1,0 +1,144 @@
+package com.github.kristofa.brave;
+
+import com.google.auto.value.AutoValue;
+import com.twitter.zipkin.gen.Span;
+import com.twitter.zipkin.gen.zipkinCoreConstants;
+
+import static com.twitter.zipkin.gen.zipkinCoreConstants.LOCAL_COMPONENT;
+
+/**
+ * Local tracer is designed for in-process activity that explains latency.
+ *
+ * <p/>For example, a local span could represent bootstrap, codec, file i/o or
+ * other activity that notably impacts performance.
+ *
+ * <p/>Local spans always have a binary annotation "lc" which indicates the
+ * component name. Usings zipkin's UI or Api, you can query by for spans that
+ * use a component like this: {@code lc=spring-boot}.
+ *
+ * <p/>Here's an example of allocating precise duration for a local span:
+ * <pre>
+ * tracer.startSpan("codec", "encode");
+ * try {
+ *   return codec.encode(input);
+ * } finally {
+ *   tracer.finishSpan();
+ * }
+ * </pre>
+ *
+ * @see zipkinCoreConstants#LOCAL_COMPONENT
+ */
+@AutoValue
+public abstract class LocalTracer {
+
+    abstract ClientTracer clientTracer();
+    abstract SpanCollector spanCollector();
+    abstract ServerAndClientSpanState state();
+
+    static LocalTracer create(ClientTracer clientTracer, SpanCollector spanCollector, ServerAndClientSpanState state) {
+        return new AutoValue_LocalTracer(clientTracer, spanCollector, state);
+    }
+
+    /**
+     * Request a new local span, which starts now.
+     *
+     * @param component {@link zipkinCoreConstants#LOCAL_COMPONENT component} responsible for the operation
+     * @param operation name of the operation that's begun
+     * @return metadata about the new span or null if one wasn't started due to sampling policy.
+     * @see zipkinCoreConstants#LOCAL_COMPONENT
+     */
+    public SpanId startSpan(String component, String operation) {
+        SpanId spanId = clientTracer().startNewSpan(operation);
+        if (spanId == null) return null;
+        clientTracer().submitBinaryAnnotation(LOCAL_COMPONENT, component);
+        state().getCurrentClientSpan()
+                .setTimestamp(clientTracer().currentTimeMicroseconds())
+                .startTick = System.nanoTime(); // embezzle start tick into an internal field.
+        return spanId;
+    }
+
+    /**
+     * Request a new local span, which started at the given timestamp.
+     *
+     * @param component {@link zipkinCoreConstants#LOCAL_COMPONENT component} responsible for the operation
+     * @param operation name of the operation that's begun
+     * @param timestamp time the operation started, in epoch microseconds.
+     * @return metadata about the new span or null if one wasn't started due to sampling policy.
+     * @see zipkinCoreConstants#LOCAL_COMPONENT
+     */
+    public SpanId startSpan(String component, String operation, long timestamp) {
+        SpanId spanId = clientTracer().startNewSpan(operation);
+        if (spanId == null) return null;
+        clientTracer().submitBinaryAnnotation(LOCAL_COMPONENT, component);
+        state().getCurrentClientSpan().setTimestamp(timestamp);
+        return spanId;
+    }
+
+    /**
+     * Associates an event that explains latency with the current system time.
+     *
+     * @param value A short tag indicating the event, like "ApplicationReady"
+     */
+    public void submitAnnotation(String value) {
+        clientTracer().submitAnnotation(value);
+    }
+
+    /**
+     * Associates an event that explains latency with a timestamp.
+     *
+     * @param value     A short tag indicating the event, like "ApplicationReady"
+     * @param timestamp microseconds from epoch
+     */
+    public void submitAnnotation(String value, long timestamp) {
+        clientTracer().submitAnnotation(value, timestamp);
+    }
+
+    /**
+     * Binary annotations are tags applied to a Span to give it context. For
+     * example, a key "your_app.version" would let you lookup spans by version.
+     *
+     * @param key   Name used to lookup spans, such as "your_app.version"
+     * @param value String value, should not be <code>null</code>.
+     */
+    public void submitBinaryAnnotation(String key, String value) {
+        clientTracer().submitBinaryAnnotation(key, value);
+    }
+
+    /**
+     * Completes the span, assigning the most precise duration possible.
+     */
+    public void finishSpan() {
+        long endTick = System.nanoTime();
+
+        Span span = state().getCurrentClientSpan();
+        if (span == null) return;
+
+        Long startTick = span.startTick;
+        final long duration;
+        if (startTick != null) {
+            duration = (endTick - startTick) / 1000;
+        } else {
+            duration = clientTracer().currentTimeMicroseconds() - span.getTimestamp();
+        }
+        finishSpan(duration);
+    }
+
+    /**
+     * Completes the span, which took {@code duration} microseconds.
+     */
+    public void finishSpan(long duration) {
+        Span span = state().getCurrentClientSpan();
+        if (span == null) return;
+
+        synchronized (span) {
+            span.setDuration(duration);
+            spanCollector().collect(span);
+        }
+
+        state().setCurrentClientSpan(null);
+        state().setCurrentClientServiceName(null);
+    }
+
+    LocalTracer() {
+    }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -46,7 +46,7 @@ public abstract class ServerSpan {
      * @param parentSpanId Parent span id, can be <code>null</code>.
      * @param name Span name. Should be lowercase and not <code>null</code> or empty.
      */
-     static ServerSpan create(long traceId, long spanId, Long parentSpanId, String name) {
+     static ServerSpan create(long traceId, long spanId, @Nullable Long parentSpanId, String name) {
         Span span = new Span();
         span.setTrace_id(traceId);
         span.setId(spanId);

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/Util.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/Util.java
@@ -1,11 +1,15 @@
 package com.github.kristofa.brave.internal;
 
+import java.nio.charset.Charset;
+
 import static java.lang.String.format;
 
 /**
  * Utilities, typically copied in from guava, so as to avoid dependency conflicts.
  */
 public final class Util {
+
+  public static final Charset UTF_8 = Charset.forName("UTF-8");
 
   /**
    * Copy of {@code com.google.common.base.Preconditions#checkNotNull}.

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -52,6 +52,11 @@ public class Span implements org.apache.thrift.TBase<Span, Span._Fields>, java.i
     schemes.put(TupleScheme.class, new SpanTupleSchemeFactory());
   }
 
+  /**
+   * Internal field, used for deriving duration with {@link System#nanoTime()}.
+   */
+  public volatile Long startTick;
+
   public long trace_id; // required
   /**
    * Span name in lowercase, rpc method for example

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/zipkinCoreConstants.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/zipkinCoreConstants.java
@@ -123,4 +123,28 @@ public class zipkinCoreConstants {
    */
   public static final String SERVER_ADDR = "sa";
 
+  /**
+   * The {@link BinaryAnnotation#value value} of "lc" is the component or namespace of a local
+   * span.
+   *
+   * <p/>{@link BinaryAnnotation#host} adds service context needed to support queries.
+   *
+   * <p/>Local Component("lc") supports three key features: flagging, query by service and filtering
+   * Span.name by namespace.
+   *
+   * <p/>While structurally the same, local spans are fundamentally different than RPC spans in how
+   * they should be interpreted. For example, zipkin v1 tools center on RPC latency and service
+   * graphs. Root local-spans are neither indicative of critical path RPC latency, nor have impact
+   * on the shape of a service graph. By flagging with "lc", tools can special-case local spans.
+   *
+   * <p/>Zipkin v1 Spans are unqueryable unless they can be indexed by service name. The only path
+   * to a {@link Endpoint#service_name service name} is via {@link BinaryAnnotation#host
+   * host}. By logging "lc", a local span can be queried even if no other annotations are logged.
+   *
+   * <p/>The value of "lc" is the namespace of {@link Span#name}. For example, it might be
+   * "finatra2", for a span named "bootstrap". "lc" allows you to resolves conflicts for the same
+   * Span.name, for example "finatra/bootstrap" vs "finch/bootstrap". Using local component, you'd
+   * search for spans named "bootstrap" where "lc=finch"
+   */
+  public static final String LOCAL_COMPONENT = "lc";
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -1,0 +1,237 @@
+package com.github.kristofa.brave;
+
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static com.twitter.zipkin.gen.zipkinCoreConstants.LOCAL_COMPONENT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(LocalTracer.class)
+public class LocalTracerTest {
+
+    private final static String COMPONENT_NAME = "componentname";
+    private final static String OPERATION_NAME = "operationname";
+
+    private ServerAndClientSpanState mockState;
+    private ClientTracer mockClientTracer;
+    private SpanCollector mockSpanCollector;
+    private Endpoint endpoint;
+
+    private LocalTracer localTracer;
+
+    @Before
+    public void setup() {
+        mockState = mock(ServerAndClientSpanState.class);
+        endpoint = new Endpoint();
+        when(mockState.getServerEndpoint()).thenReturn(endpoint);
+
+        PowerMockito.mockStatic(System.class);
+        mockClientTracer = mock(ClientTracer.class);
+        mockSpanCollector = mock(SpanCollector.class);
+
+        localTracer = LocalTracer.create(mockClientTracer, mockSpanCollector, mockState);
+    }
+
+    /**
+     * When a local span is started without a timestamp, microseconds and a tick are recorded for
+     * duration calculation. A binary annotation is added for search by component.
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startSpan(component, operation); // internally time and nanos are recorded
+     * </pre>
+     */
+    @Test
+    public void startSpan() {
+        SpanId spanId = mock(SpanId.class);
+        Span started = new Span();
+        when(mockClientTracer.startNewSpan(OPERATION_NAME)).thenReturn(spanId);
+        when(mockState.getCurrentClientSpan()).thenReturn(started);
+        when(mockClientTracer.currentTimeMicroseconds()).thenReturn(1000L);
+        PowerMockito.when(System.nanoTime()).thenReturn(500L);
+
+        assertEquals(spanId, localTracer.startSpan(COMPONENT_NAME, OPERATION_NAME));
+        assertEquals(1000L, started.timestamp);
+        assertEquals(500L, started.startTick.longValue());
+
+        verify(mockClientTracer).startNewSpan(OPERATION_NAME);
+        verify(mockClientTracer).submitBinaryAnnotation(LOCAL_COMPONENT, COMPONENT_NAME); // for lookup by service
+        verify(mockState).getCurrentClientSpan();
+        verify(mockClientTracer).currentTimeMicroseconds();
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+    }
+
+    /**
+     * When a span is started with a timestamp, we can't use nanotime for duration as we don't
+     * know the nanotime value for that timestamp.
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startSpan(component, operation, startTime);
+     *
+     * </pre>
+     */
+    @Test
+    public void startSpan_userSuppliedTimestamp() {
+        SpanId spanId = mock(SpanId.class);
+        Span started = new Span();
+        when(mockClientTracer.startNewSpan(OPERATION_NAME)).thenReturn(spanId);
+        when(mockState.getCurrentClientSpan()).thenReturn(started);
+
+        assertEquals(spanId, localTracer.startSpan(COMPONENT_NAME, OPERATION_NAME, 1000L));
+        assertEquals(1000L, started.timestamp);
+        assertNull(started.startTick);
+
+        verify(mockClientTracer).startNewSpan(OPERATION_NAME);
+        verify(mockClientTracer).submitBinaryAnnotation(LOCAL_COMPONENT, COMPONENT_NAME); // for lookup by service
+        verify(mockState).getCurrentClientSpan();
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+    }
+
+    @Test
+    public void startSpan_unsampled() {
+        when(mockClientTracer.startNewSpan(OPERATION_NAME)).thenReturn(null);
+        assertNull(localTracer.startSpan(COMPONENT_NAME, OPERATION_NAME));
+
+        verify(mockClientTracer).startNewSpan(OPERATION_NAME);
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+    }
+
+    /**
+     * When finish is called without a duration, the startTick from start is used in duration calculation.
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startSpan(component, operation); // internally nanos is recorded with system time.
+     * ...
+     * localTracer.finishSpan(); // above nanos is used to make a precise duration
+     * </pre>
+     */
+    @Test
+    public void finishSpan() {
+        Span finished = new Span().setTimestamp(1000L); // set in start span
+        finished.startTick = 500000L; // set in start span
+
+        PowerMockito.when(System.nanoTime()).thenReturn(1000000L);
+        when(mockState.getCurrentClientSpan()).thenReturn(finished);
+
+        localTracer.finishSpan();
+
+        verify(mockState, times(2)).getCurrentClientSpan(); // 2 times, since Span.duration is derived
+        verify(mockSpanCollector).collect(finished);
+        verify(mockState).setCurrentClientServiceName(null);
+        verify(mockState).setCurrentClientSpan(null);
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+
+        assertEquals(500L, finished.duration);
+    }
+
+    /**
+     * When a span is started with a timestamp, nanos aren't known, so duration calculation falls back to system time.
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startSpan(component, operation, startTime); // no tick was recorded
+     * ...
+     * localTracer.finishSpan(); // can't know which nanos startTime was associated with!
+     * </pre>
+     */
+    @Test
+    public void finishSpan_userSuppliedTimestamp() {
+        Span finished = new Span().setTimestamp(1000L); // Set by user
+
+        when(mockState.getCurrentClientSpan()).thenReturn(finished);
+        when(mockClientTracer.currentTimeMicroseconds()).thenReturn(1500L);
+
+        localTracer.finishSpan();
+
+        verify(mockState, times(2)).getCurrentClientSpan(); // 2 times, since Span.duration is derived
+        verify(mockClientTracer).currentTimeMicroseconds();
+        verify(mockSpanCollector).collect(finished);
+        verify(mockState).setCurrentClientServiceName(null);
+        verify(mockState).setCurrentClientSpan(null);
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+
+        assertEquals(500L, finished.duration);
+    }
+
+    /**
+     * When a local span completes with a user supplied duration, startTick is ignored.
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startSpan(component, operation); // startTick was recorded, but ignored
+     * ...
+     * localTracer.finishSpan(duration); // user calculated duration out-of-band, ex with a stop watch.
+     * </pre>
+     */
+    @Test
+    public void finishSpan_userSuppliedDuration() {
+        Span finished = new Span().setTimestamp(1000L); // set in start span
+        finished.startTick = 500L; // set in start span
+
+        when(mockState.getCurrentClientSpan()).thenReturn(finished);
+
+        localTracer.finishSpan(500L);
+
+        verify(mockState).getCurrentClientSpan();
+        verify(mockSpanCollector).collect(finished);
+        verify(mockState).setCurrentClientServiceName(null);
+        verify(mockState).setCurrentClientSpan(null);
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+
+        assertEquals(500L, finished.duration);
+    }
+
+    /**
+     * When a span starts and finishes with user-supplied timestamp and duration, nanotime is used
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startSpan(component, operation, startTime); // startTick was recorded
+     * ...
+     * localTracer.finishSpan(duration); // nanoTime - startTick = duration
+     * </pre>
+     */
+    @Test
+    public void finishSpan_userSuppliedTimestampAndDuration() {
+        Span finished = new Span().setTimestamp(1000L); // Set by user
+
+        when(mockState.getCurrentClientSpan()).thenReturn(finished);
+
+        localTracer.finishSpan(500L);
+
+        verify(mockState).getCurrentClientSpan();
+        verify(mockSpanCollector).collect(finished);
+        verify(mockState).setCurrentClientServiceName(null);
+        verify(mockState).setCurrentClientSpan(null);
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+
+        assertEquals(500L, finished.duration);
+    }
+
+    @Test
+    public void finishSpan_unsampled() {
+        when(mockState.getCurrentClientSpan()).thenReturn(null);
+        localTracer.finishSpan();
+        verify(mockState).getCurrentClientSpan();
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+    }
+
+    @Test
+    public void finishSpan_unsampled_userSuppliedDuration() {
+        when(mockState.getCurrentClientSpan()).thenReturn(null);
+        localTracer.finishSpan(5000L);
+        verify(mockState).getCurrentClientSpan();
+        verifyNoMoreInteractions(mockClientTracer, mockState, mockClientTracer);
+    }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/ThriftTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ThriftTest.java
@@ -1,16 +1,13 @@
 package com.github.kristofa.brave;
 
-
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 /**
- * Zipkin's thrift specifies that span and service name are lowercase. This makes sure that folks
- * modify generated thrifts to enforce that.
+ * This enforces the thrifts are modified to enforce certain behavior or use cases.
  */
 public class ThriftTest {
 
@@ -24,5 +21,11 @@ public class ThriftTest {
   public void testEndpointServiceNameLowercase() {
     assertEquals("servicename", new Endpoint(1, (short) 1, "ServiceName").getService_name());
     assertEquals("servicename", new Endpoint().setService_name("ServiceName").getService_name());
+  }
+
+  @Test
+  public void canStoreNanoTimeForDurationCalculation() {
+    Span span = new Span();
+    span.startTick = System.nanoTime();
   }
 }


### PR DESCRIPTION
A local span can represent bootstrap, codec, file i/o or other activity 
that notably impacts performance.

Local spans always have a binary annotation "lc" which indicates the 
component name. Usings zipkin's UI or Api, you can query by for spans 
that use a component like this: `lc=spring-boot`

Here's an example of allocating precise duration for a local span:
```java
tracer.startSpan("codec", "encode");
try {
  return codec.encode(input);
} finally {
  tracer.finishSpan();
}
```

Fixes #111
See https://github.com/openzipkin/zipkin/pull/821

Another example: Local span where user does know about time and duration, such as recording events that already occurred:
```java
if (localTracer.startSpan("spring-boot", "bootstrap", startTimestamp) != null) {
  // log historical annotations/binary annotations only if we know the trace was sampled
  localTracer.finishSpan(duration);
}
```
