### PR TITLE
Resolves state conflict between client and local spans

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientSpanState.java
@@ -5,8 +5,15 @@ import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 
 /**
- * Maintains client span state.
- * 
+ * Maintains state for a single client span.
+ *
+ * <p/>Client spans can be at the following locations in the span tree.
+ * <ul>
+ *     <li>The root-span of a trace originated by Brave</li>
+ *     <li>A child of a server span originated by Brave</li>
+ *     <li>A child of a local span originated by Brave</li>
+ * </ul>
+ *
  * @author kristof
  */
 public interface ClientSpanState extends CommonSpanState {

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalSpanState.java
@@ -1,0 +1,35 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Span;
+
+/**
+ * Maintains state for a single local span. This means nesting is not supported.
+ *
+ * <p/>Local spans can be at the following locations in the span tree.
+ * <ul>
+ *     <li>The root-span of a trace originated by Brave</li>
+ *     <li>A child of a server span originated by Brave</li>
+ * </ul>
+ */
+public interface LocalSpanState extends CommonSpanState {
+
+    /**
+     * Gets the Span for the local request that was started as part of current request.
+     * <p/>
+     * Should be thread-aware to support multiple parallel requests.
+     * 
+     * @return Local request span for current thread.
+     */
+    @Nullable
+    Span getCurrentLocalSpan();
+
+    /**
+     * Sets current local span.
+     * <p/>
+     * Should be thread-aware to support multiple parallel requests.
+     * 
+     * @param span Local span.
+     */
+    void setCurrentLocalSpan(Span span);
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerClientAndLocalSpanState.java
@@ -5,6 +5,6 @@ package com.github.kristofa.brave;
  * 
  * @author kristof
  */
-public interface ServerAndClientSpanState extends ServerSpanState, ClientSpanState {
+public interface ServerClientAndLocalSpanState extends ServerSpanState, ClientSpanState, LocalSpanState {
 
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanState.java
@@ -5,8 +5,14 @@ import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
 
 /**
- * Maintains server span state.
- * 
+ * Maintains state for a single server span.
+ *
+ * <p/>Server spans can be at the following locations in the span tree.
+ * <ul>
+ *     <li>The root-span of a trace originated by Brave</li>
+ *     <li>A child of a span propagated to Brave</li>
+ * </ul>
+ *
  * @author kristof
  */
 public interface ServerSpanState extends CommonSpanState {

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanAndEndpoint.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanAndEndpoint.java
@@ -62,9 +62,9 @@ public interface SpanAndEndpoint {
 
     @AutoValue
     abstract class ClientSpanAndEndpoint implements SpanAndEndpoint {
-        abstract ServerAndClientSpanState state();
+        abstract ServerClientAndLocalSpanState state();
 
-        static ClientSpanAndEndpoint create(ServerAndClientSpanState state) {
+        static ClientSpanAndEndpoint create(ServerClientAndLocalSpanState state) {
             return new AutoValue_SpanAndEndpoint_ClientSpanAndEndpoint(state);
         }
 
@@ -79,6 +79,26 @@ public interface SpanAndEndpoint {
         /**
          * {@inheritDoc}
          */
+        @Override
+        public Endpoint endpoint() {
+            return state().getClientEndpoint();
+        }
+    }
+
+    @AutoValue
+    abstract class LocalSpanAndEndpoint implements SpanAndEndpoint {
+        abstract ServerClientAndLocalSpanState state();
+
+        static LocalSpanAndEndpoint create(ServerClientAndLocalSpanState state) {
+            return new AutoValue_SpanAndEndpoint_LocalSpanAndEndpoint(state);
+        }
+
+        @Override
+        public Span span() {
+            return state().getCurrentLocalSpan();
+        }
+
+        /** The local endpoint is the same as the client endpoint. */
         @Override
         public Endpoint endpoint() {
             return state().getClientEndpoint();

--- a/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
@@ -7,11 +7,11 @@ import com.twitter.zipkin.gen.Span;
 import java.net.InetAddress;
 
 /**
- * {@link ServerAndClientSpanState} implementation that keeps trace state using a ThreadLocal variable.
+ * {@link ServerClientAndLocalSpanState} implementation that keeps trace state using a ThreadLocal variable.
  * 
  * @author kristof
  */
-public final class ThreadLocalServerAndClientSpanState implements ServerAndClientSpanState {
+public final class ThreadLocalServerClientAndLocalSpanState implements ServerClientAndLocalSpanState {
 
     private final static ThreadLocal<ServerSpan> currentServerSpan = new ThreadLocal<ServerSpan>() {
 
@@ -23,6 +23,8 @@ public final class ThreadLocalServerAndClientSpanState implements ServerAndClien
     private final static ThreadLocal<Span> currentClientSpan = new ThreadLocal<>();
 
     private final static ThreadLocal<String> currentClientServiceName = new ThreadLocal<>();
+
+    private final static ThreadLocal<Span> currentLocalSpan = new ThreadLocal<>();
 
     private final Endpoint endpoint;
 
@@ -36,7 +38,7 @@ public final class ThreadLocalServerAndClientSpanState implements ServerAndClien
      *             and using InetAddress can result in ns lookup and nasty side effects.
      */
     @Deprecated
-    public ThreadLocalServerAndClientSpanState(InetAddress ip, int port, String serviceName) {
+    public ThreadLocalServerClientAndLocalSpanState(InetAddress ip, int port, String serviceName) {
         Util.checkNotNull(ip, "ip address must be specified.");
         Util.checkNotBlank(serviceName, "Service name must be specified.");
         endpoint = new Endpoint(InetAddressUtilities.toInt(ip), (short) port, serviceName);
@@ -49,7 +51,7 @@ public final class ThreadLocalServerAndClientSpanState implements ServerAndClien
      * @param port port on which current process is listening.
      * @param serviceName Name of the local service being traced. Should be lowercase and not <code>null</code> or empty.
      */
-    public ThreadLocalServerAndClientSpanState(int ip, int port, String serviceName) {
+    public ThreadLocalServerClientAndLocalSpanState(int ip, int port, String serviceName) {
         Util.checkNotBlank(serviceName, "Service name must be specified.");
         endpoint = new Endpoint(ip, (short) port, serviceName);
     }
@@ -118,4 +120,17 @@ public final class ThreadLocalServerAndClientSpanState implements ServerAndClien
         return currentServerSpan.get().getSample();
     }
 
+    @Override
+    public Span getCurrentLocalSpan() {
+        return currentLocalSpan.get();
+    }
+
+    @Override
+    public void setCurrentLocalSpan(Span span) {
+        if (span == null) {
+            currentLocalSpan.remove();
+        } else {
+            currentLocalSpan.set(span);
+        }
+    }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITBrave.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITBrave.java
@@ -81,7 +81,7 @@ public class ITBrave {
             // Simulate local.
             final LocalTracer localTracer = brave.localTracer();
             final String localSpanName = "local span name " + random.nextLong();
-            localTracer.startSpan("test", localSpanName);
+            localTracer.startNewSpan("test", localSpanName);
             localTracer.finishSpan();
 
             serverTracer.setServerSend();

--- a/brave-core/src/test/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanStateTest.java
@@ -12,13 +12,13 @@ import org.junit.Test;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 
-public class ThreadLocalServerAndClientSpanStateTest {
+public class ThreadLocalServerClientAndLocalSpanStateTest {
 
     private static final short PORT = 80;
     private static final String SERVICE_NAME = "service";
     private static final long DURATION1 = 10;
     private static final long DURATION2 = 30;
-    private ThreadLocalServerAndClientSpanState serverAndClientSpanState;
+    private ThreadLocalServerClientAndLocalSpanState serverAndClientSpanState;
     private ServerSpan mockServerSpan;
     private Span mockSpan;
     private Endpoint mockEndpoint;
@@ -26,7 +26,7 @@ public class ThreadLocalServerAndClientSpanStateTest {
     @Before
     public void setup() {
         // -1062731775 = 192.168.0.1
-        serverAndClientSpanState = new ThreadLocalServerAndClientSpanState(-1062731775, PORT, SERVICE_NAME);
+        serverAndClientSpanState = new ThreadLocalServerClientAndLocalSpanState(-1062731775, PORT, SERVICE_NAME);
         mockServerSpan = mock(ServerSpan.class);
         mockSpan = mock(Span.class);
         mockEndpoint = mock(Endpoint.class);

--- a/brave-core/src/test/java/com/github/kristofa/brave/example/TestServerClientAndLocalSpanStateCompilation.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/example/TestServerClientAndLocalSpanStateCompilation.java
@@ -1,26 +1,20 @@
 package com.github.kristofa.brave.example;
 
-import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerAndClientSpanState;
+import com.github.kristofa.brave.ServerClientAndLocalSpanState;
 import com.github.kristofa.brave.ServerSpan;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-import org.junit.Test;
 
 /**
- * Example that shows ServerAndClientSpanState can be implemented outside brave's package.
+ * Example that shows ServerClientAndLocalSpanState can be implemented outside brave's package.
  */
-public class ServerAndClientSpanStateCompilationTest implements ServerAndClientSpanState {
-
-    @Test
-    public void buildsWithoutError() throws Exception {
-        new Brave.Builder(this).build();
-    }
+public class TestServerClientAndLocalSpanStateCompilation implements ServerClientAndLocalSpanState {
 
     private Endpoint endpoint = new Endpoint(127 << 24 | 1, (short) 8080, "tomcat");
-    private Span currentClientSpan = null;
     private ServerSpan currentServerSpan = ServerSpan.EMPTY;
+    private Span currentClientSpan = null;
     private String currentClientServiceName;
+    private Span currentLocalSpan = null;
 
     @Override
     public ServerSpan getCurrentServerSpan() {
@@ -52,7 +46,7 @@ public class ServerAndClientSpanStateCompilationTest implements ServerAndClientS
     }
 
     @Override
-    public void setCurrentClientSpan(final Span span) {
+    public void setCurrentClientSpan(Span span) {
         currentClientSpan = span;
     }
 
@@ -63,6 +57,16 @@ public class ServerAndClientSpanStateCompilationTest implements ServerAndClientS
 
     @Override
     public Boolean sample() {
-        return currentServerSpan.getSample();
+        return currentServerSpan == null ? null : currentServerSpan.getSample();
+    }
+
+    @Override
+    public Span getCurrentLocalSpan() {
+        return currentLocalSpan;
+    }
+
+    @Override
+    public void setCurrentLocalSpan(Span span) {
+        currentLocalSpan = span;
     }
 }


### PR DESCRIPTION
Before, local spans used the same thread local as client ones. This
meant a client span in the same trace would overwite a local span.

Ex. [server -> local -> client] would truncate to [server -> client]

This change adds state to ensure local spans aren't overwritten by
client spans.

This change does not introduce a state stack, eventhough local spans
should be nestable. The reason is that Brave's model isn't currently
designed for that and a nested model would significantly impact the api.