### PR TITLE
Allow more control over flushing span collector and queue buffer

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
@@ -4,6 +4,8 @@ import com.twitter.zipkin.gen.Span;
 import com.twitter.zipkin.gen.SpanCodec;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Implemented {@link #sendSpans} to transport a encoded list of spans to Zipkin.
@@ -15,9 +17,19 @@ public abstract class AbstractSpanCollector extends FlushingSpanCollector {
   /**
    * @param flushInterval in seconds. 0 implies spans are {@link #flush() flushed externally.
    */
-  public AbstractSpanCollector(SpanCodec codec, SpanCollectorMetricsHandler metrics,
-      int flushInterval) {
+  public AbstractSpanCollector(SpanCodec codec,
+                               SpanCollectorMetricsHandler metrics,
+                               int flushInterval) {
     super(metrics, flushInterval);
+    this.codec = codec;
+  }
+
+  public AbstractSpanCollector(SpanCodec codec,
+                               SpanCollectorMetricsHandler metrics,
+                               BlockingQueue<Span> pendingQueue,
+                               int flushInterval,
+                               TimeUnit unit) {
+    super(metrics, pendingQueue, flushInterval, unit);
     this.codec = codec;
   }
 


### PR DESCRIPTION
Allow providing one's own blocking queue for buffering pending spans, and allow specifying the flush interval time unit so that spans can be flushed more frequently than once per second.