### PR TITLE
Move HttpSpanCollector to its own module

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -60,12 +60,6 @@
         <version>3.1.2</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>3.0.1</version>
-        <scope>test</scope>
-    </dependency>
   </dependencies>
 
     <build>
@@ -88,7 +82,7 @@
                             <shadeTestJar>false</shadeTestJar>
                             <minimizeJar>true</minimizeJar>
                             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                            <!-- Use of zipkin-java are internal only; don't add dependencies -->
+                            <!-- Use of zipkin-java is internal only; don't add dependency -->
                             <relocations>
                                 <relocation>
                                     <pattern>zipkin</pattern>

--- a/brave-spancollector-http/LICENSE
+++ b/brave-spancollector-http/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 <kristofa@github.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/brave-spancollector-http/README.md
+++ b/brave-spancollector-http/README.md
@@ -1,0 +1,4 @@
+# brave-spancollector-http #
+
+SpanCollector that is used to submit spans to Zipkins Http endpoint `/spans`.
+

--- a/brave-spancollector-http/pom.xml
+++ b/brave-spancollector-http/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.kristofa</groupId>
+        <artifactId>brave</artifactId>
+        <version>3.4.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>brave-spancollector-http</artifactId>
+    <packaging>jar</packaging>
+
+    <name>brave-spancollector-http</name>
+    <description>Brave SpanCollector that submits spans to zipkins http endpoint</description>
+    <url>https://github.com/kristofa/brave</url>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.kristofa</groupId>
+            <artifactId>brave-core</artifactId>
+            <version>3.4.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+        <!-- org.apache.thrift.ProcessFunction v0.9 uses SLF4J at runtime -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.java</groupId>
+            <artifactId>zipkin</artifactId>
+            <version>0.4.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brave-spancollector-http/src/main/java/com/github/kristofa/brave/http/HttpSpanCollector.java
+++ b/brave-spancollector-http/src/main/java/com/github/kristofa/brave/http/HttpSpanCollector.java
@@ -1,5 +1,6 @@
-package com.github.kristofa.brave;
+package com.github.kristofa.brave.http;
 
+import com.github.kristofa.brave.*;
 import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Span;

--- a/brave-spancollector-http/src/test/java/com/github/kristofa/brave/http/HttpSpanCollectorTest.java
+++ b/brave-spancollector-http/src/test/java/com/github/kristofa/brave/http/HttpSpanCollectorTest.java
@@ -1,5 +1,6 @@
-package com.github.kristofa.brave;
+package com.github.kristofa.brave.http;
 
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.twitter.zipkin.gen.Span;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <module>brave-core-spring</module>
     <module>brave-resteasy-spring</module>
     <module>brave-resteasy3-spring</module>
+    <module>brave-spancollector-http</module>
     <module>brave-spancollector-scribe</module>
     <module>brave-spancollector-kafka</module>
     <module>brave-sampler-zookeeper</module>


### PR DESCRIPTION
similar to Kafka and Scribe, Http should be in its own module, allowing
users to pick a combination which avoids dependencies.
(If I would use script I still would get okio stuff, even when not as external dependency, it would be shaded)

This basically moves https://github.com/openzipkin/brave/commit/2a85ceca5a1b50e8cdfb363a3d82026fea65b205 to its own module