### PR TITLE
Make brave-core compile using source level 1.6

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -1,18 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-  	<groupId>com.github.kristofa</groupId>
-	<artifactId>brave</artifactId>
+    <groupId>com.github.kristofa</groupId>
+    <artifactId>brave</artifactId>
     <version>3.4.1-SNAPSHOT</version>
-  </parent>   
-  
+  </parent>
+
   <artifactId>brave-core</artifactId>
   <packaging>jar</packaging>
 
   <name>brave-core</name>
-  <description>
-  	Brave core.
-  </description>
+  <description>Brave core.</description>
   <url>https://github.com/kristofa/brave</url>
   <licenses>
     <license>
@@ -64,6 +62,35 @@
 
     <build>
         <plugins>
+            <!-- To facilitate reuse of brave in agents ensure compatibility with Java 6 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-java-api</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java16</artifactId>
+                                <version>1.1</version>
+                            </signature>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientResponseInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientResponseInterceptor.java
@@ -2,8 +2,6 @@ package com.github.kristofa.brave;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
-import java.util.Objects;
-
 /**
  * Contains logic for dealing with response from client request.
  * This means it will:

--- a/brave-core/src/main/java/com/github/kristofa/brave/InetAddressUtilities.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/InetAddressUtilities.java
@@ -40,10 +40,10 @@ class InetAddressUtilities {
         try {
             InetAddress candidateAddress = null;
             // Iterate all NICs (network interface cards)...
-            for (Enumeration ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements();) {
+            for (Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements();) {
                 NetworkInterface iface = (NetworkInterface) ifaces.nextElement();
                 // Iterate all IP addresses assigned to each card...
-                for (Enumeration inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements();) {
+                for (Enumeration<InetAddress> inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements();) {
                     InetAddress inetAddr = (InetAddress) inetAddrs.nextElement();
                     if (!inetAddr.isLoopbackAddress()) {
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
@@ -20,10 +20,8 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  */
 public class LoggingSpanCollector implements SpanCollector {
 
-    private static final String UTF_8 = "UTF-8";
-
     private final Logger logger;
-    private final Set<BinaryAnnotation> defaultAnnotations = new LinkedHashSet<>();
+    private final Set<BinaryAnnotation> defaultAnnotations = new LinkedHashSet<BinaryAnnotation>();
 
     public LoggingSpanCollector() {
         logger = Logger.getLogger(LoggingSpanCollector.class.getName());

--- a/brave-core/src/main/java/com/github/kristofa/brave/NoAnnotationsClientResponseAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/NoAnnotationsClientResponseAdapter.java
@@ -8,7 +8,7 @@ public class NoAnnotationsClientResponseAdapter implements ClientResponseAdapter
 
     private final static ClientResponseAdapter INSTANCE = new NoAnnotationsClientResponseAdapter();
 
-    private final static Collection<KeyValueAnnotation> EMPTY = Collections.EMPTY_LIST;
+    private final static Collection<KeyValueAnnotation> EMPTY = Collections.emptyList();
 
     private NoAnnotationsClientResponseAdapter() { }
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
@@ -20,11 +20,11 @@ public final class ThreadLocalServerClientAndLocalSpanState implements ServerCli
             return ServerSpan.create(null);
         }
     };
-    private final static ThreadLocal<Span> currentClientSpan = new ThreadLocal<>();
+    private final static ThreadLocal<Span> currentClientSpan = new ThreadLocal<Span>();
 
-    private final static ThreadLocal<String> currentClientServiceName = new ThreadLocal<>();
+    private final static ThreadLocal<String> currentClientServiceName = new ThreadLocal<String>();
 
-    private final static ThreadLocal<Span> currentLocalSpan = new ThreadLocal<>();
+    private final static ThreadLocal<Span> currentLocalSpan = new ThreadLocal<Span>();
 
     private final Endpoint endpoint;
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITBrave.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITBrave.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -107,7 +108,11 @@ public class ITBrave {
             assertTrue(localSpan.id != 0);
             assertEquals(localSpanName, localSpan.name);
 
-            assertEquals("Span ids should be different.", 3, Stream.of(serverSpan.id, clientSpan.id, localSpan.id).distinct().count());
+            HashSet<Long> ids = new HashSet<Long>();
+            ids.add(serverSpan.id);
+            ids.add(clientSpan.id);
+            ids.add(localSpan.id);
+            assertEquals("Span ids should be different.", 3, ids.size());
             assertEquals("Expect sr, ss and 1 custom annotation.", 3, serverSpan.getAnnotations().size());
             assertEquals(2, clientSpan.getAnnotations().size());
             assertFalse(localSpan.isSetAnnotations());


### PR DESCRIPTION
There are very few places in brave core which currently do not compile with java 6.
While I do not want to enforce this for openzipkin/brave, I needed to change these places for our fork, so maybe somebody else finds it useful. There are just a few places where diamond generic types are used. I also corrected a couple of other generic type issues.