### PR TITLE
#264 Make BraveServletFilter customizable

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientAdapterInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientAdapterInterceptor.java
@@ -1,0 +1,25 @@
+package com.github.kristofa.brave;
+
+/**
+ * Allows to intercept and modify the creation of  
+ * {@link ServerRequestAdapter} and {@link ServerResponseAdapter}.
+ */
+public interface ClientAdapterInterceptor {
+
+	/**
+	 * Allows modification for {@link ServerRequestAdapter}.
+	 * 
+	 * @param interceptedAdapter obtained from the actual implementation or a preceding interceptor. 
+	 * @return modified adapter to use.
+	 */
+	ServerRequestAdapter interceptRequestAdapter(ServerRequestAdapter interceptedAdapter);
+
+	/**
+	 * Allows modification for {@link ServerResponseAdapter}.
+	 * 
+	 * @param interceptedAdapter obtained from the actual implementation or a preceding interceptor. 
+	 * @return modified adapter to use.
+	 */
+	ServerRequestAdapter interceptResponseAdapter(ServerRequestAdapter interceptedAdapter);
+
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerAdapterInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerAdapterInterceptor.java
@@ -1,0 +1,27 @@
+package com.github.kristofa.brave;
+
+/**
+ * Allows to intercept and modify the creation of  
+ * {@link ServerRequestAdapter} and {@link ServerResponseAdapter}.
+ * Allows an application to submit additional annotations and
+ * customize the behavior of the existing adapter implementation.
+ */
+public interface ServerAdapterInterceptor {
+
+	/**
+	 * Allows modification for {@link ServerRequestAdapter}.
+	 * 
+	 * @param originalAdapter obtained from actual implementation or a preceding filter. 
+	 * @return modified adapter to use.
+	 */
+	ServerRequestAdapter interceptRequestAdapter(ServerRequestAdapter originalAdapter);
+
+	/**
+	 * Allows modification for {@link ServerResponseAdapter}.
+	 * 
+	 * @param originalAdapter obtained from actual implementation or a preceding filter. 
+	 * @return modified adapter to use.
+	 */
+	ServerResponseAdapter interceptResponseAdapter(ServerResponseAdapter originalAdapter);
+
+}

--- a/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/BraveServletFilter.java
+++ b/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/BraveServletFilter.java
@@ -1,11 +1,8 @@
 package com.github.kristofa.brave.servlet;
 
-import com.github.kristofa.brave.ServerRequestInterceptor;
-import com.github.kristofa.brave.ServerResponseInterceptor;
-import com.github.kristofa.brave.http.HttpResponse;
-import com.github.kristofa.brave.http.HttpServerRequestAdapter;
-import com.github.kristofa.brave.http.HttpServerResponseAdapter;
-import com.github.kristofa.brave.http.SpanNameProvider;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -16,7 +13,17 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
-import java.io.IOException;
+
+import com.github.kristofa.brave.ServerAdapterInterceptor;
+import com.github.kristofa.brave.ServerRequestAdapter;
+import com.github.kristofa.brave.ServerRequestInterceptor;
+import com.github.kristofa.brave.ServerResponseAdapter;
+import com.github.kristofa.brave.ServerResponseInterceptor;
+import com.github.kristofa.brave.http.HttpResponse;
+import com.github.kristofa.brave.http.HttpServerRequest;
+import com.github.kristofa.brave.http.HttpServerRequestAdapter;
+import com.github.kristofa.brave.http.HttpServerResponseAdapter;
+import com.github.kristofa.brave.http.SpanNameProvider;
 
 /**
  * Servlet filter that will extract trace headers from the request and send
@@ -29,11 +36,17 @@ public class BraveServletFilter implements Filter {
     private final SpanNameProvider spanNameProvider;
 
     private FilterConfig filterConfig;
+    
+    private List<ServerAdapterInterceptor> adapterInterceptors = new ArrayList<ServerAdapterInterceptor>();
 
     public BraveServletFilter(ServerRequestInterceptor requestInterceptor, ServerResponseInterceptor responseInterceptor, SpanNameProvider spanNameProvider) {
         this.requestInterceptor = requestInterceptor;
         this.responseInterceptor = responseInterceptor;
         this.spanNameProvider = spanNameProvider;
+    }
+    
+    public void addAdapterInterceptor(ServerAdapterInterceptor adapterInterceptor){
+        adapterInterceptors.add(adapterInterceptor);
     }
 
     @Override
@@ -52,27 +65,57 @@ public class BraveServletFilter implements Filter {
             filterChain.doFilter(request, response);
         } else {
 
-            final StatusExposingServletResponse statusExposingServletResponse = new StatusExposingServletResponse((HttpServletResponse) response);
-            requestInterceptor.handle(new HttpServerRequestAdapter(new ServletHttpServerRequest((HttpServletRequest) request), spanNameProvider));
+            final StatusExposingServletResponse statusExposingServletResponse = new StatusExposingServletResponse(
+                    (HttpServletResponse) response);
+            requestInterceptor.handle(interceptRequestAdapter(newRequestAdapter(newRequest((HttpServletRequest) request), spanNameProvider)));
 
             try {
                 filterChain.doFilter(request, statusExposingServletResponse);
-            } finally {
-                responseInterceptor.handle(new HttpServerResponseAdapter(new HttpResponse() {
-                    @Override
-                    public int getHttpStatusCode() {
-                        return statusExposingServletResponse.getStatus();
-                    }
-                }));
+            }finally {
+                HttpResponse httpResponse = newResposne(statusExposingServletResponse);
+                responseInterceptor.handle(interceptResponseAdapter(newResponseAdapter(httpResponse)));
             }
         }
     }
-
+    
+    protected ServerRequestAdapter newRequestAdapter(HttpServerRequest servletHttpServerRequest,
+            SpanNameProvider spanNameProvider) {
+        return new HttpServerRequestAdapter(servletHttpServerRequest, spanNameProvider);
+    }
+  
+    protected ServerResponseAdapter newResponseAdapter(HttpResponse httpResponse) {
+        return new HttpServerResponseAdapter(httpResponse);
+    }
+    
+    protected HttpServerRequest newRequest(HttpServletRequest request) {
+        return new ServletHttpServerRequest(request);
+    }
+    
+    protected HttpResponse newResposne(HttpServletResponse response) {
+        return new ServletHttpServerResponse(response);
+    }
+    
+    protected ServerRequestAdapter interceptRequestAdapter(ServerRequestAdapter adapter) {
+        ServerRequestAdapter interceptedAdapter = adapter;
+        for(ServerAdapterInterceptor adapterInterceptor : adapterInterceptors){
+            interceptedAdapter = adapterInterceptor.interceptRequestAdapter(interceptedAdapter);
+        }
+        return interceptedAdapter;
+    }
+    
+    protected ServerResponseAdapter interceptResponseAdapter(ServerResponseAdapter adapter) {
+        ServerResponseAdapter interceptedAdapter = adapter;
+        for(ServerAdapterInterceptor adapterInterceptor : adapterInterceptors){
+            interceptedAdapter = adapterInterceptor.interceptResponseAdapter(interceptedAdapter);
+        }
+        return interceptedAdapter;
+    }
+    
     @Override
     public void destroy() {
 
     }
-
+    
     private String getAlreadyFilteredAttributeName() {
         String name = getFilterName();
         if (name == null) {

--- a/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/ServletHttpServerResponse.java
+++ b/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/ServletHttpServerResponse.java
@@ -1,0 +1,20 @@
+package com.github.kristofa.brave.servlet;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.github.kristofa.brave.http.HttpResponse;
+
+public class ServletHttpServerResponse implements HttpResponse {
+
+    private final HttpServletResponse response;
+
+    public ServletHttpServerResponse(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return response.getStatus();
+    }
+  
+}


### PR DESCRIPTION
first step to allow customization of BraveServletFilter by subclassing it. New implementations of HttpServerRequestAdapter and HttpServerResponseAdapter can be provided by overriding the
corresponding factory methods. 

A dedicated ServerAdapterFactory class should be considered and move newServerRequestAdapter(...) and newServerResponseAdapter(...) there.