### PR TITLE
Retrofits SpanId to be effectively portable with Finagle's TraceId

### DIFF
--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -51,10 +51,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
     @Before
     public void setup() throws IOException {
         clientTracer = mock(ClientTracer.class);
-        spanId = mock(SpanId.class);
-        when(spanId.getParentSpanId()).thenReturn(null);
-        when(spanId.getSpanId()).thenReturn(SPAN_ID);
-        when(spanId.getTraceId()).thenReturn(TRACE_ID);
+        spanId = SpanId.builder().spanId(SPAN_ID).traceId(TRACE_ID).parentId(null).build();
 
         responseProvider = new DefaultHttpResponseProvider(true);
         mockServer = new MockHttpServer(PORT, responseProvider);

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -34,6 +34,13 @@
       <artifactId>brave-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- for benchmarking SpanId -->
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>finagle-core_2.11</artifactId>
+      <version>6.35.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/brave-benchmarks/src/main/java/com/github/kristofa/brave/SpanIdBenchmarks.java
+++ b/brave-benchmarks/src/main/java/com/github/kristofa/brave/SpanIdBenchmarks.java
@@ -1,0 +1,70 @@
+package com.github.kristofa.brave;
+
+import com.twitter.finagle.tracing.TraceId;
+import com.twitter.finagle.tracing.TraceId$;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 10, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(1)
+public class SpanIdBenchmarks {
+  static final SpanId sampledRootSpan =
+      new SpanId(1L, 1L, 1L, SpanId.FLAG_SAMPLED | SpanId.FLAG_SAMPLING_SET);
+  static final byte[] sampledRootSpanBytes = sampledRootSpan.bytes();
+  static final TraceId sampledRootSpanFinagle =
+      TraceId$.MODULE$.deserialize(sampledRootSpanBytes).get();
+
+  @Benchmark
+  public SpanId fromBytes_brave() {
+    return SpanId.fromBytes(sampledRootSpanBytes);
+  }
+
+  @Benchmark
+  public TraceId fromBytes_finagle() {
+    return TraceId$.MODULE$.deserialize(sampledRootSpanBytes).get();
+  }
+
+  @Benchmark
+  public byte[] bytes_finagle() {
+    return sampledRootSpanFinagle.serialize(sampledRootSpanFinagle);
+  }
+
+  @Benchmark
+  public byte[] bytes_brave() {
+    return sampledRootSpan.bytes();
+  }
+
+  @Benchmark
+  public String toString_brave() {
+    return sampledRootSpan.toString();
+  }
+
+  @Benchmark
+  public String toString_finagle() {
+    return sampledRootSpanFinagle.toString();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + SpanIdBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -54,6 +54,14 @@
         <version>3.1.2</version>
         <scope>test</scope>
     </dependency>
+
+    <!-- for testing SpanId -->
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>finagle-core_2.11</artifactId>
+      <version>6.35.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
     <build>

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
@@ -40,8 +40,8 @@ public class ServerRequestInterceptor {
             if (traceData.getSpanId() != null) {
                 LOGGER.fine("Received span information as part of request.");
                 SpanId spanId = traceData.getSpanId();
-                serverTracer.setStateCurrentTrace(spanId.getTraceId(), spanId.getSpanId(),
-                        spanId.getParentSpanId(), adapter.getSpanName());
+                serverTracer.setStateCurrentTrace(spanId.traceId, spanId.spanId,
+                        spanId.nullableParentId(), adapter.getSpanName());
             } else {
                 LOGGER.fine("Received no span state.");
                 serverTracer.setStateUnknown(adapter.getSpanName());

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
@@ -1,55 +1,323 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.Nullable;
-import com.google.auto.value.AutoValue;
+import com.twitter.zipkin.gen.Span;
+import java.nio.ByteBuffer;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
- * Identifies a Span.
- * 
- * @author kristof
+ * Contains trace data that's propagated in-band across requests, sometimes known as Baggage.
+ *
+ * <p>This implementation is biased towards a fixed-length binary serialization format that doesn't
+ * have a way to represent an absent parent (root span). In this serialized form, a root span is
+ * when all three ids are the same. Alternatively, you can use {@link #nullableParentId}.
+ *
+ * <p>Particularly, this includes sampled state, and a portable binary representation. The
+ * implementation is a port of {@code com.twitter.finagle.tracing.TraceId}.
  */
-@AutoValue
-public abstract class SpanId {
+public final class SpanId {
 
-    /**
-     * Creates a new span id.
-     *
-     * @param traceId      Trace Id.
-     * @param spanId       Span Id.
-     * @param parentSpanId Nullable parent span id.
-     */
-    public static SpanId create(long traceId, long spanId, @Nullable Long parentSpanId) {
-        return new AutoValue_SpanId(traceId, spanId, parentSpanId);
+  public static final int FLAG_DEBUG = 1 << 0;
+  /** When set, we can interpret {@link #FLAG_SAMPLED} as a set value. */
+  public static final int FLAG_SAMPLING_SET = 1 << 1;
+  public static final int FLAG_SAMPLED = 1 << 2;
+  /**
+   * When set, we can ignore the value of the {@link #parentId}
+   *
+   * <p>While many zipkin systems re-use a trace id as the root span id, we know that some don't.
+   * With this flag, we can tell for sure if the span is root as opposed to the convention trace id
+   * == span id == parent id.
+   */
+  public static final int FLAG_IS_ROOT = 1 << 3;
+
+  /**
+   * Creates a new span id.
+   *
+   * @param traceId Trace Id.
+   * @param spanId Span Id.
+   * @param parentSpanId Nullable parent span id.
+   * @deprecated Please use {@link SpanId.Builder}
+   */
+  @Deprecated
+  public static SpanId create(long traceId, long spanId, @Nullable Long parentSpanId) {
+    return SpanId.builder().traceId(traceId).parentId(parentSpanId).spanId(spanId).build();
+  }
+
+  public SpanId(long traceId, long parentId, long spanId, long flags) {
+    this.traceId = (parentId == traceId) ? parentId : traceId;
+    this.parentId = (parentId == spanId) ? traceId : parentId;
+    this.spanId = spanId;
+    this.flags = flags;
+  }
+
+  /** Deserializes this from a big-endian byte array */
+  public static SpanId fromBytes(byte[] bytes) {
+    checkNotNull(bytes, "bytes");
+    if (bytes.length != 32) {
+      throw new IllegalArgumentException("bytes.length " + bytes.length + " != 32");
+    }
+
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    long spanId = buffer.getLong(0);
+    long parentId = buffer.getLong(8);
+    long traceId = buffer.getLong(16);
+    long flags = buffer.getLong(24);
+
+    return new SpanId(traceId, parentId, spanId, flags);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Get Trace id.
+   *
+   * @return Trace id.
+   * @deprecated use {@link #traceId}
+   */
+  @Deprecated
+  public long getTraceId() {
+    return traceId;
+  }
+
+  /**
+   * Get span id.
+   *
+   * @return span id.
+   * @deprecated use {@link #spanId}
+   */
+  @Deprecated
+  public long getSpanId() {
+    return spanId;
+  }
+
+  /**
+   * Get parent span id.
+   *
+   * @return Parent span id. Can be <code>null</code>.
+   * @deprecated use {@link #nullableParentId()}
+   */
+  @Deprecated
+  @Nullable
+  public Long getParentSpanId() {
+    return nullableParentId();
+  }
+
+  /**
+   * Unique 8-byte identifier for a trace, set on all spans within it.
+   */
+  public final long traceId;
+
+  /**
+   * The parent's {@link #spanId} or {@link #spanId} if this the root span in a trace.
+   */
+  public final long parentId;
+
+  /** Returns null when this is a root span. */
+  @Nullable
+  public Long nullableParentId() {
+    return root() ? null : parentId;
+  }
+
+  /**
+   * Unique 8-byte identifier of this span within a trace.
+   *
+   * <p>A span is uniquely identified in storage by ({@linkplain #traceId}, {@code #id}).
+   */
+  public final long spanId;
+
+  /** Returns true if this is the root span. */
+  public final boolean root() {
+    return (flags & FLAG_IS_ROOT) == FLAG_IS_ROOT || parentId == traceId && parentId == spanId;
+  }
+
+  /**
+   * True is a request to store this span even if it overrides sampling policy. Implies {@link
+   * #sampled()}.
+   */
+  public final boolean debug() {
+    return (flags & FLAG_DEBUG) == FLAG_DEBUG;
+  }
+
+  /**
+   * Should we sample this request or not? True means sample, false means don't, null means we defer
+   * decision to someone further down in the stack.
+   */
+  @Nullable
+  public final Boolean sampled() {
+    if (debug()) return true;
+    return (flags & FLAG_SAMPLING_SET) == FLAG_SAMPLING_SET
+        ? (flags & FLAG_SAMPLED) == FLAG_SAMPLED
+        : null;
+  }
+
+  /** Raw flags encoded in {@link #bytes()} */
+  public final long flags;
+
+  /** Serializes this into a big-endian byte array */
+  public byte[] bytes() {
+    byte[] result = new byte[32];
+    ByteBuffer buffer = ByteBuffer.wrap(result);
+    buffer.putLong(0, spanId);
+    buffer.putLong(8, parentId);
+    buffer.putLong(16, traceId);
+    buffer.putLong(24, flags);
+    return result;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /** Returns {@code $traceId.$spanId<:$parentId} */
+  @Override
+  public String toString() {
+    char[] result = new char[(3 * 16) + 3]; // 3 ids and the constant delimiters
+    writeHexLong(result, 0, traceId);
+    result[16] = '.';
+    writeHexLong(result, 17, spanId);
+    result[33] = '<';
+    result[34] = ':';
+    writeHexLong(result, 35, parentId);
+    return new String(result);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof SpanId) {
+      SpanId that = (SpanId) o;
+      return (this.traceId == that.traceId)
+          && (this.parentId == that.parentId)
+          && (this.spanId == that.spanId);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= (traceId >>> 32) ^ traceId;
+    h *= 1000003;
+    h ^= (parentId >>> 32) ^ parentId;
+    h *= 1000003;
+    h ^= (spanId >>> 32) ^ spanId;
+    return h;
+  }
+
+  /** Preferred way to create spans, as it properly deals with the parent id */
+  public Span toSpan() {
+    Span result = new Span();
+    result.setId(spanId);
+    result.setTrace_id(traceId);
+    result.setParent_id(nullableParentId());
+    if (debug()) result.setDebug(debug());
+    return result;
+  }
+
+  public static final class Builder {
+    Long traceId;
+    Long parentId;
+    Long spanId;
+    long flags;
+
+    Builder() {
+    }
+
+    Builder(SpanId source) {
+      this.traceId = source.traceId;
+      this.parentId = source.nullableParentId();
+      this.spanId = source.spanId;
+      this.flags = source.flags;
+    }
+
+    /** @see SpanId#traceId */
+    public Builder traceId(long traceId) {
+      this.traceId = traceId;
+      return this;
     }
 
     /**
-     * Get Trace id.
+     * If your trace ids are not span ids, you must call this method to indicate absent parent.
      *
-     * @return Trace id.
+     * @see SpanId#nullableParentId()
      */
-    public abstract long getTraceId();
-
-    /**
-     * Get span id.
-     *
-     * @return span id.
-     */
-    public abstract long getSpanId();
-
-    /**
-     * Get parent span id.
-     *
-     * @return Parent span id. Can be <code>null</code>.
-     */
-    @Nullable
-    public abstract Long getParentSpanId();
-
-    @Override
-    public String toString() {
-        return "[trace id: " + getTraceId() + ", span id: " + getSpanId() + ", parent span id: "
-               + getParentSpanId() + "]";
+    public Builder parentId(@Nullable Long parentId) {
+      if (parentId == null) {
+        this.flags |= FLAG_IS_ROOT;
+      } else {
+        this.flags &= ~FLAG_IS_ROOT;
+      }
+      this.parentId = parentId;
+      return this;
     }
 
-    SpanId() {
+    /** @see SpanId#spanId */
+    public Builder spanId(long spanId) {
+      this.spanId = spanId;
+      return this;
     }
+
+    /** @see SpanId#flags */
+    public Builder flags(long flags) {
+      this.flags = flags;
+      return this;
+    }
+
+    /** @see SpanId#debug() */
+    public Builder debug(boolean debug) {
+      if (debug) {
+        this.flags |= FLAG_DEBUG;
+      } else {
+        this.flags &= ~FLAG_DEBUG;
+      }
+      return this;
+    }
+
+    /** @see SpanId#sampled */
+    public Builder sampled(@Nullable Boolean sampled) {
+      if (sampled != null) {
+        this.flags |= FLAG_SAMPLING_SET;
+        if (sampled) {
+          this.flags |= FLAG_SAMPLED;
+        } else {
+          this.flags &= ~FLAG_SAMPLED;
+        }
+      } else {
+        this.flags &= ~FLAG_SAMPLING_SET;
+      }
+      return this;
+    }
+
+    public SpanId build() {
+      long traceId = this.traceId != null ? this.traceId : checkNotNull(spanId, "spanId");
+      long parentId = this.parentId != null ? this.parentId : traceId;
+      return new SpanId(traceId, parentId, checkNotNull(spanId, "spanId"), flags);
+    }
+  }
+
+  /** Inspired by {@code okio.Buffer.writeLong} */
+  static void writeHexLong(char[] data, int pos, long v) {
+    writeHexByte(data, pos + 0,  (byte) ((v >>> 56L) & 0xff));
+    writeHexByte(data, pos + 2,  (byte) ((v >>> 48L) & 0xff));
+    writeHexByte(data, pos + 4,  (byte) ((v >>> 40L) & 0xff));
+    writeHexByte(data, pos + 6,  (byte) ((v >>> 32L) & 0xff));
+    writeHexByte(data, pos + 8,  (byte) ((v >>> 24L) & 0xff));
+    writeHexByte(data, pos + 10, (byte) ((v >>> 16L) & 0xff));
+    writeHexByte(data, pos + 12, (byte) ((v >>> 8L) & 0xff));
+    writeHexByte(data, pos + 14, (byte)  (v & 0xff));
+  }
+
+  static final char[] HEX_DIGITS =
+      {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+  static void writeHexByte(char[] data, int pos, byte b) {
+    data[pos + 0] = HEX_DIGITS[(b >> 4) & 0xf];
+    data[pos + 1] = HEX_DIGITS[b & 0xf];
+  }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -42,7 +42,7 @@ public class ClientRequestInterceptorTest {
     public void testSpanIdReturnedNoAnnotationsProvided() {
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);
-        SpanId spanId = mock(SpanId.class);
+        SpanId spanId = SpanId.builder().spanId(1L).build();
         when(clientTracer.startNewSpan(SPAN_NAME)).thenReturn(spanId);
         interceptor.handle(adapter);
 
@@ -60,7 +60,7 @@ public class ClientRequestInterceptorTest {
     public void testSpanIdReturnedAnnotationsProvided() {
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
-        SpanId spanId = mock(SpanId.class);
+        SpanId spanId = SpanId.builder().spanId(1L).build();
         when(clientTracer.startNewSpan(SPAN_NAME)).thenReturn(spanId);
         interceptor.handle(adapter);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -164,9 +164,9 @@ public class ClientTracerTest {
 
         final SpanId newSpanId = clientTracer.startNewSpan(REQUEST_NAME);
         assertNotNull(newSpanId);
-        assertEquals(TRACE_ID, newSpanId.getTraceId());
-        assertEquals(TRACE_ID, newSpanId.getSpanId());
-        assertNull(newSpanId.getParentSpanId());
+        assertEquals(TRACE_ID, newSpanId.traceId);
+        assertEquals(TRACE_ID, newSpanId.spanId);
+        assertNull(newSpanId.nullableParentId());
 
         assertEquals(
                 new Span().setTrace_id(TRACE_ID).setId(TRACE_ID).setName(REQUEST_NAME),
@@ -186,9 +186,9 @@ public class ClientTracerTest {
 
         final SpanId newSpanId = clientTracer.startNewSpan(REQUEST_NAME);
         assertNotNull(newSpanId);
-        assertEquals(TRACE_ID, newSpanId.getTraceId());
-        assertEquals(TRACE_ID, newSpanId.getSpanId());
-        assertNull(newSpanId.getParentSpanId());
+        assertEquals(TRACE_ID, newSpanId.traceId);
+        assertEquals(TRACE_ID, newSpanId.spanId);
+        assertNull(newSpanId.nullableParentId());
 
         assertEquals(
                 new Span().setTrace_id(TRACE_ID).setId(TRACE_ID).setName(REQUEST_NAME),
@@ -206,9 +206,9 @@ public class ClientTracerTest {
 
         final SpanId newSpanId = clientTracer.startNewSpan(REQUEST_NAME);
         assertNotNull(newSpanId);
-        assertEquals(PARENT_TRACE_ID, newSpanId.getTraceId());
-        assertEquals(1l, newSpanId.getSpanId());
-        assertEquals(Long.valueOf(PARENT_SPAN_ID), newSpanId.getParentSpanId());
+        assertEquals(PARENT_TRACE_ID, newSpanId.traceId);
+        assertEquals(1l, newSpanId.spanId);
+        assertEquals(PARENT_SPAN_ID, newSpanId.parentId);
 
         assertEquals(
                 new Span().setTrace_id(PARENT_TRACE_ID).setId(1).setParent_id(PARENT_SPAN_ID).setName(REQUEST_NAME),

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -66,7 +66,8 @@ public class LocalTracerTest {
         PowerMockito.when(System.currentTimeMillis()).thenReturn(1L);
         PowerMockito.when(System.nanoTime()).thenReturn(500L);
 
-        SpanId expectedSpanId = SpanId.create(PARENT_TRACE_ID, 555l, PARENT_SPAN_ID);
+        SpanId expectedSpanId =
+            SpanId.builder().traceId(PARENT_TRACE_ID).spanId(555L).parentId(PARENT_SPAN_ID).build();
 
         assertEquals(expectedSpanId, localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME));
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -58,7 +58,9 @@ public class ServerRequestInterceptorTest {
 
     @Test
     public void handleSampleRequestWithParentSpanId() {
-        TraceData traceData = TraceData.builder().spanId(SpanId.create(TRACE_ID, SPAN_ID, PARENT_SPAN_ID)).sample(true).build();
+        SpanId spanId =
+            SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(PARENT_SPAN_ID).build();
+        TraceData traceData = TraceData.builder().spanId(spanId).sample(true).build();
         when(adapter.getTraceData()).thenReturn(traceData);
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
@@ -76,7 +78,8 @@ public class ServerRequestInterceptorTest {
 
     @Test
     public void handleSampleRequestWithoutParentSpanId() {
-        TraceData traceData = TraceData.builder().spanId(SpanId.create(TRACE_ID, SPAN_ID, null)).sample(true).build();
+        SpanId spanId = SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
+        TraceData traceData = TraceData.builder().spanId(spanId).sample(true).build();
         when(adapter.getTraceData()).thenReturn(traceData);
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);

--- a/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
@@ -1,86 +1,169 @@
 package com.github.kristofa.brave;
 
-
-import org.junit.Before;
+import com.twitter.finagle.tracing.TraceId;
+import com.twitter.finagle.tracing.TraceId$;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpanIdTest {
-
-    private final static long TRACEID = 10;
-    private final static long SPANID = 11;
-    private final static Long PARENT_SPANID = new Long(12);
-
-    private SpanId spanId;
-
-    @Before
-    public void setup() {
-        spanId = SpanId.create(TRACEID, SPANID, PARENT_SPANID);
-    }
-
-    @Test
-    public void testSpanIdNullParentId() {
-        final SpanId spanId2 = SpanId.create(TRACEID, SPANID, null);
-        assertNull(spanId2.getParentSpanId());
-    }
-
-    @Test
-    public void testGetTraceId() {
-        assertEquals(TRACEID, spanId.getTraceId());
-    }
-
-    @Test
-    public void testGetSpanId() {
-        assertEquals(SPANID, spanId.getSpanId());
-    }
-
-    @Test
-    public void testGetParentSpanId() {
-        assertEquals(PARENT_SPANID, spanId.getParentSpanId());
-    }
-
-    @Test
-    public void testGetOptionalParentSpanId() {
-        assertEquals(PARENT_SPANID, spanId.getParentSpanId());
-    }
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
 
-    @Test
-    public void testHashCode() {
-        final SpanId equalSpanId = SpanId.create(TRACEID, SPANID, PARENT_SPANID);
-        assertEquals(spanId.hashCode(), equalSpanId.hashCode());
-    }
+  @Test public void rootSpan_whenTraceIdsAreSpanIds() {
+    SpanId id = SpanId.builder().spanId(333L).build();
 
-    @Test
-    public void testEquals() {
-        assertTrue(spanId.equals(spanId));
-        assertFalse(spanId.equals(null));
-        assertFalse(spanId.equals(new String()));
+    assertThat(id.root()).isTrue();
+    assertThat(id.nullableParentId()).isNull();
 
-        final SpanId equalSpanId = SpanId.create(TRACEID, SPANID, PARENT_SPANID);
-        assertTrue(spanId.equals(equalSpanId));
+    assertThat(SpanId.fromBytes(id.bytes()))
+        .isEqualToComparingFieldByField(id);
 
-        final SpanId nonEqualSpanId = SpanId.create(TRACEID + 1, SPANID, PARENT_SPANID);
-        final SpanId nonEqualSpanId2 = SpanId.create(TRACEID, SPANID + 1, PARENT_SPANID);
-        final SpanId nonEqualSpanId3 = SpanId.create(TRACEID, SPANID, PARENT_SPANID + 1);
+    checkAgainstFinagle(id);
+  }
 
-        assertFalse(spanId.equals(nonEqualSpanId));
-        assertFalse(spanId.equals(nonEqualSpanId2));
-        assertFalse(spanId.equals(nonEqualSpanId3));
-    }
+  // NOTE: finagle doesn't support this, but then again it doesn't provision non-span trace ids
+  @Test public void rootSpan_whenTraceIdsArentSpanIds() {
+    SpanId id = SpanId.builder().traceId(555L).parentId(null).spanId(333L).build();
 
-    @Test
-    public void testToString() {
-        assertEquals(
-            "[trace id: " + TRACEID + ", span id: " + SPANID + ", parent span id: " + PARENT_SPANID
-            + "]",
-            spanId.toString());
-    }
+    assertThat(id.root()).isTrue();
+    assertThat(id.nullableParentId()).isNull();
 
-    @Test
-    public void testToStringNullParent() {
-        final SpanId spanId2 = SpanId.create(TRACEID, SPANID, null);
-        assertEquals("[trace id: " + TRACEID + ", span id: " + SPANID + ", parent span id: null]", spanId2.toString());
-    }
+    assertThat(SpanId.fromBytes(id.bytes()))
+        .isEqualToComparingFieldByField(id);
+  }
+
+  @Test public void compareUnequalIds() {
+    SpanId id = SpanId.builder().spanId(0L).build();
+
+    assertThat(id)
+        .isNotEqualTo(SpanId.builder().spanId(1L).build());
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void compareEqualIds() {
+    SpanId id = SpanId.builder().spanId(0L).build();
+
+    assertThat(id)
+        .isEqualTo(SpanId.builder().spanId(0L).build());
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void compareSynthesizedParentId() {
+    SpanId id = SpanId.builder().parentId(1L).spanId(1L).build();
+
+    assertThat(id)
+        .isEqualTo(SpanId.builder().spanId(1L).build());
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void compareSynthesizedTraceId() {
+    SpanId id = SpanId.builder().traceId(1L).parentId(1L).spanId(1L).build();
+
+    assertThat(id)
+        .isEqualTo(SpanId.builder().parentId(1L).spanId(1L).build());
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void serializationRoundTrip() {
+    SpanId id = SpanId.builder().traceId(1L).parentId(2L).spanId(3L).sampled(true).build();
+
+    assertThat(SpanId.fromBytes(id.bytes()))
+        .isEqualToComparingFieldByField(id);
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void fromBytesFail() {
+    thrown.expect(IllegalArgumentException.class);
+
+    SpanId.fromBytes("not-a-trace".getBytes());
+  }
+
+  @Test public void sampledTrueWhenDebug() {
+    SpanId id = SpanId.builder().spanId(1L).debug(true).build();
+
+    assertThat(id.sampled()).isTrue();
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void builderClearsSampled() {
+    SpanId id = new SpanId(1L, 1L, 1L, SpanId.FLAG_SAMPLED | SpanId.FLAG_SAMPLING_SET);
+
+    assertThat(id.sampled()).isTrue();
+
+    checkAgainstFinagle(id);
+
+    id = id.toBuilder().sampled(null).build();
+
+    assertThat(id.sampled()).isNull();
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void builderUnsetsDebug() {
+    SpanId id = new SpanId(1L, 1L, 1L, SpanId.FLAG_DEBUG);
+
+    assertThat(id.debug()).isTrue();
+
+    checkAgainstFinagle(id);
+
+    id = id.toBuilder().debug(false).build();
+
+    assertThat(id.debug()).isFalse();
+
+    checkAgainstFinagle(id);
+  }
+
+  @Test public void equalsOnlyAccountsForIdFields() {
+    assertThat(new SpanId(1L, 1L, 1L, SpanId.FLAG_DEBUG).hashCode())
+        .isEqualTo(new SpanId(1L, 1L, 1L, SpanId.FLAG_SAMPLING_SET).hashCode());
+  }
+
+  @Test public void hashCodeOnlyAccountsForIdFields() {
+    assertThat(new SpanId(1L, 1L, 1L, SpanId.FLAG_DEBUG))
+        .isEqualTo(new SpanId(1L, 1L, 1L, SpanId.FLAG_SAMPLING_SET));
+  }
+
+  @Test
+  public void testToString() {
+    SpanId id = SpanId.builder().traceId(1).spanId(3).parentId(2L).build();
+
+    assertThat(id.toString())
+        .isEqualTo("0000000000000001.0000000000000003<:0000000000000002")
+        .isEqualTo(TraceId$.MODULE$.deserialize(id.bytes()).get().toString());
+  }
+
+  @Test
+  public void testToStringNullParent() {
+    SpanId id = SpanId.builder().traceId(1).spanId(1).build();
+
+    assertThat(id.toString())
+        .isEqualTo("0000000000000001.0000000000000001<:0000000000000001")
+        .isEqualTo(TraceId$.MODULE$.deserialize(id.bytes()).get().toString());
+  }
+
+  static void checkAgainstFinagle(SpanId brave) {
+    TraceId finagle = TraceId$.MODULE$.deserialize(brave.bytes()).get();
+
+    assertThat(finagle.traceId())
+        .isEqualTo(brave.traceId);
+    assertThat(finagle.parentId())
+        .isEqualTo(brave.parentId);
+    assertThat(finagle.spanId())
+        .isEqualTo(brave.spanId);
+    assertThat(finagle.flags().flags())
+        .isEqualTo(brave.flags);
+
+    assertThat(SpanId.fromBytes(finagle.serialize(finagle)))
+        .isEqualTo(brave);
+  }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/TraceDataTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/TraceDataTest.java
@@ -9,7 +9,8 @@ import static org.junit.Assert.assertNull;
 public class TraceDataTest {
 
     private static final boolean SAMPLE = true;
-    private static final SpanId SPAN_ID = SpanId.create(3454, 3353, 34343l);
+    private static final SpanId SPAN_ID =
+        SpanId.builder().traceId(3454).spanId(3353).parentId(34343l).build();
 
 
     @Test

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcClientInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcClientInterceptor.java
@@ -10,7 +10,6 @@ import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.internal.Nullable;
-import com.google.common.base.Strings;
 import com.twitter.zipkin.gen.Span;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -87,10 +86,10 @@ public final class BraveGrpcClientInterceptor implements ClientInterceptor {
                 headers.put(BravePropagationKeys.Sampled, "0");
             } else {
                 headers.put(BravePropagationKeys.Sampled, "1");
-                headers.put(BravePropagationKeys.TraceId, IdConversion.convertToString(spanId.getTraceId()));
-                headers.put(BravePropagationKeys.SpanId, IdConversion.convertToString(spanId.getSpanId()));
-                if (spanId.getParentSpanId() != null) {
-                    headers.put(BravePropagationKeys.ParentSpanId, IdConversion.convertToString(spanId.getParentSpanId()));
+                headers.put(BravePropagationKeys.TraceId, IdConversion.convertToString(spanId.traceId));
+                headers.put(BravePropagationKeys.SpanId, IdConversion.convertToString(spanId.spanId));
+                if (spanId.nullableParentId() != null) {
+                    headers.put(BravePropagationKeys.ParentSpanId, IdConversion.convertToString(spanId.parentId));
                 }
             }
         }

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
@@ -1,10 +1,10 @@
 package com.github.kristofa.brave.grpc;
 
+import static com.github.kristofa.brave.IdConversion.convertToLong;
 import static com.github.kristofa.brave.grpc.GrpcKeys.GRPC_STATUS_CODE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.ServerRequestAdapter;
 import com.github.kristofa.brave.ServerRequestInterceptor;
@@ -115,9 +115,9 @@ public final class BraveGrpcServerInterceptor implements ServerInterceptor {
     }
 
     static SpanId getSpanId(String traceId, String spanId, String parentSpanId) {
-        if (parentSpanId != null) {
-            return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), IdConversion.convertToLong(parentSpanId));
-        }
-        return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), null);
+        return SpanId.builder()
+            .traceId(convertToLong(traceId))
+            .spanId(convertToLong(spanId))
+            .parentId(parentSpanId == null ? null : convertToLong(parentSpanId)).build();
     }
 }

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
@@ -125,8 +125,8 @@ public class BraveGrpcInterceptorsTest {
         assertTrue("Could not find expected server span", maybeSpan.isPresent());
         Span span = maybeSpan.get();
         //Verify that the localTracer's trace id and span id were propagated to the server
-        assertThat(span.getTrace_id(), is(equalTo(spanId.getTraceId())));
-        assertThat(span.getParent_id(), is(equalTo(spanId.getSpanId())));
+        assertThat(span.getTrace_id(), is(equalTo(spanId.traceId)));
+        assertThat(span.getParent_id(), is(equalTo(spanId.spanId)));
     }
 
     /**

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/GrpcClientRequestAdapterTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/GrpcClientRequestAdapterTest.java
@@ -27,7 +27,7 @@ public class GrpcClientRequestAdapterTest {
 
   @Test
   public void sampled_rootSpan() throws Exception {
-    adapter.addSpanIdToRequest(SpanId.create(1234L, 1234L, null));
+    adapter.addSpanIdToRequest(SpanId.builder().traceId(1234L).spanId(1234L).build());
 
     assertThat(metadata.keys())
         .containsExactly("x-b3-sampled", "x-b3-traceid", "x-b3-spanid");
@@ -42,7 +42,7 @@ public class GrpcClientRequestAdapterTest {
 
   @Test
   public void sampled_childSpan() throws Exception {
-    adapter.addSpanIdToRequest(SpanId.create(1234L, 5678L, 1234L));
+    adapter.addSpanIdToRequest(SpanId.builder().traceId(1234L).parentId(1234L).spanId(5678L).build());
 
     assertThat(metadata.keys())
         .containsExactly("x-b3-sampled", "x-b3-traceid", "x-b3-spanid", "x-b3-parentspanid");

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -33,10 +33,10 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
             request.addHeader(BraveHttpHeaders.Sampled.getName(), "0");
         } else {
             request.addHeader(BraveHttpHeaders.Sampled.getName(), "1");
-            request.addHeader(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.getTraceId()));
-            request.addHeader(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.getSpanId()));
-            if (spanId.getParentSpanId() != null) {
-                request.addHeader(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(spanId.getParentSpanId()));
+            request.addHeader(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.traceId));
+            request.addHeader(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.spanId));
+            if (spanId.nullableParentId() != null) {
+                request.addHeader(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(spanId.parentId));
             }
         }
     }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -1,10 +1,14 @@
 package com.github.kristofa.brave.http;
 
-import com.github.kristofa.brave.*;
-
-import java.util.Arrays;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.ServerRequestAdapter;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceData;
+import com.github.kristofa.brave.TraceKeys;
 import java.util.Collection;
+import java.util.Collections;
 
+import static com.github.kristofa.brave.IdConversion.convertToLong;
 
 public class HttpServerRequestAdapter implements ServerRequestAdapter {
 
@@ -45,14 +49,13 @@ public class HttpServerRequestAdapter implements ServerRequestAdapter {
     public Collection<KeyValueAnnotation> requestAnnotations() {
         KeyValueAnnotation uriAnnotation = KeyValueAnnotation.create(
                 TraceKeys.HTTP_URL, serverRequest.getUri().toString());
-        return Arrays.asList(uriAnnotation);
+        return Collections.singleton(uriAnnotation);
     }
 
     private SpanId getSpanId(String traceId, String spanId, String parentSpanId) {
-        if (parentSpanId != null)
-        {
-            return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), IdConversion.convertToLong(parentSpanId));
-        }
-        return SpanId.create(IdConversion.convertToLong(traceId), IdConversion.convertToLong(spanId), null);
-    }
+        return SpanId.builder()
+            .traceId(convertToLong(traceId))
+            .spanId(convertToLong(spanId))
+            .parentId(parentSpanId == null ? null : convertToLong(parentSpanId)).build();
+   }
 }

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -51,7 +51,7 @@ public class HttpClientRequestAdapterTest {
 
     @Test
     public void addSpanIdToRequest_WithParentSpanId() {
-        SpanId id = SpanId.create(TRACE_ID, SPAN_ID, PARENT_SPAN_ID);
+        SpanId id = SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(PARENT_SPAN_ID).build();
         clientRequestAdapter.addSpanIdToRequest(id);
         verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "1");
         verify(request).addHeader(BraveHttpHeaders.TraceId.getName(), String.valueOf(TRACE_ID));
@@ -62,7 +62,7 @@ public class HttpClientRequestAdapterTest {
 
     @Test
     public void addSpanIdToRequest_WithoutParentSpanId() {
-        SpanId id = SpanId.create(TRACE_ID, SPAN_ID, null);
+        SpanId id = SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
         clientRequestAdapter.addSpanIdToRequest(id);
         verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "1");
         verify(request).addHeader(BraveHttpHeaders.TraceId.getName(), String.valueOf(TRACE_ID));

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -94,9 +94,9 @@ public class HttpServerRequestAdapterTest {
         assertTrue(traceData.getSample());
         SpanId spanId = traceData.getSpanId();
         assertNotNull(spanId);
-        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.getTraceId());
-        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.getSpanId());
-        assertNull(spanId.getParentSpanId());
+        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+        assertNull(spanId.nullableParentId());
     }
 
     /**
@@ -112,9 +112,9 @@ public class HttpServerRequestAdapterTest {
         assertTrue(traceData.getSample());
         SpanId spanId = traceData.getSpanId();
         assertNotNull(spanId);
-        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.getTraceId());
-        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.getSpanId());
-        assertNull(spanId.getParentSpanId());
+        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+        assertNull(spanId.nullableParentId());
     }
 
     @Test
@@ -129,9 +129,9 @@ public class HttpServerRequestAdapterTest {
         assertTrue(traceData.getSample());
         SpanId spanId = traceData.getSpanId();
         assertNotNull(spanId);
-        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.getTraceId());
-        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.getSpanId());
-        assertEquals(Long.valueOf(IdConversion.convertToLong(PARENT_SPAN_ID)), spanId.getParentSpanId());
+        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+        assertEquals(IdConversion.convertToLong(PARENT_SPAN_ID), spanId.parentId);
     }
 
     @Test

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -45,7 +45,8 @@ public class BraveClientHttpRequestInterceptorTest {
 
         when(execution.execute(request, body)).thenThrow(new IOException());
         when(spanNameProvider.spanName(any())).thenReturn(spanName);
-        when(clientTracer.startNewSpan(spanName)).thenReturn(SpanId.create(1, 1, 1L));
+        when(clientTracer.startNewSpan(spanName)).thenReturn(
+            SpanId.builder().traceId(1L).spanId(1L).parentId(1L).build());
 
         try {
             subject.intercept(request, body, execution);
@@ -75,7 +76,8 @@ public class BraveClientHttpRequestInterceptorTest {
         when(response.getRawStatusCode()).thenThrow(new IOException());
         when(execution.execute(request, body)).thenReturn(response);
         when(spanNameProvider.spanName(any())).thenReturn(spanName);
-        when(clientTracer.startNewSpan(spanName)).thenReturn(SpanId.create(1, 1, 1L));
+        when(clientTracer.startNewSpan(spanName)).thenReturn(
+            SpanId.builder().traceId(1L).spanId(1L).parentId(1L).build());
 
         subject.intercept(request, body, execution);
 
@@ -104,7 +106,8 @@ public class BraveClientHttpRequestInterceptorTest {
 
         when(execution.execute(request, body)).thenReturn(expected);
         when(spanNameProvider.spanName(any())).thenReturn(spanName);
-        when(clientTracer.startNewSpan(spanName)).thenReturn(SpanId.create(1, 1, 1L));
+        when(clientTracer.startNewSpan(spanName)).thenReturn(
+            SpanId.builder().traceId(1L).spanId(1L).parentId(1L).build());
 
         final ClientHttpResponse actual = subject.intercept(request, body, execution);
 


### PR DESCRIPTION
Finagle's TraceId is a propagation value and used in many places, such
as indexing data for collection. It also has a concise fixed-length
serialized form, and similarly concise toString.

The serialized form could be helpful when propagating across systems,
most notably Finagle, but also cassandra, whose baggage includes opaque
values.

See https://github.com/thelastpickle/cassandra-zipkin-tracing/tree/mck/brave-3.5
See #166

Here are the benchmarks. I noticed toString was special-cased in finagle, so I special-cased it here, too.

```
Benchmark                            Mode  Cnt   Score   Error   Units
SpanIdBenchmarks.bytes_brave        thrpt   30  55.749 ± 1.424  ops/us
SpanIdBenchmarks.bytes_finagle      thrpt   30  66.805 ± 4.009  ops/us
SpanIdBenchmarks.fromBytes_brave    thrpt   30  53.761 ± 6.293  ops/us
SpanIdBenchmarks.fromBytes_finagle  thrpt   30  37.689 ± 0.470  ops/us
SpanIdBenchmarks.toString_brave     thrpt   30  17.736 ± 0.143  ops/us
SpanIdBenchmarks.toString_finagle   thrpt   30   2.732 ± 0.031  ops/us
```