### PR TITLE
Moves Nullable annotation to source retention to make OSGi not complain

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/Nullable.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/Nullable.java
@@ -1,10 +1,12 @@
 package com.github.kristofa.brave.internal;
 
+import java.lang.annotation.RetentionPolicy;
+
 /**
- * Libraries such as Guice and AutoValue will process any annotation named {@code Nullable}.
- * This avoids a dependency on one of the many jsr305 jars.
+ * AutoValue will process any annotation named {@code Nullable}. This avoids a dependency on one of
+ * the many jsr305 jars.
  */
 @java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@java.lang.annotation.Retention(RetentionPolicy.SOURCE)
 public @interface Nullable {
 }


### PR DESCRIPTION
Nullable is used to help direct auto-value, particularly indicating
fields that should result in an NPE when not present.

It seems OSGi complains when there's a annotation in an un-exported
package, and this is the simplest way to dodge the problem.

Fixes #268 (hopefully)