### PR TITLE
Handling remote endpoint reporting as SERVER_ADDR binary annotation

### DIFF
--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.httpclient;
 
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
+import com.github.kristofa.brave.http.ClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.SpanNameProvider;
 
 import org.apache.http.HttpRequest;
@@ -15,16 +16,21 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
 
     private final SpanNameProvider spanNameProvider;
     private final ClientRequestInterceptor requestInterceptor;
+    private final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor;
 
     /**
      * Creates a new instance.
      *
      * @param requestInterceptor
      * @param spanNameProvider Provides span name for request.
+     * @param clientRemoteEndpointExtractor Extracts remote endpoint from the request.
      */
-    public BraveHttpRequestInterceptor(ClientRequestInterceptor requestInterceptor, SpanNameProvider spanNameProvider) {
+    public BraveHttpRequestInterceptor(ClientRequestInterceptor requestInterceptor,
+                                       SpanNameProvider spanNameProvider,
+                                       ClientRemoteEndpointExtractor clientRemoteEndpointExtractor) {
         this.requestInterceptor = requestInterceptor;
         this.spanNameProvider = spanNameProvider;
+        this.clientRemoteEndpointExtractor = clientRemoteEndpointExtractor;
     }
 
     /**
@@ -32,7 +38,8 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
      */
     @Override
     public void process(final HttpRequest request, final HttpContext context) {
-        HttpClientRequestAdapter adapter = new HttpClientRequestAdapter(new HttpClientRequestImpl(request), spanNameProvider);
+        HttpClientRequestAdapter adapter = new HttpClientRequestAdapter(
+                new HttpClientRequestImpl(request), spanNameProvider, clientRemoteEndpointExtractor);
         requestInterceptor.handle(adapter);
     }
 }

--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -6,6 +6,7 @@ import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.http.BraveHttpHeaders;
+import com.github.kristofa.brave.http.MissingClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.test.http.DefaultHttpResponseProvider;
 import com.github.kristofa.test.http.HttpRequestImpl;
@@ -79,7 +80,10 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(new ClientRequestInterceptor(clientTracer), new DefaultSpanNameProvider()))
+            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(
+                    new ClientRequestInterceptor(clientTracer),
+                    new DefaultSpanNameProvider(),
+                    new MissingClientRemoteEndpointExtractor()))
                 .addInterceptorFirst(new BraveHttpResponseInterceptor(new ClientResponseInterceptor(clientTracer))).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST);
@@ -115,8 +119,11 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(new ClientRequestInterceptor(clientTracer), new DefaultSpanNameProvider()))
-                        .addInterceptorFirst(new BraveHttpResponseInterceptor(new ClientResponseInterceptor(clientTracer))).build();
+                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(
+                        new ClientRequestInterceptor(clientTracer),
+                        new DefaultSpanNameProvider(),
+                        new MissingClientRemoteEndpointExtractor()))
+                    .addInterceptorFirst(new BraveHttpResponseInterceptor(new ClientResponseInterceptor(clientTracer))).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST);
             final CloseableHttpResponse httpClientResponse = httpclient.execute(httpGet);
@@ -149,7 +156,10 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(new ClientRequestInterceptor(clientTracer), new DefaultSpanNameProvider()))
+                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(
+                        new ClientRequestInterceptor(clientTracer),
+                        new DefaultSpanNameProvider(),
+                        new MissingClientRemoteEndpointExtractor()))
                         .addInterceptorFirst(new BraveHttpResponseInterceptor(new ClientResponseInterceptor(clientTracer))).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST);
@@ -183,7 +193,10 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(new ClientRequestInterceptor(clientTracer), new DefaultSpanNameProvider()))
+                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(
+                        new ClientRequestInterceptor(clientTracer),
+                        new DefaultSpanNameProvider(),
+                        new MissingClientRemoteEndpointExtractor()))
                         .addInterceptorFirst(new BraveHttpResponseInterceptor(new ClientResponseInterceptor(clientTracer))).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST_WITH_QUERY_PARAMS);

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -3,6 +3,7 @@ package com.github.kristofa.brave;
 import java.util.Collection;
 
 import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Endpoint;
 
 /**
  * Adapter used to get tracing information from and add tracing information to a new request.
@@ -36,5 +37,15 @@ public interface ClientRequestAdapter {
      * @return Collection of annotations.
      */
     Collection<KeyValueAnnotation> requestAnnotations();
