### PR TITLE
Adds LocalSpanCollector

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
@@ -1,101 +1,30 @@
 package com.github.kristofa.brave;
 
-import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Span;
 import com.twitter.zipkin.gen.SpanCodec;
-import java.io.Closeable;
-import java.io.Flushable;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Implemented {@link #sendSpans} to transport a encoded list of spans to Zipkin.
  */
-public abstract class AbstractSpanCollector implements SpanCollector, Flushable, Closeable {
+public abstract class AbstractSpanCollector extends FlushingSpanCollector {
 
   private final SpanCodec codec;
-  private final SpanCollectorMetricsHandler metrics;
-  private final BlockingQueue<Span> pending = new LinkedBlockingQueue<Span>(1000);
-  @Nullable // for testing
-  private final Flusher flusher;
 
   /**
    * @param flushInterval in seconds. 0 implies spans are {@link #flush() flushed externally.
    */
   public AbstractSpanCollector(SpanCodec codec, SpanCollectorMetricsHandler metrics,
       int flushInterval) {
+    super(metrics, flushInterval);
     this.codec = codec;
-    this.metrics = metrics;
-    this.flusher = flushInterval > 0 ? new Flusher(this, flushInterval) : null;
   }
 
-  /**
-   * Queues the span for collection, or drops it if the queue is full.
-   *
-   * @param span Span, should not be <code>null</code>.
-   */
   @Override
-  public void collect(Span span) {
-    metrics.incrementAcceptedSpans(1);
-    if (!pending.offer(span)) {
-      metrics.incrementDroppedSpans(1);
-    }
-  }
-
-  /**
-   * Calling this will flush any pending spans to the transport on the current thread.
-   */
-  @Override
-  public void flush() {
-    if (pending.isEmpty()) return;
-    List<Span> drained = new ArrayList<Span>(pending.size());
-    pending.drainTo(drained);
-    if (drained.isEmpty()) return;
-
-    // encode the spans for transport
-    int spanCount = drained.size();
-    byte[] encoded;
-    try {
-      encoded = codec.writeSpans(drained);
-    } catch (RuntimeException e) {
-      metrics.incrementDroppedSpans(spanCount);
-      return;
-    }
-
-    // transport the spans
-    try {
-      sendSpans(encoded);
-    } catch (IOException e) {
-      metrics.incrementDroppedSpans(spanCount);
-      return;
-    }
-  }
-
-  /** Calls flush on a fixed interval */
-  static final class Flusher implements Runnable {
-    final Flushable flushable;
-    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-
-    Flusher(Flushable flushable, int flushInterval) {
-      this.flushable = flushable;
-      this.scheduler.scheduleWithFixedDelay(this, 0, flushInterval, SECONDS);
-    }
-
-    @Override
-    public void run() {
-      try {
-        flushable.flush();
-      } catch (IOException ignored) {
-      }
-    }
+  protected void reportSpans(List<Span> drained) throws IOException {
+    byte[] encoded = codec.writeSpans(drained);
+    sendSpans(encoded);
   }
 
   /**
@@ -104,20 +33,4 @@ public abstract class AbstractSpanCollector implements SpanCollector, Flushable,
    * @throws IOException when thrown, drop metrics will increment accordingly
    */
   protected abstract void sendSpans(byte[] encoded) throws IOException;
-
-  @Override
-  public void addDefaultAnnotation(String key, String value) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Requests a cease of delivery. There will be at most one in-flight send after this call.
-   */
-  @Override
-  public void close() {
-    if (flusher != null) flusher.scheduler.shutdown();
-    // throw any outstanding spans on the floor
-    int dropped = pending.drainTo(new LinkedList<Span>());
-    metrics.incrementDroppedSpans(dropped);
-  }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
@@ -1,0 +1,111 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Span;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Extend this class to offload the task of reporting spans to separate thread. By doing so, callers
+ * are protected from latency or exceptions possible when exporting spans out of process.
+ */
+public abstract class FlushingSpanCollector implements SpanCollector, Flushable, Closeable {
+
+  private final SpanCollectorMetricsHandler metrics;
+  private final BlockingQueue<Span> pending = new LinkedBlockingQueue<Span>(1000);
+  @Nullable // for testing
+  private final Flusher flusher;
+
+  /**
+   * @param flushInterval in seconds. 0 implies spans are {@link #flush() flushed externally.
+   */
+  protected FlushingSpanCollector(SpanCollectorMetricsHandler metrics, int flushInterval) {
+    this.metrics = metrics;
+    this.flusher = flushInterval > 0 ? new Flusher(this, flushInterval) : null;
+  }
+
+  /**
+   * Queues the span for collection, or drops it if the queue is full.
+   *
+   * @param span Span, should not be <code>null</code>.
+   */
+  @Override
+  public void collect(Span span) {
+    metrics.incrementAcceptedSpans(1);
+    if (!pending.offer(span)) {
+      metrics.incrementDroppedSpans(1);
+    }
+  }
+
+  /**
+   * Calling this will flush any pending spans to the transport on the current thread.
+   */
+  @Override
+  public void flush() {
+    if (pending.isEmpty()) return;
+    List<Span> drained = new ArrayList<Span>(pending.size());
+    pending.drainTo(drained);
+    if (drained.isEmpty()) return;
+
+    int spanCount = drained.size();
+    try {
+      reportSpans(drained);
+    } catch (IOException e) {
+      metrics.incrementDroppedSpans(spanCount);
+    } catch (RuntimeException e) {
+      metrics.incrementDroppedSpans(spanCount);
+    }
+  }
+
+  /** Calls flush on a fixed interval */
+  static final class Flusher implements Runnable {
+    final Flushable flushable;
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    Flusher(Flushable flushable, int flushInterval) {
+      this.flushable = flushable;
+      this.scheduler.scheduleWithFixedDelay(this, 0, flushInterval, SECONDS);
+    }
+
+    @Override
+    public void run() {
+      try {
+        flushable.flush();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  /**
+   * Reports a list of spans over the current transport.
+   *
+   * @throws IOException (or RuntimeException) when thrown, drop metrics will increment accordingly
+   */
+  protected abstract void reportSpans(List<Span> drained) throws IOException;
+
+  @Override
+  public void addDefaultAnnotation(String key, String value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Requests a cease of delivery. There will be at most one in-flight send after this call.
+   */
+  @Override
+  public void close() {
+    if (flusher != null) flusher.scheduler.shutdown();
+    // throw any outstanding spans on the floor
+    int dropped = pending.drainTo(new LinkedList<Span>());
+    metrics.incrementDroppedSpans(dropped);
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/DefaultSpanCodec.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/DefaultSpanCodec.java
@@ -8,7 +8,6 @@ import com.twitter.zipkin.gen.Span;
 import com.twitter.zipkin.gen.SpanCodec;
 import java.util.ArrayList;
 import java.util.List;
-import zipkin.BinaryAnnotation.Type;
 import zipkin.Codec;
 
 public final class DefaultSpanCodec implements SpanCodec {
@@ -23,14 +22,14 @@ public final class DefaultSpanCodec implements SpanCodec {
 
   @Override
   public byte[] writeSpan(Span span) {
-    return codec.writeSpan(from(span));
+    return codec.writeSpan(span.toZipkin());
   }
 
   @Override
   public byte[] writeSpans(List<Span> spans) {
     List<zipkin.Span> out = new ArrayList<zipkin.Span>(spans.size());
     for (Span span : spans) {
-      out.add(from(span));
+      out.add(span.toZipkin());
     }
     return codec.writeSpans(out);
   }
@@ -60,35 +59,6 @@ public final class DefaultSpanCodec implements SpanCodec {
           to(a.endpoint)));
     }
     return result;
-  }
-
-  private static zipkin.Span from(Span in) {
-    zipkin.Span.Builder result = zipkin.Span.builder();
-    result.traceId(in.getTrace_id());
-    result.id(in.getId());
-    result.parentId(in.getParent_id());
-    result.name(in.getName());
-    result.timestamp(in.getTimestamp());
-    result.duration(in.getDuration());
-    result.debug(in.isDebug());
-    for (Annotation a : in.getAnnotations()) {
-      result.addAnnotation(zipkin.Annotation.create(a.timestamp, a.value, from(a.host)));
-    }
-    for (BinaryAnnotation a : in.getBinary_annotations()) {
-      result.addBinaryAnnotation(zipkin.BinaryAnnotation.builder()
-          .key(a.key)
-          .value(a.value)
-          .type(Type.fromValue(a.type.getValue()))
-          .endpoint(from(a.host))
-          .build());
-    }
-    return result.build();
-  }
-
-  private static zipkin.Endpoint from(Endpoint host) {
-    if (host == null) return null;
-    if (host.port == null) return zipkin.Endpoint.create(host.service_name, host.ipv4);
-    return zipkin.Endpoint.create(host.service_name, host.ipv4, host.port);
   }
 
   private static Endpoint to(zipkin.Endpoint host) {

--- a/brave-spancollector-local/LICENSE
+++ b/brave-spancollector-local/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 <kristofa@github.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/brave-spancollector-local/README.md
+++ b/brave-spancollector-local/README.md
@@ -1,0 +1,12 @@
+# brave-spancollector-local #
+
+Brave SpanCollector that submits spans to a local storage component.
+
+For example, if you are tracing a storage system like cassandra,
+you might prefer to write directly to cassandra as opposed to over http.
+
+## Configuration ##
+
+By default...
+
+* Spans are flushed to a POST request every second. Configure with `LocalSpanCollector.Config.flushInterval`.

--- a/brave-spancollector-local/pom.xml
+++ b/brave-spancollector-local/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave</artifactId>
+        <version>3.8.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>brave-spancollector-local</artifactId>
+    <packaging>jar</packaging>
+
+    <name>brave-spancollector-local</name>
+    <description>Brave SpanCollector that submits spans to a local storage component</description>
+    <url>locals://github.com/kristofa/brave</url>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
+++ b/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
@@ -1,0 +1,91 @@
+package com.github.kristofa.brave.local;
+
+import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
+import com.github.kristofa.brave.FlushingSpanCollector;
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.google.auto.value.AutoValue;
+import com.twitter.zipkin.gen.Span;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.Callback;
+import zipkin.storage.StorageComponent;
+
+/**
+ * SpanCollector which submits spans directly to a Zipkin {@link StorageComponent}.
+ */
+public final class LocalSpanCollector extends FlushingSpanCollector {
+
+  @AutoValue
+  public static abstract class Config {
+    public static Builder builder() {
+      return new AutoValue_LocalSpanCollector_Config.Builder()
+          .flushInterval(1);
+    }
+
+    abstract int flushInterval();
+
+    @AutoValue.Builder
+    public interface Builder {
+      /** Default 1 second. 0 implies spans are {@link #flush() flushed} externally. */
+      Builder flushInterval(int flushInterval);
+
+      Config build();
+    }
+  }
+
+  private final StorageComponent storageComponent;
+  private final SpanCollectorMetricsHandler metrics;
+
+  /**
+   * Create a new instance with default configuration.
+   *
+   * @param storageComponent spans will be written asynchronously to this
+   * @param metrics Gets notified when spans are accepted or dropped. If you are not interested in
+   *                these events you can use {@linkplain EmptySpanCollectorMetricsHandler}
+   */
+  public static LocalSpanCollector create(StorageComponent storageComponent,
+      SpanCollectorMetricsHandler metrics) {
+    return new LocalSpanCollector(storageComponent, Config.builder().build(), metrics);
+  }
+
+  /**
+   * @param storageComponent spans will be written asynchronously to this
+   * @param config includes flush interval and timeouts
+   * @param metrics Gets notified when spans are accepted or dropped. If you are not interested in
+   *                these events you can use {@linkplain EmptySpanCollectorMetricsHandler}
+   */
+  public static LocalSpanCollector create(StorageComponent storageComponent, Config config,
+      SpanCollectorMetricsHandler metrics) {
+    return new LocalSpanCollector(storageComponent, config, metrics);
+  }
+
+  // Visible for testing. Ex when tests need to explicitly control flushing, set interval to 0.
+  LocalSpanCollector(StorageComponent storageComponent, Config config,
+      SpanCollectorMetricsHandler metrics) {
+    super(metrics, config.flushInterval());
+    this.storageComponent = storageComponent;
+    this.metrics = metrics;
+  }
+
+  @Override protected void reportSpans(final List<Span> drained) throws IOException {
+    // Brave 3 doesn't use zipkin spans. Convert accordingly
+    List<zipkin.Span> zipkinSpans = new ArrayList<zipkin.Span>(drained.size());
+    for (Span input : drained) {
+      zipkinSpans.add(input.toZipkin());
+    }
+    // This dereferences a lazy, which might throw an exception if the storage system is down.
+    AsyncSpanConsumer asyncSpanConsumer = storageComponent.asyncSpanConsumer();
+
+    // We accept the spans into storage, incrementing drop metrics if there was a failure.
+    asyncSpanConsumer.accept(zipkinSpans, new Callback<Void>() {
+      @Override public void onSuccess(Void ignored) {
+      }
+
+      @Override public void onError(Throwable throwable) {
+        metrics.incrementDroppedSpans(drained.size());
+      }
+    });
+  }
+}

--- a/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
+++ b/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
@@ -1,0 +1,151 @@
+package com.github.kristofa.brave.local;
+
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.twitter.zipkin.gen.Span;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import zipkin.storage.AsyncSpanConsumer;
+import zipkin.storage.AsyncSpanStore;
+import zipkin.storage.InMemoryStorage;
+import zipkin.storage.SpanStore;
+import zipkin.storage.StorageComponent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalSpanCollectorTest {
+  public final InMemoryStorage storage = new InMemoryStorage();
+
+  TestMetricsHander metrics = new TestMetricsHander();
+  // set flush interval to 0 so that tests can drive flushing explicitly
+  LocalSpanCollector.Config config = LocalSpanCollector.Config.builder().flushInterval(0).build();
+
+  @Test
+  public void collectDoesntDoIO() throws Exception {
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
+      throw new AssertionError("spans should only report on flush!");
+    });
+
+    collector.collect(span(1L, "foo"));
+
+    assertThat(storage.spanStore().traceIds()).isEmpty();
+  }
+
+  @Test
+  public void collectIncrementsAcceptedMetrics() throws Exception {
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
+    });
+
+    collector.collect(span(1L, "foo"));
+
+    assertThat(metrics.acceptedSpans.get()).isEqualTo(1);
+    assertThat(metrics.droppedSpans.get()).isZero();
+  }
+
+  @Test
+  public void dropsWhenQueueIsFull() throws Exception {
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
+    });
+
+    for (int i = 0; i < 1001; i++)
+      collector.collect(span(1L, "foo"));
+
+    collector.flush(); // manually flush the spans
+
+    assertThat(metrics.acceptedSpans.get()).isEqualTo(1001);
+    assertThat(metrics.droppedSpans.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void bundlesSpansIntoOneMessage() throws Exception {
+    AtomicInteger spanCount = new AtomicInteger();
+    AtomicInteger messageCount = new AtomicInteger();
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
+      spanCount.addAndGet(spans.size());
+      messageCount.incrementAndGet();
+    });
+
+    collector.collect(span(1L, "foo"));
+    collector.collect(span(2L, "bar"));
+
+    collector.flush(); // manually flush the spans
+
+    assertThat(spanCount.get()).isEqualTo(2);
+    assertThat(messageCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void incrementsDroppedSpans_exceptionOnCallingThread() throws Exception {
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
+      throw new RuntimeException("couldn't store");
+    });
+
+    collector.collect(span(1L, "foo"));
+    collector.collect(span(2L, "bar"));
+
+    collector.flush(); // manually flush the spans
+
+    assertThat(metrics.droppedSpans.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void incrementsDroppedSpans_exceptionOnCallbackThread() throws Exception {
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
+      callback.onError(new RuntimeException("couldn't store"));
+    });
+
+    collector.collect(span(1L, "foo"));
+    collector.collect(span(2L, "bar"));
+
+    collector.flush(); // manually flush the spans
+
+    assertThat(metrics.droppedSpans.get()).isEqualTo(2);
+  }
+
+  class TestMetricsHander implements SpanCollectorMetricsHandler {
+
+    final AtomicInteger acceptedSpans = new AtomicInteger();
+    final AtomicInteger droppedSpans = new AtomicInteger();
+
+    @Override
+    public void incrementAcceptedSpans(int quantity) {
+      acceptedSpans.addAndGet(quantity);
+    }
+
+    @Override
+    public void incrementDroppedSpans(int quantity) {
+      droppedSpans.addAndGet(quantity);
+    }
+  }
+
+  static Span span(long traceId, String spanName) {
+    return new Span().setTrace_id(traceId).setId(traceId).setName(spanName);
+  }
+
+  static zipkin.Span zipkinSpan(long traceId, String spanName) {
+    return zipkin.Span.builder().traceId(traceId).id(traceId).name(spanName).build();
+  }
+
+  LocalSpanCollector newLocalSpanCollector(AsyncSpanConsumer consumer) {
+    return new LocalSpanCollector(new StorageComponent() {
+      @Override public SpanStore spanStore() {
+        throw new AssertionError();
+      }
+
+      @Override public AsyncSpanStore asyncSpanStore() {
+        throw new AssertionError();
+      }
+
+      @Override public AsyncSpanConsumer asyncSpanConsumer() {
+        return consumer;
+      }
+
+      @Override public CheckResult check() {
+        return CheckResult.OK;
+      }
+
+      @Override public void close() {
+        throw new AssertionError();
+      }
+    }, config, metrics);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <module>brave-spancollector-http</module>
     <module>brave-spancollector-scribe</module>
     <module>brave-spancollector-kafka</module>
+    <module>brave-spancollector-local</module>
     <module>brave-sampler-zookeeper</module>
     <module>brave-jersey</module>
     <module>brave-jersey2</module>


### PR DESCRIPTION
LocalSpanCollector submits spans to a local storage component.

For example, if you are tracing a storage system like cassandra,
you might prefer to write directly to cassandra as opposed to over http.

This code replaces a similar class in zipkin-java, and also supports
cassandra tracing.