### PR TITLE
Makes Span.toString return json

### DIFF
--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -1,5 +1,6 @@
 package com.twitter.zipkin.gen;
 
+import com.github.kristofa.brave.internal.Util;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -247,6 +248,11 @@ public class Span implements Serializable {
     h *= 1000003;
     h ^= (debug == null) ? 0 : debug.hashCode();
     return h;
+  }
+
+  @Override
+  public String toString() {
+    return new String(SpanCodec.JSON.writeSpan(this), Util.UTF_8);
   }
 }
 

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
@@ -1,6 +1,7 @@
 package com.twitter.zipkin.gen;
 
 import org.junit.Test;
+import zipkin.Constants;
 
 import static org.junit.Assert.assertEquals;
 
@@ -8,6 +9,19 @@ public class SpanTest {
   @Test
   public void testNameLowercase() {
     assertEquals("spanname", new Span().setName("SpanName").getName());
+  }
+
+  @Test
+  public void toStringIsJson() {
+    long traceId = -692101025335252320L;
+    Span span = new Span()
+        .setTrace_id(traceId)
+        .setName("get")
+        .setId(traceId)
+        .setTimestamp(1444438900939000L)
+        .setDuration(376000L);
+
+    assertEquals("{\"traceId\":\"f66529c8cc356aa0\",\"name\":\"get\",\"id\":\"f66529c8cc356aa0\",\"timestamp\":1444438900939000,\"duration\":376000,\"annotations\":[],\"binaryAnnotations\":[]}", span.toString());
   }
 
   @Test


### PR DESCRIPTION
Particularly when using `LoggingSpanCollector`, a span's string form
is better value-based (vs identity), and on a single-line.

This reuses the json codec to solve the problem without adding
maintenance.

Fixes #148