### PR TITLE
Adds slf4j logging span collectors

### DIFF
--- a/brave-spancollector-slf4j/LICENSE
+++ b/brave-spancollector-slf4j/LICENSE
@@ -1,0 +1,13 @@
+  Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/brave-spancollector-slf4j/pom.xml
+++ b/brave-spancollector-slf4j/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>brave</artifactId>
+    <groupId>io.zipkin.brave</groupId>
+    <version>3.9.2-SNAPSHOT</version>
+  </parent>
+  <artifactId>brave-slf4j</artifactId>
+  <packaging>jar</packaging>
+  <name>brave-spancollector-slf4j</name>
+  <description>
+    slf4j logging span collector
+  </description>
+  <url>https://github.com/kristofa/brave</url>
+  <licenses>
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.12</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/brave-spancollector-slf4j/src/main/java/com/github/kristofa/brave/slf4j/AsyncSlf4jLoggingSpanCollector.java
+++ b/brave-spancollector-slf4j/src/main/java/com/github/kristofa/brave/slf4j/AsyncSlf4jLoggingSpanCollector.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.kristofa.brave.slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.kristofa.brave.FlushingSpanCollector;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.github.kristofa.brave.internal.Util;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Span;
+
+/**
+ * {@link SpanCollector} implementation that logs through SLF4J at INFO level.
+ */
+public final class AsyncSlf4jLoggingSpanCollector extends FlushingSpanCollector {
+
+    private final Logger logger;
+    private final Set<BinaryAnnotation> annotations = Collections.synchronizedSet(new LinkedHashSet<BinaryAnnotation>());
+
+    public AsyncSlf4jLoggingSpanCollector(Logger logger, SpanCollectorMetricsHandler metrics, int flushInterval) {
+        super(metrics, flushInterval);
+        this.logger = Util.checkNotNull(logger, "logger must not be null");
+    }
+
+    public AsyncSlf4jLoggingSpanCollector(BlockingQueue<Span> queue,
+                                          Logger logger,
+                                          SpanCollectorMetricsHandler metrics,
+                                          int flushInterval) {
+        super(queue, metrics, flushInterval);
+        this.logger = Util.checkNotNull(logger, "logger must not be null");
+    }
+
+    private void logSpan(Span span) {
+        Util.checkNotNull(span, "span must not be null");
+        if (getLogger().isInfoEnabled()) {
+            for (BinaryAnnotation ba : annotations) {
+                span.addToBinary_annotations(ba);
+            }
+
+            getLogger().info(span.toString());
+        }
+    }
+
+    @Override
+    protected void reportSpans(List<Span> drained) throws IOException {
+        for (Span span : drained) {
+            logSpan(span);
+        }
+    }
+
+    @Override
+    public void addDefaultAnnotation(String key, String value) {
+        annotations.add(BinaryAnnotation.create(key, value, null));
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+}
+

--- a/brave-spancollector-slf4j/src/main/java/com/github/kristofa/brave/slf4j/SynchronousSlf4jLoggingSpanCollector.java
+++ b/brave-spancollector-slf4j/src/main/java/com/github/kristofa/brave/slf4j/SynchronousSlf4jLoggingSpanCollector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.kristofa.brave.slf4j;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.internal.Util;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Span;
+
+/**
+ * {@link SpanCollector} implementation that logs through SLF4J at INFO level.
+ */
+public final class SynchronousSlf4jLoggingSpanCollector implements SpanCollector {
+
+    private final Logger logger;
+    private final Set<BinaryAnnotation> annotations = new LinkedHashSet<>();
+
+    public SynchronousSlf4jLoggingSpanCollector(String loggerName) {
+        this(LoggerFactory.getLogger(Util.checkNotBlank(loggerName, "loggerName must not be blank or null")));
+    }
+
+    public SynchronousSlf4jLoggingSpanCollector(Logger logger) {
+        this.logger = Util.checkNotNull(logger, "logger must not be null");
+    }
+
+    @Override
+    public void collect(Span span) {
+        Util.checkNotNull(span, "span must not be null");
+        if (getLogger().isInfoEnabled()) {
+            for (BinaryAnnotation ba : getAnnotations()) {
+                span.addToBinary_annotations(ba);
+            }
+
+            getLogger().info(span.toString());
+        }
+    }
+
+    @Override
+    public void addDefaultAnnotation(String key, String value) {
+        getAnnotations().add(BinaryAnnotation.create(key, value, null));
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+
+    public Set<BinaryAnnotation> getAnnotations() {
+        return annotations;
+    }
+}
+

--- a/brave-spancollector-slf4j/src/test/java/com/github/kristofa/brave/slf4j/AsyncSlf4jLoggingSpanCollectorTest.java
+++ b/brave-spancollector-slf4j/src/test/java/com/github/kristofa/brave/slf4j/AsyncSlf4jLoggingSpanCollectorTest.java
@@ -1,0 +1,127 @@
+package com.github.kristofa.brave.slf4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Span;
+
+public class AsyncSlf4jLoggingSpanCollectorTest {
+
+    private static final String KEY1 = "key1";
+    private static final String VALUE1 = "value1";
+    private static final String KEY2 = "key1";
+    private static final String VALUE2 = "value1";
+    private static final int QUEUE_CAPACITY = AsyncSlf4jLoggingSpanCollector.DEFAULT_QUEUE_CAPACITY;
+
+    private Logger mockLogger;
+    private AsyncSlf4jLoggingSpanCollector spanCollector;
+    private TestMetricsHander metrics;
+
+    @Before
+    public void setup() {
+        mockLogger = mock(Logger.class);
+        when(mockLogger.isInfoEnabled()).thenReturn(true);
+
+        metrics = new TestMetricsHander();
+        spanCollector = new AsyncSlf4jLoggingSpanCollector(
+                mockLogger, metrics, 0 /* explicitly control flush */);
+    }
+
+    @Test
+    public void testCollect() {
+        final Span mockSpan = mock(Span.class);
+        spanCollector.collect(mockSpan);
+
+        verifyZeroInteractions(mockLogger);
+        spanCollector.flush(); // manually flush the spans
+
+        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).info(mockSpan.toString());
+        verifyNoMoreInteractions(mockLogger, mockSpan);
+    }
+
+    @Test
+    public void testCollectMany() {
+        List<Span> mockSpans = new ArrayList<>(QUEUE_CAPACITY);
+        for (int i = 0; i < QUEUE_CAPACITY + 1; i++) {
+            Span mockSpan = span(i, "test");
+            spanCollector.collect(mockSpan);
+            mockSpans.add(mockSpan);
+        }
+
+        verifyZeroInteractions(mockLogger);
+        spanCollector.flush(); // manually flush the spans
+
+        verify(mockLogger, times(QUEUE_CAPACITY)).isInfoEnabled();
+        verify(mockLogger, times(QUEUE_CAPACITY)).info(anyString());
+
+        assertThat(metrics.acceptedSpans.get()).isEqualTo(QUEUE_CAPACITY + 1);
+        assertThat(metrics.droppedSpans.get()).isEqualTo(1);
+
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockSpans.toArray());
+    }
+
+    @Test
+    public void testCollectAfterAddingTwoDefaultAnnotations() {
+
+        spanCollector.addDefaultAnnotation(KEY1, VALUE1);
+        spanCollector.addDefaultAnnotation(KEY2, VALUE2);
+
+        final Span mockSpan = span(1L, "test");
+        spanCollector.collect(mockSpan);
+
+        verifyZeroInteractions(mockLogger);
+        spanCollector.flush(); // manually flush the spans
+
+        // Create expected annotations.
+        final BinaryAnnotation expectedBinaryAnnotation = BinaryAnnotation.create(KEY1, VALUE1, null);
+        final BinaryAnnotation expectedBinaryAnnotation2 = BinaryAnnotation.create(KEY2, VALUE2, null);
+
+        verify(mockSpan).addToBinary_annotations(expectedBinaryAnnotation);
+        verify(mockSpan).addToBinary_annotations(expectedBinaryAnnotation2);
+        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).info(anyString());
+
+        verifyNoMoreInteractions(mockLogger, mockSpan);
+    }
+
+    private Span span(long id, String name) {
+        final Span mockSpan = mock(Span.class);
+        when(mockSpan.getId()).thenReturn(id);
+        when(mockSpan.getName()).thenReturn(name);
+        return mockSpan;
+    }
+
+    private static class TestMetricsHander implements SpanCollectorMetricsHandler {
+
+        final AtomicInteger acceptedSpans = new AtomicInteger();
+        final AtomicInteger droppedSpans = new AtomicInteger();
+
+        @Override
+        public void incrementAcceptedSpans(int quantity) {
+            acceptedSpans.addAndGet(quantity);
+        }
+
+        @Override
+        public void incrementDroppedSpans(int quantity) {
+            droppedSpans.addAndGet(quantity);
+        }
+    }
+}

