### PR TITLE
Adds builder(brave) and create(brave) methods to all instrumentation

### DIFF
--- a/brave-apache-http-interceptors/README.md
+++ b/brave-apache-http-interceptors/README.md
@@ -9,8 +9,10 @@ annotation.
 
 Example of configuring interceptors with http client:
 
-    final CloseableHttpClient httpclient =
-            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer))
-                .addInterceptorFirst(new BraveHttpResponseInterceptor(clientTracer)).build();
-
+```java
+CloseableHttpClient httpclient = HttpClients.custom()
+    .addInterceptorFirst(BraveHttpRequestInterceptor.create(brave))
+    .addInterceptorFirst(BraveHttpResponseInterceptor.create(brave))
+    .build();
+```
 It is tested with httpclient version 4.3.3.

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
@@ -1,27 +1,64 @@
 package com.github.kristofa.brave.httpclient;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
-
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * Apache http client request interceptor.
  */
 public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
 
-    private final SpanNameProvider spanNameProvider;
+    /** Creates a tracing interceptor with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveHttpRequestInterceptor create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+        SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = checkNotNull(brave, "brave");
+        }
+
+        public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
+            this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+            return this;
+        }
+
+        public BraveHttpRequestInterceptor build() {
+            return new BraveHttpRequestInterceptor(this);
+        }
+    }
+
     private final ClientRequestInterceptor requestInterceptor;
+    private final SpanNameProvider spanNameProvider;
+
+    BraveHttpRequestInterceptor(Builder b) { // intentionally hidden
+        this.requestInterceptor = b.brave.clientRequestInterceptor();
+        this.spanNameProvider = b.spanNameProvider;
+    }
 
     /**
      * Creates a new instance.
      *
      * @param requestInterceptor
      * @param spanNameProvider Provides span name for request.
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
      */
