### PR TITLE
Reverts Kafka client to 0.8.x to avoid broker compatibility issues

### DIFF
--- a/brave-spancollector-kafka/pom.xml
+++ b/brave-spancollector-kafka/pom.xml
@@ -23,7 +23,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>0.9.0.0</kafka.version>
+        <!-- This is pinned to Kafka 0.8.x client as 0.9.x brokers work with them, but not visa-versa
+             http://docs.confluent.io/2.0.0/upgrade.html -->
+        <kafka.version>0.8.2.2</kafka.version>
     </properties>
 
     <dependencies>
@@ -46,7 +48,8 @@
         <dependency>
             <groupId>com.github.charithe</groupId>
             <artifactId>kafka-junit</artifactId>
-            <version>1.8</version>
+            <!-- pinned to 0.8.2.2 -->
+            <version>1.7</version>
             <scope>test</scope>
         </dependency>
         <!-- org.apache.thrift.ProcessFunction v0.9 uses SLF4J at runtime -->


### PR DESCRIPTION
As it turns out, the upgrade path of kafka is brokers first, as 0.9
brokers are compatible with 0.8 clients, but not visa-versa. The eager
upgrade I made broke that path.

This materialized as an IllegalArgumentException with no message, so
almost impossible to debug.

This change sticks with 0.8.x clients until we either make a standalone
0.9 kafka collector or re-evaluate when 0.9 adoption is higher.

See https://groups.google.com/d/msg/confluent-platform/r8xox149Vn4/qR9q1QjwBQAJ
See https://github.com/openzipkin/zipkin/pull/904
Fixes #132