### PR TITLE
Adds Endpoint.toString that matches json

### DIFF
--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
@@ -5,8 +5,8 @@ import java.io.Serializable;
 import java.util.Arrays;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
-import static zipkin.internal.Util.checkArgument;
 import static com.github.kristofa.brave.internal.Util.equal;
+import static zipkin.internal.Util.checkArgument;
 
 /**
  * Indicates the network context of a service recording an annotation with two
@@ -182,6 +182,16 @@ public class Endpoint implements Serializable {
     h *= 1000003;
     h ^= (port == null) ? 0 : port.hashCode();
     return h;
+  }
+
+  /** Returns a json representation of this endpoint */
+  @Override public String toString() {
+    // zipkin.Endpoint.toString is json
+    return zipkin.Endpoint.builder()
+        .serviceName(service_name)
+        .port(port)
+        .ipv4(ipv4)
+        .ipv6(ipv6).build().toString();
   }
 }
 

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/EndpointTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/EndpointTest.java
@@ -1,11 +1,11 @@
 package com.twitter.zipkin.gen;
 
+import java.net.Inet6Address;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class EndpointTest {
   @Rule
@@ -17,6 +17,32 @@ public class EndpointTest {
     thrown.expectMessage("serviceName");
 
     Endpoint.builder().ipv4(127 << 24 | 1).build();
+  }
+
+  @Test
+  public void testToStringIsJson_minimal() {
+    assertThat(Endpoint.builder().serviceName("foo").build())
+        .hasToString("{\"serviceName\":\"foo\"}");
+  }
+
+  @Test
+  public void testToStringIsJson_ipv4() {
+    assertThat(Endpoint.builder().serviceName("foo").ipv4(127 << 24 | 1).build())
+        .hasToString("{\"serviceName\":\"foo\",\"ipv4\":\"127.0.0.1\"}");
+  }
+
+  @Test
+  public void testToStringIsJson_ipv4Port() {
+    assertThat(Endpoint.builder().serviceName("foo").ipv4(127 << 24 | 1).port(80).build())
+        .hasToString("{\"serviceName\":\"foo\",\"ipv4\":\"127.0.0.1\",\"port\":80}");
+  }
+
+  @Test
+  public void testToStringIsJson_ipv6() {
+    assertThat(Endpoint.builder().serviceName("foo")
+        // Cheat so we don't have to catch an exception here
+        .ipv6(sun.net.util.IPAddressUtil.textToNumericFormatV6("2001:db8::c001")).build())
+        .hasToString("{\"serviceName\":\"foo\",\"ipv6\":\"2001:db8::c001\"}");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <spring.version>4.3.2.RELEASE</spring.version>
     <jetty.version>8.1.20.v20160902</jetty.version>
-    <zipkin.version>1.12.0</zipkin.version>
+    <zipkin.version>1.13.0</zipkin.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>
     <powermock.version>1.6.5</powermock.version>


### PR DESCRIPTION
This adds Endpoint.toString for debugging. It uses json encoding so that
it is easier to compare with spans in zipkin.

Fixes #245