### PR TITLE
Added beans.xml to support brave-jaxrs2 in CDI environments

### DIFF
--- a/brave-core/src/main/resources/META-INF/beans.xml
+++ b/brave-core/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.2" bean-discovery-mode="all">
+</beans>

--- a/brave-http/src/main/resources/META-INF/beans.xml
+++ b/brave-http/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.2" bean-discovery-mode="all">
+</beans>

--- a/brave-jaxrs2/src/main/resources/META-INF/beans.xml
+++ b/brave-jaxrs2/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.2" bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
This commit adds `META-INF/beans.xml` to `brave-core`, `brave-http` and `brave-jaxrs2`. This allows it to be used in CDI based environments, which otherwise wouldn't be able to scan the resources.

With regard to the existing implementation, I think this doesn't have any impact.