### PR TITLE
Adds InheritableServerClientAndLocalSpanState for multiple local spans

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -38,6 +38,7 @@ public class Brave {
         private Random random = new Random();
         // default added so callers don't need to check null.
         private Sampler sampler = Sampler.create(1.0f);
+        private boolean allowNestedLocalSpans = false;
 
         /**
          * Builder which initializes with serviceName = "unknown".
@@ -86,6 +87,10 @@ public class Brave {
          */
         public Builder(ServerClientAndLocalSpanState state) {
             this.state = Util.checkNotNull(state, "state must be specified.");
+
+            // the legacy span state doesn't support nested spans per (#166). Only permit nesting on the span
+            // state that has instructions on how to use it properly
+            this.allowNestedLocalSpans = state instanceof InheritableServerClientAndLocalSpanState;
         }
 
         /**
@@ -222,6 +227,7 @@ public class Brave {
         localTracer = LocalTracer.builder()
                 .randomGenerator(builder.random)
                 .spanCollector(builder.spanCollector)
+                .allowNestedLocalSpans(builder.allowNestedLocalSpans)
                 .spanAndEndpoint(SpanAndEndpoint.LocalSpanAndEndpoint.create(builder.state))
                 .traceSampler(builder.sampler).build();
         

--- a/brave-core/src/main/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanState.java
@@ -1,0 +1,113 @@
+package com.github.kristofa.brave;
+
+import java.util.Deque;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import com.github.kristofa.brave.internal.Util;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+
+/**
+ * {@link ServerClientAndLocalSpanState} implementation that keeps trace state using {@link InheritableThreadLocal}
+ * variables and provides local span inheritence from parent to children.
+ * <p>
+ * Important note: when using {@link InheritableServerClientAndLocalSpanState}, tracers must
+ * {@link LocalTracer#finishSpan() finish spans} or clear the local span at
+ * completion of the local trace span to avoid linking spans with incorrect
+ * parents and avoid leaking spans and associated memory.
+ */
+public final class InheritableServerClientAndLocalSpanState implements ServerClientAndLocalSpanState {
+
+    private final InheritableThreadLocal<ServerSpan> currentServerSpan =
+            new InheritableThreadLocal<ServerSpan>() {
+                @Override
+                protected ServerSpan initialValue() {
+                    return ServerSpan.EMPTY;
+                }
+            };
+
+    private final InheritableThreadLocal<Span> currentClientSpan = new InheritableThreadLocal<Span>();
+
+    private final InheritableThreadLocal<Deque<Span>> currentLocalSpan =
+            new InheritableThreadLocal<Deque<Span>>() {
+                @Override
+                protected Deque<Span> initialValue() {
+                    return new LinkedBlockingDeque<Span>();
+                }
+            };
+
+    private final Endpoint endpoint;
+
+    /**
+     * @param endpoint Endpoint of the local service being traced.
+     */
+    public InheritableServerClientAndLocalSpanState(Endpoint endpoint) {
+        this.endpoint = Util.checkNotNull(endpoint, "Endpoint must be specified.");
+    }
+
+    @Override
+    public ServerSpan getCurrentServerSpan() {
+        return currentServerSpan.get();
+    }
+
+    @Override
+    public void setCurrentServerSpan(final ServerSpan span) {
+        if (span == null) {
+            currentServerSpan.remove();
+        } else {
+            currentServerSpan.set(span);
+        }
+    }
+
+    @Override
+    public Endpoint endpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public Span getCurrentClientSpan() {
+        return currentClientSpan.get();
+    }
+
+    @Override
+    public void setCurrentClientSpan(final Span span) {
+        currentClientSpan.set(span);
+    }
+
+    @Override
+    public Boolean sample() {
+        return getCurrentServerSpan().getSample();
+    }
+
+    @Override
+    public Span getCurrentLocalSpan() {
+        return currentLocalSpan.get().peekFirst();
+    }
+
+    /**
+     * Sets the specified local span as the active span at the top of the
+     * stack, or if the specified span is null, the top of the stack is popped.
+     *
+     * @param span Local span.
+     */
+    @Override
+    public void setCurrentLocalSpan(Span span) {
+        Deque<Span> deque = currentLocalSpan.get();
+        if (span == null) {
+            // pop to remove
+            deque.pollFirst();
+        } else {
+            deque.addFirst(span);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "InheritableServerClientAndLocalSpanState{"
+                + "endpoint=" + endpoint + ", "
+                + "currentLocalSpan=" + currentLocalSpan + ", "
+                + "currentClientSpan=" + currentClientSpan + ", "
+                + "currentServerSpan=" + currentServerSpan
+                + "}";
+    }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
@@ -1,0 +1,128 @@
+package com.github.kristofa.brave;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+
+public class InheritableServerClientAndLocalSpanStateTest {
+
+    private static final short PORT = 80;
+    private static final String SERVICE_NAME = InheritableServerClientAndLocalSpanStateTest.class.getSimpleName();
+    private static final int MAX_EXPECTED_DEPTH = 1;
+
+    private InheritableServerClientAndLocalSpanState state;
+    private ServerSpan mockServerSpan;
+    private Span mockSpan;
+
+    @Before
+    public void setup() throws UnknownHostException {
+        final int ip = InetAddressUtilities.toInt(InetAddress.getByName("192.168.0.1"));
+        state = new InheritableServerClientAndLocalSpanState(Endpoint.create(SERVICE_NAME, ip, PORT));
+        mockServerSpan = mock(ServerSpan.class);
+        mockSpan = mock(Span.class);
+    }
+
+    @After
+    public void tearDown() {
+        state.setCurrentClientSpan(null);
+        state.setCurrentServerSpan(null);
+        Span localSpan;
+        int depth = 0;
+        while ((localSpan = state.getCurrentLocalSpan()) != null) {
+            depth++;
+            state.setCurrentLocalSpan(null);
+            assertThat(state.getCurrentLocalSpan()).isNotEqualTo(localSpan);
+            assertThat(depth).isLessThanOrEqualTo(MAX_EXPECTED_DEPTH).as("Depth should not exceed %d, was %d", depth);
+        }
+        assertThat(state.getCurrentLocalSpan()).isNull();
+    }
+
+    @Test
+    public void testGetAndSetCurrentServerSpan() {
+        assertEquals(ServerSpan.create(null), state.getCurrentServerSpan());
+        state.setCurrentServerSpan(mockServerSpan);
+        assertSame(mockServerSpan, state.getCurrentServerSpan());
+        assertNull("Should not have been modified.", state.getCurrentClientSpan());
+    }
+
+    @Test
+    public void testGetAndSetCurrentClientSpan() {
+        assertNull(state.getCurrentClientSpan());
+        state.setCurrentClientSpan(mockSpan);
+        assertSame(mockSpan, state.getCurrentClientSpan());
+        assertEquals("Should not have been modified.", ServerSpan.create(null),
+                state.getCurrentServerSpan());
+    }
+
+    @Test
+    public void testGetAndSetCurrentLocalSpan() {
+        assertNull(state.getCurrentClientSpan());
+        assertNull(state.getCurrentLocalSpan());
+        state.setCurrentLocalSpan(mockSpan);
+        assertSame(mockSpan, state.getCurrentLocalSpan());
+        assertEquals("Should not have been modified.", ServerSpan.create(null),
+                state.getCurrentServerSpan());
+        assertNull(state.getCurrentClientSpan());
+    }
+
+    @Test
+    public void testGetAndSetCurrentLocalSpanInheritence() {
+        assertNull(state.getCurrentClientSpan());
+        assertNull(state.getCurrentLocalSpan());
+        state.setCurrentLocalSpan(mockSpan);
+        assertSame(mockSpan, state.getCurrentLocalSpan());
+        assertEquals("Should not have been modified.", ServerSpan.create(null),
+                state.getCurrentServerSpan());
+        assertNull(state.getCurrentClientSpan());
+    }
+
+    @Test
+    public void testGetParentSpan_localSpan_exists() throws Exception {
+        Span currentServerSpan = mock(Span.class);
+        when(mockServerSpan.getSpan()).thenReturn(currentServerSpan);
+
+        Span x = currentParentSpan(state);
+        assertThat(x).isNull();
+
+        state.setCurrentServerSpan(mockServerSpan);
+        assertThat(currentParentSpan(state)).isSameAs(state.getCurrentServerSpan().getSpan());
+        assertThat(currentParentSpan(state)).isSameAs(mockServerSpan.getSpan());
+        assertThat(currentParentSpan(state)).isNotEqualTo(mockSpan);
+
+        state.setCurrentLocalSpan(mockSpan);
+        assertThat(currentParentSpan(state)).isSameAs(state.getCurrentLocalSpan());
+        assertThat(currentParentSpan(state)).isSameAs(mockSpan);
+        assertThat(currentParentSpan(state)).isNotEqualTo(currentServerSpan);
+
+        state.setCurrentLocalSpan(null);
+        assertThat(currentParentSpan(state)).isSameAs(state.getCurrentServerSpan().getSpan());
+        assertThat(currentParentSpan(state)).isSameAs(mockServerSpan.getSpan());
+        assertThat(currentParentSpan(state)).isNotEqualTo(mockSpan);
+
+        state.setCurrentServerSpan(null);
+        assertThat(currentParentSpan(state)).isNull();
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        assertThat(state.toString()).startsWith("InheritableServerClientAndLocalSpanState");
+    }
+
+    private static Span currentParentSpan(ServerClientAndLocalSpanState state) {
+        Span parentSpan = state.getCurrentLocalSpan();
+        return (parentSpan == null) ? state.getCurrentServerSpan().getSpan() : parentSpan;
+    }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -1,0 +1,277 @@
+package com.github.kristofa.brave;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+
+public class LocalTracingInheritenceTest {
+
+    private SpanCollector spanCollector;
+    private Sampler sampler;
+    private Brave brave;
+    private ServerClientAndLocalSpanState state;
+    private ThreadFactory threadFactory;
+
+    @Before
+    public void setup() throws UnknownHostException {
+        spanCollector = mock(SpanCollector.class);
+        sampler = Sampler.ALWAYS_SAMPLE;
+
+        final int ip = InetAddressUtilities.toInt(InetAddressUtilities.getLocalHostLANAddress());
+        final String serviceName = LocalTracingInheritenceTest.class.getSimpleName();
+        state = new InheritableServerClientAndLocalSpanState(Endpoint.create(serviceName, ip, 0));
+        brave = new Brave.Builder(state)
+                .spanCollector(spanCollector)
+                .traceSampler(sampler)
+                .build();
+
+        threadFactory = new ThreadFactoryBuilder().setNameFormat("brave-%d").build();
+
+        checkState();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        checkState();
+    }
+
+    private void checkState() {
+        LocalTracer localTracer = brave.localTracer();
+        ServerClientAndLocalSpanState state = localTracer.spanAndEndpoint().state();
+        assertThat(state.getCurrentServerSpan()).isSameAs(ServerSpan.EMPTY);
+        assertThat(state.getCurrentClientSpan()).isNull();
+        assertThat(state.getCurrentLocalSpan()).isNull();
+        assertThat(localTracer.spanAndEndpoint().span()).isNull();
+    }
+
+    @Test
+    public void testGetClientTracer() {
+        final ClientTracer clientTracer = brave.clientTracer();
+        assertNotNull(clientTracer);
+        assertTrue("We expect instance of ClientTracer", clientTracer instanceof ClientTracer);
+        assertSame("ClientTracer should be configured with the spancollector we submitted.", spanCollector,
+                clientTracer.spanCollector());
+        assertSame("ClientTracer should be configured with the traceSampler we submitted.",
+                sampler, clientTracer.traceSampler());
+
+        final ClientTracer secondClientTracer = brave.clientTracer();
+        assertSame("It is important that each client tracer we get shares same state.",
+                clientTracer.spanAndEndpoint().state(), secondClientTracer.spanAndEndpoint().state());
+    }
+
+    @Test
+    public void testGetServerTracer() {
+        final ServerTracer serverTracer = brave.serverTracer();
+        assertNotNull(serverTracer);
+        assertSame(spanCollector, serverTracer.spanCollector());
+        assertSame("ServerTracer should be configured with the traceSampler we submitted.",
+                sampler, serverTracer.traceSampler());
+
+        final ServerTracer secondServerTracer = brave.serverTracer();
+        assertSame("It is important that each client tracer we get shares same state.",
+                serverTracer.spanAndEndpoint().state(), secondServerTracer.spanAndEndpoint().state());
+    }
+
+    @Test
+    public void testGetLocalTracer() {
+        final LocalTracer localTracer = brave.localTracer();
+        assertNotNull(localTracer);
+        assertSame(spanCollector, localTracer.spanCollector());
+        assertSame("LocalTracer should be configured with the traceSampler we submitted.",
+                sampler, localTracer.traceSampler());
+
+        final LocalTracer secondLocalTracer = brave.localTracer();
+        assertSame("It is important that each local tracer we get shares same state.",
+                localTracer.spanAndEndpoint().state(), secondLocalTracer.spanAndEndpoint().state());
+    }
+
+    @Test
+    public void testStateBetweenServerAndClient() {
+        final ClientTracer clientTracer = brave.clientTracer();
+        final ServerTracer serverTracer = brave.serverTracer();
+        final LocalTracer localTracer = brave.localTracer();
+
+        assertSame("Client and server tracers should share same state.", clientTracer.spanAndEndpoint().state(),
+                serverTracer.spanAndEndpoint().state());
+
+        assertSame("Client and local tracers should share same state.", clientTracer.spanAndEndpoint().state(),
+                localTracer.spanAndEndpoint().state());
+
+        assertSame("Server and local tracers should share same state.", serverTracer.spanAndEndpoint().state(),
+                localTracer.spanAndEndpoint().state());
+    }
+
+    @Test
+    public void testNestedLocalTraces() throws Exception {
+        LocalTracer localTracer = brave.localTracer();
+
+        SpanId span1 = localTracer.startNewSpan("comp1", "op1");
+        try {
+            SpanId span2 = localTracer.startNewSpan("comp2", "op2");
+            try {
+                SpanId span3 = localTracer.startNewSpan("comp3", "op3");
+                try {
+                    SpanId span4 = localTracer.startNewSpan("comp4", "op4");
+                    try {
+                        assertThat(state.getCurrentLocalSpan().getId()).isEqualTo(span4.spanId);
+                    } finally {
+
+                        localTracer.finishSpan();
+                    }
+
+                    assertThat(state.getCurrentLocalSpan().getId()).isEqualTo(span3.spanId);
+                } finally {
+                    localTracer.finishSpan();
+                }
+
+                assertThat(state.getCurrentLocalSpan().getId()).isEqualTo(span2.spanId);
+            } finally {
+                localTracer.finishSpan();
+            }
+
+            assertThat(state.getCurrentLocalSpan().getId()).isEqualTo(span1.spanId);
+        } finally {
+            localTracer.finishSpan();
+        }
+
+        assertThat(state.getCurrentLocalSpan()).isNull();
+        verify(spanCollector, times(4)).collect(any(Span.class));
+        localTracer.finishSpan(); // unmatched finish should no-op
+        verifyNoMoreInteractions(spanCollector);
+    }
+
+    @Test
+    public void testManyNestedLocalTraces() throws Exception {
+        brave = new Brave.Builder(state)
+                .spanCollector(spanCollector)
+                .traceSampler(Sampler.ALWAYS_SAMPLE)
+                .build();
+
+        LocalTracer localTracer = brave.localTracer();
+
+        assertThat(state.getCurrentLocalSpan()).isNull();
+
+        int limit = 128;
+        for (int i = 1; i <= limit; i <<= 1) {
+            runLocalSpan(i, limit);
+        }
+
+        assertThat(state.getCurrentLocalSpan()).isNull();
+        verify(spanCollector, times(777)).collect(any(Span.class));
+        localTracer.finishSpan(); // unmatched finish should no-op
+        verifyNoMoreInteractions(spanCollector);
+    }
+
+    private void runLocalSpan(final int iteration, final int limit) {
+        LocalTracer localTracer = brave.localTracer();
+        SpanId spanId = localTracer.startNewSpan("comp" + iteration, "op" + iteration);
+        try {
+            if (iteration < limit) {
+                runLocalSpan(iteration + 1, limit);
+            }
+            assertThat(state.getCurrentLocalSpan().getId()).isEqualTo(spanId.spanId);
+        } finally {
+            localTracer.finishSpan();
+        }
+    }
+
+    @Test
+    public void testNestedThreads() throws Exception {
+        LocalTracer localTracer = brave.localTracer();
+
+        for (int i = 0; i < 4; i++) {
+            int threadId = 0;
+            SpanId span0 = localTracer.startNewSpan("thread-" + threadId, "run");
+            assertThat(span0).isNotNull();
+            assertThat(span0.root()).isTrue();
+            assertThat(span0.spanId).isEqualTo(span0.traceId);
+            assertThat(span0.spanId).isEqualTo(span0.parentId);
+            assertThat(span0.nullableParentId()).isNull();
+
+            try {
+                runThreads(16, 4);
+            } finally {
+                localTracer.finishSpan();
+            }
+
+            localTracer.finishSpan(); // unmatched finish should no-op
+        }
+
+        assertThat(state.getCurrentLocalSpan()).isNull();
+        verify(spanCollector, times(844)).collect(any(Span.class));
+        localTracer.finishSpan(); // unmatched finish should no-op
+        verifyNoMoreInteractions(spanCollector);
+    }
+
+    private void runThreads(int breadth, int depth) throws InterruptedException {
+        List<Thread> threads = new ArrayList<Thread>(Math.abs(breadth * depth));
+        for (int i = 1; i < breadth; i++) {
+            for (int j = 0; j < depth; j++) {
+                threads.add(threadFactory.newThread(createRunnable(i, j)));
+            }
+        }
+
+        for (Thread t : threads) {
+            t.start();
+        }
+
+        for (Thread t : threads) {
+            t.join();
+        }
+    }
+
+    private Runnable createRunnable(final int breadth, final int depth) {
+        final SpanId baseSpan = brave.localTracer().startNewSpan("thread-" + breadth, "create-" + breadth + ":" + depth);
+        assertThat(baseSpan).isNotNull();
+        assertThat(baseSpan.nullableParentId()).isNotNull();
+        assertThat(baseSpan.root()).isFalse();
+        assertThat(baseSpan.spanId).isNotEqualTo(baseSpan.traceId);
+        try {
+            return new Runnable() {
+                @Override
+                public void run() {
+                    String originalThreadName = Thread.currentThread().getName();
+                    Thread.currentThread().setName(originalThreadName + "]"
+                            + "[create-" + breadth + ":" + depth + "]");
+                    LocalTracer localTracer = brave.localTracer();
+                    SpanId runnableSpan = localTracer.startNewSpan("thread-" + breadth + ":" + depth,
+                            "run-" + breadth + ":" + depth);
+                    assertThat(runnableSpan).isNotNull();
+                    assertThat(runnableSpan.nullableParentId()).isNotNull();
+                    assertThat(runnableSpan.root()).isFalse();
+                    assertThat(runnableSpan.spanId).isNotEqualTo(runnableSpan.traceId);
+
+                    try {
+                        runThreads(2, depth - 1);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        localTracer.finishSpan();
+                        Thread.currentThread().setName(originalThreadName);
+                    }
+                }
+            };
+        } finally {
+            brave.localTracer().finishSpan();
+        }
+    }
+}


### PR DESCRIPTION
The default ServerClientAndLocalSpanState now supports inheriting server, client, and local span state across threads via InheritableThreadLocal state. The LocalTracer now utilizes a stack to maintain multiple local spans to support variable trace shapes.  

Partly addresses #166