### PR TITLE
BRAVE-250

### DIFF
--- a/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
@@ -4,13 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 
@@ -121,6 +130,86 @@ public class InheritableServerClientAndLocalSpanStateTest {
         assertThat(state.toString()).startsWith("InheritableServerClientAndLocalSpanState");
     }
 
+    @Test
+    public void parentSpanShouldNotLeakAcrossThreads() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean passed = new AtomicBoolean(false);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("brave-%d").build();
+
+        final ServerSpan parent = ServerSpan.create(1L, 2L, 3L, "testing");
+
+        state.setCurrentServerSpan(parent);
+        threadFactory.newThread(() -> {
+            ServerSpan current = state.getCurrentServerSpan();
+            passed.set(current.equals(parent) && current != parent
+                    && current.getSpan() != parent.getSpan());
+            latch.countDown();
+
+        }).start();
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertTrue(passed.get());
+
+    }
+
+    @Test
+    public void localSpanShouldNotLeakAcrossThreads() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean passed = new AtomicBoolean(false);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("brave-%d").build();
+
+        com.twitter.zipkin.gen.Span parent = new com.twitter.zipkin.gen.Span();
+        parent.setId(1L);
+        parent.setName("testing");
+        parent.setTrace_id(2L);
+        parent.setParent_id(3L);
+        parent.setTimestamp(1000L);
+        parent.setDebug(true);
+        parent.setDuration(100000L);
+        parent.addToAnnotations(Annotation.create(100L, "", Endpoint.create("service", 12345)));
+        parent.addToBinary_annotations(BinaryAnnotation.create("key", "value", Endpoint.create("other", 12345)));
+        state.setCurrentLocalSpan(parent);
+        threadFactory.newThread(() -> {
+            Span current = state.getCurrentLocalSpan();
+            passed.set(current.equals(parent) && current != parent);
+            latch.countDown();
+
+        }).start();
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertTrue(passed.get());
+
+    }
+    
+    @Test
+    public void clientSpanShouldNotLeakAcrossThreads() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean passed = new AtomicBoolean(false);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("brave-%d").build();
+
+        com.twitter.zipkin.gen.Span parent = new com.twitter.zipkin.gen.Span();
+        parent.setId(1L);
+        parent.setName("testing");
+        parent.setTrace_id(2L);
+        parent.setParent_id(3L);
+        parent.setTimestamp(1000L);
+        parent.setDebug(true);
+        parent.setDuration(100000L);
+        parent.addToAnnotations(Annotation.create(100L, "", Endpoint.create("service", 12345)));
+        parent.addToBinary_annotations(BinaryAnnotation.create("key", "value", Endpoint.create("other", 12345)));
+        state.setCurrentClientSpan(parent);
+        threadFactory.newThread(() -> {
+            Span current = state.getCurrentClientSpan();
+            passed.set(current.equals(parent) && current != parent);
+            latch.countDown();
+
+        }).start();
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertTrue(passed.get());
+
+    }
+        
     private static Span currentParentSpan(ServerClientAndLocalSpanState state) {
         Span parentSpan = state.getCurrentLocalSpan();
         return (parentSpan == null) ? state.getCurrentServerSpan().getSpan() : parentSpan;

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -1,7 +1,9 @@
 package com.github.kristofa.brave;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -13,14 +15,20 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.twitter.zipkin.gen.Endpoint;
+
+import zipkin.Span;
 import zipkin.reporter.Reporter;
 
 public class LocalTracingInheritenceTest {
@@ -191,6 +199,142 @@ public class LocalTracingInheritenceTest {
             assertThat(state.getCurrentLocalSpan().getId()).isEqualTo(spanId.spanId);
         } finally {
             localTracer.finishSpan();
+        }
+    }
+
+    /**
+     * Test to prove using InheritableThreadLocal without cloning won't work.
+     * 
+     * When using InheritableThreadLocal the child thread inherits local
+     * properties from the parent thread, when this happens it actually inherits
+     * a reference to the parent threads properties. This works if the value
+     * stored in the InheritableThreadLocal are immutable which is not the case
+     * for Spans
+     */
+    @Test
+    public void shouldTestLocalSpansUsingInheritableThreadLocal() throws Exception {
+        MockCollector reporter = new MockCollector();
+
+        brave = new Brave.Builder(state).reporter(reporter).traceSampler(sampler).build();
+
+        final LocalTracer localTracer = brave.localTracer();
+        final ClientTracer clientTracer = brave.clientTracer();
+
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+
+        final CountDownLatch finishLatch = new CountDownLatch(2);
+
+        // Start a span on main thread
+        //
+        // parent
+        //
+        localTracer.startNewSpan("parent-component", "parent");
+        threadFactory.newThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    // Start a nested span in thread T1,
+                    //
+                    // Expected Hierarachy:
+                    // parent <- child1
+                    //
+                    // This span will be mutated in the parent thread which will be
+                    // reflected in this thread
+                    localTracer.startNewSpan("child1-component", "child1");
+                    latch1.countDown();
+                    latch2.await(5, TimeUnit.SECONDS);
+
+                    // Start another nested span in thread T1
+                    //
+                    // Expected Hierarachy:
+                    // parent <- child1 <- child2
+                    //
+                    localTracer.startNewSpan("child2-component", "child2");
+
+                    threadFactory.newThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            clientTracer.startNewSpan("client child3");
+                            clientTracer.setClientSent();
+                            clientTracer.setClientReceived();
+                            finishLatch.countDown();
+                        }
+                    }).start();
+
+                    // Finish child2 span
+                    //
+                    // Expected Hierarachy:
+                    // parent <- child1
+                    //
+                    localTracer.finishSpan();
+
+                    // Finish child1 span
+                    //
+                    // parent
+                    //
+                    localTracer.finishSpan();
+                    finishLatch.countDown();
+                } catch (InterruptedException e) {
+                    // NO-OP...
+                }
+            }
+        }).start();
+
+        latch1.await(5, TimeUnit.SECONDS);
+        // Start span on main thread
+        //
+        // Expected Hierarachy:
+        // parent
+        //    <- child1 <- child2
+        //    <- mutate-child
+        //
+        // This will leak into T1 causing the hierarachy to break
+        //
+        // Actual Hierarachy
+        //
+        // parent
+        //   <- child1 <- mutate-child <- child2
+        //
+        //
+        localTracer.startNewSpan("mutate-child-component", "mutate-child");
+        latch2.countDown();
+        finishLatch.await(5, TimeUnit.SECONDS);
+
+        localTracer.finishSpan();
+        localTracer.finishSpan();
+
+        Map<String, Span> actual = reporter.collected;
+        assertEquals(5, actual.size());
+        // Assert parent
+        assertNotNull(actual.get("parent").id);
+        assertNotNull(actual.get("parent").traceId);
+        assertNull(actual.get("parent").parentId);
+        // Assert Child1
+        assertNotNull(actual.get("child1").id);
+        assertEquals(actual.get("parent").traceId, actual.get("child1").traceId);
+        assertEquals((Long) actual.get("parent").id, actual.get("child1").parentId);
+        // Assert Child2
+        assertNotNull(actual.get("child2").id);
+        assertEquals(actual.get("child1").traceId, actual.get("child2").traceId);
+        assertEquals((Long) actual.get("child1").id, actual.get("child2").parentId);
+        // Assert Child3
+        assertNotNull(actual.get("client child3").id);
+        assertEquals(actual.get("child2").traceId, actual.get("client child3").traceId);
+        assertEquals((Long) actual.get("child2").id, actual.get("client child3").parentId);
+        // Assert mutate-child
+        assertNotNull(actual.get("mutate-child").id);
+        assertEquals(actual.get("parent").traceId, actual.get("mutate-child").traceId);
+        assertEquals((Long) actual.get("parent").id, actual.get("mutate-child").parentId);
+    }
+
+    private class MockCollector implements Reporter<zipkin.Span> {
+
+        private Map<String, zipkin.Span> collected = Maps.newHashMap();
+
+        @Override
+        public void report(zipkin.Span span) {
+            collected.put(span.name, span);
         }
     }
 


### PR DESCRIPTION
-Added tests to show InheritableThreadLocals will leak across threads

These tests will currently fail. I don't know if it's possible to provide a reliable fix without getting rid of the InheritableThreadLocal. Even if the objects are cloned they will not work in Executors that reuse threads.

A better approach would be to maintain a stack something like

```
class WrappedSpanLocal {
    Span span
    WrappedSpanLocal parent;
}
```

and use ThreadLocals. This would involve updating the BraveExecutors that pass context between the threads to not only pass server spans but client and local spans as well which would break backwards compatibility.

I will continue to think of another solution.
