### PR TITLE
Make null handling in interceptors consistent.

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
@@ -1,5 +1,7 @@
 package com.github.kristofa.brave;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 /**
  * Contains logic for handling an outgoing client request.
  * This means it will:
@@ -20,7 +22,7 @@ public class ClientRequestInterceptor {
     private final ClientTracer clientTracer;
 
     public ClientRequestInterceptor(ClientTracer clientTracer) {
-        this.clientTracer = clientTracer;
+        this.clientTracer = checkNotNull(clientTracer, "Null clientTracer");
     }
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientResponseInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientResponseInterceptor.java
@@ -1,5 +1,7 @@
 package com.github.kristofa.brave;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 import java.util.Objects;
 
 /**
@@ -18,7 +20,7 @@ public class ClientResponseInterceptor {
     private final ClientTracer clientTracer;
 
     public ClientResponseInterceptor(ClientTracer clientTracer) {
-        this.clientTracer = Objects.requireNonNull(clientTracer);
+        this.clientTracer = checkNotNull(clientTracer, "Null clientTracer");
     }
 
     /**


### PR DESCRIPTION
Takes the same approach as in ServerRequestInterceptor, avoiding JDK 7
Objects.requireNonNull()