+    @Deprecated
     public BraveHttpRequestInterceptor(ClientRequestInterceptor requestInterceptor, SpanNameProvider spanNameProvider) {
         this.requestInterceptor = requestInterceptor;
         this.spanNameProvider = spanNameProvider;

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave.httpclient;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import org.apache.http.HttpException;
@@ -9,13 +10,44 @@ import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 /**
  * Apache http client response interceptor.
  */
 public class BraveHttpResponseInterceptor implements HttpResponseInterceptor {
 
+    /** Creates a tracing interceptor with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveHttpResponseInterceptor create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+
+        Builder(Brave brave) { // intentionally hidden
+           this.brave = checkNotNull(brave, "brave");
+        }
+
+        public BraveHttpResponseInterceptor build() {
+            return new BraveHttpResponseInterceptor(this);
+        }
+    }
+
     private final ClientResponseInterceptor responseInterceptor;
 
+    BraveHttpResponseInterceptor(Builder b) { // intentionally hidden
+        this.responseInterceptor = b.brave.clientResponseInterceptor();
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     public BraveHttpResponseInterceptor(final ClientResponseInterceptor responseInterceptor) {
         this.responseInterceptor = responseInterceptor;
     }

--- a/brave-core-spring/src/main/java/com/github/kristofa/brave/BraveApiConfig.java
+++ b/brave-core-spring/src/main/java/com/github/kristofa/brave/BraveApiConfig.java
@@ -11,8 +11,10 @@ import org.springframework.context.annotation.Scope;
  * You will need to provide your own configuration for the Brave object which is
  * configured through the Brave.Builder and which configures SpanCollector, Sampler,...
  * </p>
+ * @deprecated this is no longer needed as instrumentation can now be built directly from Brave
  */
 @Configuration
+@Deprecated
 public class BraveApiConfig {
 
     @Autowired

--- a/brave-grpc/README.md
+++ b/brave-grpc/README.md
@@ -7,12 +7,12 @@ To enable tracing for a gRPC application, add the interceptors when when constru
 ```java
     Server server = ServerBuilder.forPort(serverPort)
         .addService(ServerInterceptors.intercept(
-            GreeterGrpc.bindService(new GreeterImpl()), new BraveGrpcServerInterceptor(brave)))
+            GreeterGrpc.bindService(new GreeterImpl()), BraveGrpcServerInterceptor.create(brave)))
         .build()
         .start();
         
     ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", serverPort)
-        .intercept(new BraveGrpcClientInterceptor("helloCallingService", brave))
+        .intercept(BraveGrpcClientInterceptor.create(brave))
         .usePlaintext(true)
         .build();
 ```

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcClientInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcClientInterceptor.java
@@ -10,6 +10,7 @@ import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.KeyValueAnnotation;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.internal.Nullable;
+import com.github.kristofa.brave.internal.Util;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import io.grpc.CallOptions;
@@ -31,10 +32,41 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class BraveGrpcClientInterceptor implements ClientInterceptor {
 
+    /** Creates a tracing interceptor with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveGrpcClientInterceptor create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = Util.checkNotNull(brave, "brave");
+        }
+
+        public BraveGrpcClientInterceptor build() {
+            return new BraveGrpcClientInterceptor(this);
+        }
+    }
+
     private final ClientRequestInterceptor clientRequestInterceptor;
     private final ClientResponseInterceptor clientResponseInterceptor;
     private final ClientSpanThreadBinder clientSpanThreadBinder;
 
+    BraveGrpcClientInterceptor(Builder b) { // intentionally hidden
+        this.clientRequestInterceptor = b.brave.clientRequestInterceptor();
+        this.clientResponseInterceptor = b.brave.clientResponseInterceptor();
+        this.clientSpanThreadBinder = b.brave.clientSpanThreadBinder();
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     public BraveGrpcClientInterceptor(Brave brave) {
         this.clientRequestInterceptor = checkNotNull(brave.clientRequestInterceptor());
         this.clientResponseInterceptor = checkNotNull(brave.clientResponseInterceptor());

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
@@ -13,6 +13,7 @@ import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
 
+import com.github.kristofa.brave.internal.Util;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -29,9 +30,39 @@ import java.util.Collections;
 
 public final class BraveGrpcServerInterceptor implements ServerInterceptor {
 
+    /** Creates a tracing interceptor with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveGrpcServerInterceptor create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = Util.checkNotNull(brave, "brave");
+        }
+
+        public BraveGrpcServerInterceptor build() {
+            return new BraveGrpcServerInterceptor(this);
+        }
+    }
+
     private final ServerRequestInterceptor serverRequestInterceptor;
     private final ServerResponseInterceptor serverResponseInterceptor;
 
+    BraveGrpcServerInterceptor(Builder b) { // intentionally hidden
+        this.serverRequestInterceptor = b.brave.serverRequestInterceptor();
+        this.serverResponseInterceptor = b.brave.serverResponseInterceptor();
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     public BraveGrpcServerInterceptor(Brave brave) {
         this.serverRequestInterceptor = checkNotNull(brave.serverRequestInterceptor());
         this.serverResponseInterceptor = checkNotNull(brave.serverResponseInterceptor());

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
@@ -63,12 +63,12 @@ public class BraveGrpcInterceptorsTest {
 
         int serverPort = pickUnusedPort();
         server = ServerBuilder.forPort(serverPort)
-            .addService(ServerInterceptors.intercept(new GreeterImpl(), new BraveGrpcServerInterceptor(brave)))
+            .addService(ServerInterceptors.intercept(new GreeterImpl(), BraveGrpcServerInterceptor.create(brave)))
             .build()
             .start();
 
         channel = ManagedChannelBuilder.forAddress("localhost", serverPort)
-            .intercept(new BraveGrpcClientInterceptor(brave))
+            .intercept(BraveGrpcClientInterceptor.create(brave))
             .usePlaintext(true)
             .build();
     }

--- a/brave-jaxrs2/README.md
+++ b/brave-jaxrs2/README.md
@@ -23,7 +23,8 @@ For client side setup, you just have to register the client filters with your JA
 
 It should look something like:
 
-    Client client = ClientBuilder.newClient();
-    client.register(myBraveClientRequestFilter);
-    client.register(myBraveClientResponseFilter);
-
+```java
+Client client = ClientBuilder.newClient();
+client.register(BraveClientRequestFilter.create(brave));
+client.register(BraveClientResponseFilter.create(brave));
+```

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
@@ -1,6 +1,8 @@
 package com.github.kristofa.brave.jaxrs2;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.http.HttpClientRequest;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
@@ -11,6 +13,8 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 /**
  * Intercepts JAX-RS 2 client requests and adds or forwards tracing information in the header.
  * Also sends cs annotations.
@@ -19,9 +23,45 @@ import java.io.IOException;
 @Priority(0)
 public class BraveClientRequestFilter implements ClientRequestFilter {
 
+    /** Creates a tracing filter with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveClientRequestFilter create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+        SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = checkNotNull(brave, "brave");
+        }
+
+        public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
+            this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+            return this;
+        }
+
+        public BraveClientRequestFilter build() {
+            return new BraveClientRequestFilter(this);
+        }
+    }
+
     private final ClientRequestInterceptor requestInterceptor;
     private final SpanNameProvider spanNameProvider;
 
+    BraveClientRequestFilter(Builder b) { // intentionally hidden
+        this.requestInterceptor = b.brave.clientRequestInterceptor();
+        this.spanNameProvider = b.spanNameProvider;
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     @Inject
     public BraveClientRequestFilter(SpanNameProvider spanNameProvider, ClientRequestInterceptor requestInterceptor) {
         this.requestInterceptor = requestInterceptor;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave.jaxrs2;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import com.github.kristofa.brave.http.HttpResponse;
@@ -11,6 +12,8 @@ import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 /**
  * Intercepts JAX-RS 2 client responses and sends cr annotations. Also submits the completed span.
  */
@@ -18,8 +21,37 @@ import java.io.IOException;
 @Priority(0)
 public class BraveClientResponseFilter implements ClientResponseFilter {
 
+    /** Creates a tracing filter with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveClientResponseFilter create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = checkNotNull(brave, "brave");
+        }
+
+        public BraveClientResponseFilter build() {
+            return new BraveClientResponseFilter(this);
+        }
+    }
+
     private final ClientResponseInterceptor responseInterceptor;
 
+    BraveClientResponseFilter(Builder b) { // intentionally hidden
+        this.responseInterceptor = b.brave.clientResponseInterceptor();
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     @Inject
     public BraveClientResponseFilter(ClientResponseInterceptor responseInterceptor) {
         this.responseInterceptor = responseInterceptor;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerResponseFilter.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave.jaxrs2;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.http.HttpResponse;
 import com.github.kristofa.brave.http.HttpServerResponseAdapter;
@@ -11,6 +12,8 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 /**
  * Intercepts outgoing container responses and sends ss annotations.
  */
@@ -18,8 +21,37 @@ import java.io.IOException;
 @Priority(0)
 public class BraveContainerResponseFilter implements ContainerResponseFilter {
 
+    /** Creates a tracing filter with defaults. Use {@link #builder(Brave)} to customize. */
+    public static BraveContainerResponseFilter create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = checkNotNull(brave, "brave");
+        }
+
+        public BraveContainerResponseFilter build() {
+            return new BraveContainerResponseFilter(this);
+        }
+    }
+
+    BraveContainerResponseFilter(Builder b) { // intentionally hidden
+        this.responseInterceptor = b.brave.serverResponseInterceptor();
+    }
+
     private final ServerResponseInterceptor responseInterceptor;
 
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     @Inject
     public BraveContainerResponseFilter(ServerResponseInterceptor responseInterceptor) {
         this.responseInterceptor = responseInterceptor;

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
@@ -1,10 +1,9 @@
 package com.github.kristofa.brave.jersey;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
@@ -12,24 +11,68 @@ import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.filter.ClientFilter;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * This filter creates or forwards trace headers and sends cs and cr annotations. Usage:
  *
  * <pre>
  * Client client = Client.create()
- * client.addFilter(new ClientTraceFilter(clientTracer));
+ * client.addFilter(JerseyClientTraceFilter.create(brave));
  * </pre>
  */
 @Singleton
 public class JerseyClientTraceFilter extends ClientFilter {
 
+    /** Creates a tracing filter with defaults. Use {@link #builder(Brave)} to customize. */
+    public static JerseyClientTraceFilter create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+        SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = checkNotNull(brave, "brave");
+        }
+
+        public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
+            this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+            return this;
+        }
+
+        public JerseyClientTraceFilter build() {
+            return new JerseyClientTraceFilter(this);
+        }
+    }
+
     private final ClientRequestInterceptor clientRequestInterceptor;
     private final ClientResponseInterceptor clientResponseInterceptor;
     private final SpanNameProvider spanNameProvider;
 
-    @Inject
+    JerseyClientTraceFilter(Builder b) { // intentionally hidden
+        this.clientRequestInterceptor = b.brave.clientRequestInterceptor();
+        this.clientResponseInterceptor = b.brave.clientResponseInterceptor();
+        this.spanNameProvider = b.spanNameProvider;
+    }
+
+    @Inject // internal dependency-injection constructor
+    JerseyClientTraceFilter(SpanNameProvider spanNameProvider, Brave brave) {
+        this(builder(brave).spanNameProvider(spanNameProvider));
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     public JerseyClientTraceFilter(SpanNameProvider spanNameProvider, ClientRequestInterceptor requestInterceptor, ClientResponseInterceptor responseInterceptor) {
         this.spanNameProvider = spanNameProvider;
         this.clientRequestInterceptor = requestInterceptor;

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/ServletTraceFilter.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave.jersey;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerRequestInterceptor;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.http.SpanNameProvider;
@@ -15,7 +16,15 @@ import javax.inject.Singleton;
 @Singleton
 public class ServletTraceFilter extends BraveServletFilter {
 
-    @Inject
+    @Inject // internal dependency-injection constructor
+    ServletTraceFilter(SpanNameProvider spanNameProvider, Brave brave) {
+       super(builder(brave).spanNameProvider(spanNameProvider));
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     public ServletTraceFilter(
             ServerRequestInterceptor requestInterceptor,
             ServerResponseInterceptor responseInterceptor,

--- a/brave-jersey2/README.md
+++ b/brave-jersey2/README.md
@@ -24,7 +24,8 @@ For client side setup, you just have to register the client filters with your Je
 
 It should look something like:
 
-    Client client = ClientBuilder.newClient();
-    client.register(myBraveClientRequestFilter);
-    client.register(myBraveClientResponseFilter);
-
+```java
+WebTarget target = target("/mytarget");
+target.register(BraveClientRequestFilter.create(brave));
+target.register(BraveClientResponseFilter.create(brave));
+```

--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveJersey2.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveJersey2.java
@@ -19,24 +19,22 @@ import static org.junit.Assert.assertEquals;
 
 public class ITBraveJersey2 extends JerseyTest {
 
+    private Brave brave;
     private SpanNameProvider spanNameProvider;
-    private ClientRequestInterceptor clientRequestInterceptor;
-    private ClientResponseInterceptor clientResponseInterceptor;
 
     @Override
     protected Application configure() {
         ApplicationContext context = new AnnotationConfigApplicationContext(JerseyTestSpringConfig.class);
+        brave = context.getBean(Brave.class);
         spanNameProvider = context.getBean(SpanNameProvider.class);
-        clientRequestInterceptor = context.getBean(ClientRequestInterceptor.class);
-        clientResponseInterceptor = context.getBean(ClientResponseInterceptor.class);
         return new JerseyTestConfig().property("contextConfig", context);
     }
 
     @Test
     public void testBraveJersey2() {
         WebTarget target = target("/brave-jersey2/test");
-        target.register(new BraveClientRequestFilter(spanNameProvider, clientRequestInterceptor));
-        target.register(new BraveClientResponseFilter(clientResponseInterceptor));
+        target.register(BraveClientRequestFilter.builder(brave).spanNameProvider(spanNameProvider).build());
+        target.register(BraveClientResponseFilter.create(brave));
 
         final Response response = target.request().get();
         assertEquals(200, response.getStatus());

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptor.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptor.java
@@ -1,8 +1,9 @@
 package com.github.kristofa.brave.okhttp;
 
-
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
@@ -12,16 +13,55 @@ import okhttp3.Response;
 
 import java.io.IOException;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
 public class BraveOkHttpRequestResponseInterceptor implements Interceptor {
 
-  private final ClientRequestInterceptor clientRequestInterceptor;
-  private final ClientResponseInterceptor clientResponseInterceptor;
+  /** Creates a tracing interceptor with defaults. Use {@link #builder(Brave)} to customize. */
+  public static BraveOkHttpRequestResponseInterceptor create(Brave brave) {
+    return new Builder(brave).build();
+  }
+
+  public static Builder builder(Brave brave) {
+    return new Builder(brave);
+  }
+
+  public static final class Builder {
+    final Brave brave;
+    SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+
+    Builder(Brave brave) { // intentionally hidden
+      this.brave = checkNotNull(brave, "brave");
+    }
+
+    public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
+      this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+      return this;
+    }
+
+    public BraveOkHttpRequestResponseInterceptor build() {
+      return new BraveOkHttpRequestResponseInterceptor(this);
+    }
+  }
+
+  private final ClientRequestInterceptor requestInterceptor;
+  private final ClientResponseInterceptor responseInterceptor;
   private final SpanNameProvider spanNameProvider;
 
+  BraveOkHttpRequestResponseInterceptor(Builder b) { // intentionally hidden
+    this.requestInterceptor = b.brave.clientRequestInterceptor();
+    this.responseInterceptor = b.brave.clientResponseInterceptor();
+    this.spanNameProvider = b.spanNameProvider;
+  }
+
+  /**
+   * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+   */
+  @Deprecated
   public BraveOkHttpRequestResponseInterceptor(ClientRequestInterceptor requestInterceptor, ClientResponseInterceptor responseInterceptor, SpanNameProvider spanNameProvider) {
     this.spanNameProvider = spanNameProvider;
-    this.clientRequestInterceptor = requestInterceptor;
-    this.clientResponseInterceptor = responseInterceptor;
+    this.requestInterceptor = requestInterceptor;
+    this.responseInterceptor = responseInterceptor;
   }
 
   @Override
@@ -29,9 +69,9 @@ public class BraveOkHttpRequestResponseInterceptor implements Interceptor {
     Request request = chain.request();
     Request.Builder builder = request.newBuilder();
     OkHttpRequest okHttpRequest = new OkHttpRequest(builder, request);
-    clientRequestInterceptor.handle(new HttpClientRequestAdapter(okHttpRequest, spanNameProvider));
+    requestInterceptor.handle(new HttpClientRequestAdapter(okHttpRequest, spanNameProvider));
     Response response = chain.proceed(builder.build());
-    clientResponseInterceptor.handle(new HttpClientResponseAdapter(new OkHttpResponse(response)));
+    responseInterceptor.handle(new HttpClientResponseAdapter(new OkHttpResponse(response)));
     return response;
   }
 

--- a/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptor.java
+++ b/brave-okhttp/src/main/java/com/github/kristofa/brave/okhttp/BraveTracingInterceptor.java
@@ -74,11 +74,11 @@ public final class BraveTracingInterceptor implements Interceptor {
   }
 
   public static final class Builder {
-    Brave brave;
+    final Brave brave;
     String serverName = "";
     OkHttpParser parser = new OkHttpParser();
 
-    Builder(Brave brave) {
+    Builder(Brave brave) { // intentionally hidden
       this.brave = checkNotNull(brave, "brave");
     }
 

--- a/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptorTest.java
+++ b/brave-okhttp/src/test/java/com/github/kristofa/brave/okhttp/BraveOkHttpRequestResponseInterceptorTest.java
@@ -1,11 +1,11 @@
 package com.github.kristofa.brave.okhttp;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.http.BraveHttpHeaders;
-import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -39,7 +39,8 @@ public class BraveOkHttpRequestResponseInterceptorTest {
   public final ExpectedException thrown = ExpectedException.none();
   @Rule
   public final MockWebServer server = new MockWebServer();
-
+  @Mock
+  private Brave brave;
   @Mock(answer = Answers.RETURNS_SMART_NULLS)
   private ClientTracer clientTracer;
 
@@ -50,8 +51,12 @@ public class BraveOkHttpRequestResponseInterceptorTest {
   public void setup() throws IOException {
     MockitoAnnotations.initMocks(this);
     this.spanId = SpanId.builder().spanId(SPAN_ID).traceId(TRACE_ID).parentId(null).build();
+    when(brave.clientRequestInterceptor())
+        .thenReturn(new ClientRequestInterceptor(clientTracer));
+    when(brave.clientResponseInterceptor())
+        .thenReturn(new ClientResponseInterceptor(clientTracer));
     this.client = new OkHttpClient.Builder()
-            .addInterceptor(new BraveOkHttpRequestResponseInterceptor(new ClientRequestInterceptor(clientTracer), new ClientResponseInterceptor(clientTracer), new DefaultSpanNameProvider()))
+            .addInterceptor(BraveOkHttpRequestResponseInterceptor.create(brave))
             .build();
   }
 

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -37,6 +37,13 @@
           <artifactId>brave-jaxrs2</artifactId>
           <version>3.15.5-SNAPSHOT</version>
       </dependency>
+    <!-- provided dep in brave-jaxrs2 -->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+      <scope>provided</scope>
+    </dependency>
 	<dependency>
     	<groupId>org.springframework</groupId>
 	    <artifactId>spring-core</artifactId>

--- a/brave-resteasy3-spring/src/main/java/com/github/kristofa/brave/resteasy3/ContainerFiltersConfiguration.java
+++ b/brave-resteasy3-spring/src/main/java/com/github/kristofa/brave/resteasy3/ContainerFiltersConfiguration.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave.resteasy3;
 
-import com.github.kristofa.brave.ServerRequestInterceptor;
-import com.github.kristofa.brave.ServerResponseInterceptor;
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import com.github.kristofa.brave.jaxrs2.BraveContainerRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveContainerResponseFilter;
@@ -10,30 +9,24 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * TODO: Add description
- *
- * @author volzhev
+ * Spring adapter for jaxrs2 filters, notably avoids deprecated constructors.
  */
 @Configuration
 public class ContainerFiltersConfiguration {
 
     @Autowired
-    private ServerRequestInterceptor serverRequestInterceptor;
-
-    @Autowired
-    private ServerResponseInterceptor serverResponseInterceptor;
-
+    private Brave brave;
 
     @Autowired
     private SpanNameProvider spanNameProvider;
 
     @Bean
     public BraveContainerRequestFilter getContainerRequestFilter() {
-        return new BraveContainerRequestFilter(serverRequestInterceptor, spanNameProvider);
+        return BraveContainerRequestFilter.builder(brave).spanNameProvider(spanNameProvider).build();
     }
 
     @Bean
     public BraveContainerResponseFilter getContainerResponseFilter() {
-        return new BraveContainerResponseFilter(serverResponseInterceptor);
+        return BraveContainerResponseFilter.create(brave);
     }
 }

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -1,10 +1,12 @@
 package com.github.kristofa.brave.spring;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientRequestInterceptor;
 import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.http.SpanNameProvider;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.springframework.http.HttpMethod;
@@ -26,11 +28,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class BraveClientHttpRequestInterceptorTest {
-
+    private final Brave brave = mock(Brave.class);
     private final ClientTracer clientTracer = mock(ClientTracer.class);
     private final SpanNameProvider spanNameProvider = mock(SpanNameProvider.class);
-    private final BraveClientHttpRequestInterceptor subject = new BraveClientHttpRequestInterceptor(new ClientRequestInterceptor(clientTracer),
-            new ClientResponseInterceptor(clientTracer), spanNameProvider);
+    private BraveClientHttpRequestInterceptor subject;
+
+    @Before
+    public void setup() throws IOException {
+        when(brave.clientRequestInterceptor())
+            .thenReturn(new ClientRequestInterceptor(clientTracer));
+        when(brave.clientResponseInterceptor())
+            .thenReturn(new ClientResponseInterceptor(clientTracer));
+        subject =
+            BraveClientHttpRequestInterceptor.builder(brave).spanNameProvider(spanNameProvider).build();
+    }
 
     @Test(expected = IOException.class)
     public void interceptShouldLetExceptionOccurringDuringExecuteBlowUp() throws Exception {

--- a/brave-spring-web-servlet-interceptor/README.md
+++ b/brave-spring-web-servlet-interceptor/README.md
@@ -5,9 +5,6 @@ trace information or create as required. This can be configured in either XML or
 ```xml
 <mvc:interceptors>
   <bean class="com.github.kristofa.brave.spring.ServletHandlerInterceptor">
-    <constructor-arg name="spanNameProvider">
-      <bean class="com.github.kristofa.brave.http.DefaultSpanNameProvider"/>
-    </constructor-arg>
   </bean>
 </mvc:interceptors>
 ```
@@ -16,17 +13,11 @@ trace information or create as required. This can be configured in either XML or
 public class WebConfig extends WebMvcConfigurerAdapter {
 
     @Autowired
-    private ServerRequestInterceptor requestInterceptor;
-
-    @Autowired
-    private ServerResponseInterceptor responseInterceptor;
-
-    @Autowired
-    private ServerSpanThreadBinder serverThreadBinder;
+    private Brave brave;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new ServletHandlerInterceptor(requestInterceptor, responseInterceptor, new DefaultSpanNameProvider(), serverThreadBinder));
+        registry.addInterceptor(ServletHandlerInterceptor.create(brave));
     }
 
 }

--- a/brave-spring-web-servlet-interceptor/src/main/java/com/github/kristofa/brave/spring/ServletHandlerInterceptor.java
+++ b/brave-spring-web-servlet-interceptor/src/main/java/com/github/kristofa/brave/spring/ServletHandlerInterceptor.java
@@ -1,9 +1,11 @@
 package com.github.kristofa.brave.spring;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerRequestInterceptor;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.http.HttpResponse;
 import com.github.kristofa.brave.http.HttpServerRequest;
 import com.github.kristofa.brave.http.HttpServerRequestAdapter;
@@ -11,22 +13,68 @@ import com.github.kristofa.brave.http.HttpServerResponseAdapter;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.context.annotation.Configuration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+
+@Configuration
 public class ServletHandlerInterceptor extends HandlerInterceptorAdapter {
 
     static final String HTTP_SERVER_SPAN_ATTRIBUTE = ServletHandlerInterceptor.class.getName() + ".server-span";
 
+    /** Creates a tracing interceptor with defaults. Use {@link #builder(Brave)} to customize. */
+    public static ServletHandlerInterceptor create(Brave brave) {
+        return new Builder(brave).build();
+    }
+
+    public static Builder builder(Brave brave) {
+        return new Builder(brave);
+    }
+
+    public static final class Builder {
+        final Brave brave;
+        SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
+
+        Builder(Brave brave) { // intentionally hidden
+            this.brave = checkNotNull(brave, "brave");
+        }
+
+        public Builder spanNameProvider(SpanNameProvider spanNameProvider) {
+            this.spanNameProvider = checkNotNull(spanNameProvider, "spanNameProvider");
+            return this;
+        }
+
+        public ServletHandlerInterceptor build() {
+            return new ServletHandlerInterceptor(this);
+        }
+    }
+
     private final ServerRequestInterceptor requestInterceptor;
-    private final SpanNameProvider spanNameProvider;
     private final ServerResponseInterceptor responseInterceptor;
     private final ServerSpanThreadBinder serverThreadBinder;
+    private final SpanNameProvider spanNameProvider;
 
-    @Autowired
+    @Autowired // internal
+    ServletHandlerInterceptor(SpanNameProvider spanNameProvider, Brave brave) {
+        this(builder(brave).spanNameProvider(spanNameProvider));
+    }
+
+    ServletHandlerInterceptor(Builder b) { // intentionally hidden
+        this.requestInterceptor = b.brave.serverRequestInterceptor();
+        this.responseInterceptor = b.brave.serverResponseInterceptor();
+        this.serverThreadBinder = b.brave.serverSpanThreadBinder();
+        this.spanNameProvider = b.spanNameProvider;
+    }
+
+    /**
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     */
+    @Deprecated
     public ServletHandlerInterceptor(ServerRequestInterceptor requestInterceptor, ServerResponseInterceptor responseInterceptor, SpanNameProvider spanNameProvider, final ServerSpanThreadBinder serverThreadBinder) {
         this.requestInterceptor = requestInterceptor;
         this.spanNameProvider = spanNameProvider;

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/BraveConfig.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/BraveConfig.java
@@ -1,32 +1,19 @@
 package com.github.kristofa.brave.spring;
 
 import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.BraveApiConfig;
-import com.github.kristofa.brave.ServerRequestInterceptor;
-import com.github.kristofa.brave.ServerResponseInterceptor;
-import com.github.kristofa.brave.ServerSpanThreadBinder;
-import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @Configuration
-@Import(BraveApiConfig.class)
 @EnableWebMvc
 public class BraveConfig extends WebMvcConfigurerAdapter {
 
     @Autowired
-    private ServerRequestInterceptor requestInterceptor;
-
-    @Autowired
-    private ServerResponseInterceptor responseInterceptor;
-
-    @Autowired
-    private ServerSpanThreadBinder serverThreadBinder;
+    private Brave brave;
 
     @Bean
     public Brave brave() {
@@ -42,7 +29,7 @@ public class BraveConfig extends WebMvcConfigurerAdapter {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new ServletHandlerInterceptor(requestInterceptor, responseInterceptor, new DefaultSpanNameProvider(), serverThreadBinder));
+        registry.addInterceptor(ServletHandlerInterceptor.create(brave));
     }
 
 }

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ServletHandlerInterceptorTest.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ServletHandlerInterceptorTest.java
@@ -1,12 +1,11 @@
 package com.github.kristofa.brave.spring;
 
+import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerRequestInterceptor;
 import com.github.kristofa.brave.ServerResponseAdapter;
 import com.github.kristofa.brave.ServerResponseInterceptor;
 import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
-import com.github.kristofa.brave.http.DefaultSpanNameProvider;
-import com.github.kristofa.brave.http.SpanNameProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -26,16 +25,19 @@ public class ServletHandlerInterceptorTest {
     private ServletHandlerInterceptor subject;
     private ServerSpanThreadBinder serverThreadBinder;
     private ServerRequestInterceptor requestInterceptor;
-    private SpanNameProvider spanNameProvider = new DefaultSpanNameProvider();
     private ServerResponseInterceptor responseInterceptor;
 
     @Before
     public void setUp() throws Exception {
         requestInterceptor = mock(ServerRequestInterceptor.class);
         responseInterceptor = mock(ServerResponseInterceptor.class);
-
         serverThreadBinder = mock(ServerSpanThreadBinder.class);
-        subject = new ServletHandlerInterceptor(requestInterceptor, responseInterceptor, spanNameProvider, serverThreadBinder);
+
+        Brave brave = mock(Brave.class);
+        when(brave.serverRequestInterceptor()).thenReturn(requestInterceptor);
+        when(brave.serverResponseInterceptor()).thenReturn(responseInterceptor);
+        when(brave.serverSpanThreadBinder()).thenReturn(serverThreadBinder);
+        subject = ServletHandlerInterceptor.create(brave);
     }
 
     @Test

--- a/brave-web-servlet-filter/README.md
+++ b/brave-web-servlet-filter/README.md
@@ -13,7 +13,7 @@ public class WebAppInitializer implements WebApplicationInitializer {
     public void onStartup(ServletContext servletContext) throws ServletException {
 
         Brave brave = new Brave.Builder("myservicename")).build();
-        servletContext.addFilter(“BraveServletFilter”, new BraveServletFilter(brave.serverRequestInterceptor(), brave.serverResponseInterceptor(), new DefaultSpanNameProvider()));
+        servletContext.addFilter(“BraveServletFilter”, BraveServletFilter.create(brave));
     }
 
 }

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
@@ -3,7 +3,6 @@ package com.github.kristofa.brave.servlet;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.http.BraveHttpHeaders;
-import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.twitter.zipkin.gen.Span;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
@@ -55,7 +54,7 @@ public class ITBraveServletFilter {
         context.setServer(server);
         context.setContextPath("/BraveServletFilter");
 
-        context.addFilter(new FilterHolder(new BraveServletFilter(brave.serverRequestInterceptor(), brave.serverResponseInterceptor(), new DefaultSpanNameProvider())), "/*", EnumSet.allOf(DispatcherType.class));
+        context.addFilter(new FilterHolder(BraveServletFilter.create(brave)), "/*", EnumSet.allOf(DispatcherType.class));
         context.addServlet(new ServletHolder(new ForwardServlet()), "/test");
         context.addServlet(new ServletHolder(new PingServlet()), "/forwardTo");
         context.setWar("src/test/webapp");


### PR DESCRIPTION
Before, you needed to pass several objects to configure instrumentation.
This exposes a builder, with a shortcut `create(brave)` method to lower
the learning curve and also provide a place to add hooks.

This obviates a lot of wiring complexity as well.

Fixes #274
See #276