### PR TITLE
Server request/response adapters should add binary annotations

### DIFF
--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -21,6 +21,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+import zipkin.TraceKeys;
 
 import java.io.IOException;
 
@@ -92,7 +93,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
 
             final InOrder inOrder = inOrder(clientTracer);
             inOrder.verify(clientTracer).startNewSpan(Method.GET.name());
-            inOrder.verify(clientTracer).submitBinaryAnnotation("http.uri", FULL_PATH);
+            inOrder.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_URL, FULL_PATH);
             inOrder.verify(clientTracer).setClientSent();
             inOrder.verify(clientTracer).setClientReceived();
             verifyNoMoreInteractions(clientTracer);
@@ -128,9 +129,9 @@ public class ITBraveHttpRequestAndResponseInterceptor {
 
             final InOrder inOrder = inOrder(clientTracer);
             inOrder.verify(clientTracer).startNewSpan(Method.GET.name());
-            inOrder.verify(clientTracer).submitBinaryAnnotation("http.uri", FULL_PATH);
+            inOrder.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_URL, FULL_PATH);
             inOrder.verify(clientTracer).setClientSent();
-            inOrder.verify(clientTracer).submitBinaryAnnotation("http.responsecode", "400");
+            inOrder.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_STATUS_CODE, "400");
             inOrder.verify(clientTracer).setClientReceived();
             verifyNoMoreInteractions(clientTracer);
         } finally {
@@ -196,7 +197,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
 
             final InOrder inOrder = inOrder(clientTracer);
             inOrder.verify(clientTracer).startNewSpan(Method.GET.name());
-            inOrder.verify(clientTracer).submitBinaryAnnotation("http.uri", FULL_PATH_WITH_QUERY_PARAMS);
+            inOrder.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_URL, FULL_PATH_WITH_QUERY_PARAMS);
             inOrder.verify(clientTracer).setClientSent();
             inOrder.verify(clientTracer).setClientReceived();
             verifyNoMoreInteractions(clientTracer);

--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -4,6 +4,7 @@ import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.http.BraveHttpHeaders;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.test.http.DefaultHttpResponseProvider;
@@ -21,7 +22,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import zipkin.TraceKeys;
 
 import java.io.IOException;
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/TraceKeys.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/TraceKeys.java
@@ -1,0 +1,25 @@
+package com.github.kristofa.brave;
+
+/**
+ * Used for Consistent keys without taking in zipkin-dependency.
+ * Taken from: https://github.com/openzipkin/zipkin-java/blob/master/zipkin/src/main/java/zipkin/TraceKeys.java
+ */
+public final class TraceKeys {
+
+    public static final String HTTP_HOST = "http.host";
+
+    public static final String HTTP_METHOD = "http.method";
+
+    public static final String HTTP_PATH = "http.path";
+
+    public static final String HTTP_URL = "http.url";
+
+    public static final String HTTP_STATUS_CODE = "http.status_code";
+
+    public static final String HTTP_REQUEST_SIZE = "http.request.size";
+
+    public static final String HTTP_RESPONSE_SIZE = "http.response.size";
+
+    private TraceKeys() {
+    }
+}

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
@@ -11,7 +11,7 @@ import static com.github.kristofa.brave.internal.Util.equal;
 
 /**
  * Binary annotations are tags applied to a Span to give it context. For
- * example, a binary annotation of "http.uri" could the path to a resource in a
+ * example, a binary annotation of "http.url" could be the path to a resource in a
  * RPC call.
  * 
  * Binary annotations of type STRING are always queryable, though more a
@@ -20,7 +20,7 @@ import static com.github.kristofa.brave.internal.Util.equal;
  * Binary annotations can repeat, and vary on the host. Similar to Annotation,
  * the host indicates who logged the event. This allows you to tell the
  * difference between the client and server side of the same key. For example,
- * the key "http.uri" might be different on the client and server side due to
+ * the key "http.url" might be different on the client and server side due to
  * rewriting, like "/api/v1/myresource" vs "/myresource. Via the host field,
  * you can see the different points of view, which often help in debugging.
  */

