### PR TITLE
KafkaSpanCollector metrics support

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -48,5 +48,11 @@
         <version>1.6.2</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>3.1.2</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollectorMetricsHandler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollectorMetricsHandler.java
@@ -1,9 +1,10 @@
-package com.github.kristofa.brave.scribe;
+package com.github.kristofa.brave;
+
 
 /**
  * Empty implementation ignoring all events.
  */
-class EmptyScribeCollectorMetricsHandler implements ScribeCollectorMetricsHandler {
+public class EmptySpanCollectorMetricsHandler implements SpanCollectorMetricsHandler {
 
     @Override
     public void incrementAcceptedSpans(int quantity) {

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorMetricsHandler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorMetricsHandler.java
@@ -1,7 +1,7 @@
 package com.github.kristofa.brave;
 
 /**
- * Monitor SpanCollector by implementing reactions to these events, e.g. updating suitable metrics.
+ * Monitor {@linkplain SpanCollector} by implementing reactions to these events, e.g. updating suitable metrics.
  *
  * See DropwizardMetricsScribeCollectorMetricsHandlerExample in test sources for an example.
  */

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorMetricsHandler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorMetricsHandler.java
@@ -1,14 +1,14 @@
-package com.github.kristofa.brave.scribe;
+package com.github.kristofa.brave;
 
 /**
- * Monitor {@link ScribeSpanCollector} by implementing reactions to these events, e.g. updating suitable metrics.
+ * Monitor SpanCollector by implementing reactions to these events, e.g. updating suitable metrics.
  *
  * See DropwizardMetricsScribeCollectorMetricsHandlerExample in test sources for an example.
  */
-public interface ScribeCollectorMetricsHandler {
+public interface SpanCollectorMetricsHandler {
 
     /**
-     * Called when spans are submitted to {@link ScribeSpanCollector} for processing.
+     * Called when spans are submitted to SpanCollector for processing.
      *
      * @param quantity the number of spans accepted.
      */

--- a/brave-core/src/test/java/com/github/kristofa/brave/DropwizardMetricsScribeCollectorMetricsHandlerExample.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/DropwizardMetricsScribeCollectorMetricsHandlerExample.java
@@ -1,8 +1,9 @@
-package com.github.kristofa.brave.scribe;
+package com.github.kristofa.brave;
 
 import com.codahale.metrics.MetricRegistry;
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 
-class DropwizardMetricsScribeCollectorMetricsHandlerExample implements ScribeCollectorMetricsHandler {
+class DropwizardMetricsScribeCollectorMetricsHandlerExample implements SpanCollectorMetricsHandler {
 
     static final String ACCEPTED_METER = "tracing.collector.scribe.span.accepted";
     static final String DROPPED_METER = "tracing.collector.scribe.span.dropped";

--- a/brave-core/src/test/java/com/github/kristofa/brave/DropwizardMetricsSpanCollectorMetricsHandlerExample.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/DropwizardMetricsSpanCollectorMetricsHandlerExample.java
@@ -1,16 +1,15 @@
 package com.github.kristofa.brave;
 
 import com.codahale.metrics.MetricRegistry;
-import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 
-class DropwizardMetricsScribeCollectorMetricsHandlerExample implements SpanCollectorMetricsHandler {
+class DropwizardMetricsSpanCollectorMetricsHandlerExample implements SpanCollectorMetricsHandler {
 
     static final String ACCEPTED_METER = "tracing.collector.scribe.span.accepted";
     static final String DROPPED_METER = "tracing.collector.scribe.span.dropped";
 
     private final MetricRegistry registry;
 
-    DropwizardMetricsScribeCollectorMetricsHandlerExample(MetricRegistry registry) {
+    DropwizardMetricsSpanCollectorMetricsHandlerExample(MetricRegistry registry) {
         this.registry = registry;
     }
 

--- a/brave-spancollector-kafka/README.md
+++ b/brave-spancollector-kafka/README.md
@@ -4,3 +4,13 @@ SpanCollector that is used to submit spans to Kafka.
 
 Spans are sent to kafka as keyed messages: the key is the topic `zipkin` 
 and the value is a TBinaryProtocol encoded Span.
+
+## Monitoring ##
+
+Monitor `KafkaSpanCollector`'s by providing your implementation of `SpanCollectorMetricsHandler`. It will
+be notified when a span is accepted for processing and when it gets dropped for any reason, so you can update corresponding
+counters in your metrics tool. When a span gets dropped, the reason is written to the application logs.
+The number of spans sent to the target collector can be calculated by subtracting the dropped count from the accepted count.
+
+Refer to `DropwizardMetricsScribeCollectorMetricsHandlerExample` for an example of how to integrate with
+[dropwizard metrics](https://github.com/dropwizard/metrics).

--- a/brave-spancollector-kafka/README.md
+++ b/brave-spancollector-kafka/README.md
@@ -12,5 +12,5 @@ be notified when a span is accepted for processing and when it gets dropped for 
 counters in your metrics tool. When a span gets dropped, the reason is written to the application logs.
 The number of spans sent to the target collector can be calculated by subtracting the dropped count from the accepted count.
 
-Refer to `DropwizardMetricsScribeCollectorMetricsHandlerExample` for an example of how to integrate with
+Refer to `DropwizardMetricsSpanCollectorMetricsHandlerExample` for an example of how to integrate with
 [dropwizard metrics](https://github.com/dropwizard/metrics).

--- a/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
+++ b/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
@@ -8,6 +8,7 @@ import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.twitter.zipkin.gen.Span;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -30,7 +31,7 @@ public class KafkaSpanCollector implements SpanCollector, Closeable {
 
     private static Properties defaultPropertiesWith(String bootstrapServers) {
         Properties props = new Properties();
-        for(String name: DEFAULT_PROPERTIES.stringPropertyNames()) {
+        for (String name : DEFAULT_PROPERTIES.stringPropertyNames()) {
             props.setProperty(name, DEFAULT_PROPERTIES.getProperty(name));
         }
         props.setProperty("bootstrap.servers", bootstrapServers);
@@ -42,35 +43,43 @@ public class KafkaSpanCollector implements SpanCollector, Closeable {
     private final SpanProcessingTask spanProcessingTask;
     private final Future<Integer> future;
     private final BlockingQueue<Span> queue;
+    private final SpanCollectorMetricsHandler metricsHandler;
 
     /**
      * Create a new instance with default configuration.
      *
      * @param bootstrapServers A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
      *                         Like: host1:port1,host2:port2,... Does not to be all the servers part of Kafka cluster.
+     * @param metricsHandler   Gets notified when spans are accepted or dropped. If you are not interested in these events you
+     *                         can use EmptySpanCollectorMetricsHandler
      */
-    public KafkaSpanCollector(String bootstrapServers) {
-        this(KafkaSpanCollector.defaultPropertiesWith(bootstrapServers));
+    public KafkaSpanCollector(String bootstrapServers, SpanCollectorMetricsHandler metricsHandler) {
+        this(KafkaSpanCollector.defaultPropertiesWith(bootstrapServers), metricsHandler);
     }
 
     /**
      * KafkaSpanCollector.
      *
-     * @param kafkaProperties    Configuration for Kafka producer. Essential configuration properties are:
-     *                           bootstrap.servers, key.serializer, value.serializer. For a
-     *                           full list of config options, see http://kafka.apache.org/documentation.html#producerconfigs.
+     * @param kafkaProperties Configuration for Kafka producer. Essential configuration properties are:
+     *                        bootstrap.servers, key.serializer, value.serializer. For a
+     *                        full list of config options, see http://kafka.apache.org/documentation.html#producerconfigs.
+     * @param metricsHandler  Gets notified when spans are accepted or dropped. If you are not interested in these events you
+     *                        can use EmptySpanCollectorMetricsHandler
      */
-    public KafkaSpanCollector(Properties kafkaProperties) {
+    public KafkaSpanCollector(Properties kafkaProperties, SpanCollectorMetricsHandler metricsHandler) {
         producer = new KafkaProducer<>(kafkaProperties);
+        this.metricsHandler = metricsHandler;
         executorService = Executors.newSingleThreadExecutor();
         queue = new ArrayBlockingQueue<Span>(1000);
-        spanProcessingTask = new SpanProcessingTask(queue, producer);
+        spanProcessingTask = new SpanProcessingTask(queue, producer, metricsHandler);
         future = executorService.submit(spanProcessingTask);
     }
 
     @Override
     public void collect(com.twitter.zipkin.gen.Span span) {
+        metricsHandler.incrementAcceptedSpans(1);
         if (!queue.offer(span)) {
+            metricsHandler.incrementDroppedSpans(1);
             LOGGER.log(Level.WARNING, "Queue rejected span!");
         }
     }
@@ -91,6 +100,7 @@ public class KafkaSpanCollector implements SpanCollector, Closeable {
         }
         executorService.shutdown();
         producer.close();
+        metricsHandler.incrementDroppedSpans(queue.size());
         LOGGER.info("KafkaSpanCollector closed.");
     }
 }

--- a/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
+++ b/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
@@ -12,6 +12,7 @@ import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.twitter.zipkin.gen.Span;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
 
 /**
  * SpanCollector which submits spans to Kafka using <a href="http://kafka.apache.org/documentation.html#producerapi">Kafka Producer api</a>.
@@ -51,7 +52,7 @@ public class KafkaSpanCollector implements SpanCollector, Closeable {
      * @param bootstrapServers A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
      *                         Like: host1:port1,host2:port2,... Does not to be all the servers part of Kafka cluster.
      * @param metricsHandler   Gets notified when spans are accepted or dropped. If you are not interested in these events you
-     *                         can use EmptySpanCollectorMetricsHandler
+     *                         can use {@linkplain EmptySpanCollectorMetricsHandler}
      */
     public KafkaSpanCollector(String bootstrapServers, SpanCollectorMetricsHandler metricsHandler) {
         this(KafkaSpanCollector.defaultPropertiesWith(bootstrapServers), metricsHandler);
@@ -64,7 +65,7 @@ public class KafkaSpanCollector implements SpanCollector, Closeable {
      *                        bootstrap.servers, key.serializer, value.serializer. For a
      *                        full list of config options, see http://kafka.apache.org/documentation.html#producerconfigs.
      * @param metricsHandler  Gets notified when spans are accepted or dropped. If you are not interested in these events you
-     *                        can use EmptySpanCollectorMetricsHandler
+     *                        can use {@linkplain EmptySpanCollectorMetricsHandler}
      */
     public KafkaSpanCollector(Properties kafkaProperties, SpanCollectorMetricsHandler metricsHandler) {
         producer = new KafkaProducer<>(kafkaProperties);

--- a/brave-spancollector-scribe/README.md
+++ b/brave-spancollector-scribe/README.md
@@ -24,7 +24,7 @@ be notified when a span is accepted for processing and when it gets dropped for 
 counters in your metrics tool. When a span gets dropped, the reason is written to the application logs.
 The number of spans sent to the target collector can be calculated by subtracting the dropped count from the accepted count.
 
-Refer to `DropwizardMetricsScribeCollectorMetricsHandlerExample` for an example of how to integrate with 
+Refer to `DropwizardMetricsSpanCollectorMetricsHandlerExample` for an example of how to integrate with
 [dropwizard metrics](https://github.com/dropwizard/metrics). 
 
 ## Zipkin integration

--- a/brave-spancollector-scribe/README.md
+++ b/brave-spancollector-scribe/README.md
@@ -19,7 +19,7 @@ However it makes sure that it does not keeps holding onto spans. If the buffer i
 
 ## Monitoring
 
-Monitor `ScribeSpanCollector`'s performance by providing your implementation of `ScribeCollectorMetricsHandler`. It will
+Monitor `ScribeSpanCollector`'s performance by providing your implementation of `SpanCollectorMetricsHandler`. It will
 be notified when a span is accepted for processing and when it gets dropped for any reason, so you can update corresponding
 counters in your metrics tool. When a span gets dropped, the reason is written to the application logs.
 The number of spans sent to the target collector can be calculated by subtracting the dropped count from the accepted count.

--- a/brave-spancollector-scribe/pom.xml
+++ b/brave-spancollector-scribe/pom.xml
@@ -48,11 +48,5 @@
         <artifactId>log4j-slf4j-impl</artifactId>
         <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>io.dropwizard.metrics</groupId>
-          <artifactId>metrics-core</artifactId>
-          <version>3.1.2</version>
-          <scope>test</scope>
-      </dependency>
   </dependencies>
 </project>

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.github.kristofa.brave.SpanCollector;
 
 import org.apache.thrift.TException;
@@ -47,7 +48,7 @@ public class ScribeSpanCollector implements SpanCollector, Closeable {
     private final List<ScribeClientProvider> clientProviders = new ArrayList<>();
     private final List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
     private final Set<BinaryAnnotation> defaultAnnotations = new HashSet<BinaryAnnotation>();
-    private final ScribeCollectorMetricsHandler metricsHandler;
+    private final SpanCollectorMetricsHandler metricsHandler;
 
     /**
      * Create a new instance with default queue size (= {@link ScribeSpanCollectorParams#DEFAULT_QUEUE_SIZE}) and default

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorParams.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorParams.java
@@ -1,5 +1,8 @@
 package com.github.kristofa.brave.scribe;
 
+import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
@@ -15,7 +18,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * will be thrown.</li>
  * <li>fail on setup: Indicates if {@link ScribeSpanCollector} should fail on creation when connection with collector can't
  * be established or just log error message.</li>
- * <li>metrics handler: see {@link ScribeCollectorMetricsHandler}.</li>
+ * <li>metrics handler: see {@link SpanCollectorMetricsHandler}.</li>
  * </ul>
  * 
  * @author kristof
@@ -32,7 +35,7 @@ public class ScribeSpanCollectorParams {
     private int nrOfThreads;
     private int socketTimeout;
     private boolean failOnSetup = true;
-    private ScribeCollectorMetricsHandler metricsHandler = new EmptyScribeCollectorMetricsHandler();
+    private SpanCollectorMetricsHandler metricsHandler = new EmptySpanCollectorMetricsHandler();
 
     /**
      * Create a new instance with default values.
@@ -142,11 +145,11 @@ public class ScribeSpanCollectorParams {
         return failOnSetup;
     }
 
-    public ScribeCollectorMetricsHandler getMetricsHandler() {
+    public SpanCollectorMetricsHandler getMetricsHandler() {
         return metricsHandler;
     }
 
-    public void setMetricsHandler(ScribeCollectorMetricsHandler metricsHandler) {
+    public void setMetricsHandler(SpanCollectorMetricsHandler metricsHandler) {
         this.metricsHandler = checkNotNull(metricsHandler, "Null metricsHandler");
     }
 }

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/SpanProcessingThread.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/SpanProcessingThread.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -41,7 +42,7 @@ class SpanProcessingThread implements Callable<Integer> {
     private final BlockingQueue<Span> queue;
     private final ScribeClientProvider clientProvider;
     private final TProtocolFactory protocolFactory;
-    private final ScribeCollectorMetricsHandler metricsHandler;
+    private final SpanCollectorMetricsHandler metricsHandler;
     private volatile boolean stop = false;
     private int processedSpans = 0;
     private final List<LogEntry> logEntries;
@@ -56,7 +57,7 @@ class SpanProcessingThread implements Callable<Integer> {
      * @param metricsHandler Handler to be notified of span logging events.
      */
     public SpanProcessingThread(final BlockingQueue<Span> queue, final ScribeClientProvider clientProvider,
-        final int maxBatchSize, ScribeCollectorMetricsHandler metricsHandler) {
+        final int maxBatchSize, SpanCollectorMetricsHandler metricsHandler) {
         if (maxBatchSize <= 0) throw new IllegalArgumentException("maxBatchSize must be positive");
         this.queue = checkNotNull(queue, "Null queue");
         this.clientProvider = checkNotNull(clientProvider, "Null clientProvider");


### PR DESCRIPTION
Now that we have 2 `SpanCollector` implementations (Scribe and Kafka) I renamed `ScribeCollectorMetricsHandler` and moved it to `brave-core`module so it can also be used for the Kafka implementation.  This allows us to track number of accepted and dropped spans for all current and future SpanCollectors.

@pbetkier @adriancole  