### PR TITLE
Improve brave-http request/response adapters code consistency

### DIFF
--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -35,6 +35,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- for benchmarking SpanId -->
     <dependency>
       <groupId>com.twitter</groupId>

--- a/brave-benchmarks/src/main/java/com/github/kristofa/brave/HttpServerRequestAdapterBenchmark.java
+++ b/brave-benchmarks/src/main/java/com/github/kristofa/brave/HttpServerRequestAdapterBenchmark.java
@@ -1,0 +1,101 @@
+package com.github.kristofa.brave;
+
+import java.net.URI;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+import com.github.kristofa.brave.http.HttpRequest;
+import com.github.kristofa.brave.http.HttpServerRequest;
+import com.github.kristofa.brave.http.HttpServerRequestAdapter;
+import com.github.kristofa.brave.http.SpanNameProvider;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 5, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Threads(1)
+public class HttpServerRequestAdapterBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class Data {
+        final URI URI = java.net.URI.create("http://localhost");
+        final Random random = new Random(42);
+        final HttpServerRequest request = new HttpServerRequest() {
+            @Override
+            public String getHttpHeaderValue(String headerName) {
+                if (BraveHttpHeaders.Sampled.getName().equals(headerName)) {
+                    switch (random.nextInt(6)) {
+                        case 0:
+                            return null;
+                        case 1:
+                            return "1";
+                        case 2:
+                            return "true";
+                        case 3:
+                            return "false";
+                        case 4:
+                            return "False";
+                        case 5:
+                            return "FALSE";
+                    }
+                }
+                if (BraveHttpHeaders.TraceId.getName().equals(headerName)
+                        || BraveHttpHeaders.SpanId.getName().equals(headerName)
+                        || BraveHttpHeaders.ParentSpanId.getName().equals(headerName)) {
+                    return "1234";
+                }
+                return null;
+            }
+
+            @Override
+            public URI getUri() {
+                return URI;
+            }
+
+            @Override
+            public String getHttpMethod() {
+                return "GET";
+            }
+        };
+
+        final SpanNameProvider nameProvider = new SpanNameProvider() {
+            @Override
+            public String spanName(HttpRequest request) {
+                return request.getHttpMethod() + " " + request.getUri().getPath();
+            }
+        };
+
+        final HttpServerRequestAdapter adapter = new HttpServerRequestAdapter(request, nameProvider);
+    }
+
+    @Benchmark
+    public TraceData httpServerRequestAdapter(Data data) {
+        return data.adapter.getTraceData();
+    }
+
+    // Convenience main entry-point
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + HttpServerRequestAdapterBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientRequestAdapter.java
@@ -8,9 +8,8 @@ import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
 import zipkin.TraceKeys;
 
-import java.net.URI;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public class HttpClientRequestAdapter implements ClientRequestAdapter {
 
@@ -21,7 +20,6 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
         this.request = request;
         this.spanNameProvider = spanNameProvider;
     }
-
 
     @Override
     public String getSpanName() {
@@ -42,16 +40,15 @@ public class HttpClientRequestAdapter implements ClientRequestAdapter {
         }
     }
 
-
     @Override
     public Collection<KeyValueAnnotation> requestAnnotations() {
-        URI uri = request.getUri();
-        KeyValueAnnotation annotation = KeyValueAnnotation.create(TraceKeys.HTTP_URL, uri.toString());
-        return Arrays.asList(annotation);
+        return Collections.singleton(KeyValueAnnotation.create(
+                TraceKeys.HTTP_URL, request.getUri().toString()));
     }
 
     @Override
     public Endpoint serverAddress() {
         return null;
     }
+
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpClientResponseAdapter.java
@@ -8,9 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-
 public class HttpClientResponseAdapter implements ClientResponseAdapter {
-
 
     private final HttpResponse response;
 
@@ -23,9 +21,10 @@ public class HttpClientResponseAdapter implements ClientResponseAdapter {
         int httpStatus = response.getHttpStatusCode();
 
         if ((httpStatus < 200) || (httpStatus > 299)) {
-            KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
-            return Arrays.asList(statusAnnotation);
+            return Collections.singleton(KeyValueAnnotation.create(
+                    TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus)));
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
+
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -12,6 +12,9 @@ import static com.github.kristofa.brave.IdConversion.convertToLong;
 
 public class HttpServerRequestAdapter implements ServerRequestAdapter {
 
+    private static final TraceData EMPTY_UNSAMPLED_TRACE = TraceData.builder().sample(false).build();
+    private static final TraceData EMPTY_MAYBE_TRACE = TraceData.builder().build();
+
     private final HttpServerRequest serverRequest;
     private final SpanNameProvider spanNameProvider;
 
@@ -24,8 +27,8 @@ public class HttpServerRequestAdapter implements ServerRequestAdapter {
     public TraceData getTraceData() {
         final String sampled = serverRequest.getHttpHeaderValue(BraveHttpHeaders.Sampled.getName());
         if (sampled != null) {
-            if (sampled.equals("0") || sampled.toLowerCase().equals("false")) {
-                return TraceData.builder().sample(false).build();
+            if (sampled.equals("0") || sampled.equalsIgnoreCase("false")) {
+                return EMPTY_UNSAMPLED_TRACE;
             } else {
                 final String parentSpanId = serverRequest.getHttpHeaderValue(BraveHttpHeaders.ParentSpanId.getName());
                 final String traceId = serverRequest.getHttpHeaderValue(BraveHttpHeaders.TraceId.getName());
@@ -37,7 +40,7 @@ public class HttpServerRequestAdapter implements ServerRequestAdapter {
                 }
             }
         }
-        return TraceData.builder().build();
+        return EMPTY_MAYBE_TRACE;
     }
 
     @Override

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerResponseAdapter.java
@@ -1,11 +1,10 @@
 package com.github.kristofa.brave.http;
 
+import java.util.Collection;
+import java.util.Collections;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.ServerResponseAdapter;
 import zipkin.TraceKeys;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 public class HttpServerResponseAdapter implements ServerResponseAdapter {
 
@@ -18,8 +17,7 @@ public class HttpServerResponseAdapter implements ServerResponseAdapter {
 
     @Override
     public Collection<KeyValueAnnotation> responseAnnotations() {
-        KeyValueAnnotation statusAnnotation = KeyValueAnnotation.create(
-                TraceKeys.HTTP_STATUS_CODE, String.valueOf(response.getHttpStatusCode()));
-        return Arrays.asList(statusAnnotation);
+        return Collections.singleton(KeyValueAnnotation.create(
+                TraceKeys.HTTP_STATUS_CODE, String.valueOf(response.getHttpStatusCode())));
     }
 }


### PR DESCRIPTION
Shows minor performance improvement for arbitrary microbenchmark:

```
Benchmark   Mode  Cnt   Score   Error  Units
Before      avgt   15  65.362 ± 3.308  ns/op
After       avgt   15  48.170 ± 2.641  ns/op
```