### PR TITLE
DO NOT MERGE: Adds spike of Kafka integration

### DIFF
--- a/brave-kafka/pom.xml
+++ b/brave-kafka/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>brave</artifactId>
+        <groupId>io.zipkin.brave</groupId>
+        <version>3.9.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>brave-kafka</artifactId>
+    <packaging>jar</packaging>
+    <name>brave-kafka</name>
+    <description>
+        Kafka integration that uses the brave api to submit producer and consumer spans.
+    </description>
+    <url>https://github.com/kristofa/brave</url>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- This is pinned to Kafka 0.8.x client as 0.9.x brokers work with them, but not visa-versa
+             http://docs.confluent.io/2.0.0/upgrade.html -->
+        <kafka.version>0.8.2.2</kafka.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brave-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.11</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.charithe</groupId>
+            <artifactId>kafka-junit</artifactId>
+            <!-- pinned to 0.8.2.2 -->
+            <version>1.7</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brave-spancollector-http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brave-kafka/src/main/java/com/github/kristofa/brave/kafka/SpanIdSerializer.java
+++ b/brave-kafka/src/main/java/com/github/kristofa/brave/kafka/SpanIdSerializer.java
@@ -1,0 +1,18 @@
+package com.github.kristofa.brave.kafka;
+
+import com.github.kristofa.brave.SpanId;
+import java.util.Map;
+import org.apache.kafka.common.serialization.Serializer;
+
+public final class SpanIdSerializer implements Serializer<SpanId> {
+
+  @Override public void configure(Map<String, ?> map, boolean b) {
+  }
+
+  @Override public byte[] serialize(String s, SpanId spanId) {
+    return spanId.bytes();
+  }
+
+  @Override public void close() {
+  }
+}

--- a/brave-kafka/src/main/java/com/github/kristofa/brave/kafka/TracedKafkaConsumer.java
+++ b/brave-kafka/src/main/java/com/github/kristofa/brave/kafka/TracedKafkaConsumer.java
@@ -1,0 +1,81 @@
+package com.github.kristofa.brave.kafka;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import kafka.consumer.Consumer;
+import kafka.consumer.ConsumerConfig;
+import kafka.consumer.ConsumerIterator;
+import kafka.consumer.KafkaStream;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.MessageAndMetadata;
+import zipkin.Constants;
+
+public final class TracedKafkaConsumer implements Closeable {
+  final Brave brave;
+  final ConsumerConnector delegate;
+
+  TracedKafkaConsumer(Brave brave, Properties properties) {
+    this.brave = brave;
+    this.delegate = Consumer.createJavaConsumerConnector(new ConsumerConfig(properties));
+  }
+
+  Iterator<byte[]> iterator(String topic) {
+    Map<String, Integer> topicCountMap = new HashMap<>();
+    topicCountMap.put(topic, 1);
+    final KafkaStream<byte[], byte[]> stream = delegate.createMessageStreams(topicCountMap)
+        .values()
+        .iterator()
+        .next()
+        .get(0);
+
+    return new Iterator<byte[]>() {
+      ConsumerIterator<byte[], byte[]> delegate = stream.iterator();
+
+      @Override public boolean hasNext() {
+        return delegate.hasNext();
+      }
+
+      @Override public byte[] next() {
+        MessageAndMetadata<byte[], byte[]> result = delegate.next();
+        Span span = SpanId.fromBytes(result.key()).toSpan();
+        span.setName(result.topic());
+        brave.localSpanThreadBinder().setCurrentSpan(span);
+        try {
+          brave.localTracer().submitAnnotation(Constants.WIRE_RECV);
+          brave.localTracer().submitAnnotation("mr");
+          brave.localTracer().submitBinaryAnnotation("kafka.partition", result.partition());
+
+          return result.message();
+        } finally {
+          brave.localTracer().finishSpan(0); // flush (which completes) the messaging span
+
+          // Note: we aren't associating the span that just finished as a thread context
+          // This is potentially a dual-parent problem. Imagine you are a consumer of this iterator.
+          // You may have already been in a trace prior to calling next(). Since zipkin doesn't
+          // support dual parents we have a choice to either ignore the trace that resulted in this
+          // message, or use its trace id as the current trace id.
+          //
+          // Ex. existing trace calls iterator.next() on a kafka producer-backed iterator
+          // This is a join. We could log the joining trace id into the message-trace, or visa-versa
+          //
+          // Ex. no existing trace calls iterator.next() on a kafka producer-backed iterator
+          // We could choose to simply set the Brave's current server span to the span that just finished.
+          // This would allow future local or client calls to appear caused by the message producer
+
+          // brave.serverSpanThreadBinder().setCurrentSpan(span);// doesn't work as not public visible
+        }
+      }
+    };
+  }
+
+  @Override public void close() throws IOException {
+    delegate.shutdown();
+  }
+}

--- a/brave-kafka/src/main/java/com/github/kristofa/brave/kafka/TracedKafkaProducer.java
+++ b/brave-kafka/src/main/java/com/github/kristofa/brave/kafka/TracedKafkaProducer.java
@@ -1,0 +1,59 @@
+package com.github.kristofa.brave.kafka;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import zipkin.Constants;
+
+public final class TracedKafkaProducer implements Closeable {
+  final Brave brave;
+  final Producer<SpanId, byte[]> delegate;
+
+  TracedKafkaProducer(Brave brave, Properties properties) {
+    Properties zipkinProperties = new Properties();
+    zipkinProperties.putAll(properties);
+    zipkinProperties.put("key.serializer", SpanIdSerializer.class.getName());
+    zipkinProperties.put("value.serializer", ByteArraySerializer.class.getName());
+    this.brave = brave;
+    this.delegate = new KafkaProducer<SpanId, byte[]>(zipkinProperties);
+  }
+
+  Future<RecordMetadata> send(String topic, byte[] value) {
+    SpanId spanId = brave.localTracer().startNewSpan("", topic);
+    if (spanId == null) { // send directly
+      return delegate.send(new ProducerRecord<SpanId, byte[]>(topic, value));
+    }
+    // clear local component as we are abusing local tracer as a messaging tracer
+    brave.localSpanThreadBinder().getCurrentLocalSpan().getBinary_annotations().clear();
+
+    brave.localTracer().submitAnnotation("ms");
+    brave.localTracer().submitBinaryAnnotation("kafka.topic", topic);
+    final Span span = brave.localSpanThreadBinder().getCurrentLocalSpan();
+    brave.localSpanThreadBinder().setCurrentSpan(null);
+
+    return delegate.send(new ProducerRecord<SpanId, byte[]>(topic, spanId, value), new Callback() {
+      @Override public void onCompletion(RecordMetadata recordMetadata, Exception e) {
+        brave.localSpanThreadBinder().setCurrentSpan(span);
+        if (e != null) {
+          brave.localTracer().submitBinaryAnnotation(Constants.ERROR, e.getMessage());
+        }
+        brave.localTracer().submitAnnotation(Constants.WIRE_SEND);
+        brave.localTracer().finishSpan(0); // flush the span: no more work will happen on this side
+      }
+    });
+  }
+
+  @Override public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/brave-kafka/src/test/java/com/github/kristofa/brave/kafka/TracedKafkaConsumerTest.java
+++ b/brave-kafka/src/test/java/com/github/kristofa/brave/kafka/TracedKafkaConsumerTest.java
@@ -1,0 +1,66 @@
+package com.github.kristofa.brave.kafka;
+
+import com.github.charithe.kafka.KafkaJunitRule;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+import java.util.LinkedList;
+import java.util.List;
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracedKafkaConsumerTest {
+  @ClassRule
+  public static KafkaJunitRule kafka = new KafkaJunitRule();
+  @Rule public TestName testName = new TestName();
+  List<Span> spans = new LinkedList<>();
+  Brave brave = new Brave.Builder().spanCollector(new SpanCollector() {
+    @Override public void collect(Span span) {
+      spans.add(span);
+    }
+
+    @Override public void addDefaultAnnotation(String key, String value) {
+    }
+  }).build();
+
+  TracedKafkaConsumer consumer =
+      new TracedKafkaConsumer(brave, kafka.consumerConfig().props().props());
+
+  @Test public void usesPropagatedId() throws Exception {
+    String topic = testName.getMethodName();
+    Producer producer = new Producer(kafka.producerConfigWithDefaultEncoder());
+
+    // assume the span propagated is the child span we are to join
+    SpanId producerSpanId = SpanId.builder()
+        .traceId(1L)
+        .parentId(1L)
+        .spanId(2L)
+        .sampled(true).build();
+
+    producer.send(
+        new KeyedMessage<byte[], byte[]>(topic, producerSpanId.bytes(), "foo".getBytes()));
+    producer.close();
+
+    assertThat(new String(consumer.iterator(topic).next())).isEqualTo("foo");
+    consumer.close();
+
+    Span consumerSpan = spans.get(0);
+
+    assertThat(consumerSpan.getAnnotations()).extracting(a -> a.value)
+        .containsOnly("mr", "wr");
+    assertThat(consumerSpan.getBinary_annotations()).extracting(b -> b.key)
+        .containsOnly("kafka.partition");
+
+    // In this scenario, we use the same span to cover time spent in kafka
+    assertThat(producerSpanId.traceId).isEqualTo(consumerSpan.getTrace_id());
+    assertThat(producerSpanId.nullableParentId()).isEqualTo(consumerSpan.getParent_id());
+    assertThat(producerSpanId.spanId).isEqualTo(consumerSpan.getId());
+  }
+}

--- a/brave-kafka/src/test/java/com/github/kristofa/brave/kafka/TracedKafkaIT.java
+++ b/brave-kafka/src/test/java/com/github/kristofa/brave/kafka/TracedKafkaIT.java
@@ -1,0 +1,41 @@
+package com.github.kristofa.brave.kafka;
+
+import com.github.charithe.kafka.KafkaJunitRule;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
+import com.github.kristofa.brave.http.HttpSpanCollector;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+// run this when you have zipkin running
+public class TracedKafkaIT {
+  @ClassRule
+  public static KafkaJunitRule kafka = new KafkaJunitRule();
+  @Rule public TestName testName = new TestName();
+  Brave brave = new Brave.Builder()
+      .spanCollector(HttpSpanCollector.create("http://localhost:9411/",
+          new EmptySpanCollectorMetricsHandler()))
+      .build();
+
+  TracedKafkaProducer producer =
+      new TracedKafkaProducer(brave, kafka.producerConfigWithStringEncoder().props().props());
+
+  TracedKafkaConsumer consumer =
+      new TracedKafkaConsumer(brave, kafka.consumerConfig().props().props());
+
+  // after this test, look at http://localhost:9411/
+  @Test
+  public void roundTrip() throws Exception {
+    String topic = testName.getMethodName();
+
+    producer.send(topic, "foo".getBytes()).get();
+    producer.close();
+
+    consumer.iterator(topic).next();
+    consumer.close();
+
+    Thread.sleep(1500L); // span collector
+  }
+}

--- a/brave-kafka/src/test/java/com/github/kristofa/brave/kafka/TracedKafkaProducerTest.java
+++ b/brave-kafka/src/test/java/com/github/kristofa/brave/kafka/TracedKafkaProducerTest.java
@@ -1,0 +1,82 @@
+package com.github.kristofa.brave.kafka;
+
+import com.github.charithe.kafka.KafkaJunitRule;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.SpanId;
+import com.google.common.collect.ImmutableMap;
+import com.twitter.zipkin.gen.Span;
+import java.util.LinkedList;
+import java.util.List;
+import kafka.consumer.Consumer;
+import kafka.consumer.KafkaStream;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.MessageAndMetadata;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracedKafkaProducerTest {
+  @ClassRule
+  public static KafkaJunitRule kafka = new KafkaJunitRule();
+  @Rule public TestName testName = new TestName();
+  List<Span> spans = new LinkedList<>();
+  Brave brave = new Brave.Builder().spanCollector(new SpanCollector() {
+    @Override public void collect(Span span) {
+      spans.add(span);
+    }
+
+    @Override public void addDefaultAnnotation(String key, String value) {
+    }
+  }).build();
+
+  TracedKafkaProducer producer =
+      new TracedKafkaProducer(brave, kafka.producerConfigWithStringEncoder().props().props());
+
+  @Test
+  public void sendsSpanAndPropagatesSpanId() throws Exception {
+    String topic = testName.getMethodName();
+
+    producer.send(topic, "foo".getBytes()).get();
+    producer.close();
+
+    assertThat(spans).hasSize(1);
+
+    List<String> messages = kafka.readStringMessages(topic, 1);
+    assertThat(messages).hasSize(1);
+  }
+
+  @Test public void propagatesId() throws Exception {
+    String topic = testName.getMethodName();
+
+    producer.send(topic, "foo".getBytes()).get();
+    producer.close();
+
+    ConsumerConnector connector =
+        Consumer.createJavaConsumerConnector(kafka.consumerConfig());
+
+    KafkaStream<byte[], byte[]> stream =
+        connector.createMessageStreams(ImmutableMap.of(topic, 1)).values().iterator().next().get(0);
+
+    MessageAndMetadata<byte[], byte[]> message = stream.iterator().next();
+    connector.shutdown();
+    assertThat(new String(message.message())).isEqualTo("foo");
+
+    SpanId consumerSpanId = SpanId.fromBytes(message.key());
+    Span producerSpan = spans.get(0);
+
+    assertThat(producerSpan.getAnnotations()).extracting(a -> a.value)
+        .containsOnly("ms", "ws");
+    assertThat(producerSpan.getBinary_annotations()).extracting(b -> b.key)
+        .containsOnly("kafka.topic");
+
+    // In this scenario, we use the same span to cover time spent in kafka
+    assertThat(consumerSpanId.traceId).isEqualTo(producerSpan.getTrace_id());
+    assertThat(consumerSpanId.nullableParentId()).isEqualTo(producerSpan.getParent_id());
+    assertThat(consumerSpanId.spanId).isEqualTo(producerSpan.getId());
+    assertThat(consumerSpanId.sampled()).isNull(); // TODO: add sampling step
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <module>brave-jersey2</module>
     <module>brave-jaxrs2</module>
     <module>brave-grpc</module>
+    <module>brave-kafka</module>
     <module>brave-apache-http-interceptors</module>
     <module>brave-spring-web-servlet-interceptor</module>
     <module>brave-spring-resttemplate-interceptors</module>


### PR DESCRIPTION
This abuses local tracer to send a trace across kafka (where kafka
message key is abused to hold propagated state)

There are a number of tradeoffs to consider, not the least of which the
potential of a dual parent on the consumer side. The current
implementation simulates a client-server span which notably includes
boundary annotations of "ms" "mr".

see #164 #211