### PR TITLE
Remote endpoint reporting as SERVER_ADDR binary annotation

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -3,6 +3,7 @@ package com.github.kristofa.brave;
 import java.util.Collection;
 
 import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Endpoint;
 
 /**
  * Adapter used to get tracing information from and add tracing information to a new request.
@@ -37,4 +38,14 @@ public interface ClientRequestAdapter {
      */
     Collection<KeyValueAnnotation> requestAnnotations();
 
+    /**
+     * Provides the remote server address information for additional tracking.
+     *
+     * Can be useful when communicating with non-traced services by adding server address to span
+     * i.e. {@link com.twitter.zipkin.gen.zipkinCoreConstants#SERVER_ADDR}
+     *
+     * @return request's target server endpoint information
+     */
+    @Nullable
+    Endpoint serverAddress();
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
@@ -1,5 +1,7 @@
 package com.github.kristofa.brave;
 
+import com.twitter.zipkin.gen.Endpoint;
+
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
@@ -37,12 +39,18 @@ public class ClientRequestInterceptor {
             adapter.addSpanIdToRequest(null);
         } else {
             adapter.addSpanIdToRequest(spanId);
-            for(KeyValueAnnotation annotation : adapter.requestAnnotations()) {
+            for (KeyValueAnnotation annotation : adapter.requestAnnotations()) {
                 clientTracer.submitBinaryAnnotation(annotation.getKey(), annotation.getValue());
             }
-            clientTracer.setClientSent();
+            recordClientSentAnnotations(adapter.serverAddress());
         }
-
     }
 
+    private void recordClientSentAnnotations(Endpoint serverAddress) {
+        if (serverAddress == null) {
+            clientTracer.setClientSent();
+        } else {
+            clientTracer.setClientSent(serverAddress.ipv4, serverAddress.port, serverAddress.service_name);
+        }
+    }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave;
 
+import com.twitter.zipkin.gen.Endpoint;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -13,6 +14,8 @@ public class ClientRequestInterceptorTest {
 
     private static final String SPAN_NAME = "getOrders";
     private static final String SERVICE_NAME = "orderService";
+    private static final int TARGET_IP = 192 << 24 | 168 << 16 | 1;
+    private static final int TARGET_PORT = 80;
     private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
     private ClientRequestInterceptor interceptor;
@@ -51,6 +54,7 @@ public class ClientRequestInterceptorTest {
         inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
         inOrder.verify(adapter).addSpanIdToRequest(spanId);
         inOrder.verify(adapter).requestAnnotations();
+        inOrder.verify(adapter).serverAddress();
         inOrder.verify(clientTracer).setClientSent();
 
         verifyNoMoreInteractions(clientTracer, adapter);
@@ -71,10 +75,29 @@ public class ClientRequestInterceptorTest {
         inOrder.verify(adapter).requestAnnotations();
         inOrder.verify(clientTracer).submitBinaryAnnotation(ANNOTATION1.getKey(), ANNOTATION1.getValue());
         inOrder.verify(clientTracer).submitBinaryAnnotation(ANNOTATION2.getKey(), ANNOTATION2.getValue());
+        inOrder.verify(adapter).serverAddress();
         inOrder.verify(clientTracer).setClientSent();
 
         verifyNoMoreInteractions(clientTracer, adapter);
     }
 
+    @Test
+    public void testServerAddressAdded() {
+        when(adapter.getSpanName()).thenReturn(SPAN_NAME);
+        when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);
+        when(adapter.serverAddress()).thenReturn(Endpoint.create(SERVICE_NAME, TARGET_IP, TARGET_PORT));
+        SpanId spanId = SpanId.builder().spanId(1L).build();
+        when(clientTracer.startNewSpan(SPAN_NAME)).thenReturn(spanId);
+        interceptor.handle(adapter);
+
+        InOrder inOrder = inOrder(clientTracer, adapter);
+        inOrder.verify(adapter).getSpanName();
+        inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
+        inOrder.verify(adapter).addSpanIdToRequest(spanId);
+        inOrder.verify(adapter).requestAnnotations();
+        inOrder.verify(adapter).serverAddress();
+        inOrder.verify(clientTracer).setClientSent(TARGET_IP, TARGET_PORT, SERVICE_NAME.toLowerCase());
+        verifyNoMoreInteractions(clientTracer, adapter);
+    }
 
 }

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcClientInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcClientInterceptor.java
@@ -10,6 +10,7 @@ import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -21,6 +22,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.Status.Code;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -99,6 +101,10 @@ public final class BraveGrpcClientInterceptor implements ClientInterceptor {
             return Collections.emptyList();
         }
 
+        @Override
+        public Endpoint serverAddress() {
+            return null;
+        }
     }
 
     static final class GrpcClientResponseAdapter implements ClientResponseAdapter {

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -6,6 +6,7 @@ import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Endpoint;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -47,5 +48,10 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
         URI uri = request.getUri();
         KeyValueAnnotation annotation = KeyValueAnnotation.create(TraceKeys.HTTP_URL, uri.toString());
         return Arrays.asList(annotation);
+    }
+
+    @Override
+    public Endpoint serverAddress() {
+        return null;
     }
 }


### PR DESCRIPTION
A recent change in the way Spans for Client Requests are constructed have affected some clients, which reported the CLIENT_SEND annotation with the remote endpoint information. Now the local endpoint will be used, therefore for some clients the recent change might occur as missing non-traced services in the UI.
This PR uses an existing API in the ClientTracer for adding a binary annotation with the remote endpoint metadata.
The changes are backwards compatible and the actual extraction of the Endpoint is the users' responsibility by implementing their own request adapters and interceptors.