--- a/brave-spancollector-slf4j/src/test/java/com/github/kristofa/brave/slf4j/SynchronousSlf4JLoggingSpanCollectorTest.java
+++ b/brave-spancollector-slf4j/src/test/java/com/github/kristofa/brave/slf4j/SynchronousSlf4JLoggingSpanCollectorTest.java
@@ -1,0 +1,95 @@
+package com.github.kristofa.brave.slf4j;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Span;
+
+public class SynchronousSlf4JLoggingSpanCollectorTest {
+
+    private static final String KEY1 = "key1";
+    private static final String VALUE1 = "value1";
+    private static final String KEY2 = "key1";
+    private static final String VALUE2 = "value1";
+
+    private Logger mockLogger;
+    private SynchronousSlf4jLoggingSpanCollector spanCollector;
+
+    @Before
+    public void setup() {
+        mockLogger = mock(Logger.class);
+        when(mockLogger.isInfoEnabled()).thenReturn(true);
+        spanCollector = new SynchronousSlf4jLoggingSpanCollector(mockLogger);
+    }
+
+    @Test
+    public void testCollect() {
+        final Span mockSpan = mock(Span.class);
+        spanCollector.collect(mockSpan);
+
+        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).info(mockSpan.toString());
+        verifyNoMoreInteractions(mockLogger, mockSpan);
+    }
+
+    @Test
+    public void testCollectMany() {
+        final int expectedSpansLogged = 1000;
+        List<Span> mockSpans = new ArrayList<>(expectedSpansLogged);
+        for (int i = 0; i < expectedSpansLogged; i++) {
+            Span mockSpan = span(i, "test");
+            spanCollector.collect(mockSpan);
+            mockSpans.add(mockSpan);
+        }
+
+        verify(mockLogger, times(expectedSpansLogged)).isInfoEnabled();
+        verify(mockLogger, times(expectedSpansLogged)).info(anyString());
+
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockSpans.toArray());
+    }
+
+    @Test
+    public void testCollectAfterAddingTwoDefaultAnnotations() {
+
+        spanCollector.addDefaultAnnotation(KEY1, VALUE1);
+        spanCollector.addDefaultAnnotation(KEY2, VALUE2);
+
+        verifyZeroInteractions(mockLogger);
+
+        final Span mockSpan = span(1L, "test");
+        spanCollector.collect(mockSpan);
+
+        // Create expected annotations.
+        final BinaryAnnotation expectedBinaryAnnotation = BinaryAnnotation.create(KEY1, VALUE1, null);
+        final BinaryAnnotation expectedBinaryAnnotation2 = BinaryAnnotation.create(KEY2, VALUE2, null);
+
+        verify(mockSpan).addToBinary_annotations(expectedBinaryAnnotation);
+        verify(mockSpan).addToBinary_annotations(expectedBinaryAnnotation2);
+        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).info(mockSpan.toString());
+
+        verifyNoMoreInteractions(mockLogger, mockSpan);
+    }
+
+    private Span span(long id, String name) {
+        final Span mockSpan = mock(Span.class);
+        when(mockSpan.getId()).thenReturn(id);
+        when(mockSpan.getName()).thenReturn(name);
+        return mockSpan;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <module>brave-spancollector-scribe</module>
     <module>brave-spancollector-kafka</module>
     <module>brave-spancollector-local</module>
+    <module>brave-spancollector-slf4j</module>
     <module>brave-sampler-zookeeper</module>
     <module>brave-jersey</module>
     <module>brave-jersey2</module>


### PR DESCRIPTION
Adds 2 implementations of `SpanCollector` for logging purposes:

* `AsyncSlf4jLoggingSpanCollector` collects spans and asynchronously logs to an slf4j logger at INFO level.
* `SynchronousSlf4jLoggingSpanCollector` collects spans and synchronously logs to an slf4j logger at INFO level.