--- a/brave-core/src/main/resources/zipkinCore.thrift
+++ b/brave-core/src/main/resources/zipkinCore.thrift
@@ -178,7 +178,7 @@ enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }
 
 /**
  * Binary annotations are tags applied to a Span to give it context. For
- * example, a binary annotation of "http.uri" could the path to a resource in a
+ * example, a binary annotation of "http.url" could be the path to a resource in a
  * RPC call.
  *
  * Binary annotations of type STRING are always queryable, though more a
@@ -187,7 +187,7 @@ enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }
  * Binary annotations can repeat, and vary on the host. Similar to Annotation,
  * the host indicates who logged the event. This allows you to tell the
  * difference between the client and server side of the same key. For example,
- * the key "http.uri" might be different on the client and server side due to
+ * the key "http.url" might be different on the client and server side due to
  * rewriting, like "/api/v1/myresource" vs "/myresource. Via the host field,
  * you can see the different points of view, which often help in debugging.
  */

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -3,7 +3,6 @@ package com.github.kristofa.brave;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -3,6 +3,7 @@ package com.github.kristofa.brave;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,7 +14,7 @@ public class ClientRequestInterceptorTest {
 
     private static final String SPAN_NAME = "getOrders";
     private static final String SERVICE_NAME = "orderService";
-    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create("http.uri", "/orders/user/4543");
+    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
     private ClientRequestInterceptor interceptor;
     private ClientTracer clientTracer;

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -4,7 +4,6 @@ package com.github.kristofa.brave;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -4,6 +4,7 @@ package com.github.kristofa.brave;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,7 +17,7 @@ public class ServerRequestInterceptorTest {
     private final static long TRACE_ID = 3425;
     private final static long SPAN_ID = 43435;
     private final static long PARENT_SPAN_ID = 44334435;
-    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create("http.uri", "/orders/user/4543");
+    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
 
     private ServerRequestInterceptor interceptor;

--- a/brave-http/README.md
+++ b/brave-http/README.md
@@ -10,7 +10,7 @@ which are tailored for http clients/servers.
    * `HttpServerResponseAdapter` can be used with brave-core `ServerResponseInterceptor`
 
 These adapters take care of dealing with creating new spans and submitting required annotations and will also
-submit some default annotations like `http.uri` for all requests and `http.responsecode` in case of non success response code.
+submit some default annotations like `TraceKeys.HTTP_URL` and `TraceKeys.HTTP_STATUS_CODE` for all requests.
    
 To use these adapters you will have to implement `HttpRequest`, `HttpResponse` for client integrations
 and `HttpServerRequest` and `HttpResponse` for server integrations. These HttpRequest/HttpResponse/HttpServerRequest

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -4,8 +4,8 @@ import com.github.kristofa.brave.ClientRequestAdapter;
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.internal.Nullable;
-import zipkin.TraceKeys;
 
 import java.net.URI;
 import java.util.Arrays;

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -5,6 +5,7 @@ import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.internal.Nullable;
+import zipkin.TraceKeys;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -44,7 +45,7 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
     @Override
     public Collection<KeyValueAnnotation> requestAnnotations() {
         URI uri = request.getUri();
-        KeyValueAnnotation annotation = KeyValueAnnotation.create("http.uri", uri.toString());
+        KeyValueAnnotation annotation = KeyValueAnnotation.create(TraceKeys.HTTP_URL, uri.toString());
         return Arrays.asList(annotation);
     }
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.ClientResponseAdapter;
 import com.github.kristofa.brave.KeyValueAnnotation;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,7 +23,7 @@ public class HttpClientResponseAdapter implements ClientResponseAdapter {
         int httpStatus = response.getHttpStatusCode();
 
         if ((httpStatus < 200) || (httpStatus > 299)) {
-            KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create("http.responsecode", String.valueOf(httpStatus));
+            KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
             return Arrays.asList(statusAnnotation);
         }
         return Collections.EMPTY_LIST;

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.ClientResponseAdapter;
 import com.github.kristofa.brave.KeyValueAnnotation;
-import zipkin.TraceKeys;
+import com.github.kristofa.brave.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -1,11 +1,9 @@
 package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.*;
-import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 
 public class HttpServerRequestAdapter implements ServerRequestAdapter {

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.*;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -43,7 +44,9 @@ public class HttpServerRequestAdapter implements ServerRequestAdapter {
 
     @Override
     public Collection<KeyValueAnnotation> requestAnnotations() {
-        return Collections.emptyList();
+        KeyValueAnnotation uriAnnotation = KeyValueAnnotation.create(
+                "http.uri", serverRequest.getUri().toString());
+        return Arrays.asList(uriAnnotation);
     }
 
     private SpanId getSpanId(String traceId, String spanId, String parentSpanId) {

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.*;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -45,7 +46,7 @@ public class HttpServerRequestAdapter implements ServerRequestAdapter {
     @Override
     public Collection<KeyValueAnnotation> requestAnnotations() {
         KeyValueAnnotation uriAnnotation = KeyValueAnnotation.create(
-                "http.uri", serverRequest.getUri().toString());
+                TraceKeys.HTTP_URL, serverRequest.getUri().toString());
         return Arrays.asList(uriAnnotation);
     }
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.ServerResponseAdapter;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,7 +20,7 @@ public class HttpServerResponseAdapter implements ServerResponseAdapter {
     @Override
     public Collection<KeyValueAnnotation> responseAnnotations() {
         KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(
-                "http.responsecode", String.valueOf(response.getHttpStatusCode()));
+                TraceKeys.HTTP_STATUS_CODE, String.valueOf(response.getHttpStatusCode()));
         return Arrays.asList(statusAnnotation);
     }
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
@@ -2,11 +2,10 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.ServerResponseAdapter;
-import zipkin.TraceKeys;
+import com.github.kristofa.brave.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 public class HttpServerResponseAdapter implements ServerResponseAdapter {
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
@@ -18,12 +18,8 @@ public class HttpServerResponseAdapter implements ServerResponseAdapter {
 
     @Override
     public Collection<KeyValueAnnotation> responseAnnotations() {
-        int httpStatus = response.getHttpStatusCode();
-
-        if ((httpStatus < 200) || (httpStatus > 299)) {
-            KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create("http.responsecode", String.valueOf(httpStatus));
-            return Arrays.asList(statusAnnotation);
-        }
-        return Collections.EMPTY_LIST;
+        KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(
+                "http.responsecode", String.valueOf(response.getHttpStatusCode()));
+        return Arrays.asList(statusAnnotation);
     }
 }

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -4,6 +4,7 @@ import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import java.net.URI;
 import java.util.Collection;
@@ -75,7 +76,7 @@ public class HttpClientRequestAdapterTest {
         Collection<KeyValueAnnotation> annotations = clientRequestAdapter.requestAnnotations();
         assertEquals(1, annotations.size());
         KeyValueAnnotation a = annotations.iterator().next();
-        assertEquals("http.uri", a.getKey());
+        assertEquals(TraceKeys.HTTP_URL, a.getKey());
         assertEquals(TEST_URI, a.getValue());
         verify(request).getUri();
         verifyNoMoreInteractions(request, spanNameProvider);

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -2,9 +2,9 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
-import zipkin.TraceKeys;
 
 import java.net.URI;
 import java.util.Collection;

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
@@ -2,9 +2,9 @@ package com.github.kristofa.brave.http;
 
 
 import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
-import zipkin.TraceKeys;
 
 import java.util.Collection;
 

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
@@ -4,6 +4,7 @@ package com.github.kristofa.brave.http;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import java.util.Collection;
 
@@ -36,7 +37,7 @@ public class HttpClientResponseAdapterTest {
         Collection<KeyValueAnnotation> annotations = adapter.responseAnnotations();
         assertEquals(1, annotations.size());
         KeyValueAnnotation a = annotations.iterator().next();
-        assertEquals("http.responsecode", a.getKey());
+        assertEquals(TraceKeys.HTTP_STATUS_CODE, a.getKey());
         assertEquals("500", a.getValue());
     }
 }

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -1,7 +1,11 @@
 package com.github.kristofa.brave.http;
 
 
+import java.net.URI;
+import java.util.Collection;
+
 import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
 import org.junit.Before;
@@ -128,5 +132,16 @@ public class HttpServerRequestAdapterTest {
         assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.getSpanId());
         assertEquals(Long.valueOf(IdConversion.convertToLong(PARENT_SPAN_ID)), spanId.getParentSpanId());
     }
+
+    @Test
+    public void uriAnnotation() throws Exception {
+        when(serverRequest.getUri()).thenReturn(new URI("http://youruri.com"));
+        Collection<KeyValueAnnotation> annotations = adapter.requestAnnotations();
+        assertEquals(1, annotations.size());
+        KeyValueAnnotation a = annotations.iterator().next();
+        assertEquals("http.uri", a.getKey());
+        assertEquals("http://youruri.com", a.getValue());
+    }
+
 
 }

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -135,13 +135,13 @@ public class HttpServerRequestAdapterTest {
     }
 
     @Test
-    public void uriAnnotation() throws Exception {
-        when(serverRequest.getUri()).thenReturn(new URI("http://youruri.com"));
+    public void fullUriAnnotation() throws Exception {
+        when(serverRequest.getUri()).thenReturn(new URI("http://youruri.com/a/b?myquery=you"));
         Collection<KeyValueAnnotation> annotations = adapter.requestAnnotations();
         assertEquals(1, annotations.size());
         KeyValueAnnotation a = annotations.iterator().next();
         assertEquals(TraceKeys.HTTP_URL, a.getKey());
-        assertEquals("http://youruri.com", a.getValue());
+        assertEquals("http://youruri.com/a/b?myquery=you", a.getValue());
     }
 
 

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -10,6 +10,7 @@ import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.*;
@@ -139,7 +140,7 @@ public class HttpServerRequestAdapterTest {
         Collection<KeyValueAnnotation> annotations = adapter.requestAnnotations();
         assertEquals(1, annotations.size());
         KeyValueAnnotation a = annotations.iterator().next();
-        assertEquals("http.uri", a.getKey());
+        assertEquals(TraceKeys.HTTP_URL, a.getKey());
         assertEquals("http://youruri.com", a.getValue());
     }
 

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -8,9 +8,9 @@ import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
+import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
-import zipkin.TraceKeys;
 
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.*;

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
@@ -2,14 +2,13 @@ package com.github.kristofa.brave.http;
 
 
 import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
-import zipkin.TraceKeys;
 
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
@@ -4,6 +4,7 @@ package com.github.kristofa.brave.http;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import java.util.Collection;
 
@@ -29,7 +30,7 @@ public class HttpServerResponseAdapterTest {
         Collection<KeyValueAnnotation> annotations = adapter.responseAnnotations();
         assertEquals(1, annotations.size());
         KeyValueAnnotation a = annotations.iterator().next();
-        assertEquals("http.responsecode", a.getKey());
+        assertEquals(TraceKeys.HTTP_STATUS_CODE, a.getKey());
         assertEquals("500", a.getValue());
     }
 }

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
@@ -24,15 +24,7 @@ public class HttpServerResponseAdapterTest {
     }
 
     @Test
-    public void successResponse() {
-        when(response.getHttpStatusCode()).thenReturn(200);
-        assertTrue(adapter.responseAnnotations().isEmpty());
-        verify(response).getHttpStatusCode();
-        verifyNoMoreInteractions(response);
-    }
-
-    @Test
-    public void nonSuccessResponse() {
+    public void statusAnnotations() {
         when(response.getHttpStatusCode()).thenReturn(500);
         Collection<KeyValueAnnotation> annotations = adapter.responseAnnotations();
         assertEquals(1, annotations.size());

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.mock.http.client.MockClientHttpResponse;
+import zipkin.TraceKeys;
 
 import java.io.IOException;
 import java.net.URI;
@@ -52,7 +53,7 @@ public class BraveClientHttpRequestInterceptorTest {
             final InOrder order = inOrder(clientTracer, execution);
 
             order.verify(clientTracer).startNewSpan(spanName);
-            order.verify(clientTracer).submitBinaryAnnotation("http.uri", url);
+            order.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_URL, url);
             order.verify(clientTracer).setClientSent();
             order.verify(execution).execute(request, body);
             order.verify(clientTracer).setClientReceived();
@@ -81,7 +82,7 @@ public class BraveClientHttpRequestInterceptorTest {
         final InOrder order = inOrder(clientTracer, execution);
 
         order.verify(clientTracer).startNewSpan(spanName);
-        order.verify(clientTracer).submitBinaryAnnotation("http.uri", url);
+        order.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_URL, url);
         order.verify(clientTracer).setClientSent();
         order.verify(execution).execute(request, body);
         order.verify(clientTracer).setClientReceived();
@@ -112,10 +113,10 @@ public class BraveClientHttpRequestInterceptorTest {
         final InOrder order = inOrder(clientTracer, execution);
 
         order.verify(clientTracer).startNewSpan(spanName);
-        order.verify(clientTracer).submitBinaryAnnotation("http.uri", url);
+        order.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_URL, url);
         order.verify(clientTracer).setClientSent();
         order.verify(execution).execute(request, body);
-        order.verify(clientTracer).submitBinaryAnnotation("http.responsecode", String.valueOf(status.value()));
+        order.verify(clientTracer).submitBinaryAnnotation(TraceKeys.HTTP_STATUS_CODE, String.valueOf(status.value()));
         order.verify(clientTracer).setClientReceived();
     }
 

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -4,6 +4,7 @@ import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -13,7 +14,6 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.mock.http.client.MockClientHttpResponse;
-import zipkin.TraceKeys;
 
 import java.io.IOException;
 import java.net.URI;


### PR DESCRIPTION
Problem:
When hitting http://example.com/a/b/c with a browser,
the annotations http.uri and http.responsecode are never recorded.
This means we will not be able to figure out where on the
web site a trace was triggered.

Solution:
Add annotations to server request/response adapters