### PR TITLE
Special-case externally provided trace IDs (when sampled left unset)

### DIFF
--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -1,18 +1,16 @@
 package com.github.kristofa.brave;
 
-
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-import java.util.Random;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InOrder;
-
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Random;
+import org.junit.Test;
+import zipkin.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ServerRequestInterceptorTest {
 
@@ -23,61 +21,48 @@ public class ServerRequestInterceptorTest {
     private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(zipkin.TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
 
-    private ServerRequestInterceptor interceptor;
-    private ServerTracer serverTracer;
-    private ServerRequestAdapter adapter;
-
-    @Before
-    public void setup() {
-        serverTracer = mock(ServerTracer.class);
-        interceptor = new ServerRequestInterceptor(serverTracer);
-        adapter = mock(ServerRequestAdapter.class);
-    }
+    InheritableServerClientAndLocalSpanState state =
+        new InheritableServerClientAndLocalSpanState(mock(Endpoint.class));
+    ServerTracer serverTracer = new AutoValue_ServerTracer.Builder()
+        .state(state)
+        .randomGenerator(mock(Random.class))
+        .reporter(Reporter.NOOP)
+        .traceSampler(Sampler.ALWAYS_SAMPLE)
+        .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
+        .traceId128Bit(false)
+        .build();
+    ServerRequestInterceptor interceptor = new ServerRequestInterceptor(serverTracer);
+    ServerRequestAdapter adapter = mock(ServerRequestAdapter.class);
 
     @Test
     public void handleSampleFalse() {
-        TraceData traceData = TraceData.builder().sample(false).build();
-        when(adapter.getTraceData()).thenReturn(traceData);
+        when(adapter.getTraceData()).thenReturn(TraceData.NOT_SAMPLED);
         interceptor.handle(adapter);
-        InOrder inOrder = inOrder(serverTracer);
-        inOrder.verify(serverTracer).clearCurrentSpan();
-        inOrder.verify(serverTracer).setStateNoTracing();
-        verifyNoMoreInteractions(serverTracer);
+
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.NOT_SAMPLED);
     }
 
     @Test
-    public void handleNoState() {
-        TraceData traceData = TraceData.builder().build();
-        when(adapter.getTraceData()).thenReturn(traceData);
+    public void handleNoState_whenSampleTrue() {
+        when(adapter.getTraceData()).thenReturn(TraceData.EMPTY);
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);
 
         interceptor.handle(adapter);
-        InOrder inOrder = inOrder(serverTracer);
-        inOrder.verify(serverTracer).clearCurrentSpan();
-        inOrder.verify(serverTracer).setStateUnknown(SPAN_NAME);
-        inOrder.verify(serverTracer).setServerReceived();
-        verifyNoMoreInteractions(serverTracer);
+
+        ServerSpan span = serverTracer.spanAndEndpoint().state().getCurrentServerSpan();
+        assertThat(span.getSpan().getName())
+            .isEqualTo(SPAN_NAME.toLowerCase());
+        assertThat(span.getSample())
+            .isTrue();
     }
 
     @Test
     public void handleSampleRequestWithParentSpanId() {
-        InheritableServerClientAndLocalSpanState state =
-            new InheritableServerClientAndLocalSpanState(mock(Endpoint.class));
-        serverTracer = ServerTracer.builder()
-            .state(state)
-            .randomGenerator(mock(Random.class))
-            .spanCollector(mock(SpanCollector.class))
-            .traceSampler(Sampler.ALWAYS_SAMPLE)
-            .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
-            .traceId128Bit(false)
-            .build();
-        interceptor = new ServerRequestInterceptor(serverTracer);
-
-        SpanId spanId =
-            SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(PARENT_SPAN_ID).build();
-        TraceData traceData = TraceData.builder().spanId(spanId).sample(true).build();
-        when(adapter.getTraceData()).thenReturn(traceData);
+        SpanId spanId = SpanId.builder()
+            .traceId(TRACE_ID).spanId(SPAN_ID).parentId(PARENT_SPAN_ID).sampled(true).build();
+        when(adapter.getTraceData()).thenReturn(TraceData.create(spanId));
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
 
@@ -94,49 +79,57 @@ public class ServerRequestInterceptorTest {
             .extracting(a -> a.value).containsExactly("sr");
         assertThat(span.getBinary_annotations())
             .extracting(a -> a.key).containsExactly(ANNOTATION1.getKey(), ANNOTATION2.getKey());
-
-        // don't log timestamp when span is client-originated
-        assertThat(span.getTimestamp()).isNull();
-        assertThat(span.startTick).isNull();
     }
 
     @Test
-    public void handleSampleRequestWithoutParentSpanId() {
-        InheritableServerClientAndLocalSpanState state =
-            new InheritableServerClientAndLocalSpanState(mock(Endpoint.class));
-        serverTracer = new AutoValue_ServerTracer.Builder(serverTracer)
-            .state(state)
-            .randomGenerator(mock(Random.class))
-            .spanCollector(mock(SpanCollector.class))
-            .traceSampler(Sampler.ALWAYS_SAMPLE)
-            .clock(AnnotationSubmitter.DefaultClock.INSTANCE)
-            .traceId128Bit(false)
-            .build();
-        interceptor = new ServerRequestInterceptor(serverTracer);
+    public void handle_clientOriginatedRootSpan_doesntSetTimestamp() {
+        // When client-originated, sampled flag must be set
+        SpanId spanId = SpanId.builder()
+            .traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).sampled(true).build();
 
-        SpanId spanId =
-            SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
-        TraceData traceData = TraceData.builder().spanId(spanId).sample(true).build();
-        when(adapter.getTraceData()).thenReturn(traceData);
+        when(adapter.getTraceData()).thenReturn(TraceData.create(spanId));
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
 
         interceptor.handle(adapter);
 
-        Span span = state.getCurrentServerSpan().getSpan();
-        assertThat(span.getTrace_id())
-            .isEqualTo(TRACE_ID);
-        assertThat(span.getId())
-            .isEqualTo(SPAN_ID);
-        assertThat(span.getParent_id())
-            .isNull();
-        assertThat(span.getAnnotations())
-            .extracting(a -> a.value).containsExactly("sr");
-        assertThat(span.getBinary_annotations())
-            .extracting(a -> a.key).containsExactly(ANNOTATION1.getKey(), ANNOTATION2.getKey());
-
         // don't log timestamp when span is client-originated
+        Span span = state.getCurrentServerSpan().getSpan();
         assertThat(span.getTimestamp()).isNull();
         assertThat(span.startTick).isNull();
+    }
+
+    @Test
+    public void handle_externallyProvisionedIds_setsTimestamp() {
+        // Those only controlling IDs leave sampled flag unset
+        SpanId spanId = SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
+
+        when(adapter.getTraceData()).thenReturn(TraceData.create(spanId));
+        when(adapter.getSpanName()).thenReturn(SPAN_NAME);
+        when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
+
+        interceptor.handle(adapter);
+
+        // We originated the trace, so we should set the timestamp
+        Span span = state.getCurrentServerSpan().getSpan();
+        assertThat(span.getTimestamp()).isNotNull();
+        assertThat(span.startTick).isNotNull();
+    }
+
+    @Test
+    public void handle_externallyProvisionedIds_localSample_false() {
+        serverTracer = new AutoValue_ServerTracer.Builder(serverTracer)
+            .traceSampler(Sampler.NEVER_SAMPLE)
+            .build();
+        interceptor = new ServerRequestInterceptor(serverTracer);
+
+        // Those only controlling IDs leave sampled flag unset
+        SpanId spanId = SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).parentId(null).build();
+
+        when(adapter.getTraceData()).thenReturn(TraceData.create(spanId));
+        interceptor.handle(adapter);
+
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.NOT_SAMPLED);
     }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/TraceDataTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/TraceDataTest.java
@@ -8,22 +8,20 @@ import static org.junit.Assert.assertNull;
 
 public class TraceDataTest {
 
-    private static final boolean SAMPLE = true;
     private static final SpanId SPAN_ID =
-        SpanId.builder().traceId(3454).spanId(3353).parentId(34343L).build();
+        SpanId.builder().traceId(3454).spanId(3353).parentId(34343L).sampled(true).build();
 
 
     @Test
-    public void testDefaultTraceData() {
-        TraceData defaultTraceData = TraceData.builder().build();
-        assertNull(defaultTraceData.getSample());
-        assertNull(defaultTraceData.getSpanId());
+    public void testEmptyTraceData() {
+        assertNull(TraceData.EMPTY.getSample());
+        assertNull(TraceData.EMPTY.getSpanId());
     }
 
     @Test
     public void testTraceDataConstruction() {
-        TraceData traceData = TraceData.builder().sample(SAMPLE).spanId(SPAN_ID).build();
-        assertEquals(SAMPLE, traceData.getSample());
+        TraceData traceData = TraceData.create(SPAN_ID);
+        assertEquals(true, traceData.getSample());
         assertEquals(SPAN_ID, traceData.getSpanId());
     }
 

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/GrpcServerRequestAdapterTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/GrpcServerRequestAdapterTest.java
@@ -1,0 +1,175 @@
+package com.github.kristofa.brave.grpc;
+
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TraceData;
+import com.github.kristofa.brave.grpc.BraveGrpcServerInterceptor.GrpcServerRequestAdapter;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GrpcServerRequestAdapterTest {
+  private static final String TRACE_ID = "7a842183262a6c62";
+  private static final String SPAN_ID = "bf38b90488a1e481";
+  private static final String PARENT_SPAN_ID = "8000000000000000";
+
+  Metadata metadata = new Metadata();
+  GrpcServerRequestAdapter adapter;
+
+  @Before
+  public void initMocks() {
+    ServerCall serverCall = mock(ServerCall.class);
+    MethodDescriptor method = mock(MethodDescriptor.class);
+    when(serverCall.getMethodDescriptor()).thenReturn(method);
+
+    adapter = new GrpcServerRequestAdapter(serverCall, metadata);
+  }
+
+  @Test
+  public void getTraceDataNoSampledHeader() {
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertNull(traceData.getSample());
+    assertNull(traceData.getSpanId());
+  }
+
+  @Test
+  public void getTraceDataSampledFalse() {
+    metadata.put(BravePropagationKeys.Sampled, "false");
+
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertFalse(traceData.getSample());
+    assertNull(traceData.getSpanId());
+  }
+
+  @Test
+  public void getTraceDataSampledFalseUpperCase() {
+    metadata.put(BravePropagationKeys.Sampled, "FALSE");
+
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertFalse(traceData.getSample());
+    assertNull(traceData.getSpanId());
+  }
+
+  /**
+   * This is according to the zipkin 'spec'.
+   */
+  @Test
+  public void getTraceDataSampledZero() {
+    metadata.put(BravePropagationKeys.Sampled, "0");
+
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertFalse(traceData.getSample());
+    assertNull(traceData.getSpanId());
+  }
+
+  @Test
+  public void getTraceDataSampledTrueNoOtherTraceHeaders() {
+    metadata.put(BravePropagationKeys.Sampled, "1");
+
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertNull(traceData.getSample());
+    assertNull(traceData.getSpanId());
+  }
+
+  @Test
+  public void getTraceDataSampledTrueNoParentId() {
+    metadata.put(BravePropagationKeys.Sampled, "true");
+    metadata.put(BravePropagationKeys.TraceId, TRACE_ID);
+    metadata.put(BravePropagationKeys.SpanId, SPAN_ID);
+
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertTrue(traceData.getSample());
+    SpanId spanId = traceData.getSpanId();
+    assertNotNull(spanId);
+    assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+    assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+    assertNull(spanId.nullableParentId());
+  }
+
+  /**
+   * This is according to the zipkin 'spec'.
+   */
+  @Test
+  public void getTraceDataSampledOneNoParentId() {
+    metadata.put(BravePropagationKeys.Sampled, "1");
+    metadata.put(BravePropagationKeys.TraceId, TRACE_ID);
+    metadata.put(BravePropagationKeys.SpanId, SPAN_ID);
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertTrue(traceData.getSample());
+    SpanId spanId = traceData.getSpanId();
+    assertNotNull(spanId);
+    assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+    assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+    assertNull(spanId.nullableParentId());
+  }
+
+  @Test
+  public void supports128BitTraceIdHeader() {
+    String upper64Bits = "48485a3953bb6124";
+    String lower64Bits = "48485a3953bb6124";
+    String hex128Bits = upper64Bits + lower64Bits;
+    metadata.put(BravePropagationKeys.Sampled, "1");
+    metadata.put(BravePropagationKeys.TraceId, hex128Bits);
+    metadata.put(BravePropagationKeys.SpanId, lower64Bits);
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertTrue(traceData.getSample());
+    SpanId spanId = traceData.getSpanId();
+    assertNotNull(spanId);
+    assertEquals(IdConversion.convertToLong(upper64Bits), spanId.traceIdHigh);
+    assertEquals(IdConversion.convertToLong(lower64Bits), spanId.traceId);
+    assertEquals(IdConversion.convertToLong(lower64Bits), spanId.spanId);
+    assertNull(spanId.nullableParentId());
+  }
+
+  @Test
+  public void getTraceDataSampledTrueWithParentId() {
+    metadata.put(BravePropagationKeys.Sampled, "true");
+    metadata.put(BravePropagationKeys.TraceId, TRACE_ID);
+    metadata.put(BravePropagationKeys.SpanId, SPAN_ID);
+    metadata.put(BravePropagationKeys.ParentSpanId, PARENT_SPAN_ID);
+
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertTrue(traceData.getSample());
+    SpanId spanId = traceData.getSpanId();
+    assertNotNull(spanId);
+    assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+    assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+    assertEquals(IdConversion.convertToLong(PARENT_SPAN_ID), spanId.parentId);
+  }
+
+  /**
+   * When the caller propagates IDs, but not a sampling decision, the local process should decide.
+   */
+  @Test
+  public void getTraceData_externallyProvidedIds() {
+    metadata.put(BravePropagationKeys.TraceId, TRACE_ID);
+    metadata.put(BravePropagationKeys.SpanId, SPAN_ID);
+    TraceData traceData = adapter.getTraceData();
+    assertNotNull(traceData);
+    assertNull(traceData.getSample());
+    SpanId spanId = traceData.getSpanId();
+    assertNotNull(spanId);
+    assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+    assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+    assertNull(spanId.nullableParentId());
+  }
+}

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/BraveHttpHeaders.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/BraveHttpHeaders.java
@@ -6,25 +6,27 @@ package com.github.kristofa.brave.http;
  * The names correspond with the zipkin header values.
  * <p/>
  * These can be used to submit as HTTP header in a new request.
- * 
+ *
+ * <p>See https://github.com/openzipkin/b3-propagation for details
  * @author kristof
  */
 public enum BraveHttpHeaders {
 
     /**
-     * Trace id http header field name.
+     * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
      */
     TraceId("X-B3-TraceId"),
     /**
-     * Span id http header field name.
+     * 64-bit span ID lower-hex encoded into 16 characters (required)
      */
     SpanId("X-B3-SpanId"),
     /**
-     * Parent span id http header field name.
+     * 64-bit parent span ID lower-hex encoded into 16 characters (absent on root span)
      */
     ParentSpanId("X-B3-ParentSpanId"),
     /**
-     * Sampled http header field name. Indicates if this trace should be sampled or not.
+     * "1" means report this span to the tracing system, "0" means do not. (absent means defer the
+     * decision to the receiver of this header).
      */
     Sampled("X-B3-Sampled");
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/http/HttpServerRequestAdapter.java
@@ -11,55 +11,56 @@ import zipkin.TraceKeys;
 import static com.github.kristofa.brave.IdConversion.convertToLong;
 
 public class HttpServerRequestAdapter implements ServerRequestAdapter {
-
-    private static final TraceData EMPTY_UNSAMPLED_TRACE = TraceData.builder().sample(false).build();
-    private static final TraceData EMPTY_MAYBE_TRACE = TraceData.builder().build();
-
-    private final HttpServerRequest serverRequest;
+    private final HttpServerRequest request;
     private final SpanNameProvider spanNameProvider;
 
-    public HttpServerRequestAdapter(HttpServerRequest serverRequest, SpanNameProvider spanNameProvider) {
-        this.serverRequest = serverRequest;
+    public HttpServerRequestAdapter(HttpServerRequest request, SpanNameProvider spanNameProvider) {
+        this.request = request;
         this.spanNameProvider = spanNameProvider;
     }
 
     @Override
     public TraceData getTraceData() {
-        final String sampled = serverRequest.getHttpHeaderValue(BraveHttpHeaders.Sampled.getName());
-        if (sampled != null) {
-            if (sampled.equals("0") || sampled.equalsIgnoreCase("false")) {
-                return EMPTY_UNSAMPLED_TRACE;
-            } else {
-                final String parentSpanId = serverRequest.getHttpHeaderValue(BraveHttpHeaders.ParentSpanId.getName());
-                final String traceId = serverRequest.getHttpHeaderValue(BraveHttpHeaders.TraceId.getName());
-                final String spanId = serverRequest.getHttpHeaderValue(BraveHttpHeaders.SpanId.getName());
+        String sampled = request.getHttpHeaderValue(BraveHttpHeaders.Sampled.getName());
+        String parentSpanId = request.getHttpHeaderValue(BraveHttpHeaders.ParentSpanId.getName());
+        String traceId = request.getHttpHeaderValue(BraveHttpHeaders.TraceId.getName());
+        String spanId = request.getHttpHeaderValue(BraveHttpHeaders.SpanId.getName());
 
-                if (traceId != null && spanId != null) {
-                    SpanId span = getSpanId(traceId, spanId, parentSpanId);
-                    return TraceData.builder().sample(true).spanId(span).build();
-                }
-            }
+        // Official sampled value is 1, though some old instrumentation send true
+        Boolean parsedSampled = sampled != null
+            ? sampled.equals("1") || sampled.equalsIgnoreCase("true")
+            : null;
+
+        if (traceId != null && spanId != null) {
+            return TraceData.create(getSpanId(traceId, spanId, parentSpanId, parsedSampled));
+        } else if (parsedSampled == null) {
+            return TraceData.EMPTY;
+        } else if (parsedSampled.booleanValue()) {
+            // Invalid: The caller requests the trace to be sampled, but didn't pass IDs
+            return TraceData.EMPTY;
+        } else {
+            return TraceData.NOT_SAMPLED;
         }
-        return EMPTY_MAYBE_TRACE;
     }
 
     @Override
     public String getSpanName() {
-        return spanNameProvider.spanName(serverRequest);
+        return spanNameProvider.spanName(request);
     }
 
     @Override
     public Collection<KeyValueAnnotation> requestAnnotations() {
         KeyValueAnnotation uriAnnotation = KeyValueAnnotation.create(
-                TraceKeys.HTTP_URL, serverRequest.getUri().toString());
+                TraceKeys.HTTP_URL, request.getUri().toString());
         return Collections.singleton(uriAnnotation);
     }
 
-    private SpanId getSpanId(String traceId, String spanId, String parentSpanId) {
+    static SpanId getSpanId(String traceId, String spanId, String parentSpanId, Boolean sampled) {
         return SpanId.builder()
             .traceIdHigh(traceId.length() == 32 ? convertToLong(traceId, 0) : 0)
             .traceId(convertToLong(traceId))
             .spanId(convertToLong(spanId))
+            .sampled(sampled)
             .parentId(parentSpanId == null ? null : convertToLong(parentSpanId)).build();
    }
 }

--- a/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
+++ b/brave-http/src/test/java/com/github/kristofa/brave/http/HttpServerRequestAdapterTest.java
@@ -163,5 +163,20 @@ public class HttpServerRequestAdapterTest {
         assertEquals("http://youruri.com/a/b?myquery=you", a.getValue());
     }
 
-
+    /**
+     * When the caller propagates IDs, but not a sampling decision, the local process should decide.
+     */
+    @Test
+    public void getTraceData_externallyProvidedIds() {
+        when(serverRequest.getHttpHeaderValue(BraveHttpHeaders.TraceId.getName())).thenReturn(TRACE_ID);
+        when(serverRequest.getHttpHeaderValue(BraveHttpHeaders.SpanId.getName())).thenReturn(SPAN_ID);
+        TraceData traceData = adapter.getTraceData();
+        assertNotNull(traceData);
+        assertNull(traceData.getSample());
+        SpanId spanId = traceData.getSpanId();
+        assertNotNull(spanId);
+        assertEquals(IdConversion.convertToLong(TRACE_ID), spanId.traceId);
+        assertEquals(IdConversion.convertToLong(SPAN_ID), spanId.spanId);
+        assertNull(spanId.nullableParentId());
+    }
 }


### PR DESCRIPTION
There are some who want to control trace identifiers, but leave the
sampling decision to the next hop. In this case, they propagate the
required headers (X-B3-TraceId, X-B3-ParentId) and not X-B3-Sampled.

When this happens, the receiver of the headers (the server), should
sample the trace ID before using it.

Before, we weren't implementing this (eventhough Finagle does). The
change here addresses it and also backfills tests accordingly.

See https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala#L341
See https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/tracing/Tracer.scala#L119
See https://github.com/openzipkin/b3-propagation/pull/8

Fixes #277