### PR TITLE
Deprecates SpanCollector in favor of zipkin.reporter.Reporter

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -30,6 +30,11 @@
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>0.6.0</version>
+    </dependency>
     <!-- for value types... don't worry. this dependency is compile only! -->
     <dependency>
         <groupId>com.google.auto.value</groupId>

--- a/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
@@ -7,7 +7,10 @@ import java.util.List;
 
 /**
  * Implemented {@link #sendSpans} to transport a encoded list of spans to Zipkin.
+ *
+ * @deprecated replaced by {@link zipkin.reporter.AsyncReporter}
  */
+@Deprecated
 public abstract class AbstractSpanCollector extends FlushingSpanCollector {
 
   private final SpanCodec codec;

--- a/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
@@ -5,6 +5,7 @@ import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
+import zipkin.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
@@ -109,7 +110,7 @@ public abstract class AnnotationSubmitter {
      *
      * @return true if a span was sent for collection.
      */
-    boolean submitEndAnnotation(String annotationName, SpanCollector spanCollector) {
+    boolean submitEndAnnotation(String annotationName, Reporter<zipkin.Span> reporter) {
         Span span = spanAndEndpoint().span();
         if (span == null) {
           return false;
@@ -145,7 +146,7 @@ public abstract class AnnotationSubmitter {
                 span.setDuration(duration);
             }
         }
-        spanCollector.collect(span);
+        reporter.report(span.toZipkin());
         return true;
     }
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollector.java
@@ -6,7 +6,10 @@ import com.twitter.zipkin.gen.Span;
  * A {@link SpanCollector} implementation that does nothing with collected spans.
  * 
  * @author adriaens
+ *
+ * @deprecated replaced by {@link zipkin.reporter.Reporter#NOOP}.
  */
+@Deprecated
 public class EmptySpanCollector implements SpanCollector {
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
@@ -19,7 +19,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Extend this class to offload the task of reporting spans to separate thread. By doing so, callers
  * are protected from latency or exceptions possible when exporting spans out of process.
+ *
+ * @deprecated replaced by {@link zipkin.reporter.AsyncReporter}
  */
+@Deprecated
 public abstract class FlushingSpanCollector implements SpanCollector, Flushable, Closeable {
 
   private final SpanCollectorMetricsHandler metrics;

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -8,6 +8,7 @@ import com.twitter.zipkin.gen.Span;
 import zipkin.Constants;
 
 import java.util.Random;
+import zipkin.reporter.Reporter;
 
 import static zipkin.Constants.LOCAL_COMPONENT;
 
@@ -50,7 +51,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
 
     abstract Random randomGenerator();
 
-    abstract SpanCollector spanCollector();
+    abstract Reporter<zipkin.Span> reporter();
 
     abstract boolean allowNestedLocalSpans();
 
@@ -66,7 +67,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
 
         abstract Builder randomGenerator(Random randomGenerator);
 
-        abstract Builder spanCollector(SpanCollector spanCollector);
+        abstract Builder reporter(Reporter<zipkin.Span> reporter);
 
         abstract Builder allowNestedLocalSpans(boolean allowNestedLocalSpans);
 
@@ -203,9 +204,8 @@ public abstract class LocalTracer extends AnnotationSubmitter {
     private void internalFinishSpan(Span span, long duration) {
         synchronized (span) {
             span.setDuration(duration);
-            spanCollector().collect(span);
         }
-
+        reporter().report(span.toZipkin());
         spanAndEndpoint().state().setCurrentLocalSpan(null);
     }
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/LoggingReporter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LoggingReporter.java
@@ -1,0 +1,38 @@
+package com.github.kristofa.brave;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import zipkin.reporter.Reporter;
+
+import static com.github.kristofa.brave.internal.Util.checkNotBlank;
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
+/**
+ * Simple {@link Reporter} implementation which logs the span through jul at INFO level.
+ *
+ * <p>Can be used for testing and debugging.
+ */
+public final class LoggingReporter implements Reporter<zipkin.Span> {
+
+  final Logger logger;
+
+  /**
+   * Note: this logs to the category "com.github.kristofa.brave.LoggingSpanCollector" for backwards
+   * compatiblity purposes.
+   */
+  public LoggingReporter() {
+    this("com.github.kristofa.brave.LoggingSpanCollector");
+  }
+
+  public LoggingReporter(String loggerName) {
+    checkNotBlank(loggerName, "Null or blank loggerName");
+    logger = Logger.getLogger(loggerName);
+  }
+
+  @Override public void report(zipkin.Span span) {
+    checkNotNull(span, "Null span");
+    if (logger.isLoggable(Level.INFO)) {
+      logger.info(span.toString());
+    }
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
@@ -17,7 +17,9 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * Can be used for testing and debugging.
  * 
  * @author kristof
+ * @deprecated use {@link LoggingReporter}
  */
+@Deprecated
 public class LoggingSpanCollector implements SpanCollector {
 
     private final Logger logger;

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanCollector.java
@@ -7,7 +7,10 @@ import com.twitter.zipkin.gen.Span;
  * simply log the collected spans or implementations that persist the spans to a database, submit them to a service,...
  * 
  * @author kristof
+ *
+ * @deprecated replaced by {@link zipkin.reporter.Reporter}
  */
+@Deprecated
 public interface SpanCollector {
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorReporterAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorReporterAdapter.java
@@ -1,0 +1,66 @@
+package com.github.kristofa.brave;
+
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.AnnotationType;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import zipkin.reporter.Reporter;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
+final class SpanCollectorReporterAdapter implements SpanCollector, Reporter<zipkin.Span> {
+
+  final SpanCollector delegate;
+
+  SpanCollectorReporterAdapter(SpanCollector delegate) {
+    this.delegate = checkNotNull(delegate, "span collector");
+  }
+
+  @Override public void report(zipkin.Span span) {
+    checkNotNull(span, "Null span");
+    collect(toBrave(span));
+  }
+
+  @Override
+  public void collect(Span span) {
+    checkNotNull(span, "Null span");
+    delegate.collect(span);
+  }
+
+  @Deprecated
+  @Override
+  public void addDefaultAnnotation(String key, String value) {
+    delegate.addDefaultAnnotation(key, value);
+  }
+
+  /** Changes this to a brave-native span object. */
+  static Span toBrave(zipkin.Span input) {
+    Span result = new Span();
+    result.setTrace_id(input.traceId);
+    result.setId(input.id);
+    result.setParent_id(input.parentId);
+    result.setName(input.name);
+    result.setTimestamp(input.timestamp);
+    result.setDuration(input.duration);
+    result.setDebug(input.debug);
+    for (zipkin.Annotation a : input.annotations) {
+      result.addToAnnotations(Annotation.create(a.timestamp, a.value, from(a.endpoint)));
+    }
+    for (zipkin.BinaryAnnotation a : input.binaryAnnotations) {
+      result.addToBinary_annotations(BinaryAnnotation.create(
+          a.key, a.value, AnnotationType.fromValue(a.type.value), from(a.endpoint)
+      ));
+    }
+    return result;
+  }
+
+  private static Endpoint from(zipkin.Endpoint endpoint) {
+    if (endpoint == null) return null;
+    return Endpoint.builder()
+        .ipv4(endpoint.ipv4)
+        .ipv6(endpoint.ipv6)
+        .port(endpoint.port)
+        .serviceName(endpoint.serviceName).build();
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
@@ -7,20 +7,22 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.Span;
+import zipkin.reporter.Reporter;
 
 public class BraveTest {
 
-    private SpanCollector mockSpanCollector;
+    private Reporter<Span> fakeReporter = span -> {
+    };
     private Sampler mockSampler;
     private Brave brave;
 
     @Before
     public void setup() {
-        mockSpanCollector = mock(SpanCollector.class);
         mockSampler = mock(Sampler.class);
         // -1062731775 = 192.168.0.1
         final Brave.Builder builder = new Brave.Builder(-1062731775, 8080, "unknown");
-        brave = builder.spanCollector(mockSpanCollector).traceSampler(mockSampler).build();
+        brave = builder.reporter(fakeReporter).traceSampler(mockSampler).build();
     }
 
     @Test
@@ -28,8 +30,8 @@ public class BraveTest {
         final ClientTracer clientTracer = brave.clientTracer();
         assertNotNull(clientTracer);
         assertTrue("We expect instance of ClientTracer", clientTracer instanceof ClientTracer);
-        assertSame("ClientTracer should be configured with the spancollector we submitted.", mockSpanCollector,
-            clientTracer.spanCollector());
+        assertSame("ClientTracer should be configured with the reporter we submitted.", fakeReporter,
+            clientTracer.reporter());
         assertSame("ClientTracer should be configured with the traceSampler we submitted.",
             mockSampler, clientTracer.traceSampler());
 
@@ -43,7 +45,7 @@ public class BraveTest {
     public void testGetServerTracer() {
         final ServerTracer serverTracer = brave.serverTracer();
         assertNotNull(serverTracer);
-        assertSame(mockSpanCollector, serverTracer.spanCollector());
+        assertSame(fakeReporter, serverTracer.reporter());
         assertSame("ServerTracer should be configured with the traceSampler we submitted.",
             mockSampler, serverTracer
             .traceSampler());
@@ -70,7 +72,7 @@ public class BraveTest {
     public void testGetLocalTracer() {
         final LocalTracer localTracer = brave.localTracer();
         assertNotNull(localTracer);
-        assertSame(mockSpanCollector, localTracer.spanCollector());
+        assertSame(fakeReporter, localTracer.reporter());
         assertSame("LocalTracer should be configured with the traceSampler we submitted.",
                 mockSampler, localTracer
                         .traceSampler());

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -127,7 +127,7 @@ public class ClientTracerTest {
 
     @Test
     public void testSetClientReceived() {
-        Span clientRecv = new Span().setTimestamp(100L);
+        Span clientRecv = new Span().setName("foo").setTimestamp(100L);
         state.setCurrentClientSpan(clientRecv);
 
         clientTracer.setClientReceived();
@@ -238,7 +238,7 @@ public class ClientTracerTest {
 
     @Test
     public void setClientReceived_usesPreciseDuration() {
-        Span finished = new Span().setTimestamp(1000L); // set in start span
+        Span finished = new Span().setName("foo").setTimestamp(1000L); // set in start span
         finished.startTick = 500000L; // set in start span
         state.setCurrentClientSpan(finished);
 
@@ -255,7 +255,7 @@ public class ClientTracerTest {
     /** Duration of less than one microsecond is confusing to plot and could coerce to null. */
     @Test
     public void setClientReceived_lessThanMicrosRoundUp() {
-        Span finished = new Span().setTimestamp(1000L); // set in start span
+        Span finished = new Span().setName("foo").setTimestamp(1000L); // set in start span
         finished.startTick = 500L; // set in start span
         state.setCurrentClientSpan(finished);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -38,7 +38,7 @@ public class ServerTracerTest {
     private SpanCollector mockSpanCollector;
     private ServerSpan mockServerSpan;
     private Span mockSpan;
-    private Endpoint mockEndpoint;
+    private Endpoint mockEndpoint = Endpoint.create("service", 0);
     private Random mockRandom;
     private Sampler mockSampler;
 
@@ -49,7 +49,6 @@ public class ServerTracerTest {
         mockSpan = mock(Span.class);
         mockServerSpan = mock(ServerSpan.class);
 
-        mockEndpoint = mock(Endpoint.class);
         mockRandom = mock(Random.class);
         mockSampler = mock(Sampler.class);
 
@@ -213,7 +212,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetServerSend() {
-        Span serverSend = new Span().setTimestamp(100L);
+        Span serverSend = new Span().setName("foo").setTimestamp(100L);
         when(mockServerSpan.getSpan()).thenReturn(serverSend);
         when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
         when(mockServerSpanState.endpoint()).thenReturn(mockEndpoint);
@@ -238,7 +237,7 @@ public class ServerTracerTest {
 
     @Test
     public void setServerSend_skipsDurationWhenNoTimestamp() {
-        Span finished = new Span(); // unset due to client-originated trace
+        Span finished = new Span().setName("foo"); // duration unset due to client-originated trace
         when(mockServerSpan.getSpan()).thenReturn(finished);
         when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
 
@@ -252,7 +251,7 @@ public class ServerTracerTest {
 
     @Test
     public void setServerSend_usesPreciseDuration() {
-        Span finished = new Span().setTimestamp(1000L); // set in start span
+        Span finished = new Span().setName("foo").setTimestamp(1000L); // set in start span
         finished.startTick = 500000L; // set in start span
         when(mockServerSpan.getSpan()).thenReturn(finished);
         when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
@@ -270,7 +269,7 @@ public class ServerTracerTest {
     /** Duration of less than one microsecond is confusing to plot and could coerce to null. */
     @Test
     public void setServerSend_lessThanMicrosRoundUp() {
-        Span finished = new Span().setTimestamp(1000L); // set in start span
+        Span finished = new Span().setName("foo").setTimestamp(1000L); // set in start span
         finished.startTick = 500L; // set in start span
         when(mockServerSpan.getSpan()).thenReturn(finished);
         when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);

--- a/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptorTest.java
+++ b/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptorTest.java
@@ -6,7 +6,6 @@ import com.github.kristofa.brave.InheritableServerClientAndLocalSpanState;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.LocalTracer;
 import com.github.kristofa.brave.Sampler;
-import com.github.kristofa.brave.SpanCollector;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -242,15 +241,7 @@ public class BraveTracingInterceptorTest {
         .serviceName(local.serviceName)
         .build();
     Brave brave = new Brave.Builder(new InheritableServerClientAndLocalSpanState(localEndpoint))
-        .spanCollector(new SpanCollector() {
-          @Override public void collect(com.twitter.zipkin.gen.Span span) {
-            storage.spanConsumer().accept(asList(span.toZipkin()));
-          }
-
-          @Override public void addDefaultAnnotation(String key, String value) {
-            throw new UnsupportedOperationException();
-          }
-        })
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
         .traceSampler(sampler)
         .build();
     return BraveTracingInterceptor.builder(brave);

--- a/brave-spancollector-http/src/main/java/com/github/kristofa/brave/http/HttpSpanCollector.java
+++ b/brave-spancollector-http/src/main/java/com/github/kristofa/brave/http/HttpSpanCollector.java
@@ -14,7 +14,11 @@ import java.util.zip.GZIPOutputStream;
 
 /**
  * SpanCollector which submits spans to Zipkin, using its {@code POST /spans} endpoint.
+ *
+ * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code URLConnectionSender}
+ *             located in the "io.zipkin.reporter:zipkin-sender-urlconnection" dependency.
  */
+@Deprecated
 public final class HttpSpanCollector extends AbstractSpanCollector {
 
   @AutoValue

--- a/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
+++ b/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
@@ -15,7 +15,11 @@ import org.apache.kafka.clients.producer.ProducerRecord;
  * SpanCollector which sends a thrift-encoded list of spans to a Kafka topic (default: "zipkin")
  *
  * <p><b>Important</b> If using zipkin-collector-service (or zipkin-receiver-kafka), you must run v1.35+
+ *
+ * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code KafkaSender}
+ *             located in the "io.zipkin.reporter:zipkin-sender-kafka08" dependency.
  */
+@Deprecated
 public final class KafkaSpanCollector extends AbstractSpanCollector {
 
   @AutoValue

--- a/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
+++ b/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
@@ -14,7 +14,11 @@ import zipkin.storage.StorageComponent;
 
 /**
  * SpanCollector which submits spans directly to a Zipkin {@link StorageComponent}.
+ *
+ * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code LocalSender}
+ *             located in the "io.zipkin.reporter:zipkin-sender-local" dependency.
  */
+@Deprecated
 public final class LocalSpanCollector extends FlushingSpanCollector {
 
   @AutoValue

--- a/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
+++ b/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
@@ -33,7 +33,11 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * </p>
  *
  * @author kristof
+ *
+ * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code LibthriftSender}
+ *             located in the "io.zipkin.reporter:zipkin-sender-libthrift" dependency.
  */
+@Deprecated
 public class ScribeSpanCollector implements SpanCollector, Closeable {
 
     private static final String UTF_8 = "UTF-8";


### PR DESCRIPTION
zipkin-reporter was made to allow others to re-use transport logic
without copy/paste. It has all the functionality Brave's SpanCollector
along with new functionality such as being able to send spans sooner
than a polling interval (ex on span count or byte size threshold).

This also allows re-use of third-party transports such as those for
the Amazon cloud.

See https://github.com/openzipkin/zipkin-reporter-java
See https://github.com/openzipkin/zipkin-aws