### PR TITLE
WIP: Introduces TagExtractor, for capturing binary annotations generically

### DIFF
--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
@@ -2,7 +2,8 @@ package com.github.kristofa.brave.httpclient;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
-import com.github.kristofa.brave.http.DefaultSpanNameProvider;
+import com.github.kristofa.brave.ClientRequestAdapter;
+import com.github.kristofa.brave.TagExtractor;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import org.apache.http.HttpRequest;
@@ -25,16 +26,28 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
         return new Builder(brave);
     }
 
-    public static final class Builder {
+    public static final class Builder implements TagExtractor.Config<Builder> {
         final Brave brave;
-        SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+        final HttpClientRequestAdapter.FactoryBuilder adapterFactoryBuilder
+            = HttpClientRequestAdapter.factoryBuilder();
 
         Builder(Brave brave) { // intentionally hidden
             this.brave = checkNotNull(brave, "brave");
         }
 
         public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
-            this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+            adapterFactoryBuilder.spanNameProvider(spanNameProvider);
+            return this;
+        }
+
+        @Override public Builder addKey(String key) {
+            adapterFactoryBuilder.addKey(key);
+            return this;
+        }
+
+        @Override
+        public Builder addValueParserFactory(TagExtractor.ValueParserFactory factory) {
+            adapterFactoryBuilder.addValueParserFactory(factory);
             return this;
         }
 
@@ -43,25 +56,23 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
         }
     }
 
-    private final ClientRequestInterceptor requestInterceptor;
-    private final SpanNameProvider spanNameProvider;
+    private final ClientRequestInterceptor interceptor;
+    private final ClientRequestAdapter.Factory<HttpClientRequestImpl> adapterFactory;
 
     BraveHttpRequestInterceptor(Builder b) { // intentionally hidden
-        this.requestInterceptor = b.brave.clientRequestInterceptor();
-        this.spanNameProvider = b.spanNameProvider;
+        this.interceptor = b.brave.clientRequestInterceptor();
+        this.adapterFactory = b.adapterFactoryBuilder.build(HttpClientRequestImpl.class);
     }
 
     /**
-     * Creates a new instance.
-     *
-     * @param requestInterceptor
-     * @param spanNameProvider Provides span name for request.
      * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
      */
     @Deprecated
-    public BraveHttpRequestInterceptor(ClientRequestInterceptor requestInterceptor, SpanNameProvider spanNameProvider) {
-        this.requestInterceptor = requestInterceptor;
-        this.spanNameProvider = spanNameProvider;
+    public BraveHttpRequestInterceptor(ClientRequestInterceptor interceptor, SpanNameProvider spanNameProvider) {
+        this.interceptor = interceptor;
+        this.adapterFactory = HttpClientRequestAdapter.factoryBuilder()
+            .spanNameProvider(spanNameProvider)
+            .build(HttpClientRequestImpl.class);
     }
 
     /**
@@ -69,7 +80,7 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
      */
     @Override
     public void process(final HttpRequest request, final HttpContext context) {
-        HttpClientRequestAdapter adapter = new HttpClientRequestAdapter(new HttpClientRequestImpl(request), spanNameProvider);
-        requestInterceptor.handle(adapter);
+        ClientRequestAdapter adapter = adapterFactory.create(new HttpClientRequestImpl(request));
+        interceptor.handle(adapter);
     }
 }

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -13,6 +13,8 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <jmh.version>1.12</jmh.version>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>

--- a/brave-benchmarks/src/main/java/com/github/kristofa/brave/HttpServerRequestAdapterBenchmark.java
+++ b/brave-benchmarks/src/main/java/com/github/kristofa/brave/HttpServerRequestAdapterBenchmark.java
@@ -1,9 +1,11 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+import com.github.kristofa.brave.http.HttpServerRequest;
+import com.github.kristofa.brave.http.HttpServerRequestAdapter;
 import java.net.URI;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -18,12 +20,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import com.github.kristofa.brave.http.BraveHttpHeaders;
-import com.github.kristofa.brave.http.HttpRequest;
-import com.github.kristofa.brave.http.HttpServerRequest;
-import com.github.kristofa.brave.http.HttpServerRequestAdapter;
-import com.github.kristofa.brave.http.SpanNameProvider;
 
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 5, time = 1)
@@ -75,14 +71,9 @@ public class HttpServerRequestAdapterBenchmark {
             }
         };
 
