### PR TITLE
Uses OpenZipkin deploy process and migrates to io.zipkin.brave group id

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip

--- a/.settings.xml
+++ b/.settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype</id>
+      <username>${env.SONATYPE_USER}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>bintray</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>jfrog-snapshots</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>github.com</id>
+      <username>${env.GH_USER}</username>
+      <password>${env.GH_TOKEN}</password>
+    </server>
+  </servers>
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,52 @@
 sudo: false
+
 cache:
   directories:
   - $HOME/.m2
+
 language: java
-script: "./mvnw verify"
+
 jdk:
   - oraclejdk8
+
+before_install:
+  # Parameters used during release
+  - git config user.name "$GH_USER"
+  - git config user.email "$GH_USER_EMAIL"
+  # setup https authentication credentials, used by ./mvnw release:prepare
+  - git config credential.helper "store --file=.git/credentials"
+  - echo "https://$GH_TOKEN:@github.com" > .git/credentials
+
+install:
+  # Override default travis to use the maven wrapper
+  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+script:
+  - ./travis/publish.sh
+
+# Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
+# See https://github.com/travis-ci/travis-ci/issues/1532
+branches:
+  except:
+    - /^[0-9]/
+
+env:
+  global:
+  # Ex. travis encrypt BINTRAY_USER=your_github_account
+  - secure: "JkYf85iTVHAQb+gyuKwstLApmzUvSfwEdR9nBUypQv8wgLQIi8jry461eESt6nX96votG4EC4e0olZlfYCWVbd2dF/t9VzUT8xZr5aPgP/RRNpJVnJ96UKciAScRAm41NFgXJQojlIeUJEP98eugSMceijHEEAvRcWOOH1PTHUM="
+  # Ex. travis encrypt BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx --add
+  - secure: "Rgi25T93QYhJCyQq1AATA0hpY5Tr7uJkEeFw5vHfVIv9ampPpGv9kYVkoVclThRT/V+QAyA03ii15onXySMxcYvSt2kZ2CrV4hPvQ/Pz0Be8/snM9HT4kbc6RQmJLkYgtIoe5OJSHl0lfzz1vha1fIEyLngDcajh3HZjJgUZMRc="
+  # Ex. travis encrypt GH_USER_EMAIL=for_github@domain.com --add
+  - secure: "dFn6U2yHVpRGE28dKxMNIbtMKs+5gLTfpPvc2zAs6E7XYBFYrsPLbRpVTuBnNTEzONnyEnp23BlUurMi17njIZ6x1dUIcgxBHIznPpP7e1pd8jCedl9byGy9rgkhM+mlfZL2pZqrLz/GYlJaZm53G/YGu2668eGGnysotpQz/wo="
+  # Ex. travis encrypt GH_USER=your_github_account --add
+  - secure: "kF9AxbQqxnmiO0BB79ck0A9tPSGAJoT8qVpQyTkNthWcPPlCmI0eurZ3SnjcJgCaVsseEY5vg+wH3Ao3+ZqEsaK45Jq8Sb2t6ikcTxOWbP2b0B2KRLcDkBpukeMID3qPXcvTX+0DQ2xQ3dVdVNJEclklWpsRy6KxbEv3d7JaiTU="
+  # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX --add
+  - secure: "VErYjLinb0aEv0momgbhC+vykT1ITrAgzvlooXIyA8hBPF9gvMM5sbhG9KX1UKX83uTPL6PqZW4PCs+b6WjjQwyPO/qAG8dNDl/X4IZ7cL4/NIKwDlT4mBvYtmDn7F146rvGRK+isM7BgxpqQXTj/sCboAgGriSPTTlk303KM0c="
+  # Ex. travis encrypt SONATYPE_USER=your_sonatype_account
+  - secure: "a30efC2iKHFlrtdFG0HgrNQQhiosmTRPRR0FUviqvQtBoBg3/U4o6Rqee27PVKq8m/tJ1GwLufZFMcvSMCzPs/D/sggqUw6a0wUNTjG6lpbQWy2lLpnw3RwqK46bY+jZsV2SxLyElbZOOC/qHzsPJooocuwwXvDkvRmYxocgiMc="
+  # Ex. travis encrypt SONATYPE_PASSWORD=your_sonatype_password
+  - secure: "XD8xiZw82rGZ0IK+xYJjfOTVsNdfliLdsT7izRrLt3LePj4ixQt0sD7z7RgVimYRQ8cqq0uuAU612DtWv/MrU0KQL33xYNWSKK3qw0K8ZYfch7/nJStU5LTqepC6Vldfn87X5KzgVIOoYCQpWkmUjI4Xpr4dnYrnmu+l2kpFCuY="
+
 notifications:
   webhooks:
     urls:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+# Brave Release Process
+
+This repo uses semantic versions. Please keep this in mind when choosing version numbers.
+
+1. **Alert others you are releasing**
+
+   There should be no commits made to master while the release is in progress (about 10 minutes). Before you start
+   a release, alert others on [gitter](https://gitter.im/openzipkin/zipkin) so that they don't accidentally merge
+   anything. If they do, and the build fails because of that, you'll have to recreate the release tag described below.
+
+1. **Push a git tag**
+
+   The tag should be of the format `release-N.M.L`, for example `release-3.7.1`.
+
+1. **Wait for Travis CI**
+
+   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
+   the version, publishes artifacts, and syncs to Maven Central.

--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
@@ -28,7 +28,7 @@
         <artifactId>httpcore</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-http</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </dependency>

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>

--- a/brave-core-spring/pom.xml
+++ b/brave-core-spring/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
@@ -27,7 +27,7 @@
   </properties>
   <dependencies>
      <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-core</artifactId>
         <version>3.7.1-SNAPSHOT</version>
      </dependency>

--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
@@ -97,7 +97,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/brave-grpc/pom.xml
+++ b/brave-grpc/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>brave</artifactId>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
     <artifactId>brave-grpc</artifactId>
@@ -30,7 +30,7 @@
 
         <!-- brave-http contains propagation header keys (BraveHttpHeaders) -->
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-http</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/brave-http/pom.xml
+++ b/brave-http/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
@@ -27,7 +27,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>

--- a/brave-jaxrs2/pom.xml
+++ b/brave-jaxrs2/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>brave</artifactId>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
     <artifactId>brave-jaxrs2</artifactId>
@@ -27,7 +27,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-http</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>
@@ -57,7 +57,7 @@
 
         <!--Test Dependencies-->
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core-spring</artifactId>
             <version>3.7.1-SNAPSHOT</version>
             <scope>test</scope>

--- a/brave-jersey/pom.xml
+++ b/brave-jersey/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>brave</artifactId>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
    <artifactId>brave-jersey</artifactId>
@@ -26,12 +26,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-http</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-web-servlet-filter</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>brave</artifactId>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
     <artifactId>brave-jersey2</artifactId>
@@ -27,7 +27,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-jaxrs2</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>
@@ -67,7 +67,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core-spring</artifactId>
             <version>3.7.1-SNAPSHOT</version>
             <scope>test</scope>

--- a/brave-mysql/pom.xml
+++ b/brave-mysql/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>brave</artifactId>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
    <artifactId>brave-mysql</artifactId>
@@ -26,7 +26,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>

--- a/brave-okhttp/pom.xml
+++ b/brave-okhttp/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>brave</artifactId>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -35,7 +35,7 @@
       <version>${okhttp.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.kristofa</groupId>
+      <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-http</artifactId>
       <version>3.7.1-SNAPSHOT</version>
     </dependency>

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-  	<groupId>com.github.kristofa</groupId>
+  	<groupId>io.zipkin.brave</groupId>
 	<artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>   
@@ -29,7 +29,7 @@
   
   <dependencies>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-http</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </dependency>
@@ -69,7 +69,7 @@
        <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-core-spring</artifactId>
         <version>3.7.1-SNAPSHOT</version>
         <scope>test</scope>

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-  	<groupId>com.github.kristofa</groupId>
+  	<groupId>io.zipkin.brave</groupId>
 	<artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>   
@@ -29,12 +29,12 @@
   
   <dependencies>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-http</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </dependency>
       <dependency>
-          <groupId>com.github.kristofa</groupId>
+          <groupId>io.zipkin.brave</groupId>
           <artifactId>brave-jaxrs2</artifactId>
           <version>3.7.1-SNAPSHOT</version>
       </dependency>
@@ -74,7 +74,7 @@
        <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-core-spring</artifactId>
         <version>3.7.1-SNAPSHOT</version>
         <scope>test</scope>

--- a/brave-sampler-zookeeper/pom.xml
+++ b/brave-sampler-zookeeper/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
@@ -26,7 +26,7 @@
   </properties>
   <dependencies>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-core</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </dependency>

--- a/brave-spancollector-http/pom.xml
+++ b/brave-spancollector-http/pom.xml
@@ -2,7 +2,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
@@ -27,7 +27,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>

--- a/brave-spancollector-kafka/pom.xml
+++ b/brave-spancollector-kafka/pom.xml
@@ -2,7 +2,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
@@ -36,7 +36,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>

--- a/brave-spancollector-scribe/pom.xml
+++ b/brave-spancollector-scribe/pom.xml
@@ -2,7 +2,7 @@
   
   <modelVersion>4.0.0</modelVersion>
   <parent>
-  	<groupId>com.github.kristofa</groupId>
+  	<groupId>io.zipkin.brave</groupId>
 	<artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>   
@@ -33,7 +33,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-core</artifactId>
         <version>3.7.1-SNAPSHOT</version>
     </dependency>

--- a/brave-spring-resttemplate-interceptors/pom.xml
+++ b/brave-spring-resttemplate-interceptors/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
@@ -15,7 +15,7 @@
 
   <dependencies>
      <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-http</artifactId>
         <version>3.7.1-SNAPSHOT</version>
      </dependency>

--- a/brave-spring-web-servlet-interceptor/pom.xml
+++ b/brave-spring-web-servlet-interceptor/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.github.kristofa</groupId>
+    <groupId>io.zipkin.brave</groupId>
     <artifactId>brave</artifactId>
     <version>3.7.1-SNAPSHOT</version>
   </parent>
@@ -19,7 +19,7 @@
 
     <dependencies>
      <dependency>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-http</artifactId>
         <version>3.7.1-SNAPSHOT</version>
      </dependency>
@@ -29,7 +29,7 @@
         <scope>provided</scope>
      </dependency>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core-spring</artifactId>
             <version>3.7.1-SNAPSHOT</version>
             <scope>test</scope>

--- a/brave-web-servlet-filter/pom.xml
+++ b/brave-web-servlet-filter/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>brave</artifactId>
-        <groupId>com.github.kristofa</groupId>
+        <groupId>io.zipkin.brave</groupId>
         <version>3.7.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -20,12 +20,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-http</artifactId>
             <version>3.7.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-core-spring</artifactId>
             <version>3.7.1-SNAPSHOT</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.github.kristofa</groupId>
+  <groupId>io.zipkin.brave</groupId>
   <artifactId>brave</artifactId>
   <version>3.7.1-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -40,11 +40,16 @@
     <zipkin.version>0.17.1</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
-    <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
-    <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
-    <maven-source-plugin.version>2.4</maven-source-plugin.version>
+
+    <maven-plugin.version>0.3.3</maven-plugin.version>
+    <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+    <maven-source-plugin.version>3.0.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
+    <centralsync-maven-plugin.version>0.1.0</centralsync-maven-plugin.version>
   </properties>
 
   <modules>
@@ -71,15 +76,20 @@
   </modules>
 
   <distributionManagement>
-    <snapshotRepository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
     <repository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>bintray</id>
+      <url>https://api.bintray.com/maven/openzipkin/maven/zipkin-java/;publish=1</url>
     </repository>
+    <snapshotRepository>
+      <id>jfrog-snapshots</id>
+      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    </snapshotRepository>
   </distributionManagement>
+
+  <issueManagement>
+    <system>Github</system>
+    <url>https://github.com/openzipkin/brave/issues</url>
+  </issueManagement>
 
   <dependencyManagement>
   	<dependencies>
@@ -207,6 +217,31 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.3.9 -->
+        <plugin>
+          <groupId>io.takari</groupId>
+          <artifactId>maven</artifactId>
+          <version>${maven-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven-jar-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
         <resources>
             <resource>
                 <filtering>false</filtering>
@@ -243,7 +278,6 @@
           <plugin>
               <inherited>true</inherited>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.1</version>
               <configuration>
                   <source>1.8</source>
                   <target>1.8</target>
@@ -305,11 +339,6 @@
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-deploy-plugin</artifactId>
-              <version>2.7</version>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-failsafe-plugin</artifactId>
               <version>2.14</version>
               <executions>
@@ -327,80 +356,76 @@
                   </execution>
               </executions>
           </plugin>
-          <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <version>${nexus-staging-maven-plugin.version}</version>
-              <extensions>true</extensions>
-              <configuration>
-                  <serverId>ossrh</serverId>
-                  <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                  <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              </configuration>
-          </plugin>
+      <!-- Ensures checksums are added to published jars -->
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin.version}</version>
+        <configuration>
+          <createChecksum>true</createChecksum>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>${maven-release-plugin.version}</version>
+        <configuration>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <!-- to match zipkin-scala (openzipkin/zipkin) -->
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
 
+      <plugin>
+        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
+        <artifactId>centralsync-maven-plugin</artifactId>
+        <version>${centralsync-maven-plugin.version}</version>
+        <configuration>
+          <packageName>zipkin-java</packageName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <!-- Creates source jar -->
           <plugin>
-              <artifactId>maven-release-plugin</artifactId>
-              <version>${maven-release-plugin.version}</version>
-              <configuration>
-                  <autoVersionSubmodules>true</autoVersionSubmodules>
-                  <useReleaseProfile>false</useReleaseProfile>
-                  <releaseProfiles>release</releaseProfiles>
-                  <goals>deploy</goals>
-              </configuration>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven-source-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
-      </plugins>
-    </build>
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <additionalJOption>-Xdoclint:none</additionalJOption>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>${maven-gpg-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+          <!-- Creates javadoc jar -->
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <configuration>
+              <failOnError>false</failOnError>
+              <!-- hush pedantic warnings: we don't put param and return on everything! -->
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -euo pipefail
+set -x
+
+build_started_by_tag() {
+  if [ "${TRAVIS_TAG}" == "" ]; then
+    echo "[Publishing] This build was not started by a tag, publishing snapshot"
+    return 1
+  else
+    echo "[Publishing] This build was started by the tag ${TRAVIS_TAG}, publishing release"
+    return 0
+  fi
+}
+
+is_pull_request() {
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "[Not Publishing] This is a Pull Request"
+    return 0
+  else
+    echo "[Publishing] This is not a Pull Request"
+    return 1
+  fi
+}
+
+is_travis_branch_master() {
+  if [ "${TRAVIS_BRANCH}" = master ]; then
+    echo "[Publishing] Travis branch is master"
+    return 0
+  else
+    echo "[Not Publishing] Travis branch is not master"
+    return 1
+  fi
+}
+
+check_travis_branch_equals_travis_tag() {
+  #Weird comparison comparing branch to tag because when you 'git push --tags'
+  #the branch somehow becomes the tag value
+  #github issue: https://github.com/travis-ci/travis-ci/issues/1675
+  if [ "${TRAVIS_BRANCH}" != "${TRAVIS_TAG}" ]; then
+    echo "Travis branch does not equal Travis tag, which it should, bailing out."
+    echo "  github issue: https://github.com/travis-ci/travis-ci/issues/1675"
+    exit 1
+  else
+    echo "[Publishing] Branch (${TRAVIS_BRANCH}) same as Tag (${TRAVIS_TAG})"
+  fi
+}
+
+check_release_tag() {
+    tag="${TRAVIS_TAG}"
+    if [[ "$tag" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+        echo "Build started by version tag $tag. During the release process tags like this"
+        echo "are created by the 'release' Maven plugin. Nothing to do here."
+        exit 0
+    elif [[ ! "$tag" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+        echo "You must specify a tag of the format 'release-0.0.0' to release this project."
+        echo "The provided tag ${tag} doesn't match that. Aborting."
+        exit 1
+    fi
+}
+
+is_release_commit() {
+  project_version=$(./mvnw help:evaluate -N -Dexpression=project.version|grep -v '\[')
+  if [[ "$project_version" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+    echo "Build started by release commit $project_version. Will synchronize to maven central."
+    return 0
+  else
+    return 1
+  fi
+}
+
+release_version() {
+    echo "${TRAVIS_TAG}" | sed 's/^release-//'
+}
+
+safe_checkout_master() {
+  # We need to be on a branch for release:perform to be able to create commits, and we want that branch to be master.
+  # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
+  # master is where our tag is.
+  git checkout -B master
+  git fetch origin master:origin/master
+  commit_local_master="$(git show --pretty='format:%H' master)"
+  commit_remote_master="$(git show --pretty='format:%H' origin/master)"
+  if [ "$commit_local_master" != "$commit_remote_master" ]; then
+    echo "Master on remote 'origin' has commits since the version under release, aborting"
+    exit 1
+  fi
+}
+
+#----------------------
+# MAIN
+#----------------------
+
+if ! is_pull_request && build_started_by_tag; then
+  check_travis_branch_equals_travis_tag
+  check_release_tag
+fi
+
+./mvnw install -nsu
+
+# If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
+if is_pull_request; then
+  true
+# If we are on master, we will deploy the latest snapshot or release version
+#   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
+elif is_travis_branch_master; then
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -pl -:brave-benchmarks -DskipTests deploy
+
+  # If the deployment succeeded, sync it to Maven Central. Note: this needs to be done once per project, not module, hence -N
+  if is_release_commit; then
+    ./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
+  fi
+
+# If we are on a release tag, the following will update any version references and push a version tag for deployment.
+elif build_started_by_tag; then
+  safe_checkout_master
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
+fi
+


### PR DESCRIPTION
This re-uses the deployment flow from zipkin-java which has the
following features:

* Makes Brave releaseable by anyone with access to the Bintray org
* Snapshot publishing to http://oss.jfrog.org/artifactory/oss-snapshot-local
* Fully automated release to maven central via release-N.N.N tag
  * Releases also published to https://jcenter.bintray.com

Notably, this migrates the maven group id to `io.zipkin.brave`. This
needs to be communicated on release!

Fixes #161