### PR TITLE
Updates to Zipkin 1.3 and rounds up Span duration to one when < 1μ

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -137,7 +137,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
         Long startTick = span.startTick;
         final long duration;
         if (startTick != null) {
-            duration = (endTick - startTick) / 1000;
+            duration = Math.max(1L, (endTick - startTick) / 1000L);
         } else {
             duration = currentTimeMicroseconds() - span.getTimestamp();
         }

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -137,6 +137,23 @@ public class LocalTracerTest {
         assertEquals(500L, finished.getDuration().longValue());
     }
 
+    /** Duration of less than one microsecond is confusing to plot and could coerce to null. */
+    @Test
+    public void finishSpan_lessThanMicrosRoundUp() {
+        Span finished = new Span().setTimestamp(1000L); // set in start span
+        finished.startTick = 500L; // set in start span
+        state.setCurrentLocalSpan(finished);
+
+        PowerMockito.when(System.nanoTime()).thenReturn(1000L);
+
+        localTracer.finishSpan();
+
+        verify(mockCollector).collect(finished);
+        verifyNoMoreInteractions(mockCollector);
+
+        assertEquals(1L, finished.getDuration().longValue());
+    }
+
     /**
      * When a span is started with a timestamp, nanos aren't known, so duration calculation falls back to system time.
      * <p>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>4.1.6.RELEASE</spring.version>
-    <zipkin.version>1.0.0</zipkin.version>
+    <zipkin.version>1.3.0</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
 


### PR DESCRIPTION
Duration of 0 is confusing to plot and can be misinterpreted as null.

See https://github.com/openzipkin/zipkin/issues/1174