### PR TITLE
Upgrade libthrift to 0.9.3

### DIFF
--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorFailOnSetup.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorFailOnSetup.java
@@ -36,6 +36,10 @@ public class ITScribeSpanCollectorFailOnSetup {
 
         scribeSpanCollector.collect(span);
 
+        // Sleep a small amount to give the collector time to process
+        // the span.
+        Thread.sleep(100);
+
         final ScribeServer server = new ScribeServer(PORT);
         server.start();
         try {

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeServer.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeServer.java
@@ -32,7 +32,8 @@ class ScribeServer {
         final TNonblockingServerTransport transport = new TNonblockingServerSocket(port);
         final THsHaServer.Args args = new THsHaServer.Args(transport);
 
-        args.workerThreads(1);
+        args.minWorkerThreads(1);
+        args.maxWorkerThreads(1);
         args.processor(processor);
         args.protocolFactory(new TBinaryProtocol.Factory());
         args.transportFactory(new TFramedTransport.Factory());

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrades libthrift to 0.9.3.

An application in our stack that started experience "gc-madness" last night, the thrift transport started acting out. Seems like we were bitten by the bug fixed by https://github.com/apache/thrift/commit/bb98e97fd3c82117c87d23e3fb6b8bbd800784f2.

There are probably other fixes in there as well that could be useful :)

I don't know if its related to the upgrade, but I had to add a small sleep to `ITScribeSpanCollectorFailOnSetup` to make it run in a less flaky fashion on my machine.