### PR TITLE
Adds Endpoint.ipv6; Supports Endpoint for Brave and peer addresses

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -60,7 +60,15 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-core_2.11</artifactId>
-      <version>6.35.0</version>
+      <version>6.38.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- To avoid java.lang.NoClassDefFoundError: StacktracePrintingMatcher -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
@@ -1,6 +1,5 @@
 package com.github.kristofa.brave;
 
-import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
@@ -44,7 +43,7 @@ public abstract class AnnotationSubmitter {
 
     /** The implementation of Clock to use.
      * See {@link com.github.kristofa.brave.AnnotationSubmitter#currentTimeMicroseconds}
-     * and {@link com.github.kristofa.brave.AnnotationSubmitter#Clock}
+     * and {@link com.github.kristofa.brave.AnnotationSubmitter.Clock}
      **/
     abstract Clock clock();
 
@@ -132,16 +131,13 @@ public abstract class AnnotationSubmitter {
     /**
      * Internal api for submitting an address. Until a naming function is added, this coerces null
      * {@code serviceName} to "unknown", as that's zipkin's convention.
-     *
-     * @param ipv4        ipv4 host address as int. Ex for the ip 1.2.3.4, it would be (1 << 24) | (2 << 16) | (3 << 8) | 4
-     * @param port        Port for service
-     * @param serviceName Name of service. Should be lowercase and not empty. {@code null} will coerce to "unknown", as that's zipkin's convention.
      */
-    void submitAddress(String key, int ipv4, int port, @Nullable String serviceName) {
+    void submitAddress(String key, Endpoint endpoint) {
         Span span = spanAndEndpoint().span();
         if (span != null) {
-            serviceName = serviceName != null ? serviceName : "unknown";
-            Endpoint endpoint = Endpoint.create(serviceName, ipv4, port);
+            if (endpoint.service_name == null) {
+                endpoint = endpoint.toBuilder().serviceName("unknown").build();
+            }
             BinaryAnnotation ba = BinaryAnnotation.address(key, endpoint);
             addBinaryAnnotation(span, ba);
         }

--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.Util;
+import com.twitter.zipkin.gen.Endpoint;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Random;
@@ -81,6 +82,13 @@ public class Brave {
          */
         public Builder(int ip, int port, String serviceName) {
             state = new ThreadLocalServerClientAndLocalSpanState(ip, port, serviceName);
+        }
+
+        /**
+         * @param endpoint Endpoint of the local service being traced.
+         */
+        public Builder(Endpoint endpoint) {
+            state = new ThreadLocalServerClientAndLocalSpanState(endpoint);
         }
 
         /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
@@ -50,7 +50,7 @@ public class ClientRequestInterceptor {
         if (serverAddress == null) {
             clientTracer.setClientSent();
         } else {
-            clientTracer.setClientSent(serverAddress.ipv4, serverAddress.port, serverAddress.service_name);
+            clientTracer.setClientSent(serverAddress);
         }
     }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -72,14 +72,28 @@ public abstract class ClientTracer extends AnnotationSubmitter {
     /**
      * Like {@link #setClientSent()}, except you can log the network context of the destination.
      *
+     * @param server represents the server (peer). Set {@link Endpoint#service_name} to
+     * "unknown" if unknown.
+     */
+    public void setClientSent(Endpoint server) {
+        submitAddress(Constants.SERVER_ADDR, server);
+        submitStartAnnotation(Constants.CLIENT_SEND);
+    }
+
+    /**
+     * Like {@link #setClientSent()}, except you can log the network context of the destination.
+     *
      * @param ipv4        ipv4 of the server as an int. Ex for 1.2.3.4, it would be (1 << 24) | (2 << 16) | (3 << 8) | 4
      * @param port        listen port the client is connecting to, or 0 if unknown
      * @param serviceName lowercase {@link Endpoint#service_name name} of the service being called
      *                    or null if unknown
+     *
+     * @deprecated use {@link #setClientSent(Endpoint)}
      */
+    @Deprecated
     public void setClientSent(int ipv4, int port, @Nullable String serviceName) {
-        submitAddress(Constants.SERVER_ADDR, ipv4, port, serviceName);
-        submitStartAnnotation(Constants.CLIENT_SEND);
+        if (serviceName == null) serviceName = "unknown";
+        setClientSent(Endpoint.builder().ipv4(ipv4).port(port).serviceName(serviceName).build());
     }
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -129,14 +129,29 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * Like {@link #setServerReceived()}, except you can log the network context of the caller, for
      * example an IP address from the {@code X-Forwarded-For} header.
      *
+     * @param client represents the client (peer). Set {@link Endpoint#service_name} to
+     * "unknown" if unknown.
+     */
+    public void setServerReceived(Endpoint client) {
+        submitAddress(Constants.CLIENT_ADDR, client);
+        submitStartAnnotation(Constants.SERVER_RECV);
+    }
+
+    /**
+     * Like {@link #setServerReceived()}, except you can log the network context of the caller, for
+     * example an IP address from the {@code X-Forwarded-For} header.
+     *
      * @param ipv4          ipv4 of the client as an int. Ex for 1.2.3.4, it would be (1 << 24) | (2 << 16) | (3 << 8) | 4
      * @param port          port for client-side of the socket, or 0 if unknown
      * @param clientService lowercase {@link Endpoint#service_name name} of the callee service or
      *                      null if unknown
+     *
+     * @deprecated use {@link #setServerReceived(Endpoint)}
      */
+    @Deprecated
     public void setServerReceived(int ipv4, int port, @Nullable String clientService) {
-        submitAddress(Constants.CLIENT_ADDR, ipv4, port, clientService);
-        submitStartAnnotation(Constants.SERVER_RECV);
+        if (clientService == null) clientService = "unknown";
+        setServerReceived(Endpoint.builder().ipv4(ipv4).port(port).serviceName(clientService).build());
     }
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
@@ -37,9 +37,7 @@ public final class ThreadLocalServerClientAndLocalSpanState implements ServerCli
      */
     @Deprecated
     public ThreadLocalServerClientAndLocalSpanState(InetAddress ip, int port, String serviceName) {
-        Util.checkNotNull(ip, "ip address must be specified.");
-        Util.checkNotBlank(serviceName, "Service name must be specified.");
-        endpoint = Endpoint.create(serviceName, InetAddressUtilities.toInt(ip), port);
+        this(InetAddressUtilities.toInt(Util.checkNotNull(ip, "ip address must be specified.")), port, serviceName);
     }
 
     /**
@@ -50,8 +48,16 @@ public final class ThreadLocalServerClientAndLocalSpanState implements ServerCli
      * @param serviceName Name of the local service being traced. Should be lowercase and not <code>null</code> or empty.
      */
     public ThreadLocalServerClientAndLocalSpanState(int ip, int port, String serviceName) {
-        Util.checkNotBlank(serviceName, "Service name must be specified.");
-        endpoint = Endpoint.create(serviceName, ip, port);
+        this(Endpoint.builder().ipv4(ip).port(port).serviceName(serviceName).build());
+    }
+
+    /**
+     * @param endpoint Endpoint of the local service being traced.
+     */
+    public ThreadLocalServerClientAndLocalSpanState(Endpoint endpoint) {
+        Util.checkNotNull(endpoint, "endpoint must be specified.");
+        Util.checkNotBlank(endpoint.service_name, "Service name must be specified.");
+        this.endpoint = endpoint;
     }
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/DefaultSpanCodec.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/DefaultSpanCodec.java
@@ -63,7 +63,10 @@ public final class DefaultSpanCodec implements SpanCodec {
 
   private static Endpoint to(zipkin.Endpoint host) {
     if (host == null) return null;
-    if (host.port == null) return Endpoint.create(host.serviceName, host.ipv4);
-    return Endpoint.create(host.serviceName, host.ipv4, host.port);
+    return Endpoint.builder()
+        .ipv4(host.ipv4)
+        .ipv6(host.ipv6)
+        .port(host.port)
+        .serviceName(host.serviceName).build();
   }
 }

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
@@ -2,7 +2,10 @@ package com.twitter.zipkin.gen;
 
 import com.github.kristofa.brave.internal.Nullable;
 import java.io.Serializable;
+import java.util.Arrays;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+import static zipkin.internal.Util.checkArgument;
 import static com.github.kristofa.brave.internal.Util.equal;
 
 /**
@@ -16,32 +19,47 @@ import static com.github.kristofa.brave.internal.Util.equal;
  */
 public class Endpoint implements Serializable {
 
+  /**
+   * @deprecated as leads to null pointer exceptions on port. Use {@link #builder()} instead.
+   */
+  @Deprecated
   public static Endpoint create(String serviceName, int ipv4, int port) {
-    return new Endpoint(serviceName, ipv4, (short) (port & 0xffff));
+    return new Endpoint(serviceName, ipv4, null, port == 0 ? null : (short) (port & 0xffff));
   }
 
   public static Endpoint create(String serviceName, int ipv4) {
-    return new Endpoint(serviceName, ipv4, null);
+    return new Endpoint(serviceName, ipv4, null, null);
   }
 
   static final long serialVersionUID = 1L;
 
   /**
-   * IPv4 host address packed into 4 bytes.
+   * IPv4 host address packed into 4 bytes or zero if unknown.
    *
-   * Ex for the ip 1.2.3.4, it would be (1 << 24) | (2 << 16) | (3 << 8) | 4
+   * <p>Ex for the IP 1.2.3.4, it would be {@code (1 << 24) | (2 << 16) | (3 << 8) | 4}
+   *
+   * @see java.net.Inet4Address#getAddress()
    */
-  public final int ipv4; // required
+  public final int ipv4;
 
   /**
-   * IPv4 port
+   * IPv6 host address packed into 16 bytes or null if unknown.
    *
-   * Note: this is to be treated as an unsigned integer, so watch for negatives.
-   *
-   * Null, when the port isn't known.
+   * @see java.net.Inet6Address#getAddress()
+   * @since 3.12
    */
   @Nullable
-  public final Short port; // required
+  public final byte[] ipv6;
+
+  /**
+   * Port of the IP's socket or null, if not known.
+   *
+   * <p>Note: this is to be treated as an unsigned integer, so watch for negatives.
+   *
+   * @see java.net.InetSocketAddress#getPort()
+   */
+  @Nullable
+  public final Short port;
 
   /**
    * Service name in lowercase, such as "memcache" or "zipkin-web"
@@ -50,8 +68,9 @@ public class Endpoint implements Serializable {
    */
   public final String service_name; // required
 
-  Endpoint(String service_name, int ipv4, Short port) {
+  Endpoint(String service_name, int ipv4, byte[] ipv6, Short port) {
     this.ipv4 = ipv4;
+    this.ipv6 = ipv6;
     this.port = port;
     if (service_name != null) {
       service_name = service_name.toLowerCase();
@@ -61,6 +80,81 @@ public class Endpoint implements Serializable {
     this.service_name = service_name;
   }
 
+  public Endpoint.Builder toBuilder() {
+    return new Endpoint.Builder(this);
+  }
+
+  public static Endpoint.Builder builder() {
+    return new Endpoint.Builder();
+  }
+
+  public static final class Builder {
+    private String serviceName;
+    private Integer ipv4;
+    private byte[] ipv6;
+    private Short port;
+
+    Builder() {
+    }
+
+    Builder(Endpoint source) {
+      this.serviceName = source.service_name;
+      this.ipv4 = source.ipv4;
+      this.ipv6 = source.ipv6;
+      this.port = source.port;
+    }
+
+    /** @see Endpoint#service_name */
+    public Endpoint.Builder serviceName(String serviceName) {
+      this.serviceName = serviceName;
+      return this;
+    }
+
+    /** @see Endpoint#ipv4 */
+    public Endpoint.Builder ipv4(int ipv4) {
+      this.ipv4 = ipv4;
+      return this;
+    }
+
+    /** @see Endpoint#ipv6 */
+    public Endpoint.Builder ipv6(byte[] ipv6) {
+      if (ipv6 != null) {
+        checkArgument(ipv6.length == 16, "ipv6 addresses are 16 bytes: " + ipv6.length);
+        this.ipv6 = ipv6;
+      }
+      return this;
+    }
+
+    /**
+     * Use this to set the port to an externally defined value.
+     *
+     * <p>Don't pass {@link Endpoint#port} to this method, as it may result in a
+     * NullPointerException. Instead, use {@link Endpoint#toBuilder()} or {@link
+     * #port(Short)}.
+     *
+     * @param port port associated with the endpoint. zero coerces to null (unknown)
+     * @see Endpoint#port
+     */
+    public Endpoint.Builder port(int port) {
+      checkArgument(port >= 0 && port <= 0xffff, "invalid port %s", port);
+      this.port = port == 0 ? null : (short) (port & 0xffff);
+      return this;
+    }
+
+    /** @see Endpoint#port */
+    public Endpoint.Builder port(Short port) {
+      if (port == null || port != 0) {
+        this.port = port;
+      }
+      return this;
+    }
+
+    public Endpoint build() {
+      checkNotNull(serviceName, "serviceName");
+      return new Endpoint(serviceName, ipv4 == null ? 0 : ipv4, ipv6, port);
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o == this) {
@@ -68,8 +162,9 @@ public class Endpoint implements Serializable {
     }
     if (o instanceof Endpoint) {
       Endpoint that = (Endpoint) o;
-      return this.service_name.equals(that.service_name)
-          && this.ipv4 == that.ipv4
+      return equal(this.service_name, that.service_name)
+          && (this.ipv4 == that.ipv4)
+          && (Arrays.equals(this.ipv6, that.ipv6))
           && equal(this.port, that.port);
     }
     return false;
@@ -82,6 +177,8 @@ public class Endpoint implements Serializable {
     h ^= service_name.hashCode();
     h *= 1000003;
     h ^= ipv4;
+    h *= 1000003;
+    h ^= Arrays.hashCode(ipv6);
     h *= 1000003;
     h ^= (port == null) ? 0 : port.hashCode();
     return h;

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -281,8 +281,11 @@ public class Span implements Serializable {
 
   private static zipkin.Endpoint from(Endpoint host) {
     if (host == null) return null;
-    if (host.port == null) return zipkin.Endpoint.create(host.service_name, host.ipv4);
-    return zipkin.Endpoint.create(host.service_name, host.ipv4, host.port);
+    return zipkin.Endpoint.builder()
+        .ipv4(host.ipv4)
+        .ipv6(host.ipv6)
+        .port(host.port)
+        .serviceName(host.service_name).build();
   }
 }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -32,7 +32,8 @@ public class AnnotationSubmitterTest {
     private static final int INT_VALUE = 23;
 
     private AnnotationSubmitter annotationSubmitter;
-    private Endpoint endpoint = Endpoint.create("foobar", 1 << 24 | 2 << 16 | 3 << 8 | 4, 9999);
+    private Endpoint endpoint =
+        Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
     private Span mockSpan;
 
     @Before

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -85,7 +85,8 @@ public class ClientRequestInterceptorTest {
     public void testServerAddressAdded() {
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);
-        when(adapter.serverAddress()).thenReturn(Endpoint.create(SERVICE_NAME, TARGET_IP, TARGET_PORT));
+        when(adapter.serverAddress()).thenReturn(Endpoint.builder()
+            .serviceName(SERVICE_NAME).ipv4(TARGET_IP).port(TARGET_PORT).build());
         SpanId spanId = SpanId.builder().spanId(1L).build();
         when(clientTracer.startNewSpan(SPAN_NAME)).thenReturn(spanId);
         interceptor.handle(adapter);
@@ -96,7 +97,8 @@ public class ClientRequestInterceptorTest {
         inOrder.verify(adapter).addSpanIdToRequest(spanId);
         inOrder.verify(adapter).requestAnnotations();
         inOrder.verify(adapter).serverAddress();
-        inOrder.verify(clientTracer).setClientSent(TARGET_IP, TARGET_PORT, SERVICE_NAME.toLowerCase());
+        inOrder.verify(clientTracer).setClientSent(Endpoint.builder()
+            .ipv4(TARGET_IP).port(TARGET_PORT).serviceName(SERVICE_NAME).build());
         verifyNoMoreInteractions(clientTracer, adapter);
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -86,7 +86,8 @@ public class ClientTracerTest {
         Span clientSent = new Span();
         state.setCurrentClientSpan(clientSent);
 
-        clientTracer.setClientSent(1 << 24 | 2 << 16 | 3 << 8 | 4, 9999, "foobar");
+        clientTracer.setClientSent(Endpoint.builder()
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(9999).serviceName("foobar").build());
 
         final Annotation expectedAnnotation = Annotation.create(
             CURRENT_TIME_MICROSECONDS,
@@ -100,7 +101,7 @@ public class ClientTracerTest {
 
         BinaryAnnotation serverAddress = BinaryAnnotation.address(
             Constants.SERVER_ADDR,
-            Endpoint.create("foobar", 1 << 24 | 2 << 16 | 3 << 8 | 4, 9999)
+            Endpoint.builder().serviceName("foobar").ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(9999).build()
         );
         assertEquals(serverAddress, clientSent.getBinary_annotations().get(0));
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
@@ -31,7 +31,8 @@ public class ITAnnotationSubmitterConcurrency {
 
     private ExecutorService executorService;
     private Span span;
-    private Endpoint endpoint = Endpoint.create("foobar", 1 << 24 | 2 << 16 | 3 << 8 | 4, 9999);
+    private Endpoint endpoint =
+        Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
 
     @Before
     public void setup() {

--- a/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
@@ -7,9 +7,6 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,9 +25,12 @@ public class InheritableServerClientAndLocalSpanStateTest {
     private Span mockSpan;
 
     @Before
-    public void setup() throws UnknownHostException {
-        final int ip = InetAddressUtilities.toInt(InetAddress.getByName("192.168.0.1"));
-        state = new InheritableServerClientAndLocalSpanState(Endpoint.create(SERVICE_NAME, ip, PORT));
+    public void setup() {
+        Endpoint endpoint = Endpoint.builder()
+            .serviceName(SERVICE_NAME)
+            .ipv4(192 << 24 | 168 << 16 | 1)
+            .port(PORT).build();
+        state = new InheritableServerClientAndLocalSpanState(endpoint);
         mockServerSpan = mock(ServerSpan.class);
         mockSpan = mock(Span.class);
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -253,7 +253,7 @@ public class LocalTracerTest {
 
     @Test
     public void startSpan_with_inheritable_nested_local_spans() {
-        state = new InheritableServerClientAndLocalSpanState(Endpoint.create("test-service", 127 << 24 | 1, 0));
+        state = new InheritableServerClientAndLocalSpanState(Endpoint.create("test-service", 127 << 24 | 1));
         localTracer = LocalTracer
                 .builder(localTracer)
                 .spanAndEndpoint(SpanAndEndpoint.LocalSpanAndEndpoint.create(state))
@@ -280,7 +280,7 @@ public class LocalTracerTest {
 
     @Test
     public void startSpan_nested_local_spans_disabled() {
-        state = new InheritableServerClientAndLocalSpanState(Endpoint.create("test-service", 127 << 24 | 1, 0));
+        state = new InheritableServerClientAndLocalSpanState(Endpoint.create("test-service", 127 << 24 | 1));
         localTracer = LocalTracer
                 .builder(localTracer)
                 .spanAndEndpoint(SpanAndEndpoint.LocalSpanAndEndpoint.create(state))

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -38,7 +38,7 @@ public class LocalTracingInheritenceTest {
 
         final int ip = InetAddressUtilities.toInt(InetAddressUtilities.getLocalHostLANAddress());
         final String serviceName = LocalTracingInheritenceTest.class.getSimpleName();
-        state = new InheritableServerClientAndLocalSpanState(Endpoint.create(serviceName, ip, 0));
+        state = new InheritableServerClientAndLocalSpanState(Endpoint.create(serviceName, ip));
         brave = new Brave.Builder(state)
                 .spanCollector(spanCollector)
                 .traceSampler(sampler)

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -162,7 +162,10 @@ public class ServerTracerTest {
         when(mockServerSpan.getSpan()).thenReturn(serverRecv);
         when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
         when(mockServerSpanState.endpoint()).thenReturn(mockEndpoint);
-        serverTracer.setServerReceived(1 << 24 | 2 << 16 | 3 << 8 | 4, 9999, "foobar");
+        serverTracer.setServerReceived(Endpoint.builder()
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4)
+            .port(9999)
+            .serviceName("foobar").build());
 
 
         final Annotation expectedAnnotation = Annotation.create(
@@ -181,7 +184,7 @@ public class ServerTracerTest {
 
         BinaryAnnotation serverAddress = BinaryAnnotation.address(
             Constants.CLIENT_ADDR,
-            Endpoint.create("foobar", 1 << 24 | 2 << 16 | 3 << 8 | 4, 9999)
+            Endpoint.builder().serviceName("foobar").ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(9999).build()
         );
         assertEquals(serverAddress, serverRecv.getBinary_annotations().get(0));
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/example/TestServerClientAndLocalSpanStateCompilation.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/example/TestServerClientAndLocalSpanStateCompilation.java
@@ -10,7 +10,7 @@ import com.twitter.zipkin.gen.Span;
  */
 public class TestServerClientAndLocalSpanStateCompilation implements ServerClientAndLocalSpanState {
 
-    private Endpoint endpoint = Endpoint.create("tomcat", 127 << 24 | 1, 8080);
+    private Endpoint endpoint = Endpoint.builder().serviceName("tomcat").ipv4(127 << 24 | 1).port(8080).build();
     private ServerSpan currentServerSpan = ServerSpan.EMPTY;
     private Span currentClientSpan = null;
     private Span currentLocalSpan = null;

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
@@ -12,7 +12,12 @@ import static org.junit.Assert.assertEquals;
 public class DefaultSpanCodecTest {
 
   Endpoint browser = Endpoint.create("browser-client", 1 << 24 | 2 << 16 | 3);
-  Endpoint web = Endpoint.create("zipkin-web", 172 << 24 | 17 << 16 | 3, 8080);
+  Endpoint web = Endpoint.builder()
+      .serviceName("web")
+      .ipv4(124 << 24 | 13 << 16 | 90 << 8 | 3)
+      // Cheat so we don't have to catch an exception here
+      .ipv6(sun.net.util.IPAddressUtil.textToNumericFormatV6("2001:db8::c001"))
+      .port(80).build();
 
   Span span = new Span() // browser calls web
       .setTrace_id(-692101025335252320L)

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/EndpointTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/EndpointTest.java
@@ -1,14 +1,63 @@
 package com.twitter.zipkin.gen;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class EndpointTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testServiceNameLowercase() {
-    Endpoint ep = Endpoint.create("ServiceName", 1, 1);
-    assertEquals("servicename", ep.service_name);
+  public void messageWhenMissingServiceName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("serviceName");
+
+    Endpoint.builder().ipv4(127 << 24 | 1).build();
+  }
+
+  @Test
+  public void missingIpv4CoercesTo0() {
+    assertThat(Endpoint.builder().serviceName("foo").build().ipv4)
+        .isEqualTo(0);
+  }
+
+  @Test
+  public void builderWithPort_0CoercesToNull() {
+    assertThat(Endpoint.builder().serviceName("foo").port(0).build().port)
+        .isNull();
+  }
+
+  @Test
+  public void builderWithPort_highest() {
+    assertThat(Endpoint.builder().serviceName("foo").port(65535).build().port)
+        .isEqualTo((short) -1); // an unsigned short of 65535 is the same as -1
+  }
+
+  /** The integer arg of port should be a whole number */
+  @Test
+  public void builderWithPort_negativeIsInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("invalid port -1");
+
+    assertThat(Endpoint.builder().serviceName("foo").port(-1).build().port);
+  }
+
+  /** The integer arg of port should fit in a 16bit unsigned value */
+  @Test
+  public void builderWithPort_tooHighIsInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("invalid port 65536");
+
+    assertThat(Endpoint.builder().serviceName("foo").port(65536).build().port);
+  }
+
+  @Test
+  public void lowercasesServiceName() {
+    assertThat(Endpoint.builder().serviceName("fFf").ipv4(127 << 24 | 1).build().service_name)
+        .isEqualTo("fff");
   }
 }

--- a/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptor.java
+++ b/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptor.java
@@ -7,6 +7,7 @@ import com.mysql.jdbc.ResultSetInternalMethods;
 import com.mysql.jdbc.Statement;
 import com.mysql.jdbc.StatementInterceptorV2;
 
+import com.twitter.zipkin.gen.Endpoint;
 import zipkin.Constants;
 import zipkin.TraceKeys;
 
@@ -104,7 +105,8 @@ public class MySQLStatementInterceptor implements StatementInterceptorV2 {
         	}
         }
         
-        tracer.setClientSent(ipv4, port, serviceName);
+        tracer.setClientSent(Endpoint.builder()
+            .ipv4(ipv4).port(port).serviceName(serviceName).build());
     }
 
     private void endTrace(final ClientTracer tracer, final int warningCount, final SQLException statementException) {

--- a/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorTest.java
+++ b/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorTest.java
@@ -16,6 +16,7 @@ import com.mysql.jdbc.PreparedStatement;
 import com.mysql.jdbc.ResultSetInternalMethods;
 import com.mysql.jdbc.Statement;
 
+import com.twitter.zipkin.gen.Endpoint;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -81,7 +82,8 @@ public class MySQLStatementInterceptorTest {
 
         subject.preProcess(sql, mock(Statement.class), connection);
 
-        verify(clientTracer).setClientSent(1 << 24 | 2 << 16 | 3 << 8 | 4, 9999, "mysql-test");
+        verify(clientTracer).setClientSent(Endpoint.builder()
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(9999).serviceName("mysql-test").build());
     }
 
     @Test
@@ -102,7 +104,8 @@ public class MySQLStatementInterceptorTest {
 
         subject.preProcess(sql, mock(Statement.class), connection);
 
-        verify(clientTracer).setClientSent(1 << 24 | 2 << 16 | 3 << 8 | 4, 3306, "mysql-test");
+        verify(clientTracer).setClientSent(Endpoint.builder()
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(3306).serviceName("mysql-test").build());
     }
     
     @Test
@@ -124,7 +127,8 @@ public class MySQLStatementInterceptorTest {
 
         subject.preProcess(sql, mock(Statement.class), connection);
 
-        verify(clientTracer).setClientSent(1 << 24 | 2 << 16 | 3 << 8 | 4, 3306, "hello-brave");
+        verify(clientTracer).setClientSent(Endpoint.builder()
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(3306).serviceName("hello-brave").build());
     }
     
     @Test

--- a/brave-p6spy/src/main/java/com/github/kristofa/brave/p6spy/BraveP6SpyListener.java
+++ b/brave-p6spy/src/main/java/com/github/kristofa/brave/p6spy/BraveP6SpyListener.java
@@ -5,6 +5,7 @@ import com.p6spy.engine.common.PreparedStatementInformation;
 import com.p6spy.engine.common.StatementInformation;
 import com.p6spy.engine.event.JdbcEventListener;
 
+import com.twitter.zipkin.gen.Endpoint;
 import zipkin.Constants;
 import zipkin.TraceKeys;
 
@@ -132,7 +133,8 @@ public final class BraveP6SpyListener extends JdbcEventListener {
         tracer.submitBinaryAnnotation(TraceKeys.SQL_QUERY, sql);
 
         if (ipv4 != 0 && port > 0) {
-            tracer.setClientSent(ipv4, port, serviceName);
+            tracer.setClientSent(Endpoint.builder()
+                .ipv4(ipv4).port(port).serviceName(serviceName).build());
         } else { // logging the server address is optional
             tracer.setClientSent();
         }

--- a/brave-p6spy/src/test/java/com/github/kristofa/brave/p6spy/BraveP6SpyTest.java
+++ b/brave-p6spy/src/test/java/com/github/kristofa/brave/p6spy/BraveP6SpyTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.github.kristofa.brave.ClientTracer;
 
+import com.twitter.zipkin.gen.Endpoint;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -127,7 +128,8 @@ public class BraveP6SpyTest {
 
         order.verify(clientTracer).startNewSpan("query");
         order.verify(clientTracer).submitBinaryAnnotation(eq(TraceKeys.SQL_QUERY), eq(sql));
-        order.verify(clientTracer).setClientSent(HOST, PORT, SERVICE_NAME);
+        order.verify(clientTracer).setClientSent(Endpoint.builder()
+            .ipv4(HOST).port(PORT).serviceName(SERVICE_NAME).build());
         order.verify(clientTracer).setClientReceived();
         order.verifyNoMoreInteractions();
     }


### PR DESCRIPTION
This adds Endpoint.ipv6 as a fixed-width byte array (16 bytes). This
formalizes Endpoint.ipv4 == 0 implying there's no ipv4 address. These
are supported in recent versions of Zipkin with the same semantics.

You can use this via the Endpoint constructor of Brave, or via tracer
hooks like ClientTracer.setClientSent or ServerTracer.setServerReceived

This also deprecates Endpoint.create(serviceName,ipv4,port) as it leads
to NullPointerExceptions

See https://github.com/openzipkin/zipkin/issues/306
See https://github.com/openzipkin/zipkin/pull/1309