### PR TITLE
Renaming BraveP6SpyTests to BraveP6SpyTest so that it runs under CI

### DIFF
--- a/brave-p6spy/src/test/java/com/github/kristofa/brave/p6spy/BraveP6SpyTest.java
+++ b/brave-p6spy/src/test/java/com/github/kristofa/brave/p6spy/BraveP6SpyTest.java
@@ -21,7 +21,7 @@ import zipkin.TraceKeys;
 import java.sql.ResultSet;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BraveP6SpyTests {
+public class BraveP6SpyTest {
 
     //Get rid of annoying derby.log
     static {

--- a/brave-p6spy/src/test/java/com/github/kristofa/brave/p6spy/DerbyUtils.java
+++ b/brave-p6spy/src/test/java/com/github/kristofa/brave/p6spy/DerbyUtils.java
@@ -6,7 +6,7 @@ public class DerbyUtils {
 
     //Get rid of the annoying derby.log file
     public static void disableLog() {
-        System.setProperty("derby.stream.error.field", BraveP6SpyTests.class.getName() + ".DEV_NULL");
+        System.setProperty("derby.stream.error.field", DerbyUtils.class.getName() + ".DEV_NULL");
     }
 
     public static final OutputStream DEV_NULL = new OutputStream() {


### PR DESCRIPTION
I'll add an additional comment to verify that it ran under CI once the build completes.