### PR TITLE
Package required thrift classes for brave-core

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -78,24 +78,23 @@
         <plugins>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                        <!-- retain the thrift dependency (for now) -->
                         <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>org.apache.thrift:libthrift</exclude>
-                                </excludes>
-                            </artifactSet>
                             <shadeTestJar>false</shadeTestJar>
                             <minimizeJar>true</minimizeJar>
                             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                            <!-- Use of okio and zipkin-java are internal only; don't add dependencies -->
+                            <!-- Use of thrift, okio and zipkin-java are internal only; don't add dependencies -->
                             <relocations>
+                                <relocation>
+                                    <pattern>org.apache.thrift</pattern>
+                                    <shadedPattern>com.github.kristofa.brave.internal.thrift</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>okio</pattern>
                                     <shadedPattern>com.github.kristofa.brave.internal.okio</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The generated model classes require thrift, so thrift is not optional.

libthrift 0.9.0 has a special problem: it includes java source files.
The shade-relocate would extract them and inflate brave-core-shaded to 400k
Newer versions no longer have the problem, and as the model classes were
generated with 0.9.2, I thought this might be a sensible upgrade.