### PR TITLE
Newly created local spans should inherit from the current local span

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -68,6 +68,13 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     }
 
     /**
+     * Clears current span.
+     */
+    public void clearCurrentSpan() {
+        spanAndEndpoint().state().setCurrentLocalSpan(null);
+    }
+
+    /**
      * Request a new local span, which starts now.
      *
      * @param component {@link Constants#LOCAL_COMPONENT component} responsible for the operation
@@ -83,7 +90,13 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     }
 
     private SpanId getNewSpanId() {
-        Span parentSpan = spanAndEndpoint().state().getCurrentServerSpan().getSpan();
+        Span parentSpan = spanAndEndpoint().state().getCurrentLocalSpan();
+        if (parentSpan == null) {
+            ServerSpan serverSpan = spanAndEndpoint().state().getCurrentServerSpan();
+            if (serverSpan != null) {
+                parentSpan = serverSpan.getSpan();
+            }
+        }
         long newSpanId = randomGenerator().nextLong();
         SpanId.Builder builder = SpanId.builder().spanId(newSpanId);
         if (parentSpan == null) return builder.build(); // new trace

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -50,6 +51,14 @@ public class LocalTracerTest {
                 .build();
     }
 
+    @Test
+    public void testClearCurrentSpan() {
+        state.setCurrentLocalSpan(ServerSpan.create(PARENT_TRACE_ID, PARENT_SPAN_ID, null, "name").getSpan());
+        assertNotNull(state.getCurrentLocalSpan());
+        localTracer.clearCurrentSpan();
+        assertNull(state.getCurrentLocalSpan());
+    }
+
     /**
      * When a local span is started without a timestamp, microseconds and a tick are recorded for
      * duration calculation. A binary annotation is added for search by component.
@@ -62,6 +71,38 @@ public class LocalTracerTest {
     @Test
     public void startNewSpan() {
         state.setCurrentServerSpan(ServerSpan.create(PARENT_TRACE_ID, PARENT_SPAN_ID, null, "name"));
+
+        PowerMockito.when(System.currentTimeMillis()).thenReturn(1L);
+        PowerMockito.when(System.nanoTime()).thenReturn(500L);
+
+        SpanId expectedSpanId =
+            SpanId.builder().traceId(PARENT_TRACE_ID).spanId(555L).parentId(PARENT_SPAN_ID).build();
+
+        assertEquals(expectedSpanId, localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME));
+
+        Span started = state.getCurrentLocalSpan();
+
+        assertEquals(1000L, started.getTimestamp().longValue());
+        assertEquals(500L, started.startTick.longValue());
+        assertEquals("lc", started.getBinary_annotations().get(0).getKey());
+        assertEquals(COMPONENT_NAME, new String(started.getBinary_annotations().get(0).getValue(), Util.UTF_8));
+        assertEquals(state.endpoint(), started.getBinary_annotations().get(0).host);
+        assertEquals(OPERATION_NAME, started.getName());
+    }
+
+    /**
+     * When a local span is started without a timestamp, microseconds and a tick are recorded for
+     * duration calculation. A binary annotation is added for search by component.
+     * <p>
+     * <p/>Ex.
+     * <pre>
+     * localTracer.startNewSpan(component, operation); // internally time and nanos are recorded
+     * </pre>
+     */
+    @Test
+    public void startNewSpanWithLocalParent() {
+        state.setCurrentServerSpan(ServerSpan.create(101, 102, null, "wrong-name"));
+        state.setCurrentLocalSpan(ServerSpan.create(PARENT_TRACE_ID, PARENT_SPAN_ID, null, "name").getSpan());
 
         PowerMockito.when(System.currentTimeMillis()).thenReturn(1L);
         PowerMockito.when(System.nanoTime()).thenReturn(500L);


### PR DESCRIPTION
A newly created local span should inherit from any current local span before inheriting from the current server span.

Also add method to clear the current local span.

This is needed to implement a OpenTracing to Zipkin (via Brave) bridge, see https://github.com/opentracing/opentracing-java/pull/25