### PR TITLE
Removes SpanCollector.close, deprecates addDefaultAnnotation

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollector.java
@@ -26,14 +26,4 @@ public class EmptySpanCollector implements SpanCollector {
         // Nothing
 
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void close() {
-        // Nothing
-
-    }
-
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -1,14 +1,11 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.SpanAndEndpoint.LocalSpanAndEndpoint;
-import com.github.kristofa.brave.internal.Util;
 import com.google.auto.value.AutoValue;
-import com.twitter.zipkin.gen.AnnotationType;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Span;
 import com.twitter.zipkin.gen.zipkinCoreConstants;
 
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 import static com.twitter.zipkin.gen.zipkinCoreConstants.LOCAL_COMPONENT;
@@ -129,11 +126,8 @@ public abstract class LocalTracer extends AnnotationSubmitter {
         }
         newSpan.setName(operation);
         newSpan.setTimestamp(timestamp);
-        newSpan.addToBinary_annotations(new BinaryAnnotation()
-                .setKey(LOCAL_COMPONENT)
-                .setValue(ByteBuffer.wrap(component.getBytes(Util.UTF_8)))
-                .setAnnotation_type(AnnotationType.STRING)
-                .setHost(spanAndEndpoint().endpoint()));
+        newSpan.addToBinary_annotations(
+            new BinaryAnnotation(LOCAL_COMPONENT, component, spanAndEndpoint().endpoint()));
         spanAndEndpoint().state().setCurrentLocalSpan(newSpan);
         return newSpanId;
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
@@ -1,13 +1,10 @@
 package com.github.kristofa.brave;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.twitter.zipkin.gen.AnnotationType;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Span;
 
@@ -58,30 +55,8 @@ public class LoggingSpanCollector implements SpanCollector {
      * {@inheritDoc}
      */
     @Override
-    public void close() {
-        // Nothing to do for this collector.
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void addDefaultAnnotation(final String key, final String value) {
-        checkNotBlank(key, "Null or blank key");
-        checkNotNull(value, "Null value");
-
-        try {
-            final ByteBuffer bb = ByteBuffer.wrap(value.getBytes(UTF_8));
-
-            final BinaryAnnotation binaryAnnotation = new BinaryAnnotation();
-            binaryAnnotation.setKey(key);
-            binaryAnnotation.setValue(bb);
-            binaryAnnotation.setAnnotation_type(AnnotationType.STRING);
-            defaultAnnotations.add(binaryAnnotation);
-
-        } catch (final UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
+        defaultAnnotations.add(new BinaryAnnotation(key, value));
     }
 
     Logger getLogger() {

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanCollector.java
@@ -24,12 +24,9 @@ public interface SpanCollector {
      * 
      * @param key Annotation name/key. Should not be empty or <code>null</code>.
      * @param value Annotation value. Should not be <code>null</code>.
+     *
+     * @deprecated decorate {@link #collect(Span)}, if you want to customize spans before they are sent.
      */
+    @Deprecated
     void addDefaultAnnotation(final String key, final String value);
-
-    /**
-     * Closes and cleans up resources. After close has been called SpanCollector will probably not be usable anymore.
-     */
-    void close();
-
 }

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
@@ -6,6 +6,7 @@
  */
 package com.twitter.zipkin.gen;
 
+import com.github.kristofa.brave.internal.Nullable;
 import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
@@ -24,6 +25,10 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Generated;
+
+import static com.github.kristofa.brave.internal.Util.UTF_8;
+import static com.github.kristofa.brave.internal.Util.checkNotBlank;
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 @SuppressWarnings({"cast", "rawtypes", "serial", "unchecked"})
 /**
@@ -170,6 +175,17 @@ public class BinaryAnnotation implements org.apache.thrift.TBase<BinaryAnnotatio
   }
 
   public BinaryAnnotation() {
+  }
+
+  public BinaryAnnotation(String key, String value) {
+    this.key = checkNotBlank(key, "Null or blank key");
+    this.value = ByteBuffer.wrap(checkNotNull(value, "Null value").getBytes(UTF_8));
+    this.annotation_type = AnnotationType.STRING;
+  }
+
+  public BinaryAnnotation(String key, String value, @Nullable Endpoint host) {
+    this(key, value);
+    this.host = host;
   }
 
   public BinaryAnnotation(

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITBrave.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITBrave.java
@@ -120,7 +120,6 @@ public class ITBrave {
     class IntegrationTestSpanCollector implements SpanCollector {
 
         private final List<Span> collectedSpans = new ArrayList<Span>();
-        private int closeCalled = 0;
 
         @Override
         public void collect(final Span span) {
@@ -129,15 +128,6 @@ public class ITBrave {
 
         public List<Span> getCollectedSpans() {
             return collectedSpans;
-        }
-
-        @Override
-        public void close() {
-            closeCalled++;
-        }
-
-        public int howManyTimesCloseCalled() {
-            return closeCalled;
         }
 
         @Override

--- a/brave-core/src/test/java/com/github/kristofa/brave/LoggingSpanCollectorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LoggingSpanCollectorTest.java
@@ -104,12 +104,6 @@ public class LoggingSpanCollectorTest {
     }
 
     @Test
-    public void testClose() {
-        spanCollector.close();
-        verifyNoMoreInteractions(mockLogger);
-    }
-
-    @Test
     public void testGetLogger() {
         final LoggingSpanCollector loggingSpanCollector = new LoggingSpanCollector();
         assertNotNull(loggingSpanCollector.getLogger());

--- a/brave-core/src/test/java/com/github/kristofa/brave/ThriftTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ThriftTest.java
@@ -1,15 +1,42 @@
 package com.github.kristofa.brave;
 
+import com.twitter.zipkin.gen.AnnotationType;
+import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import static com.github.kristofa.brave.internal.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
 
 /**
  * This enforces the thrifts are modified to enforce certain behavior or use cases.
  */
 public class ThriftTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testBinaryAnnotationCtorForString() {
+    BinaryAnnotation ba = new BinaryAnnotation("key", "value");
+    assertEquals("key", ba.getKey());
+    assertEquals("value", new String(ba.getValue(), UTF_8));
+    assertEquals(AnnotationType.STRING, ba.getAnnotation_type());
+  }
+
+  @Test
+  public void testBinaryAnnotationCtorForString_noBlankKeys() {
+    thrown.expect(IllegalArgumentException.class);
+    new BinaryAnnotation("", "value");
+  }
+
+  @Test
+  public void testBinaryAnnotationCtorForString_noNullValues() {
+    thrown.expect(NullPointerException.class);
+    new BinaryAnnotation("key", null);
+  }
 
   @Test
   public void testSpanNameLowercase() {

--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/SpanCollectorForTesting.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/SpanCollectorForTesting.java
@@ -38,14 +38,6 @@ public class SpanCollectorForTesting implements SpanCollector {
 
     @Override
     public void addDefaultAnnotation(final String key, final String value) {
-        // TODO Auto-generated method stub
-
+        throw new UnsupportedOperationException();
     }
-
-    @Override
-    public void close() {
-        // TODO Auto-generated method stub
-
-    }
-
 }

--- a/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/SpanCollectorForTesting.java
+++ b/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/SpanCollectorForTesting.java
@@ -38,14 +38,6 @@ public class SpanCollectorForTesting implements SpanCollector {
 
     @Override
     public void addDefaultAnnotation(final String key, final String value) {
-        // TODO Auto-generated method stub
-
+        throw new UnsupportedOperationException();
     }
-
-    @Override
-    public void close() {
-        // TODO Auto-generated method stub
-
-    }
-
 }

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/SpanCollectorForTesting.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/SpanCollectorForTesting.java
@@ -38,14 +38,6 @@ public class SpanCollectorForTesting implements SpanCollector {
 
     @Override
     public void addDefaultAnnotation(final String key, final String value) {
-        // TODO Auto-generated method stub
-
+        throw new UnsupportedOperationException();
     }
-
-    @Override
-    public void close() {
-        // TODO Auto-generated method stub
-
-    }
-
 }

--- a/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/ITKafkaSpanCollector.java
+++ b/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/ITKafkaSpanCollector.java
@@ -1,16 +1,12 @@
 package com.github.kristofa.brave.kafka;
 
 import com.github.charithe.kafka.KafkaJunitRule;
-import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
-import com.github.kristofa.brave.SpanCollector;
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.twitter.zipkin.gen.Span;
 import kafka.serializer.DefaultDecoder;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import java.util.*;
@@ -20,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 
 public class ITKafkaSpanCollector {
 
-    private final static String TOPIC = "zipkin";
     private final EventsHandler metricsHandler = new EventsHandler();
 
     private static class EventsHandler implements SpanCollectorMetricsHandler {
@@ -46,7 +41,7 @@ public class ITKafkaSpanCollector {
     @Test
     public void submitSingleSpan() throws TException, TimeoutException {
 
-        SpanCollector kafkaCollector = new KafkaSpanCollector("localhost:"+kafkaRule.kafkaBrokerPort(), metricsHandler);
+        KafkaSpanCollector kafkaCollector = new KafkaSpanCollector("localhost:"+kafkaRule.kafkaBrokerPort(), metricsHandler);
         Span span = span(1l, "test_kafka_span");
         kafkaCollector.collect(span);
         kafkaCollector.close();
@@ -61,7 +56,7 @@ public class ITKafkaSpanCollector {
 
     @Test
     public void submitMultipleSpansInParallel() throws InterruptedException, ExecutionException, TimeoutException, TException {
-        SpanCollector kafkaCollector = new KafkaSpanCollector("localhost:"+kafkaRule.kafkaBrokerPort(), metricsHandler);
+        KafkaSpanCollector kafkaCollector = new KafkaSpanCollector("localhost:"+kafkaRule.kafkaBrokerPort(), metricsHandler);
         Callable<Void> spanProducer1 = new Callable<Void>() {
 
             @Override

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
@@ -1,8 +1,6 @@
 package com.github.kristofa.brave.scribe;
 
 import java.io.Closeable;
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -20,7 +18,6 @@ import com.github.kristofa.brave.SpanCollector;
 
 import org.apache.thrift.TException;
 
-import com.twitter.zipkin.gen.AnnotationType;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Span;
 
@@ -44,10 +41,10 @@ public class ScribeSpanCollector implements SpanCollector, Closeable {
 
     private final BlockingQueue<Span> spanQueue;
     private final ExecutorService executorService;
-    private final List<SpanProcessingThread> spanProcessingThreads = new ArrayList<SpanProcessingThread>();
+    private final List<SpanProcessingThread> spanProcessingThreads = new ArrayList<>();
     private final List<ScribeClientProvider> clientProviders = new ArrayList<>();
-    private final List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
-    private final Set<BinaryAnnotation> defaultAnnotations = new HashSet<BinaryAnnotation>();
+    private final List<Future<Integer>> futures = new ArrayList<>();
+    private final Set<BinaryAnnotation> defaultAnnotations = new HashSet<>();
     private final SpanCollectorMetricsHandler metricsHandler;
 
     /**
@@ -138,21 +135,7 @@ public class ScribeSpanCollector implements SpanCollector, Closeable {
      */
     @Override
     public void addDefaultAnnotation(final String key, final String value) {
-        checkNotBlank(key, "Null or blank key");
-        checkNotNull(value, "Null value");
-
-        try {
-            final ByteBuffer bb = ByteBuffer.wrap(value.getBytes(UTF_8));
-
-            final BinaryAnnotation binaryAnnotation = new BinaryAnnotation();
-            binaryAnnotation.setKey(key);
-            binaryAnnotation.setValue(bb);
-            binaryAnnotation.setAnnotation_type(AnnotationType.STRING);
-            defaultAnnotations.add(binaryAnnotation);
-
-        } catch (final UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
+        defaultAnnotations.add(new BinaryAnnotation(key, value));
     }
 
     /**

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/SpanCollectorForTesting.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/SpanCollectorForTesting.java
@@ -38,14 +38,7 @@ public class SpanCollectorForTesting implements SpanCollector {
 
     @Override
     public void addDefaultAnnotation(final String key, final String value) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void close() {
-        // TODO Auto-generated method stub
-
+        throw new UnsupportedOperationException();
     }
 
     public void clear() {

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/SpanCollectorForTesting.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/SpanCollectorForTesting.java
@@ -41,10 +41,6 @@ public class SpanCollectorForTesting implements SpanCollector {
 
     }
 
-    @Override
-    public void close() {
-    }
-
     public void clear() {
         spans.clear();
     }


### PR DESCRIPTION
Closeable isn't the only way to close things, and in reality we weren't
doing anything with it. This punts the decision on how to close
resources to implementing types by removing `SpanCollector.close`

This also deprecates `SpanCollector.addDefaultAnnotation` as decorating
`SpanCollector.collect` can have the same effect.

Finally, this polishes call sites that make make binary annotations of
type string.

See https://github.com/openzipkin/zipkin/issues/584