### PR TITLE
Update groupId in maven central shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # brave #
 
 [![Build Status](https://travis-ci.org/openzipkin/brave.svg?branch=master)](https://travis-ci.org/openzipkin/brave)
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.kristofa/brave.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.kristofa/brave)
+[![Maven Central](https://img.shields.io/maven-central/v/io.zipkin.brave/brave.svg)](https://maven-badges.herokuapp.com/maven-central/io.zipkin.brave/brave)
 
 Java Distributed Tracing implementation compatible with [Zipkin](http://zipkin.io).
 


### PR DESCRIPTION
The Maven Central shield did not display latest brave
version because the groupId was not updated.


/cc @adriancole 