### PR TITLE
Moves to less buggy travis slave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-sudo: false
+# Default JDK is really old: 1.8.0_31; Trusty's is less old: 1.8.0_51
+# https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+sudo: required
+dist: trusty
 
 cache:
   directories:


### PR DESCRIPTION
The default travis server runs JDK 1.8.0_31, and upgrades aren't likely:
https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-159685511

This moves to trusty, which has a newer 1.8.0_51