### PR TITLE
Uses RetroLambda to get rid of IDE setup and cruft

### DIFF
--- a/brave-benchmarks/src/main/java/com/github/kristofa/brave/HttpServerRequestAdapterBenchmark.java
+++ b/brave-benchmarks/src/main/java/com/github/kristofa/brave/HttpServerRequestAdapterBenchmark.java
@@ -75,12 +75,8 @@ public class HttpServerRequestAdapterBenchmark {
             }
         };
 
-        final SpanNameProvider nameProvider = new SpanNameProvider() {
-            @Override
-            public String spanName(HttpRequest request) {
-                return request.getHttpMethod() + " " + request.getUri().getPath();
-            }
-        };
+        final SpanNameProvider nameProvider =
+            request1 -> request1.getHttpMethod() + " " + request1.getUri().getPath();
 
         final HttpServerRequestAdapter adapter = new HttpServerRequestAdapter(request, nameProvider);
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
@@ -78,12 +78,8 @@ public abstract class FlushingSpanCollector implements SpanCollector, Flushable,
 
     Flusher(Flushable flushable, int flushInterval, final String threadPoolName) {
       this.flushable = flushable;
-      this.scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-        @Override
-        public Thread newThread(final Runnable r) {
-          return new Thread(r, threadPoolName);
-        }
-      });
+      this.scheduler = Executors.newSingleThreadScheduledExecutor(
+          r -> new Thread(r, threadPoolName));
       this.scheduler.scheduleWithFixedDelay(this, 0, flushInterval, SECONDS);
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -133,9 +133,8 @@ public class AnnotationSubmitterTest {
         span.setTimestamp(CURRENT_TIME_MICROSECONDS - 1);
 
         annotationSubmitter.submitAnnotation("sr");
-        annotationSubmitter.submitEndAnnotation("ss", span -> {
-            assertThat(span.duration).isEqualTo(1);
-        });
+        annotationSubmitter.submitEndAnnotation("ss", span ->
+            assertThat(span.duration).isEqualTo(1));
     }
 
     @Test
