### PR TITLE
Introduces HttpSpanCollector

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -26,6 +26,13 @@
   </properties>
 
   <dependencies>
+    <!-- For gzipping buffer -->
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+    <!-- for sampler -->
     <dependency>
         <groupId>io.zipkin</groupId>
         <artifactId>zipkin-java-core</artifactId>
@@ -59,6 +66,12 @@
         <version>3.1.2</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>com.squareup.okhttp</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>2.7.2</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
     <build>
@@ -81,8 +94,12 @@
                             <shadeTestJar>false</shadeTestJar>
                             <minimizeJar>true</minimizeJar>
                             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                            <!-- Use of zipkin-java is internal only; don't add a dependency -->
+                            <!-- Use of okio and zipkin-java are internal only; don't add dependencies -->
                             <relocations>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>com.github.kristofa.brave.internal.okio</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>io.zipkin</pattern>
                                     <shadedPattern>com.github.kristofa.brave.internal.io.zipkin</shadedPattern>

--- a/brave-core/src/main/java/com/github/kristofa/brave/HttpSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/HttpSpanCollector.java
@@ -1,0 +1,234 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+import com.google.auto.value.AutoValue;
+import com.twitter.zipkin.gen.Span;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import okio.Buffer;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TList;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TTransport;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * SpanCollector which submits spans to Zipkin, using its {@code POST /spans} endpoint.
+ */
+public final class HttpSpanCollector implements SpanCollector, Flushable, Closeable {
+
+  @AutoValue
+  public static abstract class Config {
+    public static Builder builder() {
+      return new AutoValue_HttpSpanCollector_Config.Builder()
+          .connectTimeout(10 * 1000)
+          .readTimeout(60 * 1000)
+          .flushInterval(1);
+    }
+
+    abstract int connectTimeout();
+
+    abstract int readTimeout();
+
+    abstract int flushInterval();
+
+    @AutoValue.Builder
+    public interface Builder {
+      /** Default 10 * 1000 milliseconds. 0 implies no timeout. */
+      Builder connectTimeout(int connectTimeout);
+
+      /** Default 60 * 1000 milliseconds. 0 implies no timeout. */
+      Builder readTimeout(int readTimeout);
+
+      /** Default 1 second. 0 implies spans are {@link #flush() flushed} externally. */
+      Builder flushInterval(int flushInterval);
+
+      Config build();
+    }
+  }
+
+  private final String url;
+  private final Config config;
+  private final SpanCollectorMetricsHandler metrics;
+  private final BlockingQueue<Span> pending = new LinkedBlockingQueue<>(1000);
+  @Nullable // for testing
+  private final Flusher flusher;
+
+  /**
+   * Create a new instance with default configuration.
+   *
+   * @param baseUrl URL of the zipkin query server instance. Like: http://localhost:9411/
+   * @param metrics Gets notified when spans are accepted or dropped. If you are not interested in
+   * these events you can use {@linkplain EmptySpanCollectorMetricsHandler}
+   */
+  public static HttpSpanCollector create(String baseUrl, SpanCollectorMetricsHandler metrics) {
+    return new HttpSpanCollector(baseUrl, Config.builder().build(), metrics);
+  }
+
+  /**
+   * @param baseUrl URL of the zipkin query server instance. Like: http://localhost:9411/
+   * @param config controls flush interval and timeouts
+   * @param metrics Gets notified when spans are accepted or dropped. If you are not interested in
+   * these events you can use {@linkplain EmptySpanCollectorMetricsHandler}
+   */
+  public static HttpSpanCollector create(String baseUrl, Config config,
+      SpanCollectorMetricsHandler metrics) {
+    return new HttpSpanCollector(baseUrl, config, metrics);
+  }
+
+  // Visible for testing. Ex when tests need to explicitly control flushing, set interval to 0.
+  HttpSpanCollector(String baseUrl, Config config,
+      SpanCollectorMetricsHandler metrics) {
+    this.url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "api/v1/spans";
+    this.metrics = metrics;
+    this.config = config;
+    this.flusher = config.flushInterval() > 0 ? new Flusher(this, config.flushInterval()) : null;
+  }
+
+  /**
+   * Queues the span for collection, or drops it if the queue is full.
+   *
+   * @param span Span, should not be <code>null</code>.
+   */
+  @Override
+  public void collect(Span span) {
+    metrics.incrementAcceptedSpans(1);
+    if (!pending.offer(span)) {
+      metrics.incrementDroppedSpans(1);
+    }
+  }
+
+  /**
+   * Calling this will flush any pending spans to the http transport on the current thread.
+   */
+  @Override
+  public void flush() {
+    if (pending.isEmpty()) return;
+    Queue<Span> drained = new ArrayDeque<>(pending.size());
+    pending.drainTo(drained);
+    if (drained.isEmpty()) return;
+
+    // Thrift-encode the spans for transport
+    int spanCount = drained.size();
+    BufferTransport thrifts = new BufferTransport();
+    try {
+      TBinaryProtocol oprot = new TBinaryProtocol(thrifts);
+      oprot.writeListBegin(new TList(TType.STRUCT, drained.size()));
+      while (!drained.isEmpty()) {
+        drained.remove().write(oprot);
+      }
+      oprot.writeListEnd();
+    } catch (TException e) {
+      metrics.incrementDroppedSpans(spanCount);
+      return;
+    }
+
+    // Send the thrifts to the zipkin endpoint
+    try {
+      postSpans(thrifts.buffer);
+    } catch (IOException e) {
+      metrics.incrementDroppedSpans(spanCount);
+      return;
+    }
+  }
+
+  /** Calls flush on a fixed interval */
+  static final class Flusher implements Runnable {
+    final Flushable flushable;
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    Flusher(Flushable flushable, int flushInterval) {
+      this.flushable = flushable;
+      this.scheduler.scheduleWithFixedDelay(this, 0, flushInterval, SECONDS);
+    }
+
+    @Override
+    public void run() {
+      try {
+        flushable.flush();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  void postSpans(Buffer thrifts) throws IOException {
+    // intentionally not closing the connection, so as to use keep-alives
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setConnectTimeout(config.connectTimeout());
+    connection.setReadTimeout(config.readTimeout());
+    connection.setRequestMethod("POST");
+    connection.addRequestProperty("Content-Type", "application/x-thrift");
+    connection.setDoOutput(true);
+    connection.setFixedLengthStreamingMode(thrifts.size());
+    thrifts.writeTo(connection.getOutputStream());
+
+    try (InputStream in = connection.getInputStream()) {
+      while (in.read() != -1) ; // skip
+    } catch (IOException e) {
+      try (InputStream err = connection.getErrorStream()) {
+        if (err != null) { // possible, if the connection was dropped
+          while (err.read() != -1) ; // skip
+        }
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public void addDefaultAnnotation(String key, String value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Requests a cease of delivery. There will be at most one in-flight request processing after this
+   * call returns.
+   */
+  @Override
+  public void close() {
+    if (flusher != null) flusher.scheduler.shutdown();
+    // throw any outstanding spans on the floor
+    int dropped = pending.drainTo(new LinkedList<>());
+    metrics.incrementDroppedSpans(dropped);
+  }
+
+  /** Uses a pooled buffer instead of churning byte arrays. */
+  static final class BufferTransport extends TTransport {
+    final Buffer buffer = new Buffer();
+
+    @Override
+    public boolean isOpen() {
+      return true;
+    }
+
+    @Override
+    public void open() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) {
+      return buffer.read(buf, off, len);
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) {
+      buffer.write(buf, off, len);
+    }
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/HttpSpanCollectorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/HttpSpanCollectorTest.java
@@ -1,0 +1,119 @@
+package com.github.kristofa.brave;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.SocketPolicy;
+import com.twitter.zipkin.gen.Span;
+import io.zipkin.Codec;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpSpanCollectorTest {
+
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  TestMetricsHander metrics = new TestMetricsHander();
+  // set flush interval to 0 so that tests can drive flushing explicitly
+  HttpSpanCollector.Config config = HttpSpanCollector.Config.builder().flushInterval(0).build();
+  HttpSpanCollector collector = new HttpSpanCollector(server.url("").toString(), config, metrics);
+
+  @Test
+  public void collectDoesntDoIO() throws Exception {
+    collector.collect(span(1L, "foo"));
+
+    assertThat(server.getRequestCount()).isZero();
+  }
+
+  @Test
+  public void collectIncrementsAcceptedMetrics() throws Exception {
+    collector.collect(span(1L, "foo"));
+
+    assertThat(metrics.acceptedSpans.get()).isEqualTo(1);
+    assertThat(metrics.droppedSpans.get()).isZero();
+  }
+
+  @Test
+  public void dropsWhenQueueIsFull() throws Exception {
+    for (int i = 0; i < 1001; i++)
+      collector.collect(span(1L, "foo"));
+
+    assertThat(metrics.acceptedSpans.get()).isEqualTo(1001);
+    assertThat(metrics.droppedSpans.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void postsSpans() throws Exception {
+    server.enqueue(new MockResponse());
+
+    collector.collect(span(1L, "foo"));
+    collector.collect(span(2L, "bar"));
+
+    collector.flush(); // manually flush the spans
+
+    // Ensure a proper request was sent
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getRequestLine()).isEqualTo("POST /api/v1/spans HTTP/1.1");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/x-thrift");
+
+    // Now, let's read back the spans we sent!
+    List<io.zipkin.Span> zipkinSpans = Codec.THRIFT.readSpans(request.getBody().readByteArray());
+    assertThat(zipkinSpans).containsExactly(
+        zipkinSpan(1L, "foo"),
+        zipkinSpan(2L, "bar")
+    );
+  }
+
+  @Test
+  public void incrementsDroppedSpansWhenServerErrors() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    collector.collect(span(1L, "foo"));
+    collector.collect(span(2L, "bar"));
+
+    collector.flush(); // manually flush the spans
+
+    assertThat(metrics.droppedSpans.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void incrementsDroppedSpansWhenServerDisconnects() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+
+    collector.collect(span(1L, "foo"));
+    collector.collect(span(2L, "bar"));
+
+    collector.flush(); // manually flush the spans
+
+    assertThat(metrics.droppedSpans.get()).isEqualTo(2);
+  }
+
+  class TestMetricsHander implements SpanCollectorMetricsHandler {
+
+    final AtomicInteger acceptedSpans = new AtomicInteger();
+    final AtomicInteger droppedSpans = new AtomicInteger();
+
+    @Override
+    public void incrementAcceptedSpans(int quantity) {
+      acceptedSpans.addAndGet(quantity);
+    }
+
+    @Override
+    public void incrementDroppedSpans(int quantity) {
+      droppedSpans.addAndGet(quantity);
+    }
+  }
+
+  static Span span(long traceId, String spanName) {
+    return new Span().setTrace_id(traceId).setId(traceId).setName(spanName);
+  }
+
+  static io.zipkin.Span zipkinSpan(long traceId, String spanName) {
+    return new io.zipkin.Span.Builder().traceId(traceId).id(traceId).name(spanName).build();
+  }
+}

--- a/brave-sampler-zookeeper/pom.xml
+++ b/brave-sampler-zookeeper/pom.xml
@@ -36,12 +36,6 @@
         <version>2.8.0</version>
     </dependency>
     <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <scope>test</scope>
-        <version>3.2.0</version>
-    </dependency>
-    <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
         <version>2.8.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,12 @@
       <version>4.10</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+      <version>3.2.0</version>
+    </dependency>
     <!-- Main code uses jul and tests log with log4j -->
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
This introduces HttpSpanCollector, which sends compressed thrifts to
zipkin's POST endpoint. It intends to be similar to OpenTracing
reporter.py, but relevant for Brave. There are a few notes about that.

OpenTracing's report_span seems to allow flushing on the calling thread
whereas Brave's collect should not (as it will block application code).

This implementation optimizes for sending as many spans as possible
within a single POST. Since current zipkin servers don't yet decompress,
spans are not gzipped.

Rather than introduce an async library dependency, this uses the stock
java http client and scheduler service. A future version could allow
this to be pluggable. Current impact is that only a single http-request
will be in-flight at a time.

See https://github.com/opentracing/api-python/blob/master/example/zipkin_like/reporter.py