### PR TITLE
Starts decoupling from old span type; untangles ServerRequestInterceptor

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -139,7 +139,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
             }
         }
 
-        Span newSpan = newSpanId.toSpan();
+        Span newSpan = Span.fromSpanId(newSpanId);
         newSpan.setName(requestName);
         spanAndEndpoint().state().setCurrentClientSpan(newSpan);
         return newSpanId;

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -169,7 +169,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
             }
         }
 
-        Span newSpan = newSpanId.toSpan();
+        Span newSpan = Span.fromSpanId(newSpanId);
         newSpan.setName(operation);
         newSpan.setTimestamp(timestamp);
         newSpan.addToBinary_annotations(

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -5,8 +5,6 @@ import com.google.auto.value.AutoValue;
 
 import com.twitter.zipkin.gen.Span;
 
-import static com.github.kristofa.brave.internal.Util.checkNotNull;
-
 /**
  * The ServerSpan is initialized by {@link ServerTracer} and keeps track of Trace/Span state of our service request.
  *
@@ -15,8 +13,11 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
 @AutoValue
 public abstract class ServerSpan {
 
-    public static final ServerSpan EMPTY = new AutoValue_ServerSpan(null, null);
-    static final ServerSpan NOT_SAMPLED = new AutoValue_ServerSpan(null, false);
+    public static final ServerSpan EMPTY = new AutoValue_ServerSpan(null, null, null);
+    static final ServerSpan NOT_SAMPLED = new AutoValue_ServerSpan(null, null, false);
+
+    @Nullable
+    abstract SpanId spanId();
 
     /**
      * Gets the Trace/Span context.
@@ -36,8 +37,10 @@ public abstract class ServerSpan {
     @Nullable
     public abstract Boolean getSample();
 
-    static ServerSpan create(Span span) {
-        return new AutoValue_ServerSpan(checkNotNull(span, "span"), true);
+    static ServerSpan create(SpanId spanId, String name) {
+        if (spanId == null) throw new NullPointerException("spanId == null");
+        if (name == null) throw new NullPointerException("name == null");
+        return new AutoValue_ServerSpan(spanId, Span.fromSpanId(spanId).setName(name), true);
     }
 
     ServerSpan(){

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -100,7 +100,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      */
     public void setStateCurrentTrace(SpanId spanId, String spanName) {
         checkNotBlank(spanName, "Null or blank span name");
-        ServerSpan span = ServerSpan.create(spanId.toSpan().setName(spanName));
+        ServerSpan span = ServerSpan.create(spanId, spanName);
         spanAndEndpoint().state().setCurrentServerSpan(span);
     }
 

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -1,5 +1,6 @@
 package com.twitter.zipkin.gen;
 
+import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.internal.Util;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -272,6 +273,17 @@ public class Span implements Serializable {
   @Override
   public String toString() {
     return new String(SpanCodec.JSON.writeSpan(this), Util.UTF_8);
+  }
+
+  public static Span fromSpanId(SpanId spanId) {
+    Span result = new Span();
+    result.setTrace_id_high(spanId.traceIdHigh);
+    result.setTrace_id(spanId.traceId);
+    result.setParent_id(spanId.nullableParentId());
+    result.setId(spanId.spanId);
+    result.setName(""); // avoid NPE on equals
+    if (spanId.debug()) result.setDebug(true);
+    return result;
   }
 
   /** Changes this to a zipkin-native span object. */

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -171,7 +171,7 @@ public class ClientTracerTest {
         assertNull(newSpanId.nullableParentId());
 
         assertEquals(
-                SpanId.builder().spanId(TRACE_ID).build().toSpan().setName(REQUEST_NAME),
+                Span.fromSpanId(SpanId.builder().spanId(TRACE_ID).build()).setName(REQUEST_NAME),
                 state.getCurrentClientSpan()
         );
 
@@ -182,7 +182,7 @@ public class ClientTracerTest {
 
     @Test
     public void testStartNewSpanSampleTruePartOfExistingSpan() {
-        final ServerSpan parentSpan = ServerSpan.create(PARENT_SPAN_ID.toSpan().setName("name"));
+        final ServerSpan parentSpan = ServerSpan.create(PARENT_SPAN_ID, "name");
         state.setCurrentServerSpan(parentSpan);
         when(mockRandom.nextLong()).thenReturn(1L);
 
@@ -193,7 +193,7 @@ public class ClientTracerTest {
         assertEquals(PARENT_SPAN_ID.spanId, newSpanId.parentId);
 
         assertEquals(
-                newSpanId.toSpan().setName(REQUEST_NAME),
+                Span.fromSpanId(newSpanId).setName(REQUEST_NAME),
                 state.getCurrentClientSpan()
         );
 
@@ -252,7 +252,7 @@ public class ClientTracerTest {
     @Test
     public void startNewSpan_whenParentHas128bitTraceId() {
         ServerSpan parentSpan = ServerSpan.create(
-            PARENT_SPAN_ID.toBuilder().traceIdHigh(3).build().toSpan().setName("name"));
+            PARENT_SPAN_ID.toBuilder().traceIdHigh(3).build(), "name");
         state.setCurrentServerSpan(parentSpan);
         when(mockRandom.nextLong()).thenReturn(1L);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -66,7 +66,7 @@ public class LocalTracerTest {
      */
     @Test
     public void startNewSpan() {
-        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID.toSpan().setName("name")));
+        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID, "name"));
 
         PowerMockito.when(System.currentTimeMillis()).thenReturn(1L);
         PowerMockito.when(System.nanoTime()).thenReturn(500L);
@@ -97,7 +97,7 @@ public class LocalTracerTest {
      */
     @Test
     public void startSpan_userSuppliedTimestamp() {
-        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID.toSpan().setName("name")));
+        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID, "name"));
 
         localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME, 1000L);
 
@@ -116,7 +116,7 @@ public class LocalTracerTest {
     }
 
     /**
-     * When finish is called without a duration, the startTick from start is used in duration calculation.
+     * When receive is called without a duration, the startTick from start is used in duration calculation.
      * <p>
      * <p/>Ex.
      * <pre>
@@ -258,7 +258,7 @@ public class LocalTracerTest {
                 .build();
 
         assertNull(localTracer.getNewSpanParent());
-        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID.toSpan().setName("name")));
+        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID, "name"));
 
         SpanId span1 = localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME);
         assertEquals(PARENT_SPAN_ID.toBuilder().spanId(555L).parentId(PARENT_SPAN_ID.spanId).build(), span1);
@@ -285,7 +285,7 @@ public class LocalTracerTest {
                 .build();
 
         assertNull(localTracer.getNewSpanParent());
-        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID.toSpan().setName("name")));
+        state.setCurrentServerSpan(ServerSpan.create(PARENT_SPAN_ID, "name"));
 
         SpanId span1 = localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME);
         assertEquals(PARENT_SPAN_ID.toBuilder().spanId(555L).parentId(PARENT_SPAN_ID.spanId).build(), span1);
@@ -305,7 +305,7 @@ public class LocalTracerTest {
     @Test
     public void startNewSpan_whenParentHas128bitTraceId() {
         ServerSpan parentSpan = ServerSpan.create(
-            PARENT_SPAN_ID.toBuilder().traceIdHigh(3).build().toSpan().setName("name"));
+            PARENT_SPAN_ID.toBuilder().traceIdHigh(3).build(), "name");
         state.setCurrentServerSpan(parentSpan);
         when(mockRandom.nextLong()).thenReturn(1L);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanTest.java
@@ -19,7 +19,7 @@ public class ServerSpanTest {
 
     @Before
     public void setup() {
-        serverSpan = ServerSpan.create(SPAN_ID.toSpan().setName(NAME));
+        serverSpan = ServerSpan.create(SPAN_ID, NAME);
     }
 
     @Test
@@ -36,7 +36,7 @@ public class ServerSpanTest {
 
     @Test
     public void testGetSpan_128() {
-        serverSpan = ServerSpan.create(SPAN_ID.toSpan().setTrace_id_high(5).setName(NAME));
+        serverSpan = ServerSpan.create(SPAN_ID.toBuilder().traceIdHigh(5).build(), NAME);
 
         Span span = serverSpan.getSpan();
         assertEquals(5, span.getTrace_id_high());
@@ -51,13 +51,13 @@ public class ServerSpanTest {
     @Test
     public void testEqualsObject() {
 
-        ServerSpan equalServerSpan = ServerSpan.create(SPAN_ID.toSpan().setName(NAME));
+        ServerSpan equalServerSpan = ServerSpan.create(SPAN_ID, NAME);
         assertTrue(serverSpan.equals(equalServerSpan));
     }
 
     @Test
     public void testHashCode() {
-        ServerSpan equalServerSpan = ServerSpan.create(SPAN_ID.toSpan().setName(NAME));
+        ServerSpan equalServerSpan = ServerSpan.create(SPAN_ID, NAME);
         Assert.assertEquals(serverSpan.hashCode(), equalServerSpan.hashCode());
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -73,7 +73,7 @@ public class ServerTracerTest {
     @Test
     public void testSetStateCurrentTrace() {
         serverTracer.setStateCurrentTrace(SPAN_ID, SPAN_NAME);
-        ServerSpan expectedServerSpan = ServerSpan.create(SPAN_ID.toSpan().setName(SPAN_NAME));
+        ServerSpan expectedServerSpan = ServerSpan.create(SPAN_ID, SPAN_NAME);
         verify(mockServerSpanState).setCurrentServerSpan(expectedServerSpan);
         verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
     }
@@ -93,7 +93,7 @@ public class ServerTracerTest {
 
         serverTracer.setStateUnknown(SPAN_NAME);
         ServerSpan expectedServerSpan = ServerSpan.create(
-            SpanId.builder().spanId(TRACE_ID).build().toSpan().setName(SPAN_NAME));
+            SpanId.builder().spanId(TRACE_ID).build(), SPAN_NAME);
 
         final InOrder inOrder = inOrder(mockSampler, mockRandom, mockServerSpanState);
 
@@ -116,7 +116,7 @@ public class ServerTracerTest {
         ServerSpan expectedServerSpan = ServerSpan.create(SpanId.builder()
             .traceIdHigh(TRACE_ID + 1)
             .traceId(TRACE_ID)
-            .spanId(TRACE_ID).build().toSpan().setName(SPAN_NAME));
+            .spanId(TRACE_ID).build(), SPAN_NAME);
 
         final InOrder inOrder = inOrder(mockSampler, mockRandom, mockServerSpanState);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
@@ -206,9 +206,16 @@ public class SpanIdTest {
         .isEqualTo("00000000000000010000000000000002");
   }
 
-
   @Test
   public void serializeRoundTrip_128() {
+    SpanId id = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
+
+    assertThat(SpanId.fromBytes(id.bytes()))
+        .isEqualTo(id);
+  }
+
+  @Test
+  public void creatingAChildInvalidatesShared() {
     SpanId id = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
 
     assertThat(SpanId.fromBytes(id.bytes()))
@@ -219,7 +226,7 @@ public class SpanIdTest {
   public void toSpan_128() {
     SpanId id = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
 
-    Span span = id.toSpan();
+    Span span = Span.fromSpanId(id);
     assertThat(span.getTrace_id_high()).isEqualTo(id.traceIdHigh);
     assertThat(span.getTrace_id()).isEqualTo(id.traceId);
     assertThat(span.getId()).isEqualTo(id.spanId);

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
@@ -143,8 +143,9 @@ public class BraveGrpcInterceptorsTest {
 
     @Test
     public void propagatesAndReads128BitTraceId() throws Exception {
-        SpanId spanId = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
-        brave.localSpanThreadBinder().setCurrentSpan(spanId.toSpan().setName("myop"));
+        Span span =
+            new Span().setTrace_id_high(1).setTrace_id(2).setId(3).setParent_id(2L).setName("myop");
+        brave.localSpanThreadBinder().setCurrentSpan(span);
         GreeterBlockingStub stub = GreeterGrpc.newBlockingStub(channel);
         //This call will be made using hte context of the localTracer as it's parent
         HelloReply reply = stub.sayHello(HELLO_REQUEST);
@@ -155,12 +156,12 @@ public class BraveGrpcInterceptorsTest {
             .filter(s -> s.getAnnotations().stream().anyMatch(a -> "ss".equals(a.value)))
             .findFirst();
         assertTrue("Could not find expected server span", maybeSpan.isPresent());
-        Span span = maybeSpan.get();
+        Span result = maybeSpan.get();
 
         //Verify that the 128-bit trace id and span id were propagated to the server
-        assertThat(span.getTrace_id_high()).isEqualTo(spanId.traceIdHigh);
-        assertThat(span.getTrace_id()).isEqualTo(spanId.traceId);
-        assertThat(span.getParent_id()).isEqualTo(spanId.spanId);
+        assertThat(result.getTrace_id_high()).isEqualTo(span.getTrace_id_high());
+        assertThat(result.getTrace_id()).isEqualTo(span.getTrace_id());
+        assertThat(result.getParent_id()).isEqualTo(span.getId());
     }
 
     /**


### PR DESCRIPTION
This is a cleanup commit.

Before, it was more difficult to understand what was going on in the
`ServerRequestInterceptor` because of the nesting level. This uses early
returns to untangle some of it.

This also starts moving code away from the old gen.Span type.