@@ -146,8 +145,7 @@ public class AnnotationSubmitterTest {
         PowerMockito.when(System.nanoTime()).thenReturn(787L);
 
         annotationSubmitter.submitAnnotation("sr");
-        annotationSubmitter.submitEndAnnotation("ss", span -> {
-            assertThat(span.duration).isEqualTo(1L);
-        });
+        annotationSubmitter.submitEndAnnotation("ss", span ->
+            assertThat(span.duration).isEqualTo(1L));
     }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -246,28 +246,25 @@ public class LocalTracingInheritenceTest {
         assertThat(baseSpan.root()).isFalse();
         assertThat(baseSpan.spanId).isNotEqualTo(baseSpan.traceId);
         try {
-            return new Runnable() {
-                @Override
-                public void run() {
-                    String originalThreadName = Thread.currentThread().getName();
-                    Thread.currentThread().setName(originalThreadName + "]"
-                            + "[create-" + breadth + ":" + depth + "]");
-                    LocalTracer localTracer = brave.localTracer();
-                    SpanId runnableSpan = localTracer.startNewSpan("thread-" + breadth + ":" + depth,
-                            "run-" + breadth + ":" + depth);
-                    assertThat(runnableSpan).isNotNull();
-                    assertThat(runnableSpan.nullableParentId()).isNotNull();
-                    assertThat(runnableSpan.root()).isFalse();
-                    assertThat(runnableSpan.spanId).isNotEqualTo(runnableSpan.traceId);
+            return () -> {
+                String originalThreadName = Thread.currentThread().getName();
+                Thread.currentThread().setName(originalThreadName + "]"
+                        + "[create-" + breadth + ":" + depth + "]");
+                LocalTracer localTracer = brave.localTracer();
+                SpanId runnableSpan = localTracer.startNewSpan("thread-" + breadth + ":" + depth,
+                        "run-" + breadth + ":" + depth);
+                assertThat(runnableSpan).isNotNull();
+                assertThat(runnableSpan.nullableParentId()).isNotNull();
+                assertThat(runnableSpan.root()).isFalse();
+                assertThat(runnableSpan.spanId).isNotEqualTo(runnableSpan.traceId);
 
-                    try {
-                        runThreads(2, depth - 1);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    } finally {
-                        localTracer.finishSpan();
-                        Thread.currentThread().setName(originalThreadName);
-                    }
+                try {
+                    runThreads(2, depth - 1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    localTracer.finishSpan();
+                    Thread.currentThread().setName(originalThreadName);
                 }
             };
         } finally {

--- a/brave-core/src/test/java/com/github/kristofa/brave/SamplerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/SamplerTest.java
@@ -36,11 +36,7 @@ public abstract class SamplerTest {
     final Sampler sampler = newSampler(sampleRate);
 
     // parallel to ensure there aren't any unsynchronized race conditions
-    long passed = new Random().longs(INPUT_SIZE).parallel().filter(new LongPredicate() {
-      @Override public boolean test(long traceId) {
-        return sampler.isSampled(traceId);
-      }
-    }).count();
+    long passed = new Random().longs(INPUT_SIZE).parallel().filter(sampler::isSampled).count();
 
     assertThat(passed)
         .isCloseTo((long) (INPUT_SIZE * sampleRate), expectedErrorRate());
@@ -50,22 +46,14 @@ public abstract class SamplerTest {
   public void zeroMeansDropAllTraces() {
     final Sampler sampler = newSampler(0.0f);
 
-    assertThat(new Random().longs(INPUT_SIZE).filter(new LongPredicate() {
-      @Override public boolean test(long traceId) {
-        return sampler.isSampled(traceId);
-      }
-    }).findAny()).isEmpty();
+    assertThat(new Random().longs(INPUT_SIZE).filter(sampler::isSampled).findAny()).isEmpty();
   }
 
   @Test
   public void oneMeansKeepAllTraces() {
     final Sampler sampler = newSampler(1.0f);
 
-    assertThat(new Random().longs(INPUT_SIZE).filter(new LongPredicate() {
-      @Override public boolean test(long traceId) {
-        return sampler.isSampled(traceId);
-      }
-    }).count()).isEqualTo(INPUT_SIZE);
+    assertThat(new Random().longs(INPUT_SIZE).filter(sampler::isSampled).count()).isEqualTo(INPUT_SIZE);
   }
 
   @Test

--- a/brave-cxf3/src/test/java/com/github/kristofa/brave/cxf3/integration/ITBraveCxfInterceptorsJaxrs.java
+++ b/brave-cxf3/src/test/java/com/github/kristofa/brave/cxf3/integration/ITBraveCxfInterceptorsJaxrs.java
@@ -45,15 +45,12 @@ public class ITBraveCxfInterceptorsJaxrs {
     @Path("/foo")
     public void foo(@Suspended AsyncResponse response) {
 
-      Executors.newSingleThreadExecutor().execute(new Runnable() {
-        @Override
-        public void run() {
-          try {
-            Thread.sleep(100);
-          } catch (InterruptedException e) {
-          }
-          response.resume("foo");
+      Executors.newSingleThreadExecutor().execute(() -> {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
         }
+        response.resume("foo");
       });
     }
   }

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerResponseFilter.java
@@ -63,15 +63,7 @@ public class BraveContainerResponseFilter implements ContainerResponseFilter {
 
     @Override
     public void filter(final ContainerRequestContext containerRequestContext, final ContainerResponseContext containerResponseContext) throws IOException {
-
-        HttpResponse httpResponse = new HttpResponse() {
-
-            @Override
-            public int getHttpStatusCode() {
-                return containerResponseContext.getStatus();
-            }
-        };
-
+        HttpResponse httpResponse = containerResponseContext::getStatus;
         responseInterceptor.handle(new HttpServerResponseAdapter(httpResponse));
     }
 }

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePostProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePostProcessInterceptor.java
@@ -71,14 +71,7 @@ public class BravePostProcessInterceptor implements PostProcessInterceptor {
 
     @Override
     public void postProcess(final ServerResponse response) {
-
-        HttpResponse httpResponse = new HttpResponse() {
-
-            @Override
-            public int getHttpStatusCode() {
-                return response.getStatus();
-            }
-        };
+        HttpResponse httpResponse = response::getStatus;
         HttpServerResponseAdapter adapter = new HttpServerResponseAdapter(httpResponse);
         responseInterceptor.handle(adapter);
     }

--- a/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/KafkaSpanCollectorTest.java
+++ b/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/KafkaSpanCollectorTest.java
@@ -85,26 +85,18 @@ public class KafkaSpanCollectorTest {
 
   @Test
   public void submitMultipleSpansInParallel() throws Exception {
-    Callable<Void> spanProducer1 = new Callable<Void>() {
-
-      @Override
-      public Void call() throws Exception {
-        for (int i = 1; i <= 200; i++) {
-          collector.collect(span(i, "producer1_" + i));
-        }
-        return null;
+    Callable<Void> spanProducer1 = () -> {
+      for (int i = 1; i <= 200; i++) {
+        collector.collect(span(i, "producer1_" + i));
       }
+      return null;
     };
 
-    Callable<Void> spanProducer2 = new Callable<Void>() {
-
-      @Override
-      public Void call() throws Exception {
-        for (int i = 1; i <= 200; i++) {
-          collector.collect(span(i, "producer2_" + i));
-        }
-        return null;
+    Callable<Void> spanProducer2 = () -> {
+      for (int i = 1; i <= 200; i++) {
+        collector.collect(span(i, "producer2_" + i));
       }
+      return null;
     };
 
     ExecutorService executorService = Executors.newFixedThreadPool(2);

--- a/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
+++ b/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
@@ -89,9 +89,8 @@ public class LocalSpanCollectorTest {
 
   @Test
   public void incrementsDroppedSpans_exceptionOnCallbackThread() throws Exception {
-    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
-      callback.onError(new RuntimeException("couldn't store"));
-    });
+    LocalSpanCollector collector = newLocalSpanCollector((spans, callback) ->
+        callback.onError(new RuntimeException("couldn't store")));
 
     collector.collect(span(1L, "foo"));
     collector.collect(span(2L, "bar"));

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeServer.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeServer.java
@@ -42,16 +42,7 @@ class ScribeServer {
     }
 
     public void start() {
-
-        final Runnable serveThread = new Runnable() {
-
-            @Override
-            public void run() {
-                server.serve();
-            }
-        };
-
-        new Thread(serveThread).start();
+        new Thread(server::serve).start();
     }
 
     public void clearReceivedSpans() {

--- a/brave-spring-web-servlet-interceptor/src/main/java/com/github/kristofa/brave/spring/ServletHandlerInterceptor.java
+++ b/brave-spring-web-servlet-interceptor/src/main/java/com/github/kristofa/brave/spring/ServletHandlerInterceptor.java
@@ -123,12 +123,7 @@ public class ServletHandlerInterceptor extends HandlerInterceptorAdapter {
             serverThreadBinder.setCurrentSpan(span);
         }
 
-       responseInterceptor.handle(new HttpServerResponseAdapter(new HttpResponse() {
-           @Override
-           public int getHttpStatusCode() {
-               return response.getStatus();
-           }
-       }));
+       responseInterceptor.handle(new HttpServerResponseAdapter(response::getStatus));
     }
 
 }

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/PingController.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/PingController.java
@@ -19,10 +19,6 @@ public class PingController {
 
     @RequestMapping(value = "/async")
     public Callable<ResponseEntity<Void>> async() throws IOException {
-        return new Callable<ResponseEntity<Void>>() {
-            public ResponseEntity<Void> call() throws Exception {
-                return ResponseEntity.noContent().build();
-            }
-        };
+        return () -> ResponseEntity.noContent().build();
     }
 }

--- a/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/BraveServletFilter.java
+++ b/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/BraveServletFilter.java
@@ -99,12 +99,8 @@ public class BraveServletFilter implements Filter {
             try {
                 filterChain.doFilter(request, statusExposingServletResponse);
             } finally {
-                responseInterceptor.handle(new HttpServerResponseAdapter(new HttpResponse() {
-                    @Override
-                    public int getHttpStatusCode() {
-                        return statusExposingServletResponse.getStatus();
-                    }
-                }));
+                responseInterceptor.handle(new HttpServerResponseAdapter(
+                    statusExposingServletResponse::getStatus));
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -370,21 +370,10 @@
         <plugin>
           <inherited>true</inherited>
           <artifactId>maven-compiler-plugin</artifactId>
-          <executions>
-            <!-- Ensure main source tree compiles to Java ${main.java.version} bytecode. -->
-            <execution>
-              <id>default-compile</id>
-              <phase>compile</phase>
-              <goals>
-                <goal>compile</goal>
-              </goals>
-              <configuration>
-                <source>${main.java.version}</source>
-                <target>${main.java.version}</target>
-              </configuration>
-            </execution>
-          </executions>
           <configuration>
+            <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
+            <source>1.8</source>
+            <target>1.8</target>
             <compilerId>javac-with-errorprone</compilerId>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <showWarnings>true</showWarnings>
@@ -401,6 +390,23 @@
               <version>${errorprone.version}</version>
             </dependency>
           </dependencies>
+        </plugin>
+
+        <plugin>
+          <groupId>net.orfjackal.retrolambda</groupId>
+          <artifactId>retrolambda-maven-plugin</artifactId>
+          <version>2.3.0</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>process-main</goal>
+              </goals>
+              <configuration>
+                <target>${main.java.version}</target>
+                <fork>false</fork>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This uses RetroLambda which allows you to use Java 8 source level even
if your bytecode level is Java 6. This makes coding more fun and also
obviates IDE setup needed to manage different source levels between main
and test code trees.

The same has been in use by zipkin-reporter-java for some time.

See https://github.com/orfjackal/retrolambda