### PR TITLE
Moves to zipkin 1.0

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -24,7 +24,6 @@
   </properties>
 
   <dependencies>
-    <!-- for sampler... don't worry. this dependency is shaded out! -->
     <dependency>
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin</artifactId>
@@ -94,29 +93,6 @@
                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadeTestJar>false</shadeTestJar>
-                            <minimizeJar>true</minimizeJar>
-                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-                            <!-- Use of zipkin-java is internal only; don't add dependency -->
-                            <relocations>
-                                <relocation>
-                                    <pattern>zipkin</pattern>
-                                    <shadedPattern>com.github.kristofa.brave.internal.zipkin</shadedPattern>
-                                </relocation>
-                            </relocations>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>4.1.6.RELEASE</spring.version>
-    <zipkin.version>0.21.5</zipkin.version>
+    <zipkin.version>1.0.0</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
 


### PR DESCRIPTION
zipkin 1.0 is a stable release with semantic version guarantees. This
means we can depend on it directly and not need to shade it.

By not shading it, we have the advantage of other integrations working
without classpath confusion. For example, someone can make a span
collector that writes to zipkin storage directly.