### PR TITLE
Support local spans in BraveExecutorService, BraveCallable BraveRunnable

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveCallable.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveCallable.java
@@ -1,9 +1,12 @@
 package com.github.kristofa.brave;
 
+import com.twitter.zipkin.gen.Span;
 import java.util.concurrent.Callable;
 
 import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * Callable implementation that wraps another Callable and makes sure the wrapped Callable will be executed in the same
@@ -19,16 +22,54 @@ import com.google.auto.value.AutoValue;
 public abstract class BraveCallable<T> implements Callable<T> {
 
     /**
-     * Creates a new instance.
-     *
-     * @param wrappedCallable The wrapped Callable.
-     * @param serverSpanThreadBinder ServerSpan thread binder.
+     * @since 3.17
      */
+    public static <T> BraveCallable<T> wrap(Callable<T> callable, Brave brave) {
+        checkNotNull(brave, "brave"); // auto-value will check the others.
+        return new AutoValue_BraveCallable(
+            callable,
+            brave.localSpanThreadBinder(),
+            brave.localSpanThreadBinder().getCurrentLocalSpan(),
+            brave.serverSpanThreadBinder(),
+            brave.serverSpanThreadBinder().getCurrentServerSpan()
+        );
+    }
+
+    static <T> BraveCallable<T> wrap( // hidden for package-scoped use
+        Callable<T> callable,
+        LocalSpanThreadBinder localSpanThreadBinder,
+        ServerSpanThreadBinder serverSpanThreadBinder
+    ) {
+        return new AutoValue_BraveCallable(
+            callable,
+            localSpanThreadBinder,
+            localSpanThreadBinder.getCurrentLocalSpan(),
+            serverSpanThreadBinder,
+            serverSpanThreadBinder.getCurrentServerSpan()
+        );
+    }
+
+    /**
+     * @deprecated use {@link #wrap(Callable, Brave)} because this constructor loses thread
+     * state for local span parents.
+     */
+    @Deprecated
     public static <T> BraveCallable<T> create(Callable<T> wrappedCallable, ServerSpanThreadBinder serverSpanThreadBinder) {
-        return new AutoValue_BraveCallable<T>(wrappedCallable, serverSpanThreadBinder, serverSpanThreadBinder.getCurrentServerSpan());
+        checkNotNull(serverSpanThreadBinder, "serverSpanThreadBinder"); // auto-value will check the others.
+        return new AutoValue_BraveCallable(
+            wrappedCallable,
+            null,
+            null,
+            serverSpanThreadBinder,
+            serverSpanThreadBinder.getCurrentServerSpan()
+        );
     }
 
     abstract Callable<T> wrappedCallable();
+    @Nullable // while deprecated constructor is in use
+    abstract LocalSpanThreadBinder localSpanThreadBinder();
+    @Nullable
+    abstract Span currentLocalSpan();
     abstract ServerSpanThreadBinder serverSpanThreadBinder();
     @Nullable
     abstract ServerSpan currentServerSpan();
@@ -38,8 +79,20 @@ public abstract class BraveCallable<T> implements Callable<T> {
      */
     @Override
     public T call() throws Exception {
-        serverSpanThreadBinder().setCurrentSpan(currentServerSpan());
-        return wrappedCallable().call();
+        if (localSpanThreadBinder() == null) { // old behavior
+            serverSpanThreadBinder().setCurrentSpan(currentServerSpan());
+            return wrappedCallable().call();
+        }
+        ServerSpan previousServerSpan = serverSpanThreadBinder().getCurrentServerSpan();
+        Span previousLocalSpan = localSpanThreadBinder().getCurrentLocalSpan();
+        try {
+            serverSpanThreadBinder().setCurrentSpan(currentServerSpan());
+            localSpanThreadBinder().setCurrentSpan(currentLocalSpan());
+            return wrappedCallable().call();
+        } finally {
+            serverSpanThreadBinder().setCurrentSpan(previousServerSpan);
+            localSpanThreadBinder().setCurrentSpan(previousLocalSpan);
+        }
     }
 
     BraveCallable() {

--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveRunnable.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveRunnable.java
@@ -2,13 +2,16 @@ package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
+import com.twitter.zipkin.gen.Span;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * {@link Runnable} implementation that wraps another Runnable and makes sure the wrapped Runnable will be executed in the
  * same Span/Trace context as the thread from which the Runnable was executed.
  * <p/>
  * Is used by {@link BraveExecutorService}.
- * 
+ *
  * @author kristof
  * @see BraveExecutorService
  */
@@ -16,16 +19,54 @@ import com.google.auto.value.AutoValue;
 public abstract class BraveRunnable implements Runnable {
 
     /**
-     * Creates a new instance.
-     *
-     * @param runnable The wrapped Callable.
-     * @param serverSpanThreadBinder ServerSpan thread binder.
+     * @since 3.17
      */
+    public static BraveRunnable wrap(Runnable runnable, Brave brave) {
+        checkNotNull(brave, "brave"); // auto-value will check the others.
+        return new AutoValue_BraveRunnable(
+            runnable,
+            brave.localSpanThreadBinder(),
+            brave.localSpanThreadBinder().getCurrentLocalSpan(),
+            brave.serverSpanThreadBinder(),
+            brave.serverSpanThreadBinder().getCurrentServerSpan()
+        );
+    }
+
+    static BraveRunnable wrap( // hidden for package-scoped use
+        Runnable runnable,
+        LocalSpanThreadBinder localSpanThreadBinder,
+        ServerSpanThreadBinder serverSpanThreadBinder
+    ) {
+        return new AutoValue_BraveRunnable(
+            runnable,
+            localSpanThreadBinder,
+            localSpanThreadBinder.getCurrentLocalSpan(),
+            serverSpanThreadBinder,
+            serverSpanThreadBinder.getCurrentServerSpan()
+        );
+    }
+
+    /**
+     * @deprecated use {@link #wrap(Runnable, Brave)} because this constructor loses thread
+     * state for local span parents.
+     */
+    @Deprecated
     public static BraveRunnable create(Runnable runnable, ServerSpanThreadBinder serverSpanThreadBinder) {
-        return new AutoValue_BraveRunnable(runnable, serverSpanThreadBinder, serverSpanThreadBinder.getCurrentServerSpan());
+        checkNotNull(serverSpanThreadBinder, "serverSpanThreadBinder"); // auto-value will check the others.
+        return new AutoValue_BraveRunnable(
+            runnable,
+            null,
+            null,
+            serverSpanThreadBinder,
+            serverSpanThreadBinder.getCurrentServerSpan()
+        );
     }
 
     abstract Runnable wrappedRunnable();
+    @Nullable // while deprecated constructor is in use
+    abstract LocalSpanThreadBinder localSpanThreadBinder();
+    @Nullable
+    abstract Span currentLocalSpan();
     abstract ServerSpanThreadBinder serverSpanThreadBinder();
     @Nullable
     abstract ServerSpan currentServerSpan();
@@ -35,7 +76,21 @@ public abstract class BraveRunnable implements Runnable {
      */
     @Override
     public void run() {
+      if (localSpanThreadBinder() == null) { // old behavior
         serverSpanThreadBinder().setCurrentSpan(currentServerSpan());
         wrappedRunnable().run();
+        return;
+      }
+
+      ServerSpan previousServerSpan = serverSpanThreadBinder().getCurrentServerSpan();
+      Span previousLocalSpan = localSpanThreadBinder().getCurrentLocalSpan();
+      try {
+        serverSpanThreadBinder().setCurrentSpan(currentServerSpan());
+        localSpanThreadBinder().setCurrentSpan(currentLocalSpan());
+        wrappedRunnable().run();
+      } finally {
+        serverSpanThreadBinder().setCurrentSpan(previousServerSpan);
+        localSpanThreadBinder().setCurrentSpan(previousLocalSpan);
+      }
     }
 }


### PR DESCRIPTION
This adds new `wrap()` factory methods to `BraveExecutorService`,
`BraveCallable` and `BraveRunnable`. Notably these support attaching
local spans, needed for any async client span that isn't a direct child
of a server span. This also manages the stack properly so that you can
create a new span inside a callable or runnable without tainting the
prior state.

Fixes #289