### PR TITLE
Deprecates constants duplicated from Zipkin

### DIFF
--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -4,7 +4,6 @@ import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
-import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.http.BraveHttpHeaders;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.test.http.DefaultHttpResponseProvider;
@@ -22,6 +21,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+import zipkin.TraceKeys;
 
 import java.io.IOException;
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveAnnotations.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveAnnotations.java
@@ -1,12 +1,12 @@
 package com.github.kristofa.brave;
 
-import com.twitter.zipkin.gen.zipkinCoreConstants;
-
 /**
- * Annotations that add to the {@link zipkinCoreConstants}.
+ * Annotations that add to the {@link zipkin.Constants}.
  * 
  * @author kristof
+ * @deprecated unused; will be removed in Brave 2.0
  */
+@Deprecated
 public class BraveAnnotations {
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -42,7 +42,7 @@ public interface ClientRequestAdapter {
      * Provides the remote server address information for additional tracking.
      *
      * Can be useful when communicating with non-traced services by adding server address to span
-     * i.e. {@link com.twitter.zipkin.gen.zipkinCoreConstants#SERVER_ADDR}
+     * i.e. {@link zipkin.Constants#SERVER_ADDR}
      *
      * @return request's target server endpoint information
      */

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -6,7 +6,7 @@ import com.github.kristofa.brave.SpanAndEndpoint.ClientSpanAndEndpoint;
 import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-import com.twitter.zipkin.gen.zipkinCoreConstants;
+import zipkin.Constants;
 
 import java.util.Random;
 
@@ -63,7 +63,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * Sets 'client sent' event for current thread.
      */
     public void setClientSent() {
-        submitStartAnnotation(zipkinCoreConstants.CLIENT_SEND);
+        submitStartAnnotation(Constants.CLIENT_SEND);
     }
 
     /**
@@ -75,8 +75,8 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      *                    or null if unknown
      */
     public void setClientSent(int ipv4, int port, @Nullable String serviceName) {
-        submitAddress(zipkinCoreConstants.SERVER_ADDR, ipv4, port, serviceName);
-        submitStartAnnotation(zipkinCoreConstants.CLIENT_SEND);
+        submitAddress(Constants.SERVER_ADDR, ipv4, port, serviceName);
+        submitStartAnnotation(Constants.CLIENT_SEND);
     }
 
     /**
@@ -84,7 +84,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * event means this span is finished.
      */
     public void setClientReceived() {
-        if (submitEndAnnotation(zipkinCoreConstants.CLIENT_RECV, spanCollector())) {
+        if (submitEndAnnotation(Constants.CLIENT_RECV, spanCollector())) {
             spanAndEndpoint().state().setCurrentClientSpan(null);
         }
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -4,11 +4,11 @@ import com.github.kristofa.brave.SpanAndEndpoint.LocalSpanAndEndpoint;
 import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Span;
-import com.twitter.zipkin.gen.zipkinCoreConstants;
+import zipkin.Constants;
 
 import java.util.Random;
 
-import static com.twitter.zipkin.gen.zipkinCoreConstants.LOCAL_COMPONENT;
+import static zipkin.Constants.LOCAL_COMPONENT;
 
 /**
  * Local tracer is designed for in-process activity that explains latency.
@@ -30,7 +30,7 @@ import static com.twitter.zipkin.gen.zipkinCoreConstants.LOCAL_COMPONENT;
  * }
  * </pre>
  *
- * @see zipkinCoreConstants#LOCAL_COMPONENT
+ * @see Constants#LOCAL_COMPONENT
  */
 @AutoValue
 public abstract class LocalTracer extends AnnotationSubmitter {
@@ -70,10 +70,10 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     /**
      * Request a new local span, which starts now.
      *
-     * @param component {@link zipkinCoreConstants#LOCAL_COMPONENT component} responsible for the operation
+     * @param component {@link Constants#LOCAL_COMPONENT component} responsible for the operation
      * @param operation name of the operation that's begun
      * @return metadata about the new span or null if one wasn't started due to sampling policy.
-     * @see zipkinCoreConstants#LOCAL_COMPONENT
+     * @see Constants#LOCAL_COMPONENT
      */
     public SpanId startNewSpan(String component, String operation) {
         SpanId spanId = startNewSpan(component, operation, currentTimeMicroseconds());
@@ -93,11 +93,11 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     /**
      * Request a new local span, which started at the given timestamp.
      *
-     * @param component {@link zipkinCoreConstants#LOCAL_COMPONENT component} responsible for the operation
+     * @param component {@link Constants#LOCAL_COMPONENT component} responsible for the operation
      * @param operation name of the operation that's begun
      * @param timestamp time the operation started, in epoch microseconds.
      * @return metadata about the new span or null if one wasn't started due to sampling policy.
-     * @see zipkinCoreConstants#LOCAL_COMPONENT
+     * @see Constants#LOCAL_COMPONENT
      */
     public SpanId startNewSpan(String component, String operation, long timestamp) {
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -5,7 +5,7 @@ import com.google.auto.value.AutoValue;
 import com.github.kristofa.brave.SpanAndEndpoint.ServerSpanAndEndpoint;
 import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
-import com.twitter.zipkin.gen.zipkinCoreConstants;
+import zipkin.Constants;
 
 import java.util.Random;
 
@@ -118,7 +118,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * {@link ServerTracer#setStateUnknown(String)}.
      */
     public void setServerReceived() {
-        submitStartAnnotation(zipkinCoreConstants.SERVER_RECV);
+        submitStartAnnotation(Constants.SERVER_RECV);
     }
 
     /**
@@ -131,15 +131,15 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      *                      null if unknown
      */
     public void setServerReceived(int ipv4, int port, @Nullable String clientService) {
-        submitAddress(zipkinCoreConstants.CLIENT_ADDR, ipv4, port, clientService);
-        submitStartAnnotation(zipkinCoreConstants.SERVER_RECV);
+        submitAddress(Constants.CLIENT_ADDR, ipv4, port, clientService);
+        submitStartAnnotation(Constants.SERVER_RECV);
     }
 
     /**
      * Sets the server sent event for current thread.
      */
     public void setServerSend() {
-        if (submitEndAnnotation(zipkinCoreConstants.SERVER_SEND, spanCollector())) {
+        if (submitEndAnnotation(Constants.SERVER_SEND, spanCollector())) {
             spanAndEndpoint().state().setCurrentServerSpan(null);
         }
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/TraceKeys.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/TraceKeys.java
@@ -1,9 +1,9 @@
 package com.github.kristofa.brave;
 
 /**
- * Used for Consistent keys without taking in zipkin-dependency.
- * Taken from: https://github.com/openzipkin/zipkin-java/blob/master/zipkin/src/main/java/zipkin/TraceKeys.java
+ * @deprecated use {@link zipkin.TraceKeys}; will be removed in Brave 2.0
  */
+@Deprecated
 public final class TraceKeys {
 
     public static final String HTTP_HOST = "http.host";

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
@@ -29,10 +29,10 @@ public class BinaryAnnotation implements Serializable {
   static final long serialVersionUID = 1L;
 
   /**
-   * Special-cased form supporting {@link zipkinCoreConstants#CLIENT_ADDR} and {@link
-   * zipkinCoreConstants#SERVER_ADDR}.
+   * Special-cased form supporting {@link zipkin.Constants#CLIENT_ADDR} and {@link
+   * zipkin.Constants#SERVER_ADDR}.
    *
-   * @param key {@link zipkinCoreConstants#CLIENT_ADDR} or {@link zipkinCoreConstants#SERVER_ADDR}
+   * @param key {@link zipkin.Constants#CLIENT_ADDR} or {@link zipkin.Constants#SERVER_ADDR}
    * @param endpoint associated endpoint.
    */
   public static BinaryAnnotation address(String key, Endpoint endpoint) {

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/zipkinCoreConstants.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/zipkinCoreConstants.java
@@ -1,5 +1,9 @@
 package com.twitter.zipkin.gen;
 
+/**
+ * @deprecated use {@link zipkin.Constants}; will be removed in Brave 2.0
+ */
+@Deprecated
 public class zipkinCoreConstants {
 
   /**

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -16,7 +16,7 @@ public class ClientRequestInterceptorTest {
     private static final String SERVICE_NAME = "orderService";
     private static final int TARGET_IP = 192 << 24 | 168 << 16 | 1;
     private static final int TARGET_PORT = 80;
-    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(TraceKeys.HTTP_URL, "/orders/user/4543");
+    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(zipkin.TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
     private ClientRequestInterceptor interceptor;
     private ClientTracer clientTracer;

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -5,7 +5,6 @@ import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-import com.twitter.zipkin.gen.zipkinCoreConstants;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import zipkin.Constants;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -71,7 +71,7 @@ public class ClientTracerTest {
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
-            zipkinCoreConstants.CLIENT_SEND,
+            Constants.CLIENT_SEND,
             state.endpoint()
         );
         verifyNoMoreInteractions(mockCollector, mockSampler);
@@ -89,7 +89,7 @@ public class ClientTracerTest {
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
-            zipkinCoreConstants.CLIENT_SEND,
+            Constants.CLIENT_SEND,
             state.endpoint()
         );
         verifyNoMoreInteractions(mockCollector, mockSampler);
@@ -98,7 +98,7 @@ public class ClientTracerTest {
         assertEquals(expectedAnnotation, clientSent.getAnnotations().get(0));
 
         BinaryAnnotation serverAddress = BinaryAnnotation.address(
-            zipkinCoreConstants.SERVER_ADDR,
+            Constants.SERVER_ADDR,
             Endpoint.create("foobar", 1 << 24 | 2 << 16 | 3 << 8 | 4, 9999)
         );
         assertEquals(serverAddress, clientSent.getBinary_annotations().get(0));
@@ -132,7 +132,7 @@ public class ClientTracerTest {
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
-            zipkinCoreConstants.CLIENT_RECV,
+            Constants.CLIENT_RECV,
             state.endpoint()
         );
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -16,7 +16,7 @@ public class ServerRequestInterceptorTest {
     private final static long TRACE_ID = 3425;
     private final static long SPAN_ID = 43435;
     private final static long PARENT_SPAN_ID = 44334435;
-    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(TraceKeys.HTTP_URL, "/orders/user/4543");
+    private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(zipkin.TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
 
     private ServerRequestInterceptor interceptor;

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -4,7 +4,6 @@ import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-import com.twitter.zipkin.gen.zipkinCoreConstants;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +12,7 @@ import org.mockito.InOrder;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import zipkin.Constants;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.inOrder;
@@ -141,7 +141,7 @@ public class ServerTracerTest {
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
-            zipkinCoreConstants.SERVER_RECV,
+            Constants.SERVER_RECV,
             mockEndpoint
         );
 
@@ -165,7 +165,7 @@ public class ServerTracerTest {
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
-            zipkinCoreConstants.SERVER_RECV,
+            Constants.SERVER_RECV,
             mockEndpoint
         );
 
@@ -178,7 +178,7 @@ public class ServerTracerTest {
         assertEquals(expectedAnnotation, serverRecv.getAnnotations().get(0));
 
         BinaryAnnotation serverAddress = BinaryAnnotation.address(
-            zipkinCoreConstants.CLIENT_ADDR,
+            Constants.CLIENT_ADDR,
             Endpoint.create("foobar", 1 << 24 | 2 << 16 | 3 << 8 | 4, 9999)
         );
         assertEquals(serverAddress, serverRecv.getBinary_annotations().get(0));
@@ -215,7 +215,7 @@ public class ServerTracerTest {
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
-            zipkinCoreConstants.SERVER_SEND,
+            Constants.SERVER_SEND,
             mockEndpoint
         );
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -4,9 +4,9 @@ import com.github.kristofa.brave.ClientRequestAdapter;
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
-import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
+import zipkin.TraceKeys;
 
 import java.net.URI;
 import java.util.Arrays;

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.ClientResponseAdapter;
 import com.github.kristofa.brave.KeyValueAnnotation;
-import com.github.kristofa.brave.TraceKeys;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -4,9 +4,9 @@ import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.ServerRequestAdapter;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
-import com.github.kristofa.brave.TraceKeys;
 import java.util.Collection;
 import java.util.Collections;
+import zipkin.TraceKeys;
 
 import static com.github.kristofa.brave.IdConversion.convertToLong;
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.ServerResponseAdapter;
-import com.github.kristofa.brave.TraceKeys;
+import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -2,9 +2,9 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
-import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import java.net.URI;
 import java.util.Collection;

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
@@ -2,9 +2,9 @@ package com.github.kristofa.brave.http;
 
 
 import com.github.kristofa.brave.KeyValueAnnotation;
-import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import java.util.Collection;
 

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -8,9 +8,9 @@ import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
-import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.*;

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
@@ -2,9 +2,9 @@ package com.github.kristofa.brave.http;
 
 
 import com.github.kristofa.brave.KeyValueAnnotation;
-import com.github.kristofa.brave.TraceKeys;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.TraceKeys;
 
 import java.util.Collection;
 

--- a/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptorTest.java
+++ b/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptorTest.java
@@ -4,7 +4,6 @@ import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
-import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.http.BraveHttpHeaders;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import okhttp3.OkHttpClient;
@@ -21,6 +20,7 @@ import org.mockito.Answers;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import zipkin.TraceKeys;
 
 import java.io.IOException;
 

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -4,7 +4,6 @@ import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
-import com.github.kristofa.brave.TraceKeys;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -14,6 +13,7 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.mock.http.client.MockClientHttpResponse;
+import zipkin.TraceKeys;
 
 import java.io.IOException;
 import java.net.URI;


### PR DESCRIPTION
Also deprecates unused `BraveAnnotations` class.