### PR TITLE
Make the AnnotationSubmitter.currentTimeMicroseconds() pluggable.

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -39,6 +39,7 @@ public class Brave {
         // default added so callers don't need to check null.
         private Sampler sampler = Sampler.create(1.0f);
         private boolean allowNestedLocalSpans = false;
+        private AnnotationSubmitter.Clock clock = AnnotationSubmitter.DefaultClock.INSTANCE;
 
         /**
          * Builder which initializes with serviceName = "unknown".
@@ -111,6 +112,11 @@ public class Brave {
          */
         public Builder spanCollector(SpanCollector spanCollector) {
             this.spanCollector = spanCollector;
+            return this;
+        }
+
+        public Builder clock(AnnotationSubmitter.Clock clock) {
+            this.clock = clock;
             return this;
         }
 
@@ -216,21 +222,27 @@ public class Brave {
                 .randomGenerator(builder.random)
                 .spanCollector(builder.spanCollector)
                 .state(builder.state)
-                .traceSampler(builder.sampler).build();
+                .traceSampler(builder.sampler)
+                .clock(builder.clock)
+                .build();
 
         clientTracer = ClientTracer.builder()
                 .randomGenerator(builder.random)
                 .spanCollector(builder.spanCollector)
                 .state(builder.state)
-                .traceSampler(builder.sampler).build();
+                .traceSampler(builder.sampler)
+                .clock(builder.clock)
+                .build();
 
         localTracer = LocalTracer.builder()
                 .randomGenerator(builder.random)
                 .spanCollector(builder.spanCollector)
                 .allowNestedLocalSpans(builder.allowNestedLocalSpans)
                 .spanAndEndpoint(SpanAndEndpoint.LocalSpanAndEndpoint.create(builder.state))
-                .traceSampler(builder.sampler).build();
-        
+                .traceSampler(builder.sampler)
+                .clock(builder.clock)
+                .build();
+
         serverRequestInterceptor = new ServerRequestInterceptor(serverTracer);
         serverResponseInterceptor = new ServerResponseInterceptor(serverTracer);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer);

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -37,6 +37,8 @@ public abstract class ClientTracer extends AnnotationSubmitter {
     abstract Random randomGenerator();
     abstract SpanCollector spanCollector();
     abstract Sampler traceSampler();
+    @Override
+    abstract AnnotationSubmitter.Clock clock();
 
     @AutoValue.Builder
     public abstract static class Builder {
@@ -55,6 +57,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
         public abstract Builder spanCollector(SpanCollector spanCollector);
 
         public abstract Builder traceSampler(Sampler sampler);
+        public abstract Builder clock(AnnotationSubmitter.Clock clock);
 
         public abstract ClientTracer build();
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -56,6 +56,9 @@ public abstract class LocalTracer extends AnnotationSubmitter {
 
     abstract Sampler traceSampler();
 
+    @Override
+    abstract AnnotationSubmitter.Clock clock();
+
     @AutoValue.Builder
     abstract static class Builder {
 
@@ -68,6 +71,8 @@ public abstract class LocalTracer extends AnnotationSubmitter {
         abstract Builder allowNestedLocalSpans(boolean allowNestedLocalSpans);
 
         abstract Builder traceSampler(Sampler sampler);
+
+        abstract Builder clock(AnnotationSubmitter.Clock clock);
 
         abstract LocalTracer build();
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -23,7 +23,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotBlank;
  * <li>Service request executes its logic...
  * <li>Just before sending response we execute {@link ServerTracer#setServerSend()}.
  * </ol>
- * 
+ *
  * @author kristof
  */
 @AutoValue
@@ -38,6 +38,8 @@ public abstract class ServerTracer extends AnnotationSubmitter {
     abstract Random randomGenerator();
     abstract SpanCollector spanCollector();
     abstract Sampler traceSampler();
+    @Override
+    abstract AnnotationSubmitter.Clock clock();
 
     @AutoValue.Builder
     public abstract static class Builder {
@@ -56,6 +58,8 @@ public abstract class ServerTracer extends AnnotationSubmitter {
         public abstract Builder spanCollector(SpanCollector spanCollector);
 
         public abstract Builder traceSampler(Sampler sampler);
+
+        public abstract Builder clock(AnnotationSubmitter.Clock clock);
 
         public abstract ServerTracer build();
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -53,6 +53,7 @@ public class ClientTracerTest {
             .randomGenerator(mockRandom)
             .spanCollector(mockCollector)
             .traceSampler(mockSampler)
+            .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
             .build();
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -53,6 +53,7 @@ public class LocalTracerTest {
                 .spanCollector(mockCollector)
                 .allowNestedLocalSpans(false)
                 .traceSampler(Sampler.create(1.0f))
+                .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
                 .build();
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -58,7 +58,9 @@ public class ServerTracerTest {
             .state(mockServerSpanState)
             .randomGenerator(mockRandom)
             .spanCollector(mockSpanCollector)
-            .traceSampler(mockSampler).build();
+            .traceSampler(mockSampler)
+            .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
+            .build();
     }
 
     @Test


### PR DESCRIPTION
Make the AnnotationSubmitter.currentTimeMicroseconds() pluggable.

Even in Java8 with java.time the best precision for timestamp generation is milliseconds. Providing microsecond accuracy in spans requires an implementation to do so to be plugged in.

By making the timestamp generation contextual through the AnnotationSubmitter.Clock interface microsecond accuracy can be achieved.

An example implementation to obtain microsecond accuracy is by using the DataStax CQL java driver
(cassandra-driver-core-*.jar or com.datastax.cassandra:cassandra-driver-core artifact) and using its AtomicMonotonicTimestampGenerator class like:

    AtomicMonotonicTimestampGenerator TIMESTAMP_GENERATOR = new AtomicMonotonicTimestampGenerator();
    ...
    Brave brave = new Brave
            .Builder("my_service_name")
            .clock(() -> { return TIMESTAMP_GENERATOR.next(); })
            .build();