+
+    /**
+     * Provides the remote server address information for additional tracking.
+     *
+     * Can be useful when communicating with non-traced services by adding server address to span
+     * i.e. {@link com.twitter.zipkin.gen.zipkinCoreConstants#SERVER_ADDR}
+     *
+     * @return request's target server endpoint information
+     */
+    @Nullable Endpoint serverAddress();
 
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
@@ -1,5 +1,7 @@
 package com.github.kristofa.brave;
 
+import com.twitter.zipkin.gen.Endpoint;
+
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
@@ -40,9 +42,16 @@ public class ClientRequestInterceptor {
             for(KeyValueAnnotation annotation : adapter.requestAnnotations()) {
                 clientTracer.submitBinaryAnnotation(annotation.getKey(), annotation.getValue());
             }
-            clientTracer.setClientSent();
+            recordClientSentAnnotations(adapter.serverAddress());
         }
+    }
 
+    private void recordClientSentAnnotations(Endpoint serverAddress) {
+        if (serverAddress == null) {
+            clientTracer.setClientSent();
+        } else {
+            clientTracer.setClientSent(serverAddress.ipv4, serverAddress.port, serverAddress.service_name);
+        }
     }
 
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave;
 
+import com.twitter.zipkin.gen.Endpoint;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -15,6 +16,8 @@ public class ClientRequestInterceptorTest {
     private static final String SERVICE_NAME = "orderService";
     private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
+    private static final int TARGET_IP = 192 << 24 | 168 << 16 | 1;
+    private static final int TARGET_PORT = 80;
     private ClientRequestInterceptor interceptor;
     private ClientTracer clientTracer;
     private ClientRequestAdapter adapter;
@@ -51,6 +54,7 @@ public class ClientRequestInterceptorTest {
         inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
         inOrder.verify(adapter).addSpanIdToRequest(spanId);
         inOrder.verify(adapter).requestAnnotations();
+        inOrder.verify(adapter).serverAddress();
         inOrder.verify(clientTracer).setClientSent();
 
         verifyNoMoreInteractions(clientTracer, adapter);
@@ -71,7 +75,28 @@ public class ClientRequestInterceptorTest {
         inOrder.verify(adapter).requestAnnotations();
         inOrder.verify(clientTracer).submitBinaryAnnotation(ANNOTATION1.getKey(), ANNOTATION1.getValue());
         inOrder.verify(clientTracer).submitBinaryAnnotation(ANNOTATION2.getKey(), ANNOTATION2.getValue());
+        inOrder.verify(adapter).serverAddress();
         inOrder.verify(clientTracer).setClientSent();
+
+        verifyNoMoreInteractions(clientTracer, adapter);
+    }
+
+    @Test
+    public void testServerAddressAdded() {
+        when(adapter.getSpanName()).thenReturn(SPAN_NAME);
+        when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);
+        when(adapter.serverAddress()).thenReturn(Endpoint.create(SERVICE_NAME, TARGET_IP, TARGET_PORT));
+        SpanId spanId = mock(SpanId.class);
+        when(clientTracer.startNewSpan(SPAN_NAME)).thenReturn(spanId);
+        interceptor.handle(adapter);
+
+        InOrder inOrder = inOrder(clientTracer, adapter);
+        inOrder.verify(adapter).getSpanName();
+        inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
+        inOrder.verify(adapter).addSpanIdToRequest(spanId);
+        inOrder.verify(adapter).requestAnnotations();
+        inOrder.verify(adapter).serverAddress();
+        inOrder.verify(clientTracer).setClientSent(TARGET_IP, TARGET_PORT, SERVICE_NAME.toLowerCase());
 
         verifyNoMoreInteractions(clientTracer, adapter);
     }

--- a/brave-grpc/pom.xml
+++ b/brave-grpc/pom.xml
@@ -22,7 +22,7 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <grpc.version>0.13.2</grpc.version>
+        <grpc.version>0.14.0</grpc.version>
         <protobuf.version>3.0.0-beta-2</protobuf.version>
     </properties>
 
@@ -38,6 +38,12 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-examples</artifactId>
             <version>${grpc.version}</version>
         </dependency>
     </dependencies>

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
@@ -1,8 +1,5 @@
 package com.github.kristofa.brave.grpc;
 
-import static com.github.kristofa.brave.grpc.GrpcKeys.GRPC_STATUS_CODE;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
@@ -12,7 +9,6 @@ import com.github.kristofa.brave.ServerResponseAdapter;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
-
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -25,6 +21,9 @@ import io.grpc.Status.Code;
 
 import java.util.Collection;
 import java.util.Collections;
+
+import static com.github.kristofa.brave.grpc.GrpcKeys.GRPC_STATUS_CODE;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class BraveGrpcServerInterceptor implements ServerInterceptor {
 
@@ -57,8 +56,8 @@ public final class BraveGrpcServerInterceptor implements ServerInterceptor {
 
     static final class GrpcServerRequestAdapter<ReqT, RespT> implements ServerRequestAdapter {
 
-        private MethodDescriptor<ReqT, RespT> method;
-        private Metadata requestHeaders;
+        private final MethodDescriptor<ReqT, RespT> method;
+        private final Metadata requestHeaders;
 
         public GrpcServerRequestAdapter(MethodDescriptor<ReqT, RespT> method, Metadata requestHeaders) {
             this.method = checkNotNull(method);

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/ClientRemoteEndpointExtractor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/ClientRemoteEndpointExtractor.java
@@ -1,0 +1,9 @@
+package com.github.kristofa.brave.grpc;
+
+import com.twitter.zipkin.gen.Endpoint;
+import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
+
+public interface ClientRemoteEndpointExtractor {
+    Endpoint remoteEndpoint(Channel channel, MethodDescriptor<?, ?> method);
+}

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/MissingClientRemoteEndpointExtractor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/MissingClientRemoteEndpointExtractor.java
@@ -1,0 +1,12 @@
+package com.github.kristofa.brave.grpc;
+
+import com.twitter.zipkin.gen.Endpoint;
+import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
+
+public class MissingClientRemoteEndpointExtractor implements ClientRemoteEndpointExtractor {
+    @Override
+    public Endpoint remoteEndpoint(Channel channel, MethodDescriptor<?, ?> method) {
+        return null;
+    }
+}

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/GrpcClientRequestAdapterTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/GrpcClientRequestAdapterTest.java
@@ -2,17 +2,21 @@ package com.github.kristofa.brave.grpc;
 
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.grpc.BraveGrpcClientInterceptor.GrpcClientRequestAdapter;
+import io.grpc.Channel;
 import io.grpc.Metadata;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /** Particularly, this demonstrates what metadata values look like for non-java developers. */
 public class GrpcClientRequestAdapterTest {
   Metadata metadata = new Metadata();
+  Channel channel = mock(Channel.class);
+
   GrpcClientRequestAdapter adapter =
-      new GrpcClientRequestAdapter(GreeterGrpc.METHOD_SAY_HELLO, metadata);
+      new GrpcClientRequestAdapter(channel, GreeterGrpc.METHOD_SAY_HELLO, metadata, new MissingClientRemoteEndpointExtractor());
 
   @Test
   public void nullSpanIdMeansUnsampled() throws Exception {

--- a/brave-http/README.md
+++ b/brave-http/README.md
@@ -20,3 +20,7 @@ interfaces are adapters that let you integrate with your library of choice.
 
 The Client/Server Request adapters are also configurable. You can for example choose how a span name is represented.
 There is an implementation called `DefaultSpanNameProvider` which takes the http method as span name.
+
+It is also desirable to report remote services, for which a `ClientRemoteEndpointExtractor` can be added.
+These will be reported as `sa` binary annotations. A `MissingClientRemoteEndpointExtractor`
+default implementation is provided, which does not report the remote endpoint.

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/ClientRemoteEndpointExtractor.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/ClientRemoteEndpointExtractor.java
@@ -1,0 +1,7 @@
+package com.github.kristofa.brave.http;
+
+import com.twitter.zipkin.gen.Endpoint;
+
+public interface ClientRemoteEndpointExtractor {
+    Endpoint remoteEndpoint(HttpRequest request);
+}

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -6,6 +6,7 @@ import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Endpoint;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -15,10 +16,14 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
 
     private final HttpClientRequest request;
     private final SpanNameProvider spanNameProvider;
+    private final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor;
 
-    public HttpClientRequestAdapter(HttpClientRequest request, SpanNameProvider spanNameProvider) {
+    public HttpClientRequestAdapter(HttpClientRequest request,
+                                    SpanNameProvider spanNameProvider,
+                                    ClientRemoteEndpointExtractor clientRemoteEndpointExtractor) {
         this.request = request;
         this.spanNameProvider = spanNameProvider;
+        this.clientRemoteEndpointExtractor = clientRemoteEndpointExtractor;
     }
 
 
@@ -47,5 +52,10 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
         URI uri = request.getUri();
         KeyValueAnnotation annotation = KeyValueAnnotation.create(TraceKeys.HTTP_URL, uri.toString());
         return Arrays.asList(annotation);
+    }
+
+    @Override
+    public Endpoint serverAddress() {
+        return clientRemoteEndpointExtractor.remoteEndpoint(request);
     }
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequest.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequest.java
@@ -1,7 +1,5 @@
 package com.github.kristofa.brave.http;
 
-
-
 public interface HttpServerRequest extends HttpRequest {
 
     /**
@@ -11,5 +9,4 @@ public interface HttpServerRequest extends HttpRequest {
      * @return
      */
     String getHttpHeaderValue(String headerName);
-
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/MissingClientRemoteEndpointExtractor.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/MissingClientRemoteEndpointExtractor.java
@@ -1,0 +1,10 @@
+package com.github.kristofa.brave.http;
+
+import com.twitter.zipkin.gen.Endpoint;
+
+public class MissingClientRemoteEndpointExtractor implements ClientRemoteEndpointExtractor {
+    @Override
+    public Endpoint remoteEndpoint(HttpRequest request) {
+        return null;
+    }
+}

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -26,12 +26,14 @@ public class HttpClientRequestAdapterTest {
     private HttpClientRequestAdapter clientRequestAdapter;
     private HttpClientRequest request;
     private SpanNameProvider spanNameProvider;
+    private ClientRemoteEndpointExtractor clientRemoteEndpointExtractor;
 
     @Before
     public void setup() {
         request = mock(HttpClientRequest.class);
         spanNameProvider = mock(SpanNameProvider.class);
-        clientRequestAdapter = new HttpClientRequestAdapter(request, spanNameProvider);
+        clientRemoteEndpointExtractor = mock(ClientRemoteEndpointExtractor.class);
+        clientRequestAdapter = new HttpClientRequestAdapter(request, spanNameProvider, clientRemoteEndpointExtractor);
     }
 
     @Test
@@ -67,6 +69,13 @@ public class HttpClientRequestAdapterTest {
         verify(request).addHeader(BraveHttpHeaders.Sampled.getName(), "1");
         verify(request).addHeader(BraveHttpHeaders.TraceId.getName(), String.valueOf(TRACE_ID));
         verify(request).addHeader(BraveHttpHeaders.SpanId.getName(), String.valueOf(SPAN_ID));
+        verifyNoMoreInteractions(request, spanNameProvider);
+    }
+
+    @Test
+    public void remoteEndpoint() {
+        clientRequestAdapter.serverAddress();
+        verify(clientRemoteEndpointExtractor).remoteEndpoint(request);
         verifyNoMoreInteractions(request, spanNameProvider);
     }
 

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
@@ -3,6 +3,7 @@ package com.github.kristofa.brave.jaxrs2;
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.http.HttpClientRequest;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
+import com.github.kristofa.brave.http.ClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import javax.annotation.Priority;
 import javax.inject.Inject;
@@ -21,17 +22,21 @@ public class BraveClientRequestFilter implements ClientRequestFilter {
 
     private final ClientRequestInterceptor requestInterceptor;
     private final SpanNameProvider spanNameProvider;
+    private final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor;
 
     @Inject
-    public BraveClientRequestFilter(SpanNameProvider spanNameProvider, ClientRequestInterceptor requestInterceptor) {
+    public BraveClientRequestFilter(SpanNameProvider spanNameProvider,
+                                    ClientRequestInterceptor requestInterceptor,
+                                    ClientRemoteEndpointExtractor clientRemoteEndpointExtractor) {
         this.requestInterceptor = requestInterceptor;
         this.spanNameProvider = spanNameProvider;
+        this.clientRemoteEndpointExtractor = clientRemoteEndpointExtractor;
     }
 
 
     @Override
     public void filter(ClientRequestContext clientRequestContext) throws IOException {
         final HttpClientRequest req = new JaxRs2HttpClientRequest(clientRequestContext);
-        requestInterceptor.handle(new HttpClientRequestAdapter(req, spanNameProvider));
+        requestInterceptor.handle(new HttpClientRequestAdapter(req, spanNameProvider, clientRemoteEndpointExtractor));
     }
 }

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
@@ -1,18 +1,17 @@
 package com.github.kristofa.brave.jaxrs2;
 
-import com.github.kristofa.brave.*;
+import com.github.kristofa.brave.ServerRequestInterceptor;
 import com.github.kristofa.brave.http.HttpServerRequest;
 import com.github.kristofa.brave.http.HttpServerRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
 
-import java.io.IOException;
-
-import javax.inject.Inject;
 import javax.annotation.Priority;
+import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.ext.Provider;
+import java.io.IOException;
 
 /**
  * Intercepts incoming container requests and extracts any trace information from the request header
@@ -34,7 +33,6 @@ public class BraveContainerRequestFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext containerRequestContext) throws IOException {
-
         HttpServerRequest request = new JaxRs2HttpServerRequest(containerRequestContext);
         requestInterceptor.handle(new HttpServerRequestAdapter(request, spanNameProvider));
     }

--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveJersey2.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveJersey2.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.jersey2;
 
 import com.github.kristofa.brave.*;
+import com.github.kristofa.brave.http.MissingClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import com.github.kristofa.brave.jaxrs2.BraveClientRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveClientResponseFilter;
@@ -35,7 +36,8 @@ public class ITBraveJersey2 extends JerseyTest {
     @Test
     public void testBraveJersey2() {
         WebTarget target = target("/brave-jersey2/test");
-        target.register(new BraveClientRequestFilter(spanNameProvider, clientRequestInterceptor));
+        target.register(new BraveClientRequestFilter(
+                spanNameProvider, clientRequestInterceptor, new MissingClientRemoteEndpointExtractor()));
         target.register(new BraveClientResponseFilter(clientResponseInterceptor));
 
         final Response response = target.request().get();

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
@@ -43,6 +43,7 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
     private final ClientRequestInterceptor requestInterceptor;
     private final ClientResponseInterceptor responseInterceptor;
     private final SpanNameProvider spanNameProvider;
+    private final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor;
 
     /**
      * Create a new instance.
@@ -52,10 +53,14 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
      * @param responseInterceptor Client response interceptor.
      */
     @Autowired
-    public BraveClientExecutionInterceptor(SpanNameProvider spanNameProvider, ClientRequestInterceptor requestInterceptor, ClientResponseInterceptor responseInterceptor) {
+    public BraveClientExecutionInterceptor(SpanNameProvider spanNameProvider,
+                                           ClientRequestInterceptor requestInterceptor,
+                                           ClientResponseInterceptor responseInterceptor,
+                                           ClientRemoteEndpointExtractor clientRemoteEndpointExtractor) {
         this.requestInterceptor = requestInterceptor;
         this.spanNameProvider = spanNameProvider;
         this.responseInterceptor = responseInterceptor;
+        this.clientRemoteEndpointExtractor = clientRemoteEndpointExtractor;
     }
 
     /**
@@ -67,7 +72,8 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
         final ClientRequest request = ctx.getRequest();
 
         final HttpClientRequest httpClientRequest = new RestEasyHttpClientRequest(request);
-        final ClientRequestAdapter adapter = new HttpClientRequestAdapter(httpClientRequest, spanNameProvider);
+        final ClientRequestAdapter adapter = new HttpClientRequestAdapter(
+                httpClientRequest, spanNameProvider, clientRemoteEndpointExtractor);
         requestInterceptor.handle(adapter);
 
         ClientResponse<?> response = null;

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePreProcessInterceptor.java
@@ -1,13 +1,6 @@
 package com.github.kristofa.brave.resteasy;
 
-import java.util.logging.Logger;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.ext.Provider;
-
-import com.github.kristofa.brave.*;
+import com.github.kristofa.brave.ServerRequestInterceptor;
 import com.github.kristofa.brave.http.HttpServerRequest;
 import com.github.kristofa.brave.http.HttpServerRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
@@ -19,6 +12,11 @@ import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.interception.PreProcessInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
 
 
 /**

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveResteasy.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveResteasy.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.resteasy3;
 
 import com.github.kristofa.brave.*;
+import com.github.kristofa.brave.http.MissingClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import com.github.kristofa.brave.jaxrs2.BraveClientRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveClientResponseFilter;
@@ -75,7 +76,8 @@ public class ITBraveResteasy {
 
         final BraveRestEasyResource client =
                 new ResteasyClientBuilder().build().target("http://localhost:8080/BraveRestEasyIntegration")
-                        .register(new BraveClientRequestFilter(spanNameProvider, clientRequestInterceptor))
+                        .register(new BraveClientRequestFilter(
+                                spanNameProvider, clientRequestInterceptor, new MissingClientRemoteEndpointExtractor()))
                         .register(new BraveClientResponseFilter(clientResponseInterceptor))
                         .proxy(BraveRestEasyResource.class);
 

--- a/brave-spring-resttemplate-interceptors/src/main/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptor.java
+++ b/brave-spring-resttemplate-interceptors/src/main/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptor.java
@@ -5,6 +5,7 @@ import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.NoAnnotationsClientResponseAdapter;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
+import com.github.kristofa.brave.http.ClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
@@ -31,6 +32,7 @@ public class BraveClientHttpRequestInterceptor implements ClientHttpRequestInter
     private final ClientRequestInterceptor requestInterceptor;
     private final ClientResponseInterceptor responseInterceptor;
     private final SpanNameProvider spanNameProvider;
+    private final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor;
 
     /**
      * Creates a new instance.
@@ -39,17 +41,21 @@ public class BraveClientHttpRequestInterceptor implements ClientHttpRequestInter
      * @param requestInterceptor Client request interceptor.
      * @param responseInterceptor Client response interceptor.
      */
-    public BraveClientHttpRequestInterceptor(final ClientRequestInterceptor requestInterceptor, final ClientResponseInterceptor responseInterceptor,
-                                             final SpanNameProvider spanNameProvider) {
+    public BraveClientHttpRequestInterceptor(final ClientRequestInterceptor requestInterceptor,
+                                             final ClientResponseInterceptor responseInterceptor,
+                                             final SpanNameProvider spanNameProvider,
+                                             final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor) {
         this.requestInterceptor = requestInterceptor;
         this.responseInterceptor = responseInterceptor;
         this.spanNameProvider = spanNameProvider;
+        this.clientRemoteEndpointExtractor = clientRemoteEndpointExtractor;
     }
 
     @Override
     public ClientHttpResponse intercept(final HttpRequest request, final byte[] body, final ClientHttpRequestExecution execution) throws IOException {
 
-        requestInterceptor.handle(new HttpClientRequestAdapter(new SpringHttpClientRequest(request), spanNameProvider));
+        requestInterceptor.handle(new HttpClientRequestAdapter(
+                new SpringHttpClientRequest(request), spanNameProvider, clientRemoteEndpointExtractor));
 
         final ClientHttpResponse response;
 

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -5,6 +5,7 @@ import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceKeys;
+import com.github.kristofa.brave.http.ClientRemoteEndpointExtractor;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -29,8 +30,12 @@ public class BraveClientHttpRequestInterceptorTest {
 
     private final ClientTracer clientTracer = mock(ClientTracer.class);
     private final SpanNameProvider spanNameProvider = mock(SpanNameProvider.class);
-    private final BraveClientHttpRequestInterceptor subject = new BraveClientHttpRequestInterceptor(new ClientRequestInterceptor(clientTracer),
-            new ClientResponseInterceptor(clientTracer), spanNameProvider);
+    private final ClientRemoteEndpointExtractor clientRemoteEndpointExtractor = mock(ClientRemoteEndpointExtractor.class);
+    private final BraveClientHttpRequestInterceptor subject = new BraveClientHttpRequestInterceptor(
+            new ClientRequestInterceptor(clientTracer),
+            new ClientResponseInterceptor(clientTracer),
+            spanNameProvider,
+            clientRemoteEndpointExtractor);
 
     @Test(expected = IOException.class)
     public void interceptShouldLetExceptionOccurringDuringExecuteBlowUp() throws Exception {


### PR DESCRIPTION
A recent change in the way Spans for Client Requests are constructed have affected some clients, which reported the CLIENT_SEND annotation with the remote endpoint information. Now the local endpoint will be used, therefore for some clients the recent change might occur as missing non-traced services in the UI.
This PR uses an existing API in the `ClientTracer` for adding a binary annotation with the remote endpoint metadata.
The changes are backwards compatible and the actual extraction of the `Endpoint` is the users' responsibility.