### PR TITLE
Adds new samplers and benchmarks

### DIFF
--- a/brave-benchmarks/README.md
+++ b/brave-benchmarks/README.md
@@ -1,0 +1,14 @@
+Brave Benchmarks
+================
+
+This module includes [JMH](http://openjdk.java.net/projects/code-tools/jmh/) benchmarks for Brave.
+
+=== Running the benchmark
+From the parent directory, run `./mvnw install` to build the benchmarks, and the following to run them:
+
+```bash
+# Run with a single worker thread
+$ java -jar brave-benchmarks/target/benchmarks.jar
+# Add contention by running with 4 threads
+$ java -jar brave-benchmarks/target/benchmarks.jar -t4
+```

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.github.kristofa</groupId>
+    <artifactId>brave</artifactId>
+    <version>3.6.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>brave-benchmarks</artifactId>
+  <name>Brave benchmarks</name>
+  <description>Brave benchmarks (JMH)</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <jmh.version>1.12</jmh.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>benchmarks</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/brave-benchmarks/src/main/java/com/github/kristofa/brave/SamplerBenchmarks.java
+++ b/brave-benchmarks/src/main/java/com/github/kristofa/brave/SamplerBenchmarks.java
@@ -1,0 +1,136 @@
+package com.github.kristofa.brave;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * <p>Brave 3 uses before-the-fact sampling. This means that the decision to keep or drop the trace
+ * is made before any work is measured, or annotations are added. As such, the input parameter to
+ * Brave 3 samplers is the trace id (64-bit random number).
+ *
+ * <p>This only tests performance of various approaches against each-other. This doesn't test if the
+ * same trace id is consistently sampled or not, or how close to the retention percentage the
+ * samplers get.
+ *
+ * <p>While random sampling gives a better statistical average across all spans, it's less useful
+ * than the ability to see end to end interrelated work, such as a from a specific user, or messages
+ * blocking others in a queue. More sampling patterns are expected in OpenTracing and Zipkin v2.
+ */
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class SamplerBenchmarks {
+
+  /**
+   * Sample rate is a percentage expressed as a float. So, 0.001 is 0.1% (let one in a 1000nd pass).
+   * Zero effectively disables tracing.
+   *
+   * <p>Here are default sample rates from actual implementations:
+   * <pre>
+   * <ul>
+   *   <li>Finagle Scala Tracer: 0.001</li>
+   *   <li>Finagle Ruby Tracer: 0.001</li>
+   *   <li>Brave Java Tracer: 1.0</li>
+   *   <li>Zipkin Collector: 1.0</li>
+   * </ul>
+   * </pre>
+   */
+  static final float SAMPLE_RATE = 0.01f;
+
+  @State(Scope.Benchmark)
+  public static class Args {
+
+    /**
+     * Arguments include the most negative number, and an arbitrary one.
+     */
+    // JMH doesn't support Long.MIN_VALUE or hex references, hence the long form literals.
+    @Param({"-9223372036854775808", "1234567890987654321"})
+    long traceId;
+  }
+
+  /**
+   * This measures the boundary trace id sampler provided with brave-core
+   */
+  @Benchmark
+  public boolean sampler_boundary(Args args) {
+    return TRACE_ID_SAMPLER_BOUNDARY.isSampled(args.traceId);
+  }
+
+  static final Sampler TRACE_ID_SAMPLER_BOUNDARY = BoundarySampler.create(SAMPLE_RATE);
+
+  /**
+   * This measures the counting trace id sampler provided with brave-core
+   */
+  @Benchmark
+  public boolean sampler_counting(Args args) {
+    return TRACE_ID_SAMPLER_COUNTING.isSampled(args.traceId);
+  }
+
+  static final Sampler TRACE_ID_SAMPLER_COUNTING = CountingSampler.create(SAMPLE_RATE);
+
+  /**
+   * Finagle's scala sampler samples using modulo 10000 arithmetic, which allows a minimum sample
+   * rate of 0.01%.
+   *
+   * <p>This function is only invoked once per trace, propagating the result downstream as a field
+   * called sampled. This means it is designed for instrumented entry-points.
+   *
+   * <p>Trace id collision was noticed in practice in the Twitter front-end cluster. A random salt
+   * feature was added to defend against nodes in the same cluster sampling exactly the same subset
+   * of trace ids. The goal was full 64-bit coverage of traceIds on multi-host deployments.
+   *
+   * <p>See https://github.com/twitter/finagle/blob/develop/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Sampler.scala#L68
+   */
+  @Benchmark
+  public boolean compare_modulo10000_salted(Args args) {
+    long traceId = args.traceId;
+    long t = Math.abs(traceId ^ SALT);
+    // Minimum sample rate is one in 10000, or 0.01% of traces
+    return t % 10000 < SAMPLE_RATE * 10000; // Constant expression for readability
+  }
+
+  static final long SALT = new Random().nextLong();
+
+  /**
+   * Finagle's ruby sampler gets a random number and compares that against the sample rate.
+   *
+   * <p>This function is only invoked once per trace, propagating the result downstream as a field
+   * called sampled. This means it is designed for instrumented entry-points.
+   *
+   * <p>See https://github.com/twitter/finagle/blob/develop/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb#L135
+   */
+  @Benchmark
+  public boolean compareRandomNumber(Args args) {
+    return RNG.nextFloat() < SAMPLE_RATE; // notice trace id is not used
+  }
+
+  final Random RNG = new Random();
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + SamplerBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/BoundarySampler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BoundarySampler.java
@@ -1,0 +1,53 @@
+package com.github.kristofa.brave;
+
+import java.util.Random;
+
+import static zipkin.internal.Util.checkArgument;
+
+/**
+ * This sampler is appropriate for high-traffic instrumentation (ex edge web servers that each
+ * receive >100K requests) who provision random trace ids, and make the sampling decision only once.
+ * It defends against nodes in the cluster selecting exactly the same ids.
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This uses modulo 10000 arithmetic, which allows a minimum sample rate of 0.01%. Trace id
+ * collision was noticed in practice in the Twitter front-end cluster. A random salt is here to
+ * defend against nodes in the same cluster sampling exactly the same subset of trace ids. The goal
+ * was full 64-bit coverage of trace IDs on multi-host deployments.
+ *
+ * <p>Based on https://github.com/twitter/finagle/blob/develop/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Sampler.scala#L68
+ */
+public final class BoundarySampler extends Sampler {
+  static final long SALT = new Random().nextLong();
+
+  /**
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is
+   * 0.0001, or 0.01% of traces
+   */
+  public static Sampler create(float rate) {
+    if (rate == 0) return Sampler.NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    checkArgument(rate > 0.0001 && rate < 1, "rate should be between 0.0001 and 1: was %s", rate);
+    final long boundary = (long) (rate * 10000); // safe cast as less <= 1
+    return new BoundarySampler(boundary);
+  }
+
+  private final long boundary;
+
+  BoundarySampler(long boundary) {
+    this.boundary = boundary;
+  }
+
+  /** Returns true when {@code abs(traceId) <= boundary} */
+  @Override
+  public boolean isSampled(long traceId) {
+    long t = Math.abs(traceId ^ SALT);
+    return t % 10000 <= boundary;
+  }
+
+  @Override
+  public String toString() {
+    return "BoundaryTraceIdSampler(" + boundary + ")";
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/CountingSampler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/CountingSampler.java
@@ -1,0 +1,77 @@
+package com.github.kristofa.brave;
+
+import java.util.BitSet;
+import java.util.Random;
+
+import static zipkin.internal.Util.checkArgument;
+
+/**
+ * This sampler is appropriate for low-traffic instrumentation (ex servers that each receive <100K
+ * requests), or those who do not provision random trace ids. It not appropriate for collectors as
+ * the sampling decision isn't idempotent (consistent based on trace id).
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This initializes a random bitset of size 100 (corresponding to 1% granularity). This means
+ * that it is accurate in units of 100 traces. At runtime, this loops through the bitset, returning
+ * the value according to a counter.
+ */
+public final class CountingSampler extends Sampler {
+
+  /**
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
+   * or 1% of traces
+   */
+  public static Sampler create(final float rate) {
+    if (rate == 0) return NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    checkArgument(rate >= 0.01f && rate < 1, "rate should be between 0.01 and 1: was %s", rate);
+    return new CountingSampler(rate);
+  }
+
+  private int i; // guarded by this
+  private final BitSet sampleDecisions;
+
+  /** Fills a bitset with decisions according to the supplied rate. */
+  CountingSampler(float rate) {
+    int outOf100 = (int) (rate * 100.0f);
+    this.sampleDecisions = randomBitSet(100, outOf100, new Random());
+  }
+
+  /** loops over the pre-canned decisions, resetting to zero when it gets to the end. */
+  @Override
+  public synchronized boolean isSampled(long traceIdIgnored) {
+    boolean result = sampleDecisions.get(i++);
+    if (i == 100) i = 0;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CountingSampler()";
+  }
+
+  /**
+   * Reservoir sampling algorithm borrowed from Stack Overflow.
+   *
+   * http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+   */
+  static BitSet randomBitSet(int size, int cardinality, Random rnd) {
+    BitSet result = new BitSet(size);
+    int[] chosen = new int[cardinality];
+    int i;
+    for (i = 0; i < cardinality; ++i) {
+      chosen[i] = i;
+      result.set(i);
+    }
+    for (; i < size; ++i) {
+      int j = rnd.nextInt(i + 1);
+      if (j < cardinality) {
+        result.clear(chosen[j]);
+        result.set(i);
+        chosen[j] = i;
+      }
+    }
+    return result;
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/Sampler.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Sampler.java
@@ -1,39 +1,51 @@
 package com.github.kristofa.brave;
 
 /**
- * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. recorded in
- * permanent storage.
+ * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether the
+ * overhead of tracing will occur and/or if a trace will be reported to the collection tier.
  *
  * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
  * trace is made before any work is measured, or annotations are added. As such, the input parameter
  * to zipkin v1 samplers is the trace ID (64-bit random number).
+ *
+ * <p>The instrumentation sampling decision happens once, at the root of the trace, and is
+ * propagated downstream. For this reason, the decision needn't be consistent based on trace ID.
  */
 // abstract for factory-method support on Java language level 7
 public abstract class Sampler {
 
-  /** Returns true if the trace ID should be recorded. */
+  public static final Sampler ALWAYS_SAMPLE = new Sampler() {
+    @Override public boolean isSampled(long traceId) {
+      return true;
+    }
+
+    @Override public String toString() {
+      return "AlwaysSample";
+    }
+  };
+
+  public static final Sampler NEVER_SAMPLE = new Sampler() {
+    @Override public boolean isSampled(long traceId) {
+      return false;
+    }
+
+    @Override public String toString() {
+      return "NeverSample";
+    }
+  };
+
+  /** Returns true if the trace ID should be measured. */
   public abstract boolean isSampled(long traceId);
 
   /**
    * Returns a sampler, given a rate expressed as a percentage.
    *
+   * <p>The sampler returned is good for low volumes of traffic (<100K requests), as it is precise.
+   * If you have high volumes of traffic, consider {@link BoundarySampler}.
+   *
    * @param rate minimum sample rate is 0.0001, or 0.01% of traces
    */
   public static Sampler create(float rate) {
-    return new ZipkinSampler(rate);
-  }
-
-  static final class ZipkinSampler extends Sampler {
-
-    private final zipkin.Sampler delegate;
-
-    ZipkinSampler(float rate) {
-      this.delegate = zipkin.Sampler.create(rate);
-    }
-
-    @Override
-    public boolean isSampled(long traceId) {
-      return delegate.isSampled(traceId);
-    }
+    return CountingSampler.create(rate);
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/BoundarySamplerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/BoundarySamplerTest.java
@@ -1,0 +1,15 @@
+package com.github.kristofa.brave;
+
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class BoundarySamplerTest extends SamplerTest {
+  @Override Sampler newSampler(float rate) {
+    return BoundarySampler.create(rate);
+  }
+
+  @Override Percentage expectedErrorRate() {
+    return withPercentage(10);
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/CountingSamplerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/CountingSamplerTest.java
@@ -1,0 +1,15 @@
+package com.github.kristofa.brave;
+
+import org.assertj.core.data.Percentage;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class CountingSamplerTest extends SamplerTest {
+  @Override Sampler newSampler(float rate) {
+    return CountingSampler.create(rate);
+  }
+
+  @Override Percentage expectedErrorRate() {
+    return withPercentage(0);
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/SamplerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/SamplerTest.java
@@ -1,0 +1,84 @@
+package com.github.kristofa.brave;
+
+import java.util.Random;
+import java.util.function.LongPredicate;
+import org.assertj.core.data.Percentage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Theories.class)
+public abstract class SamplerTest {
+  /**
+   * Zipkin trace ids are random 64bit numbers. This creates a relatively large input to avoid
+   * flaking out due to PRNG nuance.
+   */
+  static final int INPUT_SIZE = 100000;
+
+  abstract Sampler newSampler(float rate);
+
+  abstract Percentage expectedErrorRate();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @DataPoints
+  public static final float[] SAMPLE_RATES = {0.01f, 0.5f, 0.9f};
+
+  @Theory
+  public void retainsPerSampleRate(float sampleRate) {
+    final Sampler sampler = newSampler(sampleRate);
+
+    // parallel to ensure there aren't any unsynchronized race conditions
+    long passed = new Random().longs(INPUT_SIZE).parallel().filter(new LongPredicate() {
+      @Override public boolean test(long traceId) {
+        return sampler.isSampled(traceId);
+      }
+    }).count();
+
+    assertThat(passed)
+        .isCloseTo((long) (INPUT_SIZE * sampleRate), expectedErrorRate());
+  }
+
+  @Test
+  public void zeroMeansDropAllTraces() {
+    final Sampler sampler = newSampler(0.0f);
+
+    assertThat(new Random().longs(INPUT_SIZE).filter(new LongPredicate() {
+      @Override public boolean test(long traceId) {
+        return sampler.isSampled(traceId);
+      }
+    }).findAny()).isEmpty();
+  }
+
+  @Test
+  public void oneMeansKeepAllTraces() {
+    final Sampler sampler = newSampler(1.0f);
+
+    assertThat(new Random().longs(INPUT_SIZE).filter(new LongPredicate() {
+      @Override public boolean test(long traceId) {
+        return sampler.isSampled(traceId);
+      }
+    }).count()).isEqualTo(INPUT_SIZE);
+  }
+
+  @Test
+  public void rateCantBeNegative() {
+    thrown.expect(IllegalArgumentException.class);
+
+    newSampler(-1.0f);
+  }
+
+  @Test
+  public void rateCantBeOverOne() {
+    thrown.expect(IllegalArgumentException.class);
+
+    newSampler(1.1f);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>4.1.6.RELEASE</spring.version>
-    <zipkin.version>0.6.1</zipkin.version>
+    <zipkin.version>0.16.1</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
@@ -49,6 +49,7 @@
 
   <modules>
     <module>brave-core</module>
+    <module>brave-benchmarks</module>
     <module>brave-http</module>
     <module>brave-core-spring</module>
     <module>brave-resteasy-spring</module>


### PR DESCRIPTION
This introduces two options for trace sampling:

* BoundaryTraceIdSampler - For high-volume sites, based on Finagle
* CountingTraceIdSampler - Trades lower performance for high accuracy

These include benchmarks and both work well, although the boundary
one is an order of magnitude faster under contention.

Here's the JMH comparison from my macbook pro and 4 threads:

```
SamplerBenchmarks.sampler_boundary            -9223372036854775808  thrpt   15  875.378 ± 28.245  ops/us
SamplerBenchmarks.sampler_boundary             1234567890987654321  thrpt   15  819.325 ± 81.720  ops/us
SamplerBenchmarks.sampler_counting            -9223372036854775808  thrpt   15   22.777 ±  0.540  ops/us
SamplerBenchmarks.sampler_counting             1234567890987654321  thrpt   15   22.223 ±  0.695  ops/us
```

CountingSampler is a better default, as support questions have come up with boundary tracing. A lot of people don't have much traffic and they can be surprised to find nothing being sampled at all!

This counting sampler is a thread-safe version of the old one, which gives an exact sample rate, per 100 decisions. The decisions are shuffled, so people should get fair decisions even before the 100 interval is over. It can do several samples per microsecond under contention, which is good enough for people getting started.

Basically, by switching to this, people can have a better experience, and save the tricky stuff for later.