### PR TITLE
OpenTracing To Zipkin via Brave Bridge

### DIFF
--- a/brave-opentracing/.gitignore
+++ b/brave-opentracing/.gitignore
@@ -1,0 +1,14 @@
+*~
+#*
+*#
+.#*
+.factorypath
+.classpath
+.project
+.settings/
+target/
+_site/
+.idea
+*.iml
+*.swp
+/opentracing-brave/nbproject/

--- a/brave-opentracing/.settings.xml
+++ b/brave-opentracing/.settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype</id>
+      <username>${env.SONATYPE_USER}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>bintray</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>jfrog-snapshots</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>github.com</id>
+      <username>${env.GH_USER}</username>
+      <password>${env.GH_TOKEN}</password>
+    </server>
+  </servers>
+</settings>
+

--- a/brave-opentracing/README.md
+++ b/brave-opentracing/README.md
@@ -1,0 +1,10 @@
+# OpenTracing API for Java
+
+This library is a Java Bridge for the API to OpenTracing.
+
+## Required Reading
+
+In order to understand OpenTracing API, one must first be familiar with
+the [OpenTracing project](http://opentracing.io) and
+[terminology](http://opentracing.io/spec/) more generally.
+

--- a/brave-opentracing/pom.xml
+++ b/brave-opentracing/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>3.9.2-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.opentracing</groupId>
+    <artifactId>opentracing-brave</artifactId>
+    <name>OpenTracing Brave</name>
+    <description>OpenTracing Brave bridge</description>
+
+    <properties>
+        <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+
+        <main.basedir>${project.basedir}</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-impl-java8</artifactId>
+            <version>0.14-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-core</artifactId>
+            <version>3.9.2-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-http</artifactId>
+            <version>3.9.2-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Ensure main source tree compiles to Java 8 bytecode.    -->
+            <plugin>
+                <inherited>true</inherited>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Language-level aside, make sure Java 9 types and methods aren't used -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.15</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java18</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/brave-opentracing/src/main/java/io/opentracing/BraveSpanBuilderImpl.java
+++ b/brave-opentracing/src/main/java/io/opentracing/BraveSpanBuilderImpl.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import java.util.Optional;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.ServerTracer;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+
+
+final class BraveSpanBuilderImpl extends AbstractSpanBuilder {
+
+    Long traceId = null;
+    Long parentSpanId = null;
+    ServerTracer serverTracer = null;
+    SpanContext spanContext = null;
+
+    private final Brave brave;
+
+    static BraveSpanBuilderImpl create(Brave brave, String operationName) {
+        return new BraveSpanBuilderImpl(brave, operationName);
+    }
+
+    private BraveSpanBuilderImpl(Brave brave, String operationName) {
+        super(operationName);
+        this.brave = brave;
+    }
+
+    @Override
+    protected BraveSpanImpl createSpan() {
+        BraveSpanImpl parent = getParent();
+        if (null != parent) {
+            traceId = parent.spanId.getTraceId();
+            parentSpanId = parent.spanId.getSpanId();
+
+            // push this into the serverSpanState as the current span as that is where new localSpans find their parents
+            brave.serverTracer()
+                    .setStateCurrentTrace(traceId, parentSpanId, parent.spanId.parentId, parent.operationName);
+        }
+        if (null == traceId && null == parentSpanId) {
+            brave.serverTracer().clearCurrentSpan();
+        }
+
+        BraveSpanImpl span = BraveSpanImpl.create(brave,
+                operationName,
+                Optional.ofNullable(parent),
+                start,
+                Optional.ofNullable(serverTracer));
+
+        // push this into the serverSpanState as the current span as that is where new localSpans find their parents
+        brave.serverTracer().setStateCurrentTrace(
+                span.spanId.traceId,
+                span.spanId.spanId,
+                span.spanId.parentId,
+                span.operationName);
+
+        assert (null == traceId && null == parentSpanId) || (null != traceId && null != parentSpanId);
+        assert null == traceId || span.spanId.getTraceId() == traceId;
+        assert null == parentSpanId || parentSpanId.equals(span.spanId.getParentSpanId());
+
+        if (null == traceId && null == parentSpanId) {
+            // called through tracer.buildSpan(..), as opposed to builder.extract(..)
+            brave.serverTracer().setStateCurrentTrace(
+                    span.spanId.getTraceId(),
+                    span.spanId.getSpanId(),
+                    span.spanId.getParentSpanId(),
+                    operationName);
+        }
+
+        return span;
+    }
+
+    BraveSpanBuilderImpl withServerTracer(ServerTracer serverTracer) {
+        this.serverTracer = serverTracer;
+        return this;
+    }
+
+    /** @Nullable **/
+    private BraveSpanImpl getParent() {
+        for (Reference reference : references) {
+            if (References.CHILD_OF.equals(reference.getReferenceType())) {
+                return (BraveSpanImpl) reference.getReferredTo();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    boolean isTraceState(String key, Object value) {
+        return null != valueOf(key);
+    }
+
+    private static BraveHttpHeaders valueOf(String key) {
+        for (BraveHttpHeaders header : BraveHttpHeaders.values()) {
+            if (header.getName().equals(key)) {
+                return header;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    BraveSpanBuilderImpl withStateItem(String key, Object value) {
+        BraveHttpHeaders header = valueOf(key);
+        if (null == header) {
+            throw new IllegalArgumentException(key + " is not a valid brave header");
+        }
+        switch (header) {
+            case TraceId:
+                traceId = value instanceof Number
+                        ? ((Number)value).longValue()
+                        : IdConversion.convertToLong(value.toString());
+                break;
+            case SpanId:
+                parentSpanId = value instanceof Number
+                        ? ((Number)value).longValue()
+                        : IdConversion.convertToLong(value.toString());
+                break;
+            case ParentSpanId:
+                if (null == parentSpanId) {
+                    parentSpanId = value instanceof Number
+                            ? ((Number)value).longValue()
+                            : IdConversion.convertToLong(value.toString());
+                }
+                break;
+        }
+        return this;
+    }
+}

--- a/brave-opentracing/src/main/java/io/opentracing/BraveSpanImpl.java
+++ b/brave-opentracing/src/main/java/io/opentracing/BraveSpanImpl.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.ServerTracer;
+import com.github.kristofa.brave.SpanId;
+
+
+final class BraveSpanImpl extends AbstractSpan {
+
+    final SpanId spanId;
+    final Optional<Span> parent;
+    final Optional<ServerTracer> serverTracer;
+
+    private final Brave brave;
+    private Optional<ClientTracer> clientTracer = Optional.empty();
+
+    public static BraveSpanImpl create(
+            Brave brave,
+            String operationName,
+            Optional<Span> parent,
+            Instant start,
+            Optional<ServerTracer> serverTracer) {
+
+        return new BraveSpanImpl(brave, operationName, parent, start, serverTracer);
+    }
+
+    private BraveSpanImpl(
+            Brave brave,
+            String operationName,
+            Optional<Span> parent,
+            Instant start,
+            Optional<ServerTracer> serverTracer) {
+
+        super(operationName, start);
+        this.brave = brave;
+        this.parent = parent;
+        this.serverTracer = serverTracer;
+
+        this.spanId = brave.localTracer().startNewSpan(
+                "jvm",
+                operationName,
+                TimeUnit.SECONDS.toMicros(start.getEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(start.getNano()));
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
+        brave.localTracer().finishSpan();
+        if (clientTracer.isPresent()) {
+            clientTracer.get().setClientReceived();
+        }
+        if (serverTracer.isPresent()) {
+            serverTracer.get().setServerSend();
+        }
+    }
+
+    void setClientTracer(ClientTracer clientTracer) {
+        this.clientTracer = Optional.of(clientTracer);
+    }
+}

--- a/brave-opentracing/src/main/java/io/opentracing/BraveTracerImpl.java
+++ b/brave-opentracing/src/main/java/io/opentracing/BraveTracerImpl.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import java.util.Map;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+
+import io.opentracing.propagation.Format;
+import java.util.HashMap;
+
+public final class BraveTracerImpl extends AbstractTracer {
+
+    final Brave brave;
+
+    public BraveTracerImpl() {
+        this(new Brave.Builder());
+    }
+
+    public BraveTracerImpl(Brave.Builder builder) {
+        brave = builder.build();
+    }
+
+    @Override
+    BraveSpanBuilderImpl createSpanBuilder(String operationName) {
+        return BraveSpanBuilderImpl.create(brave, operationName);
+    }
+
+    @Override
+    Map<String, Object> getTraceState(SpanContext spanContext) {
+        Span span = (Span)spanContext;
+
+        return new HashMap<String,Object>() {{
+            SpanId spanId = ((BraveSpanImpl)span).spanId;
+            put(BraveHttpHeaders.Sampled.getName(), "1");
+            put(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.getTraceId()));
+            put(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.getSpanId()));
+            if (null != spanId.getParentSpanId()) {
+                put(BraveHttpHeaders.ParentSpanId.getName(), IdConversion.convertToString(spanId.getParentSpanId()));
+            }
+        }};
+    }
+
+    Map<String, String> getBaggage(Span span) {
+        return ((BraveSpanImpl)span).baggage;
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        brave.clientTracer().startNewSpan(((BraveSpanImpl)spanContext).operationName);
+        brave.clientTracer().setClientSent();
+        super.inject(spanContext, format, carrier);
+        ((BraveSpanImpl)spanContext).setClientTracer(brave.clientTracer());
+    }
+
+    @Override
+    public <C> SpanBuilder extract(Format<C> format, C carrier) {
+
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) super.extract(format, carrier);
+
+        if (null != builder.traceId
+                && null != builder.parentSpanId
+                && null != builder.operationName) {
+
+            brave.serverTracer().setStateCurrentTrace(
+                    builder.traceId,
+                    builder.parentSpanId,
+                    null,
+                    builder.operationName);
+
+            brave.serverTracer().setServerReceived();
+            builder.withServerTracer(brave.serverTracer());
+            return builder;
+        }
+        return NoopSpanBuilder.INSTANCE;
+    }
+
+}

--- a/brave-opentracing/src/test/java/io/opentracing/BraveSpanBuilderImplTest.java
+++ b/brave-opentracing/src/test/java/io/opentracing/BraveSpanBuilderImplTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.Sampler;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+
+public final class BraveSpanBuilderImplTest {
+
+    private SpanCollector mockSpanCollector;
+    private Brave brave;
+
+    @Before
+    public void setup() {
+        mockSpanCollector = mock(SpanCollector.class);
+        // -1062731775 = 192.168.0.1
+        final Brave.Builder builder = new Brave.Builder(-1062731775, 8080, "unknown");
+        brave = builder.spanCollector(mockSpanCollector).traceSampler(Sampler.create(1)).build();
+    }
+
+    @Test
+    public void testCreateSpan() {
+        String operationName = "test-testCreateSpan";
+        brave.serverTracer().clearCurrentSpan();
+        BraveSpanBuilderImpl builder = BraveSpanBuilderImpl.create(brave, operationName);
+        BraveSpanImpl span = builder.createSpan();
+
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+        assert 0 != span.spanId.getTraceId() : span.spanId.getTraceId();
+        assert null == span.spanId.getParentSpanId() : span.spanId.getParentSpanId();
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+    }
+
+    @Test
+    public void testWithServerTracer() {
+        String operationName = "test-testWithServerTracer";
+        brave.serverTracer().clearCurrentSpan();
+
+        BraveSpanBuilderImpl builder = BraveSpanBuilderImpl
+                .create(brave, operationName)
+                .withServerTracer(brave.serverTracer());
+
+        BraveSpanImpl span = builder.createSpan();
+
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+        assert 0 != span.spanId.getTraceId() : span.spanId.getTraceId();
+        assert null == span.spanId.getParentSpanId() : span.spanId.getParentSpanId();
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+    }
+
+    @Test
+    public void testWithServerTracer_withParent() {
+        String operationName = "test-testWithServerTracer_withParent";
+        Instant start = Instant.now();
+        brave.serverTracer().clearCurrentSpan();
+
+        BraveSpanImpl parent = BraveSpanImpl.create(
+                brave,
+                operationName + "-parent",
+                Optional.empty(),
+                start.minusMillis(100),
+                Optional.of(brave.serverTracer()));
+
+        brave.serverTracer().setStateCurrentTrace(
+                parent.spanId.getTraceId(),
+                parent.spanId.getSpanId(),
+                null,
+                parent.operationName);
+
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) BraveSpanBuilderImpl
+                .create(brave, operationName)
+                .withServerTracer(brave.serverTracer())
+                .asChildOf((Span)parent);
+
+        BraveSpanImpl span = builder.createSpan();
+
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+        assert 0 != span.spanId.getTraceId() : span.spanId.getTraceId();
+        assert null != span.spanId.getParentSpanId() : span.spanId.getParentSpanId();
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert span.parent.isPresent();
+        assert parent.equals(span.parent.get());
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+    }
+
+    @Test
+    public void testIsTraceState() {
+        String operationName = "test-testCreateSpan";
+        BraveSpanBuilderImpl builder = BraveSpanBuilderImpl.create(brave, operationName);
+
+        for (BraveHttpHeaders header : BraveHttpHeaders.values()) {
+            assert builder.isTraceState(header.getName(), "any-value")
+                    : header.getName() + " should be a trace state key";
+        }
+
+        assert !builder.isTraceState("not-a-zipkin-header", "any-value");
+    }
+
+    @Test
+    public void testWithStateItem() {
+        String operationName = "test-testWithStateItem";
+        brave.serverTracer().clearCurrentSpan();
+
+        BraveSpanBuilderImpl builder = BraveSpanBuilderImpl
+                .create(brave, operationName)
+                .withServerTracer(brave.serverTracer())
+                .withStateItem(BraveHttpHeaders.TraceId.getName(), "123")
+                .withStateItem(BraveHttpHeaders.SpanId.getName(), "234");
+
+        brave.serverTracer().setStateCurrentTrace(
+                builder.traceId,
+                builder.parentSpanId,
+                null,
+                builder.operationName);
+
+        BraveSpanImpl span = builder.createSpan();
+
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+        assert 291 == span.spanId.getTraceId() : span.spanId.getTraceId();
+        assert 564 == span.spanId.getParentSpanId() : span.spanId.getParentSpanId();
+        assert operationName.equals(span.operationName) :  span.operationName;
+        assert !span.parent.isPresent();
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+    }
+
+}

--- a/brave-opentracing/src/test/java/io/opentracing/BraveSpanImplTest.java
+++ b/brave-opentracing/src/test/java/io/opentracing/BraveSpanImplTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.Sampler;
+import com.github.kristofa.brave.ServerTracer;
+import com.github.kristofa.brave.SpanCollector;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public final class BraveSpanImplTest {
+
+    private SpanCollector mockSpanCollector;
+    private Brave brave;
+
+    @Before
+    public void setup() {
+        mockSpanCollector = mock(SpanCollector.class);
+        // -1062731775 = 192.168.0.1
+        final Brave.Builder builder = new Brave.Builder(-1062731775, 8080, "unknown");
+        brave = builder.spanCollector(mockSpanCollector).traceSampler(Sampler.create(1)).build();
+    }
+
+    @Test
+    public void test() {
+        String operationName = "test-test";
+        Optional<Span> parent = Optional.empty();
+        Instant start = Instant.now();
+        Optional<ServerTracer> serverTracer = Optional.empty();
+
+        BraveSpanImpl span = BraveSpanImpl.create(brave, operationName, parent, start, serverTracer);
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+
+        span.finish();
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+    }
+
+    @Test
+    public void test_withServerTracer() {
+        String operationName = "test-test_withServerTracer";
+        Optional<Span> parent = Optional.empty();
+        Instant start = Instant.now();
+        Optional<ServerTracer> serverTracer = Optional.of(brave.serverTracer());
+
+        BraveSpanImpl span = BraveSpanImpl.create(brave, operationName, parent, start, serverTracer);
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+
+        span.finish();
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+    }
+
+    @Test
+    public void test_withParent() {
+        String operationName = "test-test_withParent";
+        Instant start = Instant.now();
+        Optional<ServerTracer> serverTracer = Optional.empty();
+
+        Optional<Span> parent = Optional.of(
+                BraveSpanImpl.create(brave, operationName, Optional.empty(), start.minusMillis(100), serverTracer));
+
+        BraveSpanImpl span = BraveSpanImpl.create(brave, operationName, parent, start, serverTracer);
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert span.parent.isPresent();
+        assert span.parent.get() == parent.get();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+
+        span.finish();
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert span.parent.isPresent();
+        assert span.parent.get() == parent.get();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+    }
+
+    @Test
+    public void test_withParent_withServerTracer() {
+        String operationName = "test-test_withParent_withServerTracer";
+        Instant start = Instant.now();
+        Optional<ServerTracer> serverTracer = Optional.of(brave.serverTracer());
+
+        Optional<Span> parent = Optional.of(
+                BraveSpanImpl.create(brave, operationName, Optional.empty(), start.minusMillis(100), serverTracer));
+
+        BraveSpanImpl span = BraveSpanImpl.create(brave, operationName, parent, start, serverTracer);
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert span.parent.isPresent();
+        assert span.parent.get() == parent.get();
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+
+        span.finish();
+
+        assert null != span.spanId;
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert span.parent.isPresent();
+        assert span.parent.get() == parent.get();
+        assert span.serverTracer.isPresent();
+        assert brave.serverTracer().equals(span.serverTracer.get());
+        assert span.baggage.isEmpty();
+    }
+
+}

--- a/brave-opentracing/src/test/java/io/opentracing/BraveTracerImplTest.java
+++ b/brave-opentracing/src/test/java/io/opentracing/BraveTracerImplTest.java
@@ -1,0 +1,460 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.ServerTracer;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import io.opentracing.propagation.TextMapInjectAdapter;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+
+
+public final class BraveTracerImplTest {
+
+    @Test
+    public void test_buildSpan() {
+        String operationName = "test-test_buildSpan";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        tracer.brave.serverTracer().clearCurrentSpan();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName);
+
+        assert operationName.equals(builder.operationName) : builder.operationName;
+        assert null == builder.parentSpanId : builder.parentSpanId;
+        assert builder.references.isEmpty();
+        assert null == builder.serverTracer : builder.serverTracer;
+        assert builder.start.isBefore(Instant.now().plusMillis(1));
+        assert null == builder.traceId : builder.traceId;
+
+        BraveSpanImpl span = builder.createSpan();
+
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+        assert 0 != span.spanId.getTraceId() : span.spanId.getTraceId();
+        assert null == span.spanId.getParentSpanId() : span.spanId.getParentSpanId();
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+
+        span.finish();
+    }
+
+    @Test
+    public void test_buildSpan_child() {
+        String parentOperationName = "test-test_buildSpan_child-parent";
+        String operationName = "test-test_buildSpan_child";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        tracer.brave.serverTracer().clearCurrentSpan();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(parentOperationName);
+
+        assert parentOperationName.equals(builder.operationName) : builder.operationName;
+        assert null == builder.parentSpanId : builder.parentSpanId;
+        assert builder.references.isEmpty();
+        assert null == builder.serverTracer : builder.serverTracer;
+        assert builder.start.isBefore(Instant.now().plusMillis(1));
+        assert null == builder.traceId : builder.traceId;
+
+        BraveSpanImpl parent = builder.createSpan();
+
+        assert null != parent.spanId;
+        assert 0 != parent.spanId.getSpanId() : parent.spanId.getSpanId();
+        assert 0 != parent.spanId.getTraceId() : parent.spanId.getTraceId();
+        assert null == parent.spanId.getParentSpanId() : parent.spanId.getParentSpanId();
+        assert parentOperationName.equals(parent.operationName) : "span.operationName was " + parent.operationName;
+        assert !parent.parent.isPresent();
+        assert !parent.serverTracer.isPresent();
+        assert parent.baggage.isEmpty();
+
+        builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName).asChildOf((Span)parent);
+        BraveSpanImpl span = builder.createSpan();
+
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assertChildToParent(span, parent, false);
+
+        span.finish();
+        parent.finish();
+    }
+
+    @Test
+    public void test_buildSpan_seperate_traces() {
+        String parentOperationName = "test-test_buildSpan_seperate_traces-parent";
+        String operationName = "test-test_buildSpan_seperate_traces";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        tracer.brave.serverTracer().clearCurrentSpan();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(parentOperationName);
+
+        assert parentOperationName.equals(builder.operationName) : builder.operationName;
+        assert null == builder.parentSpanId : builder.parentSpanId;
+        assert builder.references.isEmpty();
+        assert null == builder.serverTracer : builder.serverTracer;
+        assert builder.start.isBefore(Instant.now().plusMillis(1));
+        assert null == builder.traceId : builder.traceId;
+
+        BraveSpanImpl first = builder.createSpan();
+
+        assert null != first.spanId;
+        assert 0 != first.spanId.getSpanId() : first.spanId.getSpanId();
+        assert 0 != first.spanId.getTraceId() : first.spanId.getTraceId();
+        assert null == first.spanId.getParentSpanId() : first.spanId.getParentSpanId();
+        assert parentOperationName.equals(first.operationName) : "span.operationName was " + first.operationName;
+        assert !first.parent.isPresent();
+        assert !first.serverTracer.isPresent();
+        assert first.baggage.isEmpty();
+
+        first.finish();
+        builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName);
+        BraveSpanImpl second = builder.createSpan();
+
+        assert null != second.spanId;
+        assert 0 != second.spanId.getSpanId() : second.spanId.getSpanId();
+        assert 0 != second.spanId.getSpanId() : second.spanId.getSpanId();
+        assert 0 != second.spanId.getTraceId() : second.spanId.getTraceId();
+
+        assert first.spanId.getTraceId() != second.spanId.getTraceId()
+                : "child: " + first.spanId.getTraceId() + " ; parent: " + second.spanId.getTraceId();
+
+        assert null == second.spanId.getParentSpanId() : second.spanId.getParentSpanId();
+        assert operationName.equals(second.operationName) : "span.operationName was " + second.operationName;
+        assert !first.parent.isPresent();
+        assert !second.serverTracer.isPresent();
+        assert second.baggage.isEmpty();
+
+        second.finish();
+    }
+
+    @Test
+    public void test_buildSpan_same_trace() {
+        String parentOperationName = "test-test_buildSpan_same_trace-parent";
+        String operationName1 = "test-test_buildSpan_same_trace-1";
+        String operationName2 = "test-test_buildSpan_same_trace-2";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        tracer.brave.serverTracer().clearCurrentSpan();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(parentOperationName);
+
+        assert parentOperationName.equals(builder.operationName) : builder.operationName;
+        assert null == builder.parentSpanId : builder.parentSpanId;
+        assert builder.references.isEmpty();
+        assert null == builder.serverTracer : builder.serverTracer;
+        assert builder.start.isBefore(Instant.now().plusMillis(1));
+        assert null == builder.traceId : builder.traceId;
+
+        BraveSpanImpl parent = builder.createSpan();
+
+        assert null != parent.spanId;
+        assert 0 != parent.spanId.getSpanId() : parent.spanId.getSpanId();
+        assert 0 != parent.spanId.getTraceId() : parent.spanId.getTraceId();
+        assert null == parent.spanId.getParentSpanId() : parent.spanId.getParentSpanId();
+        assert parentOperationName.equals(parent.operationName) : "span.operationName was " + parent.operationName;
+        assert !parent.parent.isPresent();
+        assert !parent.serverTracer.isPresent();
+        assert parent.baggage.isEmpty();
+
+        builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName1).asChildOf((Span)parent);
+        BraveSpanImpl first = builder.createSpan();
+
+        assert operationName1.equals(first.operationName) : "span.operationName was " + first.operationName;
+        assertChildToParent(first, parent, false);
+
+        first.finish();
+        builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName2).asChildOf((Span)parent);
+        BraveSpanImpl second = builder.createSpan();
+
+        assert operationName2.equals(second.operationName) : "span.operationName was " + second.operationName;
+        assertChildToParent(second, parent, false);
+
+        second.finish();
+        parent.finish();
+    }
+
+    @Test
+    public void test_buildSpan_notChild_seperate_traces() {
+        String parentOperationName = "test-test_buildSpan_notChild_seperate_traces-parent";
+        String operationName = "test-test_buildSpan_notChild_seperate_traces";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        tracer.brave.serverTracer().clearCurrentSpan();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(parentOperationName);
+
+        assert parentOperationName.equals(builder.operationName) : builder.operationName;
+        assert null == builder.parentSpanId : builder.parentSpanId;
+        assert builder.references.isEmpty();
+        assert null == builder.serverTracer : builder.serverTracer;
+        assert builder.start.isBefore(Instant.now().plusMillis(1));
+        assert null == builder.traceId : builder.traceId;
+
+        BraveSpanImpl first = builder.createSpan();
+
+        assert null != first.spanId;
+        assert 0 != first.spanId.getSpanId() : first.spanId.getSpanId();
+        assert 0 != first.spanId.getTraceId() : first.spanId.getTraceId();
+        assert null == first.spanId.getParentSpanId() : first.spanId.getParentSpanId();
+        assert parentOperationName.equals(first.operationName) : "span.operationName was " + first.operationName;
+        assert !first.parent.isPresent();
+        assert !first.serverTracer.isPresent();
+        assert first.baggage.isEmpty();
+
+        builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName);
+        BraveSpanImpl second = builder.createSpan();
+
+        assert null != second.spanId;
+        assert 0 != second.spanId.getSpanId() : second.spanId.getSpanId();
+        assert 0 != second.spanId.getSpanId() : second.spanId.getSpanId();
+        assert 0 != second.spanId.getTraceId() : second.spanId.getTraceId();
+
+        assert first.spanId.getTraceId() != second.spanId.getTraceId()
+                : "child: " + first.spanId.getTraceId() + " ; parent: " + second.spanId.getTraceId();
+
+        assert null == second.spanId.getParentSpanId() : second.spanId.getParentSpanId();
+        assert operationName.equals(second.operationName) : "span.operationName was " + second.operationName;
+        assert !first.parent.isPresent();
+        assert !second.serverTracer.isPresent();
+        assert second.baggage.isEmpty();
+
+        first.finish();
+        second.finish();
+    }
+
+    @Test
+    public void testGetTraceState() {
+        String operationName = "test-testGetTraceState";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+
+        Optional<Span> parent = Optional.empty();
+        Instant start = Instant.now();
+        Optional<ServerTracer> serverTracer = Optional.empty();
+
+        BraveSpanImpl span = BraveSpanImpl.create(tracer.brave, operationName, parent, start, serverTracer);
+
+        assert tracer.getTraceState(span).containsKey(BraveHttpHeaders.TraceId.getName());
+        assert tracer.getTraceState(span).containsKey(BraveHttpHeaders.SpanId.getName());
+        assert tracer.getTraceState(span).containsKey(BraveHttpHeaders.Sampled.getName());
+
+        assert tracer.getTraceState(span).get(BraveHttpHeaders.TraceId.getName())
+                .equals(IdConversion.convertToString(span.spanId.getTraceId()));
+
+        assert tracer.getTraceState(span).get(BraveHttpHeaders.SpanId.getName())
+                .equals(IdConversion.convertToString(span.spanId.getSpanId()));
+
+        span.finish();
+    }
+
+    @Test
+    public void testGetBaggage() {
+        String operationName = "test-testGetBaggage";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName);
+
+        Span span = builder.withBaggageItem("baggage-key-1", "baggage-value-1").start();
+
+        assert tracer.getBaggage(span).containsKey("baggage-key-1");
+        assert "baggage-value-1".equals(tracer.getBaggage(span).get("baggage-key-1"));
+
+        span.finish();
+    }
+
+    @Test
+    public void testInject() {
+        String operationName = "test-testInject";
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.buildSpan(operationName);
+
+        assert operationName.equals(builder.operationName) : builder.operationName;
+        assert null == builder.parentSpanId : builder.parentSpanId;
+        assert builder.references.isEmpty();
+        assert null == builder.serverTracer : builder.serverTracer;
+        assert builder.start.isBefore(Instant.now().plusMillis(1));
+        assert null == builder.traceId : builder.traceId;
+
+        BraveSpanImpl span = builder.createSpan();
+
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+        assert 0 != span.spanId.getTraceId() : span.spanId.getTraceId();
+        assert null == span.spanId.getParentSpanId() : span.spanId.getParentSpanId();
+        assert operationName.equals(span.operationName) : "span.operationName was " + span.operationName;
+        assert !span.parent.isPresent();
+        assert !span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+
+        Map<String,String> map = new HashMap<>();
+        TextMapInjectAdapter adapter = new TextMapInjectAdapter(map);
+        tracer.inject(span, Format.Builtin.TEXT_MAP, adapter);
+
+        assert map.containsKey(BraveHttpHeaders.TraceId.getName());
+        assert map.containsKey(BraveHttpHeaders.SpanId.getName());
+
+        span.finish();
+    }
+
+    @Test
+    public void testExtract() {
+
+        Map<String,String> map = new HashMap<String,String>() {{
+            put(BraveHttpHeaders.Sampled.getName(), "1");
+            put(BraveHttpHeaders.TraceId.getName(), "123");
+            put(BraveHttpHeaders.SpanId.getName(), "234");
+        }};
+
+        TextMapExtractAdapter adapter = new TextMapExtractAdapter(map);
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        BraveSpanBuilderImpl builder = (BraveSpanBuilderImpl) tracer.extract(Format.Builtin.TEXT_MAP, adapter);
+
+        assert 291 == builder.traceId : builder.traceId;
+        assert 564 == builder.parentSpanId : builder.parentSpanId;
+    }
+
+    @Test
+    public void test_stack() throws InterruptedException {
+
+        BraveTracerImpl tracer = new BraveTracerImpl();
+        tracer.brave.serverTracer().clearCurrentSpan();
+
+        long start = System.currentTimeMillis() - 10000;
+
+        // start a span
+        try ( Span span0 = tracer.buildSpan("span-0")
+                .withStartTimestamp(start)
+                .withTag("description", "top level initial span in the original process")
+                .start() ) {
+
+
+            try ( Span span1 = tracer.buildSpan("span-1")
+                    .withStartTimestamp(start +100)
+                    .asChildOf(span0)
+                    .withTag("description", "the first inner span in the original process")
+                    .start() ) {
+
+                assertChildToParent((BraveSpanImpl) span1, (BraveSpanImpl) span0, false);
+
+                try ( Span span2 = tracer.buildSpan("span-2")
+                        .withStartTimestamp(start +200)
+                        .asChildOf(span1)
+                        .withTag("description", "the second inner span in the original process")
+                        .start() ) {
+
+                    assertChildToParent((BraveSpanImpl) span2, (BraveSpanImpl) span1, false);
+
+                    // cross process boundary
+                    Map<String,String> map = new HashMap<>();
+                    tracer.inject(span2.context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(map));
+
+                    try ( Span span3 = tracer.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(map))
+                            .withStartTimestamp(start +300)
+                            .withTag("description", "the third inner span in the second process")
+                            .start() ) {
+
+                        assertChildToParent((BraveSpanImpl) span3, (BraveSpanImpl) span2, true);
+
+                        try ( Span span4 = tracer.buildSpan("span-4")
+                                .withStartTimestamp(start +400)
+                                .asChildOf(span3)
+                                .withTag("description", "the fourth inner span in the second process")
+                                .start() ) {
+
+                            assertChildToParent((BraveSpanImpl) span4, (BraveSpanImpl) span3, false);
+
+                            // cross process boundary
+                            map = new HashMap<>();
+                            tracer.inject(span4.context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(map));
+
+                            try ( Span span5 = tracer.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(map))
+                                    .withStartTimestamp(start +500)
+                                    .withTag("description", "the fifth inner span in the third process")
+                                    .start() ) {
+
+                                assertChildToParent((BraveSpanImpl) span5, (BraveSpanImpl) span4, true);
+
+                                try ( Span span6 = tracer.buildSpan("span-6")
+                                        .withStartTimestamp(start +600)
+                                        .asChildOf(span5)
+                                        .withTag("description", "the sixth inner span in the third process")
+                                        .start() ) {
+
+                                    assertChildToParent((BraveSpanImpl) span6, (BraveSpanImpl) span5, false);
+
+                                    try ( Span span7 = tracer.buildSpan("span-7")
+                                            .withStartTimestamp(start +700)
+                                            .asChildOf(span6)
+                                            .withTag("description", "the seventh span in the third process")
+                                            .start() ) {
+
+                                        assertChildToParent((BraveSpanImpl) span7, (BraveSpanImpl) span6, false);
+
+                                        // cross process boundary
+                                        map = new HashMap<>();
+
+                                        tracer.inject(
+                                                span7.context(),
+                                                Format.Builtin.TEXT_MAP,
+                                                new TextMapInjectAdapter(map));
+
+                                        try ( Span span8 = tracer
+                                                .extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(map))
+                                                .withStartTimestamp(start +800)
+                                                .withTag("description", "the eight inner span in the fourth process")
+                                                .start() ) {
+
+                                            assertChildToParent((BraveSpanImpl) span8, (BraveSpanImpl) span7, true);
+
+                                            try ( Span span9 = tracer.buildSpan("span-9")
+                                                    .withStartTimestamp(start +900)
+                                                    .asChildOf(span8)
+                                                    .withTag("description", "the ninth inner span in the fouth process")
+                                                    .start() ) {
+
+                                                assertChildToParent((BraveSpanImpl) span9, (BraveSpanImpl) span8, false);
+                                                Thread.sleep(10);
+                                            }
+                                            Thread.sleep(10);
+                                        }
+                                        Thread.sleep(10);
+                                    }
+                                    Thread.sleep(10);
+                                }
+                                Thread.sleep(10);
+                            }
+                            Thread.sleep(10);
+                        }
+                        Thread.sleep(10);
+                    }
+                    Thread.sleep(10);
+                }
+                Thread.sleep(10);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private void assertChildToParent(BraveSpanImpl span, BraveSpanImpl parent, boolean extracted) {
+        assert null != span.spanId;
+        assert 0 != span.spanId.getSpanId() : span.spanId.getSpanId();
+
+        assert parent.spanId.getTraceId() == span.spanId.getTraceId()
+                : "parent: " + parent.spanId.getTraceId() + " ; child: " + span.spanId.getTraceId();
+
+        assert parent.spanId.getSpanId() == span.spanId.getParentSpanId()
+                : "parent: " + parent.spanId.getSpanId() + " ; child: " + span.spanId.getParentSpanId();
+
+        assert extracted || span.parent.isPresent();
+        assert extracted || span.parent.get().equals(parent);
+        assert !extracted || span.serverTracer.isPresent();
+        assert span.baggage.isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <module>brave-mysql</module>
     <module>brave-web-servlet-filter</module>
     <module>brave-okhttp</module>
+    <module>brave-opentracing</module>
   </modules>
 
   <distributionManagement>


### PR DESCRIPTION
Design:
 - All spans that are explicitly created are done so with the local tracer.
 - CS+CR and SR+SS annotations are done around the inject and extract methods.
 - There is a mismatch between the two APIs in how state of the current span is held. OpenTracing does not hold any such state and passes in the
current span intended to be a parent is an explicit action in the API, while in Brave this state is known and such action not required. OpenTracing's
expectations are honoured here and Brave's internal state is overridden as needed.
 - It is noted that it probably would have been simpler to have implemented against lower APIs in brave, like directly against the collector and spans,
than the top level Brave api.

ref: https://github.com/opentracing/opentracing-java/commit/99a0c6add9b769cb54693756cfc58b6817205b84