### PR TITLE
Renames parent from brave to brave-parent

### DIFF
--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
   <artifactId>brave-apache-http-interceptors</artifactId>

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
 

--- a/brave-core-spring/pom.xml
+++ b/brave-core-spring/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
   

--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
 

--- a/brave-cxf3/pom.xml
+++ b/brave-cxf3/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <groupId>io.zipkin.brave</groupId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>

--- a/brave-grpc/pom.xml
+++ b/brave-grpc/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/brave-http-tests/pom.xml
+++ b/brave-http-tests/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <groupId>io.zipkin.brave</groupId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>

--- a/brave-http/pom.xml
+++ b/brave-http/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>
 

--- a/brave-jaxrs2/pom.xml
+++ b/brave-jaxrs2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/brave-jersey/pom.xml
+++ b/brave-jersey/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/brave-mysql/pom.xml
+++ b/brave-mysql/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/brave-okhttp/pom.xml
+++ b/brave-okhttp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <groupId>io.zipkin.brave</groupId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>

--- a/brave-p6spy/pom.xml
+++ b/brave-p6spy/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<groupId>io.zipkin.brave</groupId>
-	<artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>   
   

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<groupId>io.zipkin.brave</groupId>
-	<artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>   
   

--- a/brave-sampler-zookeeper/pom.xml
+++ b/brave-sampler-zookeeper/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
   

--- a/brave-spancollector-http/pom.xml
+++ b/brave-spancollector-http/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>
 

--- a/brave-spancollector-kafka/pom.xml
+++ b/brave-spancollector-kafka/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>
 

--- a/brave-spancollector-local/pom.xml
+++ b/brave-spancollector-local/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>
 

--- a/brave-spancollector-scribe/pom.xml
+++ b/brave-spancollector-scribe/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<groupId>io.zipkin.brave</groupId>
-	<artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>   
   

--- a/brave-spring-resttemplate-interceptors/pom.xml
+++ b/brave-spring-resttemplate-interceptors/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
   

--- a/brave-spring-web-servlet-interceptor/pom.xml
+++ b/brave-spring-web-servlet-interceptor/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave</artifactId>
+    <artifactId>brave-parent</artifactId>
     <version>3.16.1-SNAPSHOT</version>
   </parent>
   

--- a/brave-web-servlet-filter/pom.xml
+++ b/brave-web-servlet-filter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>brave</artifactId>
+        <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
         <version>3.16.1-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin.brave</groupId>
-  <artifactId>brave</artifactId>
+  <artifactId>brave-parent</artifactId>
   <version>3.16.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>brave</name>
+  <name>Brave (parent)</name>
   <description>
   Java implementation of Dapper (http://research.google.com/pubs/pub36356.html) compatible with Zipkin (https://github.com/twitter/zipkin/).
   </description>


### PR DESCRIPTION
The root pom was squatting on a nice artifact name. This unlocks it.

See #180