### PR TITLE
LoggingSpanCollector logs span data as JSON

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Span;
+import com.twitter.zipkin.gen.SpanCodec;
 
 import static com.github.kristofa.brave.internal.Util.checkNotBlank;
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
@@ -45,7 +46,7 @@ public class LoggingSpanCollector implements SpanCollector {
         }
 
         if (getLogger().isLoggable(Level.INFO)) {
-            getLogger().info(span.toString());
+            getLogger().info(new String(SpanCodec.JSON.writeSpan(span)));
         }
     }
 


### PR DESCRIPTION
It used to log object references, which was not very useful:

```
apr 11, 2016 10:05:53 PM com.github.kristofa.brave.LoggingSpanCollector collect
INFO: com.twitter.zipkin.gen.Span@a6aa0157
```

It now logs spans in JSON format:

```
apr 11, 2016 10:25:23 PM com.github.kristofa.brave.LoggingSpanCollector collect
INFO:
{"traceId":"172152af88585c29","name":"get","id":"172152af88585c29","timestamp":1460406308237000,"duration":15212000,"annotations":[{"endpoint":{"serviceName":"eirslett-test","ipv4":"192.168.0.8"},"timestamp":1460406308237000,"value":"sr"},{"endpoint":{"serviceName":"eirslett-test","ipv4":"192.168.0.8"},"timestamp":1460406323449000,"value":"ss"}],"binaryAnnotations":[]}
```