-        final SpanNameProvider nameProvider = new SpanNameProvider() {
-            @Override
-            public String spanName(HttpRequest request) {
-                return request.getHttpMethod() + " " + request.getUri().getPath();
-            }
-        };
-
-        final HttpServerRequestAdapter adapter = new HttpServerRequestAdapter(request, nameProvider);
+        final ServerRequestAdapter adapter = HttpServerRequestAdapter.factoryBuilder()
+            .spanNameProvider(r -> r.getHttpMethod() + " " + r.getUri().getPath())
+            .build(HttpServerRequest.class).create(request);
     }
 
     @Benchmark

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -11,6 +11,10 @@ import com.twitter.zipkin.gen.Endpoint;
  */
 public interface ClientRequestAdapter {
 
+    interface Factory<R> {
+        ClientRequestAdapter create(R request);
+    }
+
     /**
      * Gets the span name for request.
      *

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientResponseAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientResponseAdapter.java
@@ -4,6 +4,10 @@ import java.util.Collection;
 
 public interface ClientResponseAdapter {
 
+    interface Factory<R> {
+        ClientResponseAdapter create(R response);
+    }
+
     /**
      * Returns a collection of annotations that should be added to span
      * based on response.

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestAdapter.java
@@ -9,6 +9,10 @@ import java.util.Collection;
  */
 public interface ServerRequestAdapter {
 
+    interface Factory<R> {
+        ServerRequestAdapter create(R request);
+    }
+
     /**
      * Get the trace data from request.
      *

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerResponseAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerResponseAdapter.java
@@ -5,6 +5,10 @@ import java.util.Collection;
 
 public interface ServerResponseAdapter {
 
+    interface Factory<R> {
+        ServerResponseAdapter create(R response);
+    }
+
     /**
      * Returns a collection of annotations that should be added to span
      * before returning response.

--- a/brave-core/src/main/java/com/github/kristofa/brave/TagExtractor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/TagExtractor.java
@@ -1,0 +1,50 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+import java.util.Collection;
+
+/**
+ * Parses binary annotation/tags based for a given input type. Implemented as a list of key and
+ * value parsers
+ */
+public interface TagExtractor<T> {
+
+  /**
+   * Builders will typically implement this, so that configuration can be applied generically. For
+   * example, all http instrumentation would receive the same configuration callbacks.
+   */
+  interface Config<T extends Config<T>> {
+    /** A key that the user wants to add to a span */
+    T addKey(String key);
+
+    /** Overrides behavior of value conversion, or adds support for new ones. */
+    T addValueParserFactory(ValueParserFactory factory);
+  }
+
+  /**
+   * Implement this to teach TagExtractor how to parse a key, potentially across multiple
+   * libraries.
+   */
+  interface ValueParserFactory {
+    /**
+     * Returns a parser that can handle the input type and the binary annotation key or null if
+     * unsupported
+     *
+     * @param type the class of the input to {@link ValueParser#parse(Object)}, typically a request
+     * or response object.
+     * @param key the {@link KeyValueAnnotation#getKey()} which the parser will create.
+     */
+    ValueParser<?> create(Class<?> type, String key);
+  }
+
+  /** Used to get binary annotation values from an input, such as a request object */
+  interface ValueParser<T> {
+    /** Returns a {@link KeyValueAnnotation#getValue()} or null if not present. */
+    @Nullable String parse(T input);
+  }
+
+  /**
+   * any non-null values parsed from the configured keys are returned
+   */
+  Collection<KeyValueAnnotation> extractTags(T input);
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/TagExtractorBuilder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/TagExtractorBuilder.java
@@ -1,0 +1,110 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.TagExtractor;
+import com.github.kristofa.brave.TagExtractor.ValueParser;
+import com.github.kristofa.brave.TagExtractor.ValueParserFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
+public final class TagExtractorBuilder implements TagExtractor.Config<TagExtractorBuilder> {
+  public static TagExtractorBuilder create() {
+    return new TagExtractorBuilder();
+  }
+
+  final List<ValueParserFactory> valueParserFactories = new ArrayList<ValueParserFactory>();
+  final Set<String> keys = new LinkedHashSet<String>();
+
+  @Override
+  public TagExtractorBuilder addKey(String key) {
+    keys.add(checkNotNull(key, "key"));
+    return this;
+  }
+
+  @Override
+  public TagExtractorBuilder addValueParserFactory(ValueParserFactory factory) {
+    valueParserFactories.add(0, checkNotNull(factory, "factory"));
+    return this;
+  }
+
+  public <T> TagExtractor<T> build(Class<? extends T> type) {
+    Map<String, ValueParser<T>> result = new LinkedHashMap<String, ValueParser<T>>();
+    for (String key : keys) {
+      for (ValueParserFactory factory : valueParserFactories) {
+        ValueParser valueParser = factory.create(type, key);
+        if (valueParser != null) {
+          result.put(key, valueParser);
+        }
+      }
+    }
+    if (result.isEmpty()) {
+      return (TagExtractor<T>) EMPTY;
+    }
+    if (result.size() == 1) {
+      Map.Entry<String, ValueParser<T>> only = result.entrySet().iterator().next();
+      return new SingleTagExtractor<T>(only.getKey(), only.getValue());
+    }
+    return new MultipleTagExtractor<T>(result);
+  }
+
+  TagExtractorBuilder() {
+  }
+
+  private static final TagExtractor<Object> EMPTY = new TagExtractor() {
+    @Override public Set<KeyValueAnnotation> extractTags(Object input) {
+      return Collections.emptySet();
+    }
+  };
+
+  static final class SingleTagExtractor<T> implements TagExtractor<T> {
+    final String key;
+    final ValueParser<T> valueParser;
+
+    SingleTagExtractor(String key, ValueParser<T> valueParser) {
+      this.valueParser = valueParser;
+      this.key = key;
+    }
+
+    @Override public Set<KeyValueAnnotation> extractTags(T input) {
+      String value = valueParser.parse(input);
+      if (value != null) {
+        return Collections.<KeyValueAnnotation>singleton(KeyValueAnnotation.create(key, value));
+      } else {
+        return Collections.<KeyValueAnnotation>emptySet();
+      }
+    }
+  }
+
+  static final class MultipleTagExtractor<T> implements TagExtractor<T> {
+    final String[] keys;
+    final ValueParser<T>[] valueParsers;
+
+    MultipleTagExtractor(Map<String, ValueParser<T>> map) {
+      this.keys = new String[map.size()];
+      this.valueParsers = new ValueParser[map.size()];
+      int i = 0;
+      for (Map.Entry<String, ValueParser<T>> entry : map.entrySet()) {
+        keys[i] = entry.getKey();
+        valueParsers[i++] = entry.getValue();
+      }
+    }
+
+    @Override public Set<KeyValueAnnotation> extractTags(T input) {
+      Set<KeyValueAnnotation> result = new LinkedHashSet<KeyValueAnnotation>();
+      for (int i = 0; i < keys.length; i++) {
+        String value = valueParsers[i].parse(input);
+        if (value != null) {
+          result.add(KeyValueAnnotation.create(keys[i], value));
+        }
+      }
+      return result;
+    }
+  }
+}

--- a/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/BraveClientInInterceptor.java
+++ b/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/BraveClientInInterceptor.java
@@ -1,8 +1,10 @@
 package com.github.kristofa.brave.cxf3;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientResponseAdapter;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientSpanThreadBinder;
+import com.github.kristofa.brave.TagExtractor;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import com.twitter.zipkin.gen.Span;
 import org.apache.cxf.interceptor.Fault;
@@ -25,11 +27,24 @@ public final class BraveClientInInterceptor extends AbstractPhaseInterceptor<Mes
     return new Builder(brave);
   }
 
-  public static final class Builder {
+  public static final class Builder implements TagExtractor.Config<Builder> {
     final Brave brave;
+    final HttpClientResponseAdapter.FactoryBuilder adapterFactoryBuilder
+        = HttpClientResponseAdapter.factoryBuilder();
 
     Builder(Brave brave) { // intentionally hidden
       this.brave = checkNotNull(brave, "brave");
+    }
+
+    @Override public Builder addKey(String key) {
+      adapterFactoryBuilder.addKey(key);
+      return this;
+    }
+
+    @Override
+    public Builder addValueParserFactory(TagExtractor.ValueParserFactory factory) {
+      adapterFactoryBuilder.addValueParserFactory(factory);
+      return this;
     }
 
     public BraveClientInInterceptor build() {
@@ -38,13 +53,15 @@ public final class BraveClientInInterceptor extends AbstractPhaseInterceptor<Mes
   }
 
   final ClientSpanThreadBinder threadBinder;
-  final ClientResponseInterceptor responseInterceptor;
+  final ClientResponseInterceptor interceptor;
+  final ClientResponseAdapter.Factory<HttpMessage.Response> adapterFactory;
 
   BraveClientInInterceptor(Builder b) { // intentionally hidden
     super(Phase.RECEIVE);
     addBefore(StaxInInterceptor.class.getName());
     this.threadBinder = b.brave.clientSpanThreadBinder();
-    this.responseInterceptor = b.brave.clientResponseInterceptor();
+    this.interceptor = b.brave.clientResponseInterceptor();
+    this.adapterFactory = b.adapterFactoryBuilder.build(HttpMessage.Response.class);
   }
 
   @Override
@@ -52,7 +69,8 @@ public final class BraveClientInInterceptor extends AbstractPhaseInterceptor<Mes
     Span span = (Span) message.getExchange().get(BRAVE_CLIENT_SPAN);
     if (span != null) {
       threadBinder.setCurrentSpan(span);
-      responseInterceptor.handle(new HttpClientResponseAdapter(new HttpMessage.Response(message)));
+      ClientResponseAdapter adapter = adapterFactory.create(new HttpMessage.Response(message));
+      interceptor.handle(adapter);
     }
   }
 }

--- a/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/BraveServerOutInterceptor.java
+++ b/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/BraveServerOutInterceptor.java
@@ -1,9 +1,11 @@
 package com.github.kristofa.brave.cxf3;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerResponseAdapter;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.TagExtractor;
 import com.github.kristofa.brave.http.HttpServerResponseAdapter;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
@@ -25,11 +27,24 @@ public final class BraveServerOutInterceptor extends AbstractPhaseInterceptor<Me
     return new Builder(brave);
   }
 
-  public static final class Builder {
+  public static final class Builder implements TagExtractor.Config<Builder> {
     final Brave brave;
+    final HttpServerResponseAdapter.FactoryBuilder adapterFactoryBuilder
+        = HttpServerResponseAdapter.factoryBuilder();
 
     Builder(Brave brave) { // intentionally hidden
       this.brave = checkNotNull(brave, "brave");
+    }
+
+    @Override public Builder addKey(String key) {
+      adapterFactoryBuilder.addKey(key);
+      return this;
+    }
+
+    @Override
+    public Builder addValueParserFactory(TagExtractor.ValueParserFactory factory) {
+      adapterFactoryBuilder.addValueParserFactory(factory);
+      return this;
     }
 
     public BraveServerOutInterceptor build() {
@@ -37,22 +52,25 @@ public final class BraveServerOutInterceptor extends AbstractPhaseInterceptor<Me
     }
   }
 
-  final ServerSpanThreadBinder serverSpanThreadBinder;
-  final ServerResponseInterceptor responseInterceptor;
+  final ServerSpanThreadBinder threadBinder;
+  final ServerResponseInterceptor interceptor;
+  final ServerResponseAdapter.Factory<HttpMessage.Response> adapterFactory;
 
   BraveServerOutInterceptor(Builder b) { // intentionally hidden
     super(Phase.PRE_STREAM);
     addBefore(LoggingOutInterceptor.class.getName());
-    this.serverSpanThreadBinder = b.brave.serverSpanThreadBinder();
-    this.responseInterceptor = b.brave.serverResponseInterceptor();
+    this.threadBinder = b.brave.serverSpanThreadBinder();
+    this.interceptor = b.brave.serverResponseInterceptor();
+    this.adapterFactory = b.adapterFactoryBuilder.build(HttpMessage.Response.class);
   }
 
   @Override
   public void handleMessage(final Message message) throws Fault {
     ServerSpan serverSpan = (ServerSpan) message.getExchange().get(BRAVE_SERVER_SPAN);
     if (serverSpan != null) {
-      serverSpanThreadBinder.setCurrentSpan(serverSpan);
-      responseInterceptor.handle(new HttpServerResponseAdapter(new HttpMessage.Response(message)));
+      threadBinder.setCurrentSpan(serverSpan);
+      ServerResponseAdapter adapter = adapterFactory.create(new HttpMessage.Response(message));
+      interceptor.handle(adapter);
     }
   }
 }

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpRequestAdapter.java
@@ -1,0 +1,67 @@
+package com.github.kristofa.brave.http;
+
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.TagExtractor;
+import com.github.kristofa.brave.internal.TagExtractorBuilder;
+import java.util.Collection;
+import zipkin.TraceKeys;
+
+class HttpRequestAdapter<R extends HttpRequest> {
+
+  final R request;
+  private final SpanNameProvider spanNameProvider;
+  private final TagExtractor<R> tagExtractor;
+
+  static abstract class FactoryBuilder<B extends FactoryBuilder<B>>
+      implements TagExtractor.Config<B> {
+    private final TagExtractorBuilder tagExtractorBuilder = TagExtractorBuilder.create()
+        .addKey(TraceKeys.HTTP_URL)
+        .addValueParserFactory(new HttpRequestValueParserFactory());
+    private SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+
+    public B spanNameProvider(SpanNameProvider spanNameProvider) {
+      this.spanNameProvider = spanNameProvider;
+      return (B) this;
+    }
+
+    @Override public B addKey(String key) {
+      tagExtractorBuilder.addKey(key);
+      return (B) this;
+    }
+
+    @Override public B addValueParserFactory(TagExtractor.ValueParserFactory factory) {
+      tagExtractorBuilder.addValueParserFactory(factory);
+      return (B) this;
+    }
+
+    FactoryBuilder() { // intentionally hidden
+    }
+  }
+
+  static abstract class Factory<R extends HttpRequest, A> {
+    final SpanNameProvider spanNameProvider;
+    final TagExtractor<R> tagExtractor;
+
+    Factory(FactoryBuilder<?> builder, Class<? extends R> requestType) {
+      this.spanNameProvider = builder.spanNameProvider;
+      // java 6 generics cannot figure this out
+      this.tagExtractor = (TagExtractor) builder.tagExtractorBuilder.build(requestType);
+    }
+
+    abstract A create(R request);
+  }
+
+  HttpRequestAdapter(Factory<R, ?> builder, R request) { // intentionally hidden
+    this.spanNameProvider = builder.spanNameProvider;
+    this.tagExtractor = builder.tagExtractor;
+    this.request = request;
+  }
+
+  public String getSpanName() {
+    return spanNameProvider.spanName(request);
+  }
+
+  public Collection<KeyValueAnnotation> requestAnnotations() {
+    return tagExtractor.extractTags(request);
+  }
+}

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpRequestValueParserFactory.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpRequestValueParserFactory.java
@@ -1,0 +1,45 @@
+package com.github.kristofa.brave.http;
+
+import com.github.kristofa.brave.TagExtractor;
+import zipkin.TraceKeys;
+
+final class HttpRequestValueParserFactory implements TagExtractor.ValueParserFactory {
+  @Override public TagExtractor.ValueParser<?> create(Class<?> type, String key) {
+    if (!HttpRequest.class.isAssignableFrom(type)) return null;
+
+    if (key.equals(TraceKeys.HTTP_HOST)) { // Can't switch on string since minimum JRE 6
+      return new TagExtractor.ValueParser<HttpRequest>() {
+        @Override public String parse(HttpRequest input) {
+          return input.getUri().getHost();
+        }
+      };
+    } else if (key.equals(TraceKeys.HTTP_METHOD)) {
+      return new TagExtractor.ValueParser<HttpRequest>() {
+        @Override public String parse(HttpRequest input) {
+          return input.getHttpMethod();
+        }
+      };
+    } else if (key.equals(TraceKeys.HTTP_PATH)) {
+      return new TagExtractor.ValueParser<HttpRequest>() {
+        @Override public String parse(HttpRequest input) {
+          return input.getUri().getPath();
+        }
+      };
+    } else if (key.equals(TraceKeys.HTTP_URL)) {
+      return new TagExtractor.ValueParser<HttpRequest>() {
+        @Override public String parse(HttpRequest input) {
+          return input.getUri().toASCIIString();
+        }
+      };
+    } else if (key.equals(TraceKeys.HTTP_REQUEST_SIZE)
+        && HttpServerRequest.class.isAssignableFrom(type)) {
+      return new TagExtractor.ValueParser<HttpServerRequest>() {
+        @Override public String parse(HttpServerRequest input) {
+          return input.getHttpHeaderValue("Content-Length");
+        }
+      };
+    } else {
+      return null;
+    }
+  }
+}

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpResponseAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpResponseAdapter.java
@@ -1,0 +1,53 @@
+package com.github.kristofa.brave.http;
+
+import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.TagExtractor;
+import com.github.kristofa.brave.TagExtractor.ValueParserFactory;
+import com.github.kristofa.brave.internal.TagExtractorBuilder;
+import java.util.Collection;
+import zipkin.TraceKeys;
+
+class HttpResponseAdapter<R extends HttpResponse> {
+  private final R response;
+  private final TagExtractor<R> tagExtractor;
+
+  static abstract class FactoryBuilder<B extends FactoryBuilder<B>>
+      implements TagExtractor.Config<B> {
+    private final TagExtractorBuilder tagExtractorBuilder = TagExtractorBuilder.create()
+        .addKey(TraceKeys.HTTP_STATUS_CODE)
+        .addValueParserFactory(new HttpResponseValueParserFactory());
+
+    @Override public B addKey(String key) {
+      tagExtractorBuilder.addKey(key);
+      return (B) this;
+    }
+
+    @Override public B addValueParserFactory(ValueParserFactory factory) {
+      tagExtractorBuilder.addValueParserFactory(factory);
+      return (B) this;
+    }
+
+    FactoryBuilder() { // intentionally hidden
+    }
+  }
+
+  static abstract class Factory<R extends HttpResponse, A> {
+    final TagExtractor<R> tagExtractor;
+
+    Factory(FactoryBuilder<?> builder, Class<? extends R> responseType) {
+      // java 6 generics cannot figure this out
+      this.tagExtractor = (TagExtractor) builder.tagExtractorBuilder.build(responseType);
+    }
+
+    abstract A create(R request);
+  }
+
+  HttpResponseAdapter(Factory<R, ?> factory, R response) { // intentionally hidden
+    this.tagExtractor = factory.tagExtractor;
+    this.response = response;
+  }
+
+  public Collection<KeyValueAnnotation> responseAnnotations() {
+    return tagExtractor.extractTags(response);
+  }
+}

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpResponseValueParserFactory.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpResponseValueParserFactory.java
@@ -1,0 +1,22 @@
+package com.github.kristofa.brave.http;
+
+import com.github.kristofa.brave.TagExtractor;
+import java.lang.reflect.Type;
+import zipkin.TraceKeys;
+
+final class HttpResponseValueParserFactory implements TagExtractor.ValueParserFactory {
+  @Override public TagExtractor.ValueParser<?> create(Class<?> type, String key) {
+    if (!HttpResponse.class.isAssignableFrom(type)) return null;
+
+    if (key.equals(TraceKeys.HTTP_STATUS_CODE)) { // Can't switch on string since minimum JRE 6
+      return new TagExtractor.ValueParser<HttpResponse>() {
+        @Override public String parse(HttpResponse input) {
+          int httpStatus = input.getHttpStatusCode();
+          return httpStatus < 200 || httpStatus > 299 ? String.valueOf(httpStatus) : null;
+        }
+      };
+    } else {
+      return null;
+    }
+  }
+}

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientRequestAdapterTest.java
@@ -1,19 +1,19 @@
 package com.github.kristofa.brave.http;
 
+import com.github.kristofa.brave.ClientRequestAdapter;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
+import java.net.URI;
+import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.TraceKeys;
 
-import java.net.URI;
-import java.util.Collection;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class HttpClientRequestAdapterTest {
 
@@ -23,7 +23,7 @@ public class HttpClientRequestAdapterTest {
     private static final Long PARENT_SPAN_ID = 3L;
     private static final String TEST_URI = "http://abc.com/request";
 
-    private HttpClientRequestAdapter clientRequestAdapter;
+    private ClientRequestAdapter clientRequestAdapter;
     private HttpClientRequest request;
     private SpanNameProvider spanNameProvider;
 
@@ -31,7 +31,10 @@ public class HttpClientRequestAdapterTest {
     public void setup() {
         request = mock(HttpClientRequest.class);
         spanNameProvider = mock(SpanNameProvider.class);
-        clientRequestAdapter = new HttpClientRequestAdapter(request, spanNameProvider);
+        clientRequestAdapter = HttpClientRequestAdapter.factoryBuilder()
+            .spanNameProvider(spanNameProvider)
+            .build(HttpClientRequest.class)
+            .create(request);
     }
 
     @Test

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpClientResponseAdapterTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.http;
 
 
+import com.github.kristofa.brave.ClientResponseAdapter;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,13 +15,14 @@ import static org.mockito.Mockito.*;
 
 public class HttpClientResponseAdapterTest {
 
-    private HttpClientResponseAdapter adapter;
+    private ClientResponseAdapter adapter;
     private HttpResponse response;
 
     @Before
     public void setup() {
         response = mock(HttpResponse.class);
-        adapter = new HttpClientResponseAdapter(response);
+        adapter = HttpClientResponseAdapter.factoryBuilder()
+            .build(HttpResponse.class).create(response);
     }
 
     @Test

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -1,19 +1,21 @@
 package com.github.kristofa.brave.http;
 
-
-import java.net.URI;
-import java.util.Collection;
-
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.ServerRequestAdapter;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
+import java.net.URI;
+import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.TraceKeys;
 
 import static junit.framework.Assert.assertNull;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,7 +25,7 @@ public class HttpServerRequestAdapterTest {
     private final static String SPAN_ID = "bf38b90488a1e481";
     private final static String PARENT_SPAN_ID = "8000000000000000";
 
-    private HttpServerRequestAdapter adapter;
+    private ServerRequestAdapter adapter;
     private HttpServerRequest serverRequest;
     private SpanNameProvider spanNameProvider;
 
@@ -31,7 +33,9 @@ public class HttpServerRequestAdapterTest {
     public void setup() {
         serverRequest = mock(HttpServerRequest.class);
         spanNameProvider = mock(SpanNameProvider.class);
-        adapter = new HttpServerRequestAdapter(serverRequest, spanNameProvider);
+        adapter = HttpServerRequestAdapter.factoryBuilder()
+            .spanNameProvider(spanNameProvider).build(HttpServerRequest.class)
+            .create(serverRequest);
     }
 
     @Test

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerResponseAdapterTest.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.http;
 
 
 import com.github.kristofa.brave.KeyValueAnnotation;
+import com.github.kristofa.brave.ServerResponseAdapter;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin.TraceKeys;
@@ -14,13 +15,14 @@ import static org.mockito.Mockito.when;
 
 public class HttpServerResponseAdapterTest {
 
-    private HttpServerResponseAdapter adapter;
+    private ServerResponseAdapter adapter;
     private HttpResponse response;
 
     @Before
     public void setup() {
         response = mock(HttpResponse.class);
-        adapter = new HttpServerResponseAdapter(response);
+        adapter = HttpServerResponseAdapter.factoryBuilder()
+            .build(HttpResponse.class).create(response);
     }
 
     @Test

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
@@ -2,8 +2,8 @@ package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
-import com.github.kristofa.brave.http.DefaultSpanNameProvider;
-import com.github.kristofa.brave.http.HttpClientRequest;
+import com.github.kristofa.brave.ClientRequestAdapter;
+import com.github.kristofa.brave.TagExtractor;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import javax.annotation.Priority;
@@ -32,16 +32,28 @@ public class BraveClientRequestFilter implements ClientRequestFilter {
         return new Builder(brave);
     }
 
-    public static final class Builder {
+    public static final class Builder implements TagExtractor.Config<Builder> {
         final Brave brave;
-        SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+        final HttpClientRequestAdapter.FactoryBuilder adapterFactoryBuilder
+            = HttpClientRequestAdapter.factoryBuilder();
 
         Builder(Brave brave) { // intentionally hidden
             this.brave = checkNotNull(brave, "brave");
         }
 
         public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
-            this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+            adapterFactoryBuilder.spanNameProvider(spanNameProvider);
+            return this;
+        }
+
+        @Override public Builder addKey(String key) {
+            adapterFactoryBuilder.addKey(key);
+            return this;
+        }
+
+        @Override
+        public Builder addValueParserFactory(TagExtractor.ValueParserFactory factory) {
+            adapterFactoryBuilder.addValueParserFactory(factory);
             return this;
         }
 
@@ -50,12 +62,12 @@ public class BraveClientRequestFilter implements ClientRequestFilter {
         }
     }
 
-    private final ClientRequestInterceptor requestInterceptor;
-    private final SpanNameProvider spanNameProvider;
+    private final ClientRequestInterceptor interceptor;
+    private final ClientRequestAdapter.Factory<JaxRs2HttpClientRequest> adapterFactory;
 
     BraveClientRequestFilter(Builder b) { // intentionally hidden
-        this.requestInterceptor = b.brave.clientRequestInterceptor();
-        this.spanNameProvider = b.spanNameProvider;
+        this.interceptor = b.brave.clientRequestInterceptor();
+        this.adapterFactory = b.adapterFactoryBuilder.build(JaxRs2HttpClientRequest.class);
     }
 
     @Inject // internal dependency-injection constructor
@@ -67,15 +79,18 @@ public class BraveClientRequestFilter implements ClientRequestFilter {
      * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
      */
     @Deprecated
-    public BraveClientRequestFilter(SpanNameProvider spanNameProvider, ClientRequestInterceptor requestInterceptor) {
-        this.requestInterceptor = requestInterceptor;
-        this.spanNameProvider = spanNameProvider;
+    public BraveClientRequestFilter(SpanNameProvider spanNameProvider, ClientRequestInterceptor interceptor) {
+        this.interceptor = interceptor;
+        this.adapterFactory = HttpClientRequestAdapter.factoryBuilder()
+            .spanNameProvider(spanNameProvider)
+            .build(JaxRs2HttpClientRequest.class);
     }
 
 
     @Override
     public void filter(ClientRequestContext clientRequestContext) throws IOException {
-        final HttpClientRequest req = new JaxRs2HttpClientRequest(clientRequestContext);
-        requestInterceptor.handle(new HttpClientRequestAdapter(req, spanNameProvider));
+        ClientRequestAdapter adapter =
+            adapterFactory.create(new JaxRs2HttpClientRequest(clientRequestContext));
+        interceptor.handle(adapter);
     }
 }

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
@@ -12,7 +12,10 @@ import javax.inject.Singleton;
 /**
  * Servlet filter that will extract trace headers from the request and send
  * sr (server received) and ss (server sent) annotations.
+ *
+ * @deprecated wire up {@link BraveServletFilter} directly
  */
+@Deprecated
 @Singleton
 public class ServletTraceFilter extends BraveServletFilter {
 

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/OkHttpParser.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/OkHttpParser.java
@@ -32,14 +32,24 @@ public class OkHttpParser {
     return request.method();
   }
 
-  /** Returns the {@link zipkin.TraceKeys#HTTP_URL} */
+  /**
+   * Returns the {@link zipkin.TraceKeys#HTTP_URL}
+   *
+   * @deprecated use {@link BraveTracingInterceptor.Builder#tagInjectorBuilder()}
+   */
+  @Deprecated
   public List<KeyValueAnnotation> networkRequestTags(Request request) {
     return Collections.singletonList(
         KeyValueAnnotation.create(TraceKeys.HTTP_URL, request.url().toString())
     );
   }
 
-  /** Returns the {@link zipkin.TraceKeys#HTTP_STATUS_CODE} if unsuccessful */
+  /**
+   * Returns the {@link zipkin.TraceKeys#HTTP_STATUS_CODE} if unsuccessful
+   *
+   * @deprecated use {@link BraveTracingInterceptor.Builder#tagInjectorBuilder()}
+   */
+  @Deprecated
   public List<KeyValueAnnotation> networkResponseTags(Response response) {
     int code = response.code();
     if (response.isSuccessful()) return Collections.EMPTY_LIST;

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/OkHttpValueParserFactory.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/OkHttpValueParserFactory.java
@@ -1,0 +1,70 @@
+package com.github.kristofa.brave.okhttp;
+
+import com.github.kristofa.brave.TagExtractor.ValueParser;
+import com.github.kristofa.brave.TagExtractor.ValueParserFactory;
+import java.io.IOException;
+import okhttp3.Request;
+import okhttp3.Response;
+import zipkin.TraceKeys;
+
+public final class OkHttpValueParserFactory implements ValueParserFactory {
+
+  @Override public ValueParser<?> create(Class<?> type, String key) {
+    if (type == Request.class) {
+      switch (key) { // Switch on string is ok since OkHttp is minimum JRE 7 anyway
+        case TraceKeys.HTTP_HOST:
+          return new ValueParser<Request>() {
+            @Override public String parse(Request input) {
+              return input.url().host();
+            }
+          };
+        case TraceKeys.HTTP_METHOD:
+          return new ValueParser<Request>() {
+            @Override public String parse(Request input) {
+              return input.method();
+            }
+          };
+        case TraceKeys.HTTP_PATH:
+          return new ValueParser<Request>() {
+            @Override public String parse(Request input) {
+              return input.url().encodedPath();
+            }
+          };
+        case TraceKeys.HTTP_URL:
+          return new ValueParser<Request>() {
+            @Override public String parse(Request input) {
+              return input.url().toString();
+            }
+          };
+        case TraceKeys.HTTP_REQUEST_SIZE:
+          return new ValueParser<Request>() {
+            @Override public String parse(Request input) {
+              if (input.body() == null) return null;
+              try {
+                long result = input.body().contentLength();
+                return result != -1 ? String.valueOf(result) : null;
+              } catch (IOException e) {
+                return null;
+              }
+            }
+          };
+      }
+    } else if (type == Response.class) {
+      if (key.equals(TraceKeys.HTTP_STATUS_CODE)) {
+        return new ValueParser<Response>() {
+          @Override public String parse(Response input) {
+            return input.isSuccessful() ? null : String.valueOf(input.code());
+          }
+        };
+      } else if (key.equals(TraceKeys.HTTP_RESPONSE_SIZE)) {
+        return new ValueParser<Response>() {
+          @Override public String parse(Response input) {
+            long result = input.body().contentLength();
+            return result != -1 ? String.valueOf(result) : null;
+          }
+        };
+      }
+    }
+    return null;
+  }
+}

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePostProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePostProcessInterceptor.java
@@ -3,6 +3,8 @@ package com.github.kristofa.brave.resteasy;
 import javax.ws.rs.ext.Provider;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerResponseAdapter;
+import com.github.kristofa.brave.TagExtractor;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.http.HttpResponse;
 import com.github.kristofa.brave.http.HttpServerResponseAdapter;
@@ -11,8 +13,6 @@ import org.jboss.resteasy.core.ServerResponse;
 import org.jboss.resteasy.spi.interception.PostProcessInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import com.github.kristofa.brave.ServerTracer;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
@@ -35,11 +35,24 @@ public class BravePostProcessInterceptor implements PostProcessInterceptor {
         return new Builder(brave);
     }
 
-    public static final class Builder {
+    public static final class Builder implements TagExtractor.Config<Builder> {
         final Brave brave;
+        final HttpServerResponseAdapter.FactoryBuilder adapterFactoryBuilder
+            = HttpServerResponseAdapter.factoryBuilder();
 
         Builder(Brave brave) { // intentionally hidden
             this.brave = checkNotNull(brave, "brave");
+        }
+
+        @Override public Builder addKey(String key) {
+            adapterFactoryBuilder.addKey(key);
+            return this;
+        }
+
+        @Override
+        public Builder addValueParserFactory(TagExtractor.ValueParserFactory factory) {
+            adapterFactoryBuilder.addValueParserFactory(factory);
+            return this;
         }
 
         public BravePostProcessInterceptor build() {
@@ -47,7 +60,8 @@ public class BravePostProcessInterceptor implements PostProcessInterceptor {
         }
     }
 
-    private final ServerResponseInterceptor responseInterceptor;
+    private final ServerResponseInterceptor interceptor;
+    private final ServerResponseAdapter.Factory<HttpResponse> adapterFactory;
 
     @Autowired // internal
     BravePostProcessInterceptor(Brave brave) {
@@ -55,18 +69,18 @@ public class BravePostProcessInterceptor implements PostProcessInterceptor {
     }
 
     BravePostProcessInterceptor(Builder b) { // intentionally hidden
-        this.responseInterceptor = b.brave.serverResponseInterceptor();
+        this.interceptor = b.brave.serverResponseInterceptor();
+        this.adapterFactory = b.adapterFactoryBuilder.build(HttpResponse.class);
     }
 
     /**
-     * Creates a new instance.
-     * 
-     * @param responseInterceptor {@link ServerTracer}. Should not be null.
      * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
      */
     @Deprecated
-    public BravePostProcessInterceptor(ServerResponseInterceptor responseInterceptor) {
-        this.responseInterceptor = responseInterceptor;
+    public BravePostProcessInterceptor(ServerResponseInterceptor interceptor) {
+        this.interceptor = interceptor;
+        this.adapterFactory = HttpServerResponseAdapter.factoryBuilder()
+            .build(HttpResponse.class);
     }
 
     @Override
@@ -79,8 +93,8 @@ public class BravePostProcessInterceptor implements PostProcessInterceptor {
                 return response.getStatus();
             }
         };
-        HttpServerResponseAdapter adapter = new HttpServerResponseAdapter(httpResponse);
-        responseInterceptor.handle(adapter);
+        ServerResponseAdapter adapter = adapterFactory.create(httpResponse);
+        interceptor.handle(adapter);
     }
 
 }

--- a/brave-resteasy3-spring/src/main/java/com/github/kristofa/brave/resteasy3/ContainerFiltersConfiguration.java
+++ b/brave-resteasy3-spring/src/main/java/com/github/kristofa/brave/resteasy3/ContainerFiltersConfiguration.java
@@ -9,8 +9,8 @@ import org.springframework.context.annotation.Import;
  * Imports jaxrs2 filters used in resteasy3.
  * @deprecated use {@link BraveTracingFeatureConfiguration} now.
  */
+@Deprecated
 @Configuration
 @Import({BraveContainerRequestFilter.class, BraveContainerResponseFilter.class})
-@Deprecated
 public class ContainerFiltersConfiguration {
 }


### PR DESCRIPTION
This starts a decoupling between the mechanism to extract a tag, for
example the http path from a request, and actually wanting to add it to
a span. Once complete, it should be possible to add custom dimensions
like `servlet.user` without changing core code.

This is eagerly raised to get opinions on the general approach.. there's a lot to prove out here, and it won't be merged until it proves it can commonly deal with tags across http libraries (at least)