### PR TITLE
Adds Client Address to grpc and servlet-based instrumentation

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/InetAddresses.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/InetAddresses.java
@@ -1,0 +1,178 @@
+package com.github.kristofa.brave.internal;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+
+/** Utilities for working with IP Addresses. */
+public final class InetAddresses {
+
+  //** Start code from Guava v20 **//
+  private static final int IPV4_PART_COUNT = 4;
+  private static final int IPV6_PART_COUNT = 8;
+
+  /**
+   * Returns the {@link InetAddress#getAddress()} having the given string representation or null if
+   * unable to parse.
+   *
+   * <p>This deliberately avoids all nameservice lookups (e.g. no DNS).
+   *
+   * <p>This is the same as com.google.common.net.InetAddresses.ipStringToBytes(), except internally
+   * Splitter isn't used (as that would introduce more dependencies).
+   *
+   * @param ipString {@code String} containing an IPv4 or IPv6 string literal, e.g. {@code
+   * "192.168.0.1"} or {@code "2001:db8::1"}
+   */
+  @Nullable
+  public static byte[] ipStringToBytes(String ipString) {
+    // PATCHED! adding null/empty escape
+    if (ipString == null || ipString.isEmpty()) return null;
+    // Make a first pass to categorize the characters in this string.
+    boolean hasColon = false;
+    boolean hasDot = false;
+    for (int i = 0; i < ipString.length(); i++) {
+      char c = ipString.charAt(i);
+      if (c == '.') {
+        hasDot = true;
+      } else if (c == ':') {
+        if (hasDot) {
+          return null; // Colons must not appear after dots.
+        }
+        hasColon = true;
+      } else if (Character.digit(c, 16) == -1) {
+        return null; // Everything else must be a decimal or hex digit.
+      }
+    }
+
+    // Now decide which address family to parse.
+    if (hasColon) {
+      if (hasDot) {
+        ipString = convertDottedQuadToHex(ipString);
+        if (ipString == null) {
+          return null;
+        }
+      }
+      return textToNumericFormatV6(ipString);
+    } else if (hasDot) {
+      return textToNumericFormatV4(ipString);
+    }
+    return null;
+  }
+
+  @Nullable
+  private static byte[] textToNumericFormatV4(String ipString) {
+    byte[] bytes = new byte[IPV4_PART_COUNT];
+    int i = 0;
+    try {
+      // PATCHED! for (String octet : IPV4_SPLITTER.split(ipString)) {
+      for (String octet : ipString.split("\\.", 5)) {
+        bytes[i++] = parseOctet(octet);
+      }
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+
+    return i == IPV4_PART_COUNT ? bytes : null;
+  }
+
+  @Nullable
+  private static byte[] textToNumericFormatV6(String ipString) {
+    // An address can have [2..8] colons, and N colons make N+1 parts.
+    String[] parts = ipString.split(":", IPV6_PART_COUNT + 2);
+    if (parts.length < 3 || parts.length > IPV6_PART_COUNT + 1) {
+      return null;
+    }
+
+    // Disregarding the endpoints, find "::" with nothing in between.
+    // This indicates that a run of zeroes has been skipped.
+    int skipIndex = -1;
+    for (int i = 1; i < parts.length - 1; i++) {
+      if (parts[i].length() == 0) {
+        if (skipIndex >= 0) {
+          return null; // Can't have more than one ::
+        }
+        skipIndex = i;
+      }
+    }
+
+    int partsHi; // Number of parts to copy from above/before the "::"
+    int partsLo; // Number of parts to copy from below/after the "::"
+    if (skipIndex >= 0) {
+      // If we found a "::", then check if it also covers the endpoints.
+      partsHi = skipIndex;
+      partsLo = parts.length - skipIndex - 1;
+      if (parts[0].length() == 0 && --partsHi != 0) {
+        return null; // ^: requires ^::
+      }
+      if (parts[parts.length - 1].length() == 0 && --partsLo != 0) {
+        return null; // :$ requires ::$
+      }
+    } else {
+      // Otherwise, allocate the entire address to partsHi. The endpoints
+      // could still be empty, but parseHextet() will check for that.
+      partsHi = parts.length;
+      partsLo = 0;
+    }
+
+    // If we found a ::, then we must have skipped at least one part.
+    // Otherwise, we must have exactly the right number of parts.
+    int partsSkipped = IPV6_PART_COUNT - (partsHi + partsLo);
+    if (!(skipIndex >= 0 ? partsSkipped >= 1 : partsSkipped == 0)) {
+      return null;
+    }
+
+    // Now parse the hextets into a byte array.
+    ByteBuffer rawBytes = ByteBuffer.allocate(2 * IPV6_PART_COUNT);
+    try {
+      for (int i = 0; i < partsHi; i++) {
+        rawBytes.putShort(parseHextet(parts[i]));
+      }
+      for (int i = 0; i < partsSkipped; i++) {
+        rawBytes.putShort((short) 0);
+      }
+      for (int i = partsLo; i > 0; i--) {
+        rawBytes.putShort(parseHextet(parts[parts.length - i]));
+      }
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+    return rawBytes.array();
+  }
+
+  @Nullable
+  private static String convertDottedQuadToHex(String ipString) {
+    int lastColon = ipString.lastIndexOf(':');
+    String initialPart = ipString.substring(0, lastColon + 1);
+    String dottedQuad = ipString.substring(lastColon + 1);
+    byte[] quad = textToNumericFormatV4(dottedQuad);
+    if (quad == null) {
+      return null;
+    }
+    String penultimate = Integer.toHexString(((quad[0] & 0xff) << 8) | (quad[1] & 0xff));
+    String ultimate = Integer.toHexString(((quad[2] & 0xff) << 8) | (quad[3] & 0xff));
+    return initialPart + penultimate + ":" + ultimate;
+  }
+
+  private static byte parseOctet(String ipPart) {
+    // Note: we already verified that this string contains only hex digits.
+    int octet = Integer.parseInt(ipPart);
+    // Disallow leading zeroes, because no clear standard exists on
+    // whether these should be interpreted as decimal or octal.
+    if (octet > 255 || (ipPart.startsWith("0") && ipPart.length() > 1)) {
+      throw new NumberFormatException();
+    }
+    return (byte) octet;
+  }
+
+  private static short parseHextet(String ipPart) {
+    // Note: we already verified that this string contains only hex digits.
+    int hextet = Integer.parseInt(ipPart, 16);
+    if (hextet > 0xffff) {
+      throw new NumberFormatException();
+    }
+    return (short) hextet;
+  }
+  //** End code from Guava v20 **//
+
+  InetAddresses() {
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/MaybeAddClientAddress.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/MaybeAddClientAddress.java
@@ -1,0 +1,114 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import zipkin.Constants;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
+import static zipkin.Constants.CLIENT_ADDR;
+
+/**
+ * Parses the {@link Constants#CLIENT_ADDR client address}, possibly by looking at
+ * "X-Forwarded-For", then the remote address of the input. This performs no DNS lookups.
+ *
+ * <p>This is a hack as {@code com.github.kristofa.brave.http.HttpServerRequest} is an interface and
+ * would break api if we changed it. Moreover, this can work on non-http input types.
+ */
+public abstract class MaybeAddClientAddress<T> {
+  final ServerSpanThreadBinder threadBinder;
+
+  protected MaybeAddClientAddress(Brave brave) { // accepts brave so we can re-factor thread state
+    this.threadBinder = checkNotNull(brave, "brave").serverSpanThreadBinder();
+  }
+
+  @Nullable
+  public final void accept(T input) {
+    // Kick out if we can't read the current span
+    ServerSpan serverSpan = threadBinder.getCurrentServerSpan();
+    Span span = serverSpan != null ? serverSpan.getSpan() : null;
+    if (span == null) return;
+
+    // Kick out if we can't cheaply read the address
+    byte[] addressBytes;
+    try {
+      addressBytes = parseAddressBytes(input);
+      if (addressBytes == null) return;
+    } catch (RuntimeException e) {
+      return;
+    }
+
+    // Build an endpoint with no service name (rather than risk cluttering the service list!)
+    Endpoint.Builder builder = Endpoint.builder().serviceName("");
+    if (addressBytes.length == 4) {
+      builder.ipv4(ByteBuffer.wrap(addressBytes).getInt());
+    } else if (addressBytes.length == 16) {
+      // https://tools.ietf.org/html/rfc4291#section-2.5.5.2
+      boolean maybeIpv4Compat = true; // if it starts with 80 unset bits
+      for (int i = 0; i < 10; i++) {
+        if (addressBytes[i] != 0) {
+          maybeIpv4Compat = false;
+          break;
+        }
+      }
+      if (maybeIpv4Compat) {
+        ByteBuffer buffer = ByteBuffer.wrap(addressBytes, 10, 6);
+        short flag = buffer.getShort();
+        if (flag == 0 || flag == -1) { // IPv4-Compatible or IPv4-Mapped
+          builder.ipv4(buffer.getInt());
+        } else {
+          builder.ipv6(addressBytes);
+        }
+      } else {
+        builder.ipv6(addressBytes);
+      }
+    } else {
+      return; // invalid
+    }
+    try {
+      int port = parsePort(input);
+      if (port > 0) builder.port(port);
+    } catch (RuntimeException ignore) {
+      // still store the ip address
+    }
+    Endpoint ca = builder.build();
+
+    // Internally, ServerTracer locks on span when adding an address. let's do that, too
+    synchronized (span) {
+      span.addToBinary_annotations(BinaryAnnotation.address(CLIENT_ADDR, ca));
+    }
+  }
+
+  /**
+   * Returns the 4 byte ipv4 address or the 16-byte ipv6 address associated with the input type.
+   *
+   * <pre>{@code
+   * byte[] addressBytes = ipStringToBytes(input.getHeader("X-Forwarded-For"));
+   * if (addressBytes == null) addressBytes = ipStringToBytes(input.getRemoteAddr());
+   * return addressBytes;
+   * }</pre>
+   */
+  protected abstract byte[] parseAddressBytes(T input);
+
+  /** Returns port associated with the input or <=0 if unreadable. */
+  protected abstract int parsePort(T input);
+
+  /**
+   * Returns the {@link InetAddress#getAddress()} having the given string representation or null if
+   * unable to parse.
+   *
+   * <p>This deliberately avoids all nameservice lookups (e.g. no DNS).
+   *
+   * @param ipString {@code String} containing an IPv4 or IPv6 string literal, e.g. {@code
+   * "192.168.0.1"} or {@code "2001:db8::1"}
+   */
+  @Nullable
+  protected byte[] ipStringToBytes(String ipString) {
+    return InetAddresses.ipStringToBytes(ipString);
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
@@ -1,0 +1,301 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.twitter.zipkin.gen.Span;
+import java.net.Inet6Address;
+import java.net.UnknownHostException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public final class MaybeAddClientAddressTest {
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  ServerSpan serverSpan;
+  Span span = new Span();
+  @Mock
+  Brave brave;
+  @Mock
+  ServerSpanThreadBinder threadBinder;
+
+  @Before
+  public void setup(){
+    when(brave.serverSpanThreadBinder()).thenReturn(threadBinder);
+  }
+
+  @Test
+  public void kickOutIfNoServerSpan() {
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        throw new AssertionError();
+      }
+
+      @Override protected int parsePort(Object input) {
+        throw new AssertionError();
+      }
+    };
+
+    // shouldn't throw exceptions
+    function.accept(new Object());
+  }
+
+  @Test
+  public void kickOutIfNoServerSpan_Span() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        throw new AssertionError();
+      }
+
+      @Override protected int parsePort(Object input) {
+        throw new AssertionError();
+      }
+    };
+
+    // shouldn't throw exceptions
+    function.accept(new Object());
+  }
+
+  @Test
+  public void kickOutIfExceptionParsingAddress() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        throw new IllegalStateException();
+      }
+
+      @Override protected int parsePort(Object input) {
+        throw new AssertionError();
+      }
+    };
+
+    function.accept(new Object());
+
+    // shouldn't add to span
+    assertThat(span.getBinary_annotations()).isEmpty();
+  }
+
+  @Test
+  public void kickOutIfNullAddress() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return null;
+      }
+
+      @Override protected int parsePort(Object input) {
+        throw new AssertionError();
+      }
+    };
+
+    function.accept(new Object());
+
+    // shouldn't add to span
+    assertThat(span.getBinary_annotations()).isEmpty();
+  }
+
+  @Test
+  public void kickOutIfInvalidAddress() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return new byte[] {1, 2, 3, 4, 5};
+      }
+
+      @Override protected int parsePort(Object input) {
+        throw new AssertionError();
+      }
+    };
+
+    function.accept(new Object());
+
+    // shouldn't add to span
+    assertThat(span.getBinary_annotations()).isEmpty();
+  }
+
+  @Test
+  public void ignoreExceptionParsingPort() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return new byte[] {1, 2, 3, 4};
+      }
+
+      @Override protected int parsePort(Object input) {
+        throw new IllegalStateException();
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+  }
+
+  // don't clutter the UI with bad client service names. we can revisit this topic later.
+  @Test
+  public void usesBlankServiceName() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return new byte[] {1, 2, 3, 4};
+      }
+
+      @Override protected int parsePort(Object input) {
+        return -1;
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.service_name)
+        .containsExactly("");
+  }
+
+  @Test
+  public void addsPort() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return new byte[] {1, 2, 3, 4};
+      }
+
+      @Override protected int parsePort(Object input) {
+        return 8080;
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.port)
+        .containsExactly((short) 8080);
+  }
+
+  @Test
+  public void ignoresNegativePort() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return new byte[] {1, 2, 3, 4};
+      }
+
+      @Override protected int parsePort(Object input) {
+        return -1;
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.port)
+        .containsNull();
+  }
+
+  @Test
+  public void acceptsIpv6() throws UnknownHostException {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    final byte[] ipv6 = Inet6Address.getByName("2001:db8::c001").getAddress();
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return ipv6;
+      }
+
+      @Override protected int parsePort(Object input) {
+        return -1;
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(0);
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv6)
+        .containsExactly(ipv6);
+  }
+
+  @Test
+  public void acceptsIpv4MappedIpV6Address() throws UnknownHostException {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return InetAddresses.ipStringToBytes("::ffff:1.2.3.4");
+      }
+
+      @Override protected int parsePort(Object input) {
+        return -1;
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv6)
+        .containsNull();
+  }
+
+  @Test
+  public void acceptsIpv4CompatIpV6Address() throws UnknownHostException {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+
+    MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
+      @Override protected byte[] parseAddressBytes(Object input) {
+        return InetAddresses.ipStringToBytes("::0000:1.2.3.4");
+      }
+
+      @Override protected int parsePort(Object input) {
+        return -1;
+      }
+    };
+
+    function.accept(new Object());
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv6)
+        .containsNull();
+  }
+}

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/BraveGrpcServerInterceptor.java
@@ -53,10 +53,12 @@ public final class BraveGrpcServerInterceptor implements ServerInterceptor {
 
     private final ServerRequestInterceptor serverRequestInterceptor;
     private final ServerResponseInterceptor serverResponseInterceptor;
+    private final MaybeAddClientAddressFromAttributes maybeAddClientAddressFromAttributes;
 
     BraveGrpcServerInterceptor(Builder b) { // intentionally hidden
         this.serverRequestInterceptor = b.brave.serverRequestInterceptor();
         this.serverResponseInterceptor = b.brave.serverResponseInterceptor();
+        this.maybeAddClientAddressFromAttributes = new MaybeAddClientAddressFromAttributes(b.brave);
     }
 
     /**
@@ -64,8 +66,7 @@ public final class BraveGrpcServerInterceptor implements ServerInterceptor {
      */
     @Deprecated
     public BraveGrpcServerInterceptor(Brave brave) {
-        this.serverRequestInterceptor = checkNotNull(brave.serverRequestInterceptor());
-        this.serverResponseInterceptor = checkNotNull(brave.serverResponseInterceptor());
+        this(builder(brave));
     }
 
     @Override
@@ -75,6 +76,7 @@ public final class BraveGrpcServerInterceptor implements ServerInterceptor {
             @Override
             public void request(int numMessages) {
                 serverRequestInterceptor.handle(new GrpcServerRequestAdapter<>(call, requestHeaders));
+                maybeAddClientAddressFromAttributes.accept(call.attributes());
                 super.request(numMessages);
             }
 

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/GrpcKeys.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/GrpcKeys.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.grpc;
 
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import io.grpc.Status;
+import zipkin.Constants;
 
 /** Well-known {@link BinaryAnnotation#key binary annotation keys} for gRPC */
 public final class GrpcKeys {
@@ -15,7 +16,10 @@ public final class GrpcKeys {
 
     /**
      * The remote address of the client
+     *
+     * @deprecated see {@link Constants#CLIENT_ADDR}
      */
+    @Deprecated
     public static final String GRPC_REMOTE_ADDR = "grpc.remote_addr";
 
     private GrpcKeys() {

--- a/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/MaybeAddClientAddressFromAttributes.java
+++ b/brave-grpc/src/main/java/com/github/kristofa/brave/grpc/MaybeAddClientAddressFromAttributes.java
@@ -1,0 +1,32 @@
+package com.github.kristofa.brave.grpc;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.internal.MaybeAddClientAddress;
+import io.grpc.Attributes;
+import io.grpc.ServerCall;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import zipkin.Constants;
+
+/**
+ * Parses the {@link Constants#CLIENT_ADDR client address}, by looking at "X-Forwarded-For", then
+ * the remote address of the headers. This performs no DNS lookups.
+ */
+final class MaybeAddClientAddressFromAttributes extends MaybeAddClientAddress<Attributes> {
+
+  MaybeAddClientAddressFromAttributes(Brave brave) { // intentionally hidden
+    super(brave);
+  }
+
+  @Override protected byte[] parseAddressBytes(Attributes input) {
+    SocketAddress address = input.get(ServerCall.REMOTE_ADDR_KEY);
+    if (!(address instanceof InetSocketAddress)) return null;
+    return ((InetSocketAddress) address).getAddress().getAddress();
+  }
+
+  @Override protected int parsePort(Attributes input) {
+    SocketAddress address = input.get(ServerCall.REMOTE_ADDR_KEY);
+    if (!(address instanceof InetSocketAddress)) return 0;
+    return ((InetSocketAddress) address).getPort();
+  }
+}

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import zipkin.Constants;
 
 public class BraveGrpcInterceptorsTest {
 
@@ -181,6 +182,12 @@ public class BraveGrpcInterceptorsTest {
             .filteredOn(b -> b.key.equals(GrpcKeys.GRPC_REMOTE_ADDR))
             .extracting(b -> new String(b.value))
             .has(new Condition<>(b -> b.matches("^/127.0.0.1:[\\d]+$"), "a local IP address"), atIndex(0));
+
+        //Server spans should have the client address binary annotation
+        assertThat(serverSpan.getBinary_annotations())
+            .filteredOn(b -> b.key.equals(Constants.CLIENT_ADDR))
+            .extracting(b -> b.host.port)
+            .doesNotContainNull(); // if we got a port, we also got an ipv4 or ipv6
 
         validateSpan(spans.get(1), Arrays.asList("cs", "cr"));
     }

--- a/brave-spring-web-servlet-interceptor/pom.xml
+++ b/brave-spring-web-servlet-interceptor/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
      <dependency>
         <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave-http</artifactId>
+        <artifactId>brave-web-servlet-filter</artifactId>
         <version>3.16.1-SNAPSHOT</version>
      </dependency>
      <dependency>

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ITBraveServletHandlerInterceptor.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ITBraveServletHandlerInterceptor.java
@@ -16,6 +16,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class ITBraveServletHandlerInterceptor {
@@ -88,6 +89,9 @@ public class ITBraveServletHandlerInterceptor {
             assertEquals("Expected service name.",
                 serverSpan.getAnnotations().get(0).host.service_name, "braveservletinterceptorintegration");
 
+            // make sure client address is added!
+            assertThat(serverSpan.getBinary_annotations()).filteredOn(b -> b.getKey().equals("ca"))
+                .isNotEmpty();
         } finally {
             connection.disconnect();
         }

--- a/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/ServletHttpServerRequest.java
+++ b/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/ServletHttpServerRequest.java
@@ -21,11 +21,7 @@ public class ServletHttpServerRequest implements HttpServerRequest {
 
     @Override
     public URI getUri() {
-        try {
-            return new URI(request.getRequestURI());
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return URI.create(request.getRequestURI());
     }
 
     @Override

--- a/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequest.java
+++ b/brave-web-servlet-filter/src/main/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequest.java
@@ -1,0 +1,35 @@
+package com.github.kristofa.brave.servlet.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerResponseInterceptor;
+import com.github.kristofa.brave.internal.MaybeAddClientAddress;
+import javax.servlet.http.HttpServletRequest;
+import zipkin.Constants;
+
+/**
+ * Parses the {@link Constants#CLIENT_ADDR client address}, by looking at "X-Forwarded-For", then
+ * the remote address of the request. This performs no DNS lookups.
+ *
+ * <p>This is a hack as {@link ServerResponseInterceptor} doesn't yet support client addresses.
+ */
+public final class MaybeAddClientAddressFromRequest
+    extends MaybeAddClientAddress<HttpServletRequest> {
+
+  public static MaybeAddClientAddressFromRequest create(Brave brave) {
+    return new MaybeAddClientAddressFromRequest(brave);
+  }
+
+  MaybeAddClientAddressFromRequest(Brave brave) { // intentionally hidden
+    super(brave);
+  }
+
+  @Override protected byte[] parseAddressBytes(HttpServletRequest input) {
+    byte[] addressBytes = ipStringToBytes(input.getHeader("X-Forwarded-For"));
+    if (addressBytes == null) addressBytes = ipStringToBytes(input.getRemoteAddr());
+    return addressBytes;
+  }
+
+  @Override protected int parsePort(HttpServletRequest input) {
+    return input.getRemotePort();
+  }
+}

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/ITBraveServletFilter.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.EnumSet;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -115,6 +116,9 @@ public class ITBraveServletFilter {
             assertEquals("Expected service name.",
                 serverSpan.getAnnotations().get(0).host.service_name, "braveservletfilterservice");
 
+            // make sure client address is added!
+            assertThat(serverSpan.getBinary_annotations()).filteredOn(b -> b.getKey().equals("ca"))
+                .isNotEmpty();
         } finally {
             connection.disconnect();
         }

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.kristofa.brave.servlet.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerSpan;
+import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.twitter.zipkin.gen.Span;
+import java.net.Inet6Address;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public final class MaybeAddClientAddressFromRequestTest {
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  HttpServletRequest request;
+  @Mock
+  ServerSpan serverSpan;
+  Span span = new Span();
+  @Mock
+  Brave brave;
+  @Mock
+  ServerSpanThreadBinder threadBinder;
+  MaybeAddClientAddressFromRequest addressFunction;
+
+  @Before
+  public void setup() {
+    when(brave.serverSpanThreadBinder()).thenReturn(threadBinder);
+    addressFunction = new MaybeAddClientAddressFromRequest(brave);
+  }
+
+  @Test
+  public void kickOutIfXForwardedForAndRemoteAddrAreInvalid() {
+    for (String invalid : Arrays.asList(null, "unknown", "999.999.999")) {
+      when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+      when(serverSpan.getSpan()).thenReturn(span);
+      when(request.getHeader("X-Forwarded-For")).thenReturn(invalid);
+      when(request.getRemoteAddr()).thenReturn(invalid);
+
+      // shouldn't throw exceptions
+      addressFunction.accept(request);
+
+      // shouldn't add anything to the span
+      assertThat(span.getBinary_annotations())
+          .isEmpty();
+    }
+  }
+
+  @Test
+  public void fallbackToRemoteAddrWhenXForwardedForIsInvalid() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("unknown");
+    when(request.getRemoteAddr()).thenReturn("1.2.3.4");
+
+    addressFunction.accept(request);
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+  }
+
+  @Test
+  public void prefersXForwardedFor() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
+    when(request.getRemoteAddr()).thenReturn("5.6.7.8");
+
+    addressFunction.accept(request);
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+  }
+
+  @Test
+  public void parsesIpv6() throws UnknownHostException {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("2001:db8::c001");
+
+    addressFunction.accept(request);
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv6)
+        .containsExactly(Inet6Address.getByName("2001:db8::c001").getAddress());
+  }
+
+  @Test
+  public void parsesIpv4MappedIpV6Address() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("::ffff:1.2.3.4");
+
+    addressFunction.accept(request);
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+  }
+
+  @Test
+  public void parsesIpv4CompatIpV6Address() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("::0000:1.2.3.4");
+
+    addressFunction.accept(request);
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+  }
+
+  @Test
+  public void addsRemotePort() {
+    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
+    when(serverSpan.getSpan()).thenReturn(span);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
+    when(request.getRemotePort()).thenReturn(124);
+
+    addressFunction.accept(request);
+
+    assertThat(span.getBinary_annotations()).extracting(b -> b.host.port)
+        .containsExactly((short) 124);
+  }
+}

--- a/brave-web-servlet-filter/src/test/resources/log4j2.properties
+++ b/brave-web-servlet-filter/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders = console
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
This adds the client address to servlet-based instrumentation. This does
so without breaking any apis, by directly modifying the span.

The address heuristic is widely used:
* Prefer `X-Forwarded-For` (which returns the origin's IP)
* Fallback to `ServletRequest.getRemoteAddr()`

This also adds the client address for gRPC using
* `ServerCall.REMOTE_ADDR_KEY`

This doesn't use anything expensive to derive the values. For example,
it doesn't use DNS, nor does it attempt to pick a nice, low cardinality
client service name. This intentionally avoids all of this to get a
working implementation out, which people can use today.

The heaviest lifting of this code was done by copying a method from
guava, notably `com.google.common.net.InetAddresses.ipStringToBytes()`
which was cited in the source comments.

See #264 (for servlet customizations)
See #205 (for generic hook for client address, which this doesn't solve)
See #108 (original request for X-Forwarded-For)