### PR TITLE
More precise timestamps by using nanos offsets where available

### DIFF
--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -98,9 +98,18 @@ public class AnnotationSubmitterTest {
     }
 
     @Test
-    public void testCurrentTimeMicroSeconds() {
+    public void testCurrentTimeMicroSeconds_fromSystemCurrentMillis() {
         AnnotationSubmitter anotherAnnotationSubmitter = AnnotationSubmitter.create(
             StaticSpanAndEndpoint.create(null, endpoint));
-        assertEquals(CURRENT_TIME_MICROSECONDS, anotherAnnotationSubmitter.currentTimeMicroseconds());
+        assertEquals(CURRENT_TIME_MICROSECONDS, anotherAnnotationSubmitter.currentTimeMicroseconds(null));
+    }
+
+    @Test
+    public void testCurrentTimeMicroSeconds_fromRelativeNanoTick() {
+        AnnotationSubmitter anotherAnnotationSubmitter = AnnotationSubmitter.create(
+            StaticSpanAndEndpoint.create(null, endpoint));
+
+        PowerMockito.when(System.nanoTime()).thenReturn(1000L);
+        assertEquals(1, anotherAnnotationSubmitter.currentTimeMicroseconds(0L));
     }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -1,6 +1,10 @@
 package com.github.kristofa.brave;
 
 
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -8,6 +12,8 @@ import org.mockito.InOrder;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static com.github.kristofa.brave.Sampler.ALWAYS_SAMPLE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class ServerRequestInterceptorTest {
@@ -58,6 +64,17 @@ public class ServerRequestInterceptorTest {
 
     @Test
     public void handleSampleRequestWithParentSpanId() {
+        InheritableServerClientAndLocalSpanState state =
+            new InheritableServerClientAndLocalSpanState(mock(Endpoint.class));
+        serverTracer = ServerTracer.builder()
+            .state(state)
+            .randomGenerator(mock(Random.class))
+            .spanCollector(mock(SpanCollector.class))
+            .traceSampler(Sampler.ALWAYS_SAMPLE)
+            .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
+            .build();
+        interceptor = new ServerRequestInterceptor(serverTracer);
+
         SpanId spanId =
             SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(PARENT_SPAN_ID).build();
         TraceData traceData = TraceData.builder().spanId(spanId).sample(true).build();
@@ -66,29 +83,60 @@ public class ServerRequestInterceptorTest {
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
 
         interceptor.handle(adapter);
-        InOrder inOrder = inOrder(serverTracer, adapter);
-        inOrder.verify(serverTracer).clearCurrentSpan();
-        inOrder.verify(serverTracer).setStateCurrentTrace(TRACE_ID, SPAN_ID, PARENT_SPAN_ID, SPAN_NAME);
-        inOrder.verify(serverTracer).setServerReceived();
-        inOrder.verify(adapter).requestAnnotations();
-        inOrder.verify(serverTracer).submitBinaryAnnotation(ANNOTATION1.getKey(), ANNOTATION1.getValue());
-        inOrder.verify(serverTracer).submitBinaryAnnotation(ANNOTATION2.getKey(), ANNOTATION2.getValue());
-        verifyNoMoreInteractions(serverTracer);
+
+        Span span = state.getCurrentServerSpan().getSpan();
+        assertThat(span.getTrace_id())
+            .isEqualTo(TRACE_ID);
+        assertThat(span.getId())
+            .isEqualTo(SPAN_ID);
+        assertThat(span.getParent_id())
+            .isEqualTo(PARENT_SPAN_ID);
+        assertThat(span.getAnnotations())
+            .extracting(a -> a.value).containsExactly("sr");
+        assertThat(span.getBinary_annotations())
+            .extracting(a -> a.key).containsExactly(ANNOTATION1.getKey(), ANNOTATION2.getKey());
+
+        // don't log timestamp when span is client-originated
+        assertThat(span.getTimestamp()).isNull();
+        assertThat(span.startTick).isNull();
     }
 
     @Test
     public void handleSampleRequestWithoutParentSpanId() {
-        SpanId spanId = SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
+        InheritableServerClientAndLocalSpanState state =
+            new InheritableServerClientAndLocalSpanState(mock(Endpoint.class));
+        serverTracer = ServerTracer.builder()
+            .state(state)
+            .randomGenerator(mock(Random.class))
+            .spanCollector(mock(SpanCollector.class))
+            .traceSampler(Sampler.ALWAYS_SAMPLE)
+            .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
+            .build();
+        interceptor = new ServerRequestInterceptor(serverTracer);
+
+        SpanId spanId =
+            SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
         TraceData traceData = TraceData.builder().spanId(spanId).sample(true).build();
         when(adapter.getTraceData()).thenReturn(traceData);
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
-        when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);
+        when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
 
         interceptor.handle(adapter);
-        InOrder inOrder = inOrder(serverTracer);
-        inOrder.verify(serverTracer).clearCurrentSpan();
-        inOrder.verify(serverTracer).setStateCurrentTrace(TRACE_ID, SPAN_ID, null, SPAN_NAME);
-        inOrder.verify(serverTracer).setServerReceived();
-        verifyNoMoreInteractions(serverTracer);
+
+        Span span = state.getCurrentServerSpan().getSpan();
+        assertThat(span.getTrace_id())
+            .isEqualTo(TRACE_ID);
+        assertThat(span.getId())
+            .isEqualTo(SPAN_ID);
+        assertThat(span.getParent_id())
+            .isNull();
+        assertThat(span.getAnnotations())
+            .extracting(a -> a.value).containsExactly("sr");
+        assertThat(span.getBinary_annotations())
+            .extracting(a -> a.key).containsExactly(ANNOTATION1.getKey(), ANNOTATION2.getKey());
+
+        // don't log timestamp when span is client-originated
+        assertThat(span.getTimestamp()).isNull();
+        assertThat(span.startTick).isNull();
     }
 }


### PR DESCRIPTION
This change brings Brave into the best timestamp practice by doing the
following:
* Fixes unsafe access to Span.startTick
* Records Span.startTick when starting any span the local process owns
* Ensures Span.timestamp/duration are not reported on spans the local process doesn't own
* Uses nanos offsets where available for annotation timestamps

The above corrects the common misalignment of spans in the UI, where
within a local process, operations that vary on microsecond basis have
annotations that extend beyond the span duration.

See https://github.com/openzipkin/openzipkin.github.io/issues/49