### PR TITLE
Adds error-prone checks to the build

### DIFF
--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -40,9 +40,9 @@ public class ITBraveHttpRequestAndResponseInterceptor {
     private final static String FULL_PATH_WITH_QUERY_PARAMS = "/" + CONTEXT + PATH + "?x=1&y=2";
     private final static String REQUEST = "http://localhost:" + PORT + "/" + CONTEXT + PATH;
     private final static String REQUEST_WITH_QUERY_PARAMS = REQUEST + "?x=1&y=2";
-    private static final Long SPAN_ID = 151864l;
+    private static final Long SPAN_ID = 151864L;
 
-    private static final Long TRACE_ID = 8494864l;
+    private static final Long TRACE_ID = 8494864L;
     private MockHttpServer mockServer;
     private DefaultHttpResponseProvider responseProvider;
     private ClientTracer clientTracer;

--- a/brave-benchmarks/src/main/java/com/github/kristofa/brave/SpanIdBenchmarks.java
+++ b/brave-benchmarks/src/main/java/com/github/kristofa/brave/SpanIdBenchmarks.java
@@ -41,7 +41,7 @@ public class SpanIdBenchmarks {
 
   @Benchmark
   public byte[] bytes_finagle() {
-    return sampledRootSpanFinagle.serialize(sampledRootSpanFinagle);
+    return TraceId.serialize(sampledRootSpanFinagle);
   }
 
   @Benchmark

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -207,7 +207,7 @@ public class ClientTracerTest {
         final SpanId newSpanId = clientTracer.startNewSpan(REQUEST_NAME);
         assertNotNull(newSpanId);
         assertEquals(PARENT_TRACE_ID, newSpanId.traceId);
-        assertEquals(1l, newSpanId.spanId);
+        assertEquals(1L, newSpanId.spanId);
         assertEquals(PARENT_SPAN_ID, newSpanId.parentId);
 
         assertEquals(

--- a/brave-core/src/test/java/com/github/kristofa/brave/IdConversionTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/IdConversionTest.java
@@ -8,7 +8,7 @@ public class IdConversionTest {
 	
 	@Test
 	public void testPositiveId() {
-		final long longId = 8828218016717761634l;
+		final long longId = 8828218016717761634L;
 		// This id was generated using the zipkin code.
 		final String expectedId = "7a842183262a6c62";
 		assertEquals(expectedId, IdConversion.convertToString(longId));
@@ -18,7 +18,7 @@ public class IdConversionTest {
 
 	@Test
 	public void testNegativeId() {
-		final long longId = -4667777584646200191l;
+		final long longId = -4667777584646200191L;
 		// This id was generated using the zipkin code.
 		final String expectedId = "bf38b90488a1e481";
 		assertEquals(expectedId, IdConversion.convertToString(longId));

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -37,7 +37,7 @@ public class LocalTracerTest {
     @Before
     public void setup() {
         mockRandom = mock(Random.class);
-        when(mockRandom.nextLong()).thenReturn(555l);
+        when(mockRandom.nextLong()).thenReturn(555L);
 
         mockCollector = mock(SpanCollector.class);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -27,9 +27,9 @@ import static org.mockito.Mockito.when;
 public class ServerTracerTest {
 
     private final static long CURRENT_TIME_MICROSECONDS = System.currentTimeMillis() * 1000;
-    private final static long TRACE_ID = 1l;
-    private final static long SPAN_ID = 2l;
-    private final static Long PARENT_SPANID = 3l;
+    private final static long TRACE_ID = 1L;
+    private final static long SPAN_ID = 2L;
+    private final static Long PARENT_SPANID = 3L;
     private final static String SPAN_NAME = "span name";
 
     private ServerTracer serverTracer;

--- a/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
@@ -163,7 +163,7 @@ public class SpanIdTest {
     assertThat(finagle.flags().flags())
         .isEqualTo(brave.flags);
 
-    assertThat(SpanId.fromBytes(finagle.serialize(finagle)))
+    assertThat(SpanId.fromBytes(TraceId.serialize(finagle)))
         .isEqualTo(brave);
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/TraceDataTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/TraceDataTest.java
@@ -10,7 +10,7 @@ public class TraceDataTest {
 
     private static final boolean SAMPLE = true;
     private static final SpanId SPAN_ID =
-        SpanId.builder().traceId(3454).spanId(3353).parentId(34343l).build();
+        SpanId.builder().traceId(3454).spanId(3353).parentId(34343L).build();
 
 
     @Test

--- a/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptorTest.java
+++ b/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptorTest.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.*;
 
 public class BraveOkHttpRequestResponseInterceptorTest {
 
-  private static final Long SPAN_ID = 151864l;
-  private static final Long TRACE_ID = 8494864l;
+  private static final Long SPAN_ID = 151864L;
+  private static final Long TRACE_ID = 8494864L;
   private static final String HTTP_METHOD_GET = "GET";
 
   @Rule

--- a/brave-spancollector-scribe/src/main/java/com/twitter/zipkin/gen/LogEntry.java
+++ b/brave-spancollector-scribe/src/main/java/com/twitter/zipkin/gen/LogEntry.java
@@ -13,12 +13,14 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Generated;
 import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
 import org.apache.thrift.scheme.TupleScheme;
 
+@Generated("thrift")
 public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("LogEntry");
 

--- a/brave-spancollector-scribe/src/main/java/com/twitter/zipkin/gen/scribe.java
+++ b/brave-spancollector-scribe/src/main/java/com/twitter/zipkin/gen/scribe.java
@@ -15,12 +15,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Generated;
 import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
 import org.apache.thrift.scheme.TupleScheme;
 
+@Generated("thrift")
 public class scribe {
 
   public interface Iface {

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ITBraveServletHandlerInterceptor.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ITBraveServletHandlerInterceptor.java
@@ -69,9 +69,9 @@ public class ITBraveServletHandlerInterceptor {
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
         connection.setRequestMethod("GET");
         connection.addRequestProperty(BraveHttpHeaders.Sampled.getName(), "1");
-        connection.addRequestProperty(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(1l));
-        connection.addRequestProperty(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(2l));
-        connection.addRequestProperty(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(3l));
+        connection.addRequestProperty(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(1L));
+        connection.addRequestProperty(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(2L));
+        connection.addRequestProperty(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(3L));
         connection.connect();
 
         try {
@@ -80,9 +80,9 @@ public class ITBraveServletHandlerInterceptor {
             assertEquals(1, collectedSpans.size());
             final Span serverSpan = collectedSpans.get(0);
 
-            assertEquals("Expected trace id", serverSpan.getTrace_id(), 1l);
-            assertEquals("Expected span id", serverSpan.getId(), 2l);
-            assertEquals("Expected parent id", serverSpan.getParent_id().longValue(), 3l);
+            assertEquals("Expected trace id", serverSpan.getTrace_id(), 1L);
+            assertEquals("Expected span id", serverSpan.getId(), 2L);
+            assertEquals("Expected parent id", serverSpan.getParent_id().longValue(), 3L);
             assertEquals("Span name.", "get", serverSpan.getName());
             assertEquals("Expect 2 annotations.", 2, serverSpan.getAnnotations().size());
             assertEquals("Expected service name.",

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
@@ -97,9 +97,9 @@ public class ITBraveServletFilter {
         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
         connection.setRequestMethod("GET");
         connection.addRequestProperty(BraveHttpHeaders.Sampled.getName(), "1");
-        connection.addRequestProperty(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(1l));
-        connection.addRequestProperty(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(2l));
-        connection.addRequestProperty(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(3l));
+        connection.addRequestProperty(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(1L));
+        connection.addRequestProperty(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(2L));
+        connection.addRequestProperty(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(3L));
         connection.connect();
 
         try {
@@ -108,9 +108,9 @@ public class ITBraveServletFilter {
             assertEquals(1, collectedSpans.size());
             final Span serverSpan = collectedSpans.get(0);
 
-            assertEquals("Expected trace id", serverSpan.getTrace_id(), 1l);
-            assertEquals("Expected span id", serverSpan.getId(), 2l);
-            assertEquals("Expected parent id", serverSpan.getParent_id().longValue(), 3l);
+            assertEquals("Expected trace id", serverSpan.getTrace_id(), 1L);
+            assertEquals("Expected span id", serverSpan.getId(), 2L);
+            assertEquals("Expected parent id", serverSpan.getParent_id().longValue(), 3L);
             assertEquals("Span name.", "get", serverSpan.getName());
             assertEquals("Expect 2 annotations.", 2, serverSpan.getAnnotations().size());
             assertEquals("Expected service name.",

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,10 @@
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
     <centralsync-maven-plugin.version>0.1.0</centralsync-maven-plugin.version>
+
+    <!-- Catch common Java mistakes as compile-time errors -->
+    <plexus-compiler-javac-errorprone.version>2.8</plexus-compiler-javac-errorprone.version>
+    <errorprone.version>2.0.9</errorprone.version>
   </properties>
 
   <modules>
@@ -284,7 +288,23 @@
                   <target>1.8</target>
                   <optimize>true</optimize>
                   <debug>true</debug>
+                  <compilerId>javac-with-errorprone</compilerId>
+                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                  <showWarnings>true</showWarnings>
+                  <compilerArgument>-XepDisableWarningsInGeneratedCode</compilerArgument>
               </configuration>
+              <dependencies>
+                  <dependency>
+                      <groupId>org.codehaus.plexus</groupId>
+                      <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                      <version>${plexus-compiler-javac-errorprone.version}</version>
+                  </dependency>
+                  <dependency>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>${errorprone.version}</version>
+                  </dependency>
+              </dependencies>
               <executions>
                   <!-- Ensure main source tree compiles to Java 7 bytecode. -->
                   <execution>


### PR DESCRIPTION
error-prone is a tool that catches common problems at compile time. For
example, it can figure out if you wrote equals incorrectly, or didn't
use a volatile when double-checking a value.

Non-critical concerns print out as warnings in the compiler log.

See http://errorprone.info/