### PR TITLE
Allow BraveOkHttpRequestResponseInterceptor handler injection

### DIFF
--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
@@ -183,5 +183,15 @@ public class Endpoint implements Serializable {
     h ^= (port == null) ? 0 : port.hashCode();
     return h;
   }
+
+  @Override
+  public String toString() {
+    return "Endpoint{" +
+            "service_name='" + service_name + '\'' +
+            ", ipv4=" + ipv4 +
+            (ipv6 == null ? "" : (", ipv6=" + Arrays.toString(ipv6))) +
+            ", port=" + port +
+            '}';
+  }
 }
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
@@ -8,9 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-
 public class HttpClientResponseAdapter implements ClientResponseAdapter {
-
 
     private final HttpResponse response;
 
@@ -23,9 +21,10 @@ public class HttpClientResponseAdapter implements ClientResponseAdapter {
         int httpStatus = response.getHttpStatusCode();
 
         if ((httpStatus < 200) || (httpStatus > 299)) {
-            KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
-            return Arrays.asList(statusAnnotation);
+            return Collections.singleton(KeyValueAnnotation.create(
+                    TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus)));
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
+
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
@@ -6,6 +6,7 @@ import zipkin.TraceKeys;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public class HttpServerResponseAdapter implements ServerResponseAdapter {
 
@@ -18,8 +19,7 @@ public class HttpServerResponseAdapter implements ServerResponseAdapter {
 
     @Override
     public Collection<KeyValueAnnotation> responseAnnotations() {
-        KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(
-                TraceKeys.HTTP_STATUS_CODE, String.valueOf(response.getHttpStatusCode()));
-        return Arrays.asList(statusAnnotation);
+        return Collections.singleton(KeyValueAnnotation.create(
+                TraceKeys.HTTP_STATUS_CODE, String.valueOf(response.getHttpStatusCode())));
     }
 }

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptor.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptor.java
@@ -1,16 +1,18 @@
 package com.github.kristofa.brave.okhttp;
 
 
+import java.io.IOException;
+
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.http.HttpClientRequest;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
+
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
-
-import java.io.IOException;
 
 public class BraveOkHttpRequestResponseInterceptor implements Interceptor {
 
@@ -18,7 +20,9 @@ public class BraveOkHttpRequestResponseInterceptor implements Interceptor {
   private final ClientResponseInterceptor clientResponseInterceptor;
   private final SpanNameProvider spanNameProvider;
 
-  public BraveOkHttpRequestResponseInterceptor(ClientRequestInterceptor requestInterceptor, ClientResponseInterceptor responseInterceptor, SpanNameProvider spanNameProvider) {
+  public BraveOkHttpRequestResponseInterceptor(ClientRequestInterceptor requestInterceptor,
+                                               ClientResponseInterceptor responseInterceptor,
+                                               SpanNameProvider spanNameProvider) {
     this.spanNameProvider = spanNameProvider;
     this.clientRequestInterceptor = requestInterceptor;
     this.clientResponseInterceptor = responseInterceptor;
@@ -29,10 +33,22 @@ public class BraveOkHttpRequestResponseInterceptor implements Interceptor {
     Request request = chain.request();
     Request.Builder builder = request.newBuilder();
     OkHttpRequest okHttpRequest = new OkHttpRequest(builder, request);
-    clientRequestInterceptor.handle(new HttpClientRequestAdapter(okHttpRequest, spanNameProvider));
+    clientRequestInterceptor.handle(createRequestAdapter(okHttpRequest));
     Response response = chain.proceed(builder.build());
-    clientResponseInterceptor.handle(new HttpClientResponseAdapter(new OkHttpResponse(response)));
+    clientResponseInterceptor.handle(createResponseAdapter(response));
     return response;
+  }
+
+  protected SpanNameProvider getSpanNameProvider() {
+    return spanNameProvider;
+  }
+
+  protected HttpClientRequestAdapter createRequestAdapter(HttpClientRequest request) {
+    return new HttpClientRequestAdapter(request, getSpanNameProvider());
+  }
+
+  protected HttpClientResponseAdapter createResponseAdapter(Response response) {
+    return new HttpClientResponseAdapter(new OkHttpResponse(response));
   }
 
 }


### PR DESCRIPTION
While instrumenting an OkHTTP client, realized we'd like to specify the behavior of the `HttpServerRequestAdapter` and `HttpClientRequestAdapter` to provide additional context (e.g. adding an annotation from an HTTP request header such as from `User-Agent`.

Also optimize HTTP client & server request adapters to avoid allocations when trace sampling is not enabled.

Adds toString for Endpoint debugging.