### PR TITLE
Rewrites OkHttp interceptor as BraveTracingInterceptor

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -40,13 +40,13 @@
     <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>1.6.2</version>
+        <version>${powermock.version}</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
-        <version>1.6.2</version>
+        <version>${powermock.version}</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/brave-okhttp/README.md
+++ b/brave-okhttp/README.md
@@ -1,16 +1,89 @@
 # brave-okhttp #
+This is an [OkHttp](https://github.com/square/okhttp) interceptor which
+traces client requests. It should be applied as both an application
+interceptor and as a network interceptor.
 
-This implementation makes it easy to integrate with brave to catch/trace [OkHttp](https://github.com/square/okhttp) requests. The `BraveOkHttpRequestResponseInterceptor` OkHttp [`Interceptor`](http://square.github.io/okhttp/3.x/okhttp/index.html?okhttp3/Interceptor.html) implementation will start a new Span and submit a `cs` (client sent) annotation and then submit `cr` (client received) annotation after the request is received.
+The implementation models the application request as a local span. Each
+network request will be a child span. For example, if there's a redirect,
+there will be one span for the application request and two child spans
+for the associated network requests.
 
-Example of configuring the interceptor with OkHttp:
+Trace identifiers of each network attempt are propagated to the server
+via headers prefixed with `X-B3`. These spans are also reported out of
+band, with `cs` (client sent) and `cr` (client receive) annotations,
+binary annotations (tags) like `http.url`, and `sa` including the
+server's ip and port.
 
+### Configuration
+Since this interceptor creates nested spans, you should use nesting-aware
+span state like `InheritableServerClientAndLocalSpanState`. If using
+asynchronous calls, you must also wrap the dispatcher's executor
+service. Regardless, the interceptor must be registered as both an
+application and network interceptor. 
+
+Here's how to add tracing to OkHttp:
+```java
+brave = new Brave.Builder(new InheritableServerClientAndLocalSpanState(localEndpoint))..
+
+// The request dispatcher uses an executor service.. wrap it!
+tracePropagatingExecutor = new BraveExecutorService(
+    new Dispatcher().executorService(),
+    brave.serverSpanThreadBinder()
+);
+
+client = new OkHttpClient.Builder()
+  .addInterceptor(tracingInterceptor)
+  .addNetworkInterceptor(tracingInterceptor)
+  .dispatcher(new Dispatcher(tracePropagatingExecutor));
+  .build();
 ```
-import com.github.kristofa.brave.okhttp.BraveOkHttpRequestResponseInterceptor;
-import okhttp3.OkHttpClient;
 
-...
+### Customizing span data
+The span associated with the application request is by default named
+according to the request tag, falling back to the http method name.
 
-OkHttpClient client = new OkHttpClient.Builder()
-    .addInterceptor(new BraveOkHttpRequestResponseInterceptor(...))
-    .build();
+Ex.
+```java
+// This request's span name will be "get"
+request = new Request.Builder()
+    .url("https://myhost.com/gummybears").build();
+
+// This request's span name will be "get-gummy-bears"
+request = new Request.Builder()
+    .url("https://myhost.com/gummybears")
+    .tag("get-gummy-bears").build();
 ```
+
+If you want to change span names or tags, you can override the default
+parser.
+```java
+tracingInterceptor = BraveTracingInterceptor.builder(brave)
+  ...
+  .parser(new MyOkHttpParser()).build();
+```
+
+Be careful when customizing, particularly not to add too much data.
+Larges span (ex large orders of kilobytes) can be problematic and/or
+dropped. Also, be careful that span names have low cardinality (ex no
+embedded variables). Finally, prefer names in `zipkin.TraceKeys` where
+possible, so that lookup keys are coherent.
+
+For more information, look at our
+[instrumentation docs](http://zipkin.io/pages/instrumenting.html)
+
+### Naming the server
+When calling an service that isn't traced with Zipkin, such as a cloud
+service. You'll want to assign a server name so that it shows up in
+Zipkin's service dependency graph. You can set this via
+`BraveTracingInterceptor.Builder.serverName()`
+
+```java
+tracingInterceptor = BraveTracingInterceptor.builder(brave)
+  ...
+  .serverName("github").build();
+
+request = new Request.Builder()
+    .url("https://api.github.com/repos/square/okhttp/issues")
+    ...
+```
+

--- a/brave-okhttp/pom.xml
+++ b/brave-okhttp/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>brave-okhttp</artifactId>
 
-  <description>OkHttp request and response interceptor implementation</description>
+  <description>OkHttp tracing interceptor implementation</description>
 
   <url>https://github.com/kristofa/brave</url>
 
@@ -23,24 +23,36 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okhttp.version>3.2.0</okhttp.version>
+    <okhttp.version>3.4.1</okhttp.version>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>${okhttp.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.brave</groupId>
-      <artifactId>brave-http</artifactId>
-      <version>3.11.2-SNAPSHOT</version>
-    </dependency>
-    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptor.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptor.java
@@ -1,0 +1,205 @@
+package com.github.kristofa.brave.okhttp;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.InheritableServerClientAndLocalSpanState;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.LocalTracer;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+import com.twitter.zipkin.gen.Endpoint;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.List;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import zipkin.Constants;
+import zipkin.TraceKeys;
+
+import static com.github.kristofa.brave.IdConversion.convertToString;
+import static com.github.kristofa.brave.http.BraveHttpHeaders.Sampled;
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
+/**
+ * This is an OkHttp interceptor which traces client requests. It should be applied as both an
+ * {@link OkHttpClient#interceptors() application interceptor} and as a {@link
+ * OkHttpClient#networkInterceptors() network interceptor}.
+ *
+ * <p>The implementation models the application request as a local span. Each network request will
+ * be a child span. For example, if there's a redirect, there will be one for the application
+ * request and two spans for the associated network requests.
+ *
+ * Trace identifiers of each network attempt are propagated to the server via headers prefixed with
+ * `X-B3`. These spans are also reported out of band, with {@link zipkin.Constants#CLIENT_SEND} and
+ * {@link zipkin.Constants#CLIENT_RECV} annotations, binary annotations (tags) like {@link
+ * TraceKeys#HTTP_URL} and {@link zipkin.Constants#SERVER_ADDR the server's ip and port}.
+ *
+ * <h3>Configuration</h3>
+ *
+ * <p>Since this interceptor creates nested spans, you should use nesting-aware
+ * span state like {@link InheritableServerClientAndLocalSpanState}. If using
+ * asynchronous calls, you must also wrap the dispatcher's executor
+ * service. Regardless, the interceptor must be registered as both an
+ * application and network interceptor.
+ *
+ * <p>Here's how to add tracing to OkHttp:
+ * <pre>{@code
+ * brave = new Brave.Builder(new InheritableServerClientAndLocalSpanState(localEndpoint))..
+ *
+ * // The request dispatcher uses an executor service.. wrap it!
+ * tracePropagatingExecutor = new BraveExecutorService(
+ *   new Dispatcher().executorService(),
+ *   brave.serverSpanThreadBinder()
+ * );
+ *
+ * client = new OkHttpClient.Builder()
+ *   .addInterceptor(tracingInterceptor)
+ *   .addNetworkInterceptor(tracingInterceptor)
+ *   .dispatcher(new Dispatcher(tracePropagatingExecutor));
+ *   .build();
+ * }</pre>
+ */
+public final class BraveTracingInterceptor implements Interceptor {
+  public static BraveTracingInterceptor create(Brave brave) {
+    return builder(brave).build();
+  }
+
+  /** Defaults to use {@link OkHttpParser} */
+  public static Builder builder(Brave brave) {
+    return new Builder(brave);
+  }
+
+  public static final class Builder {
+    Brave brave;
+    String serverName = "";
+    OkHttpParser parser = new OkHttpParser();
+
+    Builder(Brave brave) {
+      this.brave = checkNotNull(brave, "brave");
+    }
+
+    /**
+     * Indicates the service name used for the {@link Constants#SERVER_ADDR server address}.Default
+     * is empty string.
+     *
+     * <p>Setting this is not important when the server is instrumented with Zipkin. This is
+     * important when the server is not instrumented with Zipkin. For example, if you are calling a
+     * cloud service, you will see this name as a leaf in your service dependency graph.
+     */
+    public Builder serverName(String serverName) {
+      this.serverName = checkNotNull(serverName, "serverName");
+      return this;
+    }
+
+    /** Controls the metadata recorded in spans representing http operations. */
+    public Builder parser(OkHttpParser parser) {
+      this.parser = checkNotNull(parser, "parser");
+      return this;
+    }
+
+    public BraveTracingInterceptor build() {
+      return new BraveTracingInterceptor(this);
+    }
+  }
+
+  final LocalTracer localTracer;
+  final ClientTracer clientTracer;
+  final OkHttpParser parser;
+  final String serverName;
+
+  BraveTracingInterceptor(Builder builder) {
+    localTracer = builder.brave.localTracer();
+    clientTracer = builder.brave.clientTracer();
+    parser = builder.parser;
+    serverName = builder.serverName;
+  }
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Connection connection = chain.connection();
+    boolean applicationRequest = connection == null;
+
+    Request request = chain.request();
+    SpanId spanId;
+    if (applicationRequest) {
+      spanId = localTracer.startNewSpan("okhttp", parser.applicationSpanName(request));
+    } else {
+      spanId = clientTracer.startNewSpan(parser.networkSpanName(request));
+    }
+
+    if (spanId == null) { // trace was unsampled
+      return applicationRequest
+          ? chain.proceed(request)
+          : chain.proceed(request.newBuilder().header(Sampled.getName(), "0").build());
+    } else if (applicationRequest) {
+      return traceApplicationRequest(chain, request);
+    } else {
+      Request tracedRequest = addTraceHeaders(request, spanId).build();
+      return traceNetworkRequest(chain, tracedRequest);
+    }
+  }
+
+  static Request.Builder addTraceHeaders(Request request, SpanId spanId) {
+    Request.Builder tracedRequest = request.newBuilder();
+    tracedRequest.header(BraveHttpHeaders.TraceId.getName(), convertToString(spanId.traceId));
+    tracedRequest.header(BraveHttpHeaders.SpanId.getName(), convertToString(spanId.spanId));
+    if (spanId.nullableParentId() != null) {
+      tracedRequest.header(BraveHttpHeaders.ParentSpanId.getName(),
+          convertToString(spanId.parentId));
+    }
+    tracedRequest.header(BraveHttpHeaders.Sampled.getName(), "1");
+    return tracedRequest;
+  }
+
+  /** We do not add trace headers to the application request, as it never leaves the process */
+  Response traceApplicationRequest(Chain chain, Request request) throws IOException {
+    try {
+      return chain.proceed(request);
+    } catch (IOException | RuntimeException | Error e) {
+      // TODO: revisit https://github.com/openzipkin/openzipkin.github.io/issues/52
+      localTracer.submitBinaryAnnotation(Constants.ERROR, e.getMessage());
+      throw e;
+    } finally {
+      localTracer.finishSpan(); // span must be closed!
+    }
+  }
+
+  Response traceNetworkRequest(Chain chain, Request request) throws IOException {
+    appendToSpan(parser.networkRequestTags(request));
+    try {
+      clientTracer.setClientSent(serverAddress(chain.connection()));
+      Response response = chain.proceed(request);
+      appendToSpan(parser.networkResponseTags(response));
+      return response;
+    } catch (IOException | RuntimeException | Error e) {
+      // TODO: revisit https://github.com/openzipkin/openzipkin.github.io/issues/52
+      clientTracer.submitAnnotation(Constants.ERROR);
+      throw e;
+    } finally {
+      clientTracer.setClientReceived(); // span must be closed!
+    }
+  }
+
+  void appendToSpan(List<KeyValueAnnotation> annotations) {
+    for (int i = 0, length = annotations.size(); i < length; i++) {
+      KeyValueAnnotation tag = annotations.get(i);
+      clientTracer.submitBinaryAnnotation(tag.getKey(), tag.getValue());
+    }
+  }
+
+  Endpoint serverAddress(Connection connection) {
+    InetSocketAddress sa = connection.route().socketAddress();
+    Endpoint.Builder builder = Endpoint.builder().serviceName(serverName).port(sa.getPort());
+    byte[] address = sa.getAddress().getAddress();
+    if (address.length == 4) {
+      builder.ipv4(ByteBuffer.wrap(address).getInt());
+    } else if (address.length == 16) {
+      builder.ipv6(address);
+    }
+    return builder.build();
+  }
+}

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/OkHttpParser.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/OkHttpParser.java
@@ -1,0 +1,51 @@
+package com.github.kristofa.brave.okhttp;
+
+import com.github.kristofa.brave.KeyValueAnnotation;
+import java.util.Collections;
+import java.util.List;
+import okhttp3.Request;
+import okhttp3.Response;
+import zipkin.TraceKeys;
+
+/**
+ * Extend this type to change metadata recorded in spans representing http operations.
+ *
+ * <p><em>Be careful when customizing</em>, particularly not to add too much data. Large spans (ex
+ * large orders of kilobytes) can be problematic and/or dropped. Also, be careful that span names
+ * have low cardinality (ex no embedded variables). Finally, prefer names in {@link TraceKeys} where
+ * possible, so that lookup keys are coherent.
+ *
+ * For more information, look at our <a href="http://zipkin.io/pages/instrumenting.html">instrumentation
+ * docs</a>
+ */
+public class OkHttpParser {
+
+  /** Returns the {@link Request#tag()} or the http method when absent. */
+  public String applicationSpanName(Request request) {
+    return !(request.tag() instanceof Request)
+        ? request.tag().toString()
+        : request.method();
+  }
+
+  /** Returns the http method. */
+  public String networkSpanName(Request request) {
+    return request.method();
+  }
+
+  /** Returns the {@link zipkin.TraceKeys#HTTP_URL} */
+  public List<KeyValueAnnotation> networkRequestTags(Request request) {
+    return Collections.singletonList(
+        KeyValueAnnotation.create(TraceKeys.HTTP_URL, request.url().toString())
+    );
+  }
+
+  /** Returns the {@link zipkin.TraceKeys#HTTP_STATUS_CODE} if unsuccessful */
+  public List<KeyValueAnnotation> networkResponseTags(Response response) {
+    int code = response.code();
+    if (response.isSuccessful()) return Collections.EMPTY_LIST;
+
+    return Collections.singletonList(
+        KeyValueAnnotation.create(TraceKeys.HTTP_STATUS_CODE, String.valueOf(code))
+    );
+  }
+}

--- a/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptorTest.java
+++ b/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptorTest.java
@@ -1,0 +1,273 @@
+package com.github.kristofa.brave.okhttp;
+
+import com.github.kristofa.brave.AnnotationSubmitter;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.InheritableServerClientAndLocalSpanState;
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.LocalTracer;
+import com.github.kristofa.brave.Sampler;
+import com.github.kristofa.brave.SpanCollector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.TraceKeys;
+import zipkin.internal.TraceUtil;
+import zipkin.storage.InMemoryStorage;
+
+import static com.github.kristofa.brave.http.BraveHttpHeaders.ParentSpanId;
+import static com.github.kristofa.brave.http.BraveHttpHeaders.Sampled;
+import static com.github.kristofa.brave.http.BraveHttpHeaders.SpanId;
+import static com.github.kristofa.brave.http.BraveHttpHeaders.TraceId;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
+import static zipkin.Constants.LOCAL_COMPONENT;
+import static zipkin.TraceKeys.HTTP_STATUS_CODE;
+import static zipkin.TraceKeys.HTTP_URL;
+
+@RunWith(PowerMockRunner.class)
+// tell mock not to mess with our rules or loggers!
+@PowerMockIgnore({"okhttp3.*", "org.apache.logging.*", "com.sun.*"})
+@PrepareForTest({AnnotationSubmitter.class, LocalTracer.class})
+public class BraveTracingInterceptorTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Rule public MockWebServer server = new MockWebServer();
+
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  Endpoint sa = local.toBuilder().serviceName("").port(server.getPort()).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  OkHttpClient client;
+  BraveTracingInterceptor interceptor;
+
+  Span localSpan = Span.builder()
+      .traceId(1L).id(1L).name("get")
+      .timestamp(1000L).duration(4000L)
+      .addBinaryAnnotation(BinaryAnnotation.create(LOCAL_COMPONENT, "okhttp", local))
+      .build();
+
+  Span clientSpan = Span.builder()
+      .traceId(1L).parentId(1L).id(2L).name("get")
+      .timestamp(3000L).duration(1000L)
+      .addAnnotation(Annotation.create(3000, Constants.CLIENT_SEND, local))
+      .addAnnotation(Annotation.create(4000, Constants.CLIENT_RECV, local))
+      .addBinaryAnnotation(BinaryAnnotation.create(HTTP_URL, server.url("foo").toString(), local))
+      .addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR, sa))
+      .build();
+
+  @Before
+  public void setup() throws Exception {
+    PowerMockito.mockStatic(System.class);
+    // Each call to nanoTime or currentTimeMillis increases the fake clock by 1 millisecond
+    final AtomicLong clock = new AtomicLong();
+    PowerMockito.when(System.currentTimeMillis())
+        .then(i -> clock.addAndGet(1000000L) / 1000000L);
+    PowerMockito.when(System.nanoTime())
+        .then(i -> clock.addAndGet(1000000L));
+
+    interceptor = interceptorBuilder(Sampler.ALWAYS_SAMPLE).build();
+    client = new OkHttpClient.Builder()
+        .addInterceptor(interceptor)
+        .addNetworkInterceptor(interceptor).build();
+  }
+
+  @After
+  public void close() {
+    client.dispatcher().executorService().shutdownNow();
+  }
+
+  @Test
+  public void propagatesSpan() throws Exception {
+    server.enqueue(new MockResponse());
+
+    client.newCall(new Request.Builder().url(server.url("foo")).build()).execute();
+
+    RecordedRequest request = server.takeRequest();
+    Map<String, List<String>> headers = washIds(request.getHeaders().toMultimap());
+    assertThat(headers.get(TraceId.getName())).isEqualTo(asList("1"));
+
+    assertThat(headers).contains(
+        entry(TraceId.getName(), asList("1")),
+        entry(ParentSpanId.getName(), asList("1")),
+        entry(SpanId.getName(), asList("2")),
+        entry(Sampled.getName(), asList("1"))
+    );
+  }
+
+  @Test
+  public void propagates_sampledFalse() throws Exception {
+    interceptor = interceptorBuilder(Sampler.NEVER_SAMPLE).build();
+    client = new OkHttpClient.Builder().
+        addInterceptor(interceptor).addNetworkInterceptor(interceptor).build();
+
+    server.enqueue(new MockResponse());
+    client.newCall(new Request.Builder().url(server.url("foo")).build()).execute();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeaders().toMultimap()).contains(
+        entry(Sampled.getName(), asList("0"))
+    ).doesNotContainKeys(TraceId.getName(), SpanId.getName(), ParentSpanId.getName());
+  }
+
+  @Test
+  public void reportsToZipkin() throws Exception {
+    server.enqueue(new MockResponse());
+
+    HttpUrl url = server.url("foo");
+    client.newCall(new Request.Builder().url(url).build()).execute();
+
+    assertThat(collectedSpans()).containsExactly(clientSpan, localSpan);
+  }
+
+  @Test
+  public void reportsToZipkin_addsCodeWhenNotOk() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    HttpUrl url = server.url("foo");
+    client.newCall(new Request.Builder().url(url).build()).execute();
+
+    assertThat(collectedSpans()).containsExactly(
+        clientSpan.toBuilder()
+            .addBinaryAnnotation(BinaryAnnotation.create(TraceKeys.HTTP_STATUS_CODE, "404", local))
+            .build(), localSpan
+    );
+  }
+
+  @Test
+  public void reportsToZipkin_IncludesQueryParams() throws Exception {
+    server.enqueue(new MockResponse());
+
+    HttpUrl url = server.url("foo?z=2&yAA");
+    client.newCall(new Request.Builder().url(url).build()).execute();
+
+    assertThat(collectedSpans()).containsExactly(
+        clientSpan.toBuilder().binaryAnnotations(asList(
+            BinaryAnnotation.create(HTTP_URL, url.toString(), local),
+            BinaryAnnotation.address(Constants.SERVER_ADDR, sa))
+        ).build(), localSpan
+    );
+  }
+
+  @Test
+  public void tagIsApplicationSpanName() throws Exception {
+    server.enqueue(new MockResponse());
+
+    HttpUrl url = server.url("foo");
+    client.newCall(new Request.Builder().url(url).tag("foo").build()).execute();
+
+    assertThat(collectedSpans())
+        .containsExactly(clientSpan, localSpan.toBuilder().name("foo").build());
+  }
+
+  @Test
+  public void addMoreTags() throws Exception {
+    close();
+    interceptor = interceptorBuilder(Sampler.ALWAYS_SAMPLE).parser(new OkHttpParser() {
+      @Override
+      public List<KeyValueAnnotation> networkRequestTags(Request request) {
+        List<KeyValueAnnotation> result = new ArrayList<>();
+        result.addAll(super.networkRequestTags(request));
+        String userAgent = request.header("User-Agent");
+        if (userAgent != null) {
+          result.add(KeyValueAnnotation.create("http.user_agent", userAgent));
+        }
+        return result;
+      }
+    }).build();
+    client = new OkHttpClient.Builder()
+        .addInterceptor(interceptor).addNetworkInterceptor(interceptor).build();
+
+    server.enqueue(new MockResponse());
+
+    HttpUrl url = server.url("foo");
+
+    String userAgent = "Microservice Client v2.0";
+    client.newCall(new Request.Builder().url(url)
+        .header("User-Agent", userAgent).build()).execute();
+
+    assertThat(collectedSpans().get(0).binaryAnnotations)
+        .extracting(b -> tuple(b.key, new String(b.value)))
+        .contains(tuple("http.user_agent", userAgent));
+  }
+
+  @Test
+  public void reportsToZipkin_followupsAsNewSpans() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(408));
+    server.enqueue(new MockResponse());
+
+    HttpUrl url = server.url("foo");
+    client.newCall(new Request.Builder().url(url).build()).execute();
+
+    assertThat(collectedSpans()).containsOnly(
+        clientSpan.toBuilder()
+            .addBinaryAnnotation(BinaryAnnotation.create(HTTP_STATUS_CODE, "408", local))
+            .build(),
+        clientSpan.toBuilder()
+            .id(3L).timestamp(6000L).annotations(asList(
+            Annotation.create(6000, Constants.CLIENT_SEND, local),
+            Annotation.create(7000, Constants.CLIENT_RECV, local)))
+            .build(),
+        localSpan.toBuilder().duration(7000L).build()
+    );
+  }
+
+  BraveTracingInterceptor.Builder interceptorBuilder(Sampler sampler) {
+    com.twitter.zipkin.gen.Endpoint localEndpoint = com.twitter.zipkin.gen.Endpoint.builder()
+        .ipv4(local.ipv4)
+        .ipv6(local.ipv6)
+        .port(local.port)
+        .serviceName(local.serviceName)
+        .build();
+    Brave brave = new Brave.Builder(new InheritableServerClientAndLocalSpanState(localEndpoint))
+        .spanCollector(new SpanCollector() {
+          @Override public void collect(com.twitter.zipkin.gen.Span span) {
+            storage.spanConsumer().accept(asList(span.toZipkin()));
+          }
+
+          @Override public void addDefaultAnnotation(String key, String value) {
+            throw new UnsupportedOperationException();
+          }
+        })
+        .traceSampler(sampler)
+        .build();
+    return BraveTracingInterceptor.builder(brave);
+  }
+
+  /** washes trace identifiers in the collected span */
+  List<Span> collectedSpans() {
+    List<Long> traceIds = storage.spanStore().traceIds();
+    assertThat(traceIds).hasSize(1);
+    return TraceUtil.washIds(storage.spanStore().getRawTrace(traceIds.get(0)));
+  }
+
+  /** washes propagated trace identifiers in the request headers */
+  Map<String, List<String>> washIds(Map<String, List<String>> headers) {
+    List<Long> traceIds = storage.spanStore().traceIds();
+    assertThat(traceIds).hasSize(1);
+    List<Span> unwashed = storage.spanStore().getRawTrace(traceIds.get(0));
+    return TraceUtil.washIds(headers, unwashed);
+  }
+}

--- a/brave-okhttp/src/test/java/zipkin/internal/TraceUtil.java
+++ b/brave-okhttp/src/test/java/zipkin/internal/TraceUtil.java
@@ -1,0 +1,61 @@
+package zipkin.internal;
+
+import com.github.kristofa.brave.IdConversion;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import zipkin.Span;
+
+import static java.util.Arrays.asList;
+
+/** In internal package to access zipkin internal code */
+public class TraceUtil {
+  public static List<Span> washIds(List<Span> trace) {
+    // we want to return spans in their original order
+    Map<Span, Span> map = new LinkedHashMap<>();
+    for (Span span : trace) map.put(span, span);
+
+    long traceId = 1L, id = 1L;
+    // traverse the tree breadth-first, and replace the ids with incrementing ones
+    for (Iterator<Node<Span>> iter = Node.constructTree(trace).traverse(); iter.hasNext(); id++) {
+      Node<Span> next = iter.next();
+      if (next.parent() == null) {
+        Span root = next.value().toBuilder().traceId(traceId).id(id).build();
+        map.replace(next.value(), root);
+        next.value(root);
+      } else {
+        Span parent = next.parent().value();
+        Span child = next.value().toBuilder().traceId(traceId).parentId(parent.id).id(id).build();
+        map.replace(next.value(), child);
+        next.value(child);
+      }
+    }
+    return new ArrayList<>(map.values());
+  }
+
+  /** washes propagated trace identifiers in the request headers */
+  public static Map<String, List<String>> washIds(Map<String, List<String>> headers,
+      List<Span> unwashed) {
+    List<Span> washed = washIds(unwashed);
+    Map<String, String> idMapping = new LinkedHashMap<>();
+    for (int i = 0; i < unwashed.size(); i++) {
+      idMapping.put(
+          IdConversion.convertToString(unwashed.get(i).id),
+          IdConversion.convertToString(washed.get(i).id)
+      );
+    }
+
+    Map<String, List<String>> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    result.putAll(headers);
+    for (Map.Entry<String, List<String>> entry : result.entrySet()) {
+      String replacement = idMapping.get(entry.getValue().get(0));
+      if (replacement != null) {
+        result.put(entry.getKey(), asList(replacement));
+      }
+    }
+    return result;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <zipkin.version>1.12.0</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
+    <powermock.version>1.6.5</powermock.version>
 
     <maven-plugin.version>0.3.3</maven-plugin.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>


### PR DESCRIPTION
This is an [OkHttp](https://github.com/square/okhttp) interceptor which
traces client requests. It should be applied as both an application
interceptor and as a network interceptor.

The implementation models the application request as a local span. Each
network request will be a child span. For example, if there's a redirect,
there will be one span for the application request and two child spans
for the associated network requests.

Trace identifiers of each network attempt are propagated to the server
via headers prefixed with `X-B3`. These spans are also reported out of
band, with `cs` (client sent) and `cr` (client receive) annotations,
binary annotations (tags) like `http.url`, and `sa` including the
server's ip and port.

### Configuration
Since this interceptor creates nested spans, you should use nesting-aware
span state like `InheritableServerClientAndLocalSpanState`. If using
asynchronous calls, you must also wrap the dispatcher's executor
service. Regardless, the interceptor must be registered as both an
application and network interceptor. 

Here's how to add tracing to OkHttp:
```java
brave = new Brave.Builder(new InheritableServerClientAndLocalSpanState(localEndpoint))..

// The request dispatcher uses an executor service.. wrap it!
tracePropagatingExecutor = new BraveExecutorService(
    new Dispatcher().executorService(),
    brave.serverSpanThreadBinder()
);

client = new OkHttpClient.Builder()
  .addInterceptor(tracingInterceptor)
  .addNetworkInterceptor(tracingInterceptor)
  .dispatcher(new Dispatcher(tracePropagatingExecutor));
  .build();
```

### Customizing span data
The span associated with the application request is by default named
according to the request tag, falling back to the http method name.

Ex.
```java
// This request's span name will be "get"
request = new Request.Builder()
    .url("https://myhost.com/gummybears").build();

// This request's span name will be "get-gummy-bears"
request = new Request.Builder()
    .url("https://myhost.com/gummybears")
    .tag("get-gummy-bears").build();
```

If you want to change span names or tags, you can override the default
parser.
```java
tracingInterceptor = BraveTracingInterceptor.builder(brave)
  ...
  .parser(new MyOkHttpParser()).build();
```

Be careful when customizing, particularly not to add too much data.
Large span (ex large orders of kilobytes) can be problematic and/or
dropped. Also, be careful that span names have low cardinality (ex no
embedded variables). Finally, prefer names in `zipkin.TraceKeys` where
possible, so that lookup keys are coherent.

For more information, look at our
[instrumentation docs](http://zipkin.io/pages/instrumenting.html)

### Naming the server
When calling an service that isn't traced with Zipkin, such as a cloud
service. You'll want to assign a server name so that it shows up in
Zipkin's service dependency graph. You can set this via
`BraveTracingInterceptor.Builder.serverName()`

```java
tracingInterceptor = BraveTracingInterceptor.builder(brave)
  ...
  .serverName("github").build();

request = new Request.Builder()
    .url("https://api.github.com/repos/square/okhttp/issues")
    ...
```