### PR TITLE
Localtracer - Make builder public

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -56,15 +56,15 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     @AutoValue.Builder
     public abstract static class Builder {
 
-        abstract Builder spanAndEndpoint(LocalSpanAndEndpoint spanAndEndpoint);
+        public abstract Builder spanAndEndpoint(LocalSpanAndEndpoint spanAndEndpoint);
 
-        abstract Builder randomGenerator(Random randomGenerator);
+        public abstract Builder randomGenerator(Random randomGenerator);
 
-        abstract Builder spanCollector(SpanCollector spanCollector);
+        public abstract Builder spanCollector(SpanCollector spanCollector);
 
-        abstract Builder traceSampler(Sampler sampler);
+        public abstract Builder traceSampler(Sampler sampler);
 
-        abstract LocalTracer build();
+        public abstract LocalTracer build();
     }
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -35,7 +35,7 @@ import static zipkin.Constants.LOCAL_COMPONENT;
 @AutoValue
 public abstract class LocalTracer extends AnnotationSubmitter {
 
-    static Builder builder() {
+    public static Builder builder() {
         return new AutoValue_LocalTracer.Builder();
     }
 
@@ -54,7 +54,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     abstract Sampler traceSampler();
 
     @AutoValue.Builder
-    abstract static class Builder {
+    public abstract static class Builder {
 
         abstract Builder spanAndEndpoint(LocalSpanAndEndpoint spanAndEndpoint);
 


### PR DESCRIPTION
I was incorporating LocalTracer into some code with a custom LocalSpanAndEndpoint.
I could not create a LocalTracer itself without going through the Brave class which was a bit frustrating.

I'm working on a non-blocking webserver framework and the provided implementation of LocalSpanAndEndpoint does not work - as it relies on thread local.

Instead each request through the framework ([Vert.x](http://vertx.io/)) is given a 'Context' object that is associated to the request and passed through the handler chain (the context object has a Map<String, Object> to store request specific information).

I must create a new LocalSpanAndEndpoint and feed it the request underlying Map at the start of every request - which was wanting me to create a new LocalTracer. 

PS: thanks for getting back to me on the google groups. We are already logging some internal timings to a `MetricScope` class (a directed acyclic graph) with start time/duration. 
I was hoping to try and just convert those tracings but hit the wall against the recursive LocalSpans