### PR TITLE
Adds HttpSpanCollector.Config.compressionEnabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>4.1.6.RELEASE</spring.version>
-    <zipkin.version>0.6.0</zipkin.version>
+    <zipkin.version>0.6.1</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>


### PR DESCRIPTION
HttpSpanCollector.Config.compressionEnabled will gzip spans before
uploading them to a zipkin server. This defaults to false, as server
support requires zipkin-scala 1.34+ or zipkin-java 0.6+.