### PR TITLE
Bumps the provided dep of brave-web-servlet-filter to servlet 3

### DIFF
--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -24,7 +24,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <resteasy.version>2.3.5.Final</resteasy.version>
-    <jetty.version>8.1.9.v20130131</jetty.version>
   </properties>
   
   <dependencies>

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -24,7 +24,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <resteasy.version>3.0.8.Final</resteasy.version>
-    <jetty.version>8.1.9.v20130131</jetty.version>
   </properties>
   
   <dependencies>

--- a/brave-spring-web-servlet-interceptor/pom.xml
+++ b/brave-spring-web-servlet-interceptor/pom.xml
@@ -13,10 +13,6 @@
       Spring HandlerInterceptorAdapter implementation.
   </description>
 
-    <properties>
-        <jetty.version>8.1.9.v20130131</jetty.version>
-    </properties>
-
     <dependencies>
      <dependency>
         <groupId>io.zipkin.brave</groupId>

--- a/brave-web-servlet-filter/pom.xml
+++ b/brave-web-servlet-filter/pom.xml
@@ -14,10 +14,6 @@
         Servlet Filter implementation.
     </description>
 
-    <properties>
-        <jetty.version>7.5.4.v20111024</jetty.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.zipkin.brave</groupId>
@@ -32,8 +28,8 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
@@ -6,7 +6,6 @@ import com.github.kristofa.brave.http.BraveHttpHeaders;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.twitter.zipkin.gen.Span;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.DispatcherType;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.bio.SocketConnector;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -16,6 +15,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <spring.version>4.1.6.RELEASE</spring.version>
+    <jetty.version>8.1.20.v20160902</jetty.version>
     <zipkin.version>1.8.4</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>


### PR DESCRIPTION
brave-web-servlet-filter was implicitly pointing to a really old version
of the servlet spec. This bumps to the over 5 year old servlet 3.0.1 :)

Anyone wishing to use servlet 2.5 can set that in their dependencies
explicitly.

Incidentally, this allows us to consolidate jetty versions.