### PR TITLE
Updates to latest zipkin-java and MockWebServer

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -34,9 +34,9 @@
     </dependency>
     <!-- for sampler -->
     <dependency>
-        <groupId>io.zipkin</groupId>
-        <artifactId>zipkin-java-core</artifactId>
-        <version>0.4.0</version>
+        <groupId>io.zipkin.java</groupId>
+        <artifactId>zipkin</artifactId>
+        <version>0.4.3</version>
     </dependency>
     <dependency>
         <groupId>com.google.auto.value</groupId>
@@ -67,9 +67,9 @@
         <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>com.squareup.okhttp</groupId>
+        <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>2.7.2</version>
+        <version>3.0.1</version>
         <scope>test</scope>
     </dependency>
   </dependencies>
@@ -101,8 +101,8 @@
                                     <shadedPattern>com.github.kristofa.brave.internal.okio</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>io.zipkin</pattern>
-                                    <shadedPattern>com.github.kristofa.brave.internal.io.zipkin</shadedPattern>
+                                    <pattern>zipkin</pattern>
+                                    <shadedPattern>com.github.kristofa.brave.internal.zipkin</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/brave-core/src/main/java/com/github/kristofa/brave/Sampler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Sampler.java
@@ -25,10 +25,10 @@ public abstract class Sampler {
 
   static final class ZipkinSampler extends Sampler {
 
-    private final io.zipkin.Sampler delegate;
+    private final zipkin.Sampler delegate;
 
     ZipkinSampler(float rate) {
-      this.delegate = io.zipkin.Sampler.create(rate);
+      this.delegate = zipkin.Sampler.create(rate);
     }
 
     @Override

--- a/brave-core/src/test/java/com/github/kristofa/brave/HttpSpanCollectorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/HttpSpanCollectorTest.java
@@ -1,15 +1,15 @@
 package com.github.kristofa.brave;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-import com.squareup.okhttp.mockwebserver.SocketPolicy;
 import com.twitter.zipkin.gen.Span;
-import io.zipkin.Codec;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.Rule;
 import org.junit.Test;
+import zipkin.Codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,7 +62,7 @@ public class HttpSpanCollectorTest {
     assertThat(request.getHeader("Content-Type")).isEqualTo("application/x-thrift");
 
     // Now, let's read back the spans we sent!
-    List<io.zipkin.Span> zipkinSpans = Codec.THRIFT.readSpans(request.getBody().readByteArray());
+    List<zipkin.Span> zipkinSpans = Codec.THRIFT.readSpans(request.getBody().readByteArray());
     assertThat(zipkinSpans).containsExactly(
         zipkinSpan(1L, "foo"),
         zipkinSpan(2L, "bar")
@@ -113,7 +113,7 @@ public class HttpSpanCollectorTest {
     return new Span().setTrace_id(traceId).setId(traceId).setName(spanName);
   }
 
-  static io.zipkin.Span zipkinSpan(long traceId, String spanName) {
-    return new io.zipkin.Span.Builder().traceId(traceId).id(traceId).name(spanName).build();
+  static zipkin.Span zipkinSpan(long traceId, String spanName) {
+    return new zipkin.Span.Builder().traceId(traceId).id(traceId).name(spanName).build();
   }
 }


### PR DESCRIPTION
In both cases, there are maven artifact and package changes. Also in
both cases, there's no user impact as these types are not exposed to users.