### PR TITLE
Removes the @Inject annotations in brave-jaxrs2

### DIFF
--- a/brave-jaxrs2/pom.xml
+++ b/brave-jaxrs2/pom.xml
@@ -32,11 +32,6 @@
             <version>3.14.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-        </dependency>
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.2</version>

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
@@ -5,7 +5,6 @@ import com.github.kristofa.brave.http.HttpClientRequest;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.ext.Provider;
@@ -22,7 +21,6 @@ public class BraveClientRequestFilter implements ClientRequestFilter {
     private final ClientRequestInterceptor requestInterceptor;
     private final SpanNameProvider spanNameProvider;
 
-    @Inject
     public BraveClientRequestFilter(SpanNameProvider spanNameProvider, ClientRequestInterceptor requestInterceptor) {
         this.requestInterceptor = requestInterceptor;
         this.spanNameProvider = spanNameProvider;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
@@ -4,7 +4,6 @@ import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import com.github.kristofa.brave.http.HttpResponse;
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
@@ -20,7 +19,6 @@ public class BraveClientResponseFilter implements ClientResponseFilter {
 
     private final ClientResponseInterceptor responseInterceptor;
 
-    @Inject
     public BraveClientResponseFilter(ClientResponseInterceptor responseInterceptor) {
         this.responseInterceptor = responseInterceptor;
     }

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
@@ -7,7 +7,6 @@ import com.github.kristofa.brave.http.SpanNameProvider;
 
 import java.io.IOException;
 
-import javax.inject.Inject;
 import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -26,7 +25,6 @@ public class BraveContainerRequestFilter implements ContainerRequestFilter {
     private final ServerRequestInterceptor requestInterceptor;
     private final SpanNameProvider spanNameProvider;
 
-    @Inject
     public BraveContainerRequestFilter(ServerRequestInterceptor interceptor, SpanNameProvider spanNameProvider) {
         this.requestInterceptor = interceptor;
         this.spanNameProvider = spanNameProvider;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerResponseFilter.java
@@ -4,7 +4,6 @@ import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.http.HttpResponse;
 import com.github.kristofa.brave.http.HttpServerResponseAdapter;
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -20,7 +19,6 @@ public class BraveContainerResponseFilter implements ContainerResponseFilter {
 
     private final ServerResponseInterceptor responseInterceptor;
 
-    @Inject
     public BraveContainerResponseFilter(ServerResponseInterceptor responseInterceptor) {
         this.responseInterceptor = responseInterceptor;
     }


### PR DESCRIPTION
The `@Inject` annotations create instantiation errors in CDI based environments and don’t seem to serve any purpose.

See discussion on #251