### PR TITLE
New core api (Brave 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ You can use brave if you use the JVM and:
 *   You don't want to add Scala as a dependency to your Java project.
 *   You want out of the box integration support for [RESTEasy](http://resteasy.jboss.org), [Jersey](https://jersey.java.net), [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.3.x/index.html).
 
-Brave is compatible with OpenZipkin and its back-end components (zipkin-collector, zipkin-query, zipkin-web). 
+Brave is compatible with OpenZipkin backends such as [zipkin-server](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md)
+
+A deep dive on Brave's api can be found [here](brave/README.md)
 
 ## Maven artifacts ##
 
@@ -29,3 +31,6 @@ Maven artifacts for each release are published to Maven Central.
 
 For an overview of the available releases see [Github releases](https://github.com/kristofa/brave/releases).
 As of release 2.0 we try to stick to [Semantic Versioning](http://semver.org).
+
+Brave was redesigned starting with version 4. Please see the
+[README](brave/README.md) for details on how to use Brave's Tracer.

--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>brave-apache-http-interceptors</artifactId>
   <name>brave-apache-http-interceptors</name>

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-benchmarks</artifactId>
@@ -26,6 +26,12 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>${jmh.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/brave-benchmarks/src/main/java/brave/SpanCreationBenchmarks.java
+++ b/brave-benchmarks/src/main/java/brave/SpanCreationBenchmarks.java
@@ -1,0 +1,144 @@
+package brave;
+
+import brave.internal.recorder.Recorder;
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.LocalTracer;
+import com.twitter.zipkin.gen.Endpoint;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import zipkin.Constants;
+import zipkin.TraceKeys;
+import zipkin.reporter.Reporter;
+
+import static brave.Span.Kind.CLIENT;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class SpanCreationBenchmarks {
+
+  Tracer tracer;
+  Recorder recorder;
+  Clock clock;
+  Brave brave;
+
+  @Setup
+  public void setup() {
+    // real everything except reporting
+    tracer = Tracer.newBuilder()
+        .reporter(Reporter.NOOP)
+        .build();
+    recorder = tracer.recorder;
+    clock = tracer.clock;
+    brave = new Brave.Builder()
+        .reporter(Reporter.NOOP)
+        .build();
+  }
+
+  @Benchmark
+  public LocalTracer simpleRootSpan_brave3() {
+    LocalTracer tracer = brave.localTracer();
+    tracer.startNewSpan("codec", "encode");
+    try {
+      return tracer; // pretend we are doing codec work
+    } finally {
+      tracer.finishSpan();
+    }
+  }
+
+  @Benchmark
+  public ClientTracer elaborateSpan_brave3() {
+    ClientTracer tracer = brave.clientTracer();
+
+    tracer.startNewSpan("getOrCreate");
+    tracer.submitBinaryAnnotation("clnt/finagle.version", "6.36.0");
+    tracer.submitBinaryAnnotation(TraceKeys.HTTP_PATH, "/api");
+
+    tracer.setClientSent(Endpoint.builder() // implicit start
+        .serviceName("backend")
+        .ipv4(127 << 24 | 1)
+        .port(8080).build());
+    tracer.submitAnnotation(Constants.WIRE_SEND);
+    tracer.submitAnnotation(Constants.WIRE_RECV);
+    tracer.setClientReceived(); // implicit finish
+
+    return tracer;
+  }
+
+  @Benchmark
+  public Span simpleRootSpan_brave4() {
+    try (Span span = tracer.newTrace().name("encode").start()) {
+      // pretend we are doing codec work
+      return span; // to satisfy the signature
+    }
+  }
+
+  @Benchmark
+  public Span elaborateSpan_brave4() {
+    Span span = tracer.newTrace().kind(CLIENT).name("getOrCreate");
+
+    span.tag("clnt/finagle.version", "6.36.0");
+    span.tag(TraceKeys.HTTP_PATH, "/api");
+    span.remoteEndpoint(zipkin.Endpoint.builder()
+        .serviceName("backend")
+        .ipv4(127 << 24 | 1)
+        .port(8080).build());
+
+    span.start();
+    span.annotate(Constants.WIRE_SEND);
+    span.annotate(Constants.WIRE_RECV);
+    span.finish();
+
+    return span;
+  }
+
+  @Benchmark
+  public Recorder simpleRootSpan_brave4_recorder() {
+    TraceContext context = tracer.nextContext(null, SamplingFlags.SAMPLED);
+    recorder.name(context, "encode");
+    recorder.start(context, clock.currentTimeMicroseconds());
+    recorder.finish(context, clock.currentTimeMicroseconds());
+    return recorder;
+  }
+
+  @Benchmark
+  public Recorder elaborateSpan_brave4_recorder() {
+    TraceContext context = tracer.nextContext(null, SamplingFlags.SAMPLED);
+    recorder.kind(context, CLIENT);
+    recorder.name(context, "getOrCreate");
+    recorder.tag(context, "clnt/finagle.version", "6.36.0");
+    recorder.tag(context, TraceKeys.HTTP_PATH, "/api");
+    recorder.remoteEndpoint(context, zipkin.Endpoint.builder()
+        .serviceName("backend")
+        .ipv4(127 << 24 | 1)
+        .port(8080).build());
+
+    recorder.start(context, clock.currentTimeMicroseconds());
+    recorder.annotate(context, clock.currentTimeMicroseconds(), Constants.WIRE_SEND);
+    recorder.annotate(context, clock.currentTimeMicroseconds(), Constants.WIRE_RECV);
+    recorder.finish(context, clock.currentTimeMicroseconds());
+
+    return recorder;
+  }
+
+  @Benchmark
+  public Span newTrace_brave4() {
+    return tracer.newTrace();
+  }
+  // TODO: add comparisons for joinSpan (ex server collaborates with client-originated span
+}

--- a/brave-core-spring/pom.xml
+++ b/brave-core-spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>brave-core-spring</artifactId>

--- a/brave-core/README.md
+++ b/brave-core/README.md
@@ -1,5 +1,8 @@
-# brave-core #
+# Deprecation Notice
+Brave was redesigned starting with version 4. Please see the
+[README](../brave/README.md) for details on how to use Brave's Tracer.
 
+# Brave Api (version 3)
 brave-core contains the core brave implementations used to set up and keep track of
 tracing state. 
 

--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-core</artifactId>
@@ -60,7 +60,12 @@
         <version>3.1.2</version>
         <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
     <!-- for testing SpanId -->
     <dependency>
       <groupId>com.twitter</groupId>

--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -151,6 +151,18 @@ public class Brave {
             return this;
         }
 
+        /** Internal hook */
+        Builder spanFactory(SpanFactory spanFactory) {
+            this.spanFactory = spanFactory;
+            return this;
+        }
+
+        /** Internal hook */
+        Builder recorder(Recorder recorder) {
+            this.recorder = recorder;
+            return this;
+        }
+
         /**
          * @deprecated use {@link #reporter(Reporter)}
          */

--- a/brave-core/src/main/java/com/github/kristofa/brave/TracerAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/TracerAdapter.java
@@ -1,0 +1,164 @@
+package com.github.kristofa.brave;
+
+import brave.Tracer;
+import brave.internal.Internal;
+import brave.propagation.TraceContext;
+import com.github.kristofa.brave.internal.InternalSpan;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import zipkin.Constants;
+
+/**
+ * This is a bridge between the new {@linkplain Tracer} api in {@code io.zipkin.brave:brave} and the
+ * former model defined prior.
+ *
+ * <p>This class uses package-protected hooks to integrate, and is optional. For example, those not
+ * using {@linkplain Tracer} do not have a runtime dependency on {@code io.zipkin.brave:brave}.
+ */
+public final class TracerAdapter {
+  /** The endpoint in {@linkplain ServerClientAndLocalSpanState} is no longer used. */
+  static final Endpoint DUMMY_ENDPOINT = Endpoint.builder().serviceName("not used").build();
+
+  public static Brave newBrave(Tracer tracer) {
+    if (tracer == null) throw new NullPointerException("tracer == null");
+    return newBrave(tracer, new ThreadLocalServerClientAndLocalSpanState(DUMMY_ENDPOINT));
+  }
+
+  /**
+   * Constructs a new Brave instance that sends traces to the provided tracer.
+   *
+   * @param state for in-process propagation. Note {@link CommonSpanState#endpoint()} is ignored.
+   */
+  public static Brave newBrave(Tracer tracer, ServerClientAndLocalSpanState state) {
+    if (tracer == null) throw new NullPointerException("tracer == null");
+    if (state == null) throw new NullPointerException("state == null");
+    return new Brave.Builder(state)
+        .clock(tracer.clock()::currentTimeMicroseconds)
+        .spanFactory(new Brave4SpanFactory(tracer))
+        .recorder(new Brave4Recorder(tracer)).build();
+  }
+
+  public static brave.Span toSpan(Tracer tracer, Span span) {
+    if (tracer == null) throw new NullPointerException("tracer == null");
+    return tracer.toSpan(toTraceContext(Brave.context(span)));
+  }
+
+  public static brave.Span toSpan(Tracer tracer, SpanId spanId) {
+    if (tracer == null) throw new NullPointerException("tracer == null");
+    return tracer.toSpan(toTraceContext(spanId));
+  }
+
+  static TraceContext toTraceContext(SpanId spanId) {
+    if (spanId == null) throw new NullPointerException("spanId == null");
+    return TraceContext.newBuilder()
+        .traceIdHigh(spanId.traceIdHigh)
+        .traceId(spanId.traceId)
+        .parentId(spanId.nullableParentId())
+        .spanId(spanId.spanId)
+        .debug(spanId.debug())
+        .sampled(spanId.sampled())
+        .shared(spanId.shared).build();
+  }
+
+  public static Span toSpan(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    return InternalSpan.instance.toSpan(toSpanId(context));
+  }
+
+  static final class Brave4SpanFactory extends SpanFactory {
+    final Tracer delegate;
+
+    Brave4SpanFactory(Tracer tracer) {
+      this.delegate = tracer;
+    }
+
+    @Override Span nextSpan(SpanId maybeParent) {
+      brave.Span span = maybeParent != null
+          ? delegate.newChild(toTraceContext(maybeParent))
+          : delegate.newTrace();
+      return Brave.toSpan(toSpanId(span.context()));
+    }
+
+    @Override Span joinSpan(SpanId spanId) {
+      TraceContext context = toTraceContext(spanId);
+      return Brave.toSpan(toSpanId(delegate.joinSpan(context).context()));
+    }
+  }
+
+  static final class Brave4Recorder extends Recorder {
+    final Tracer tracer;
+
+    Brave4Recorder(Tracer tracer) {
+      this.tracer = tracer;
+    }
+
+    @Override void name(Span span, String name) {
+      brave4(span).name(name);
+    }
+
+    @Override void start(Span span, long timestamp) {
+      brave4(span).start(timestamp);
+    }
+
+    @Override Long timestamp(Span span) {
+      TraceContext context = toTraceContext(InternalSpan.instance.context(span));
+      return Internal.instance.timestamp(tracer, context);
+    }
+
+    @Override void annotate(Span span, long timestamp, String value) {
+      brave4(span).annotate(timestamp, value);
+    }
+
+    @Override void address(Span span, String key, Endpoint endpoint) {
+      brave.Span brave4 = brave4(span);
+      switch (key) {
+        case Constants.SERVER_ADDR:
+          brave4.kind(brave.Span.Kind.CLIENT);
+          break;
+        case Constants.CLIENT_ADDR:
+          brave4.kind(brave.Span.Kind.SERVER);
+          break;
+        default:
+          throw new AssertionError(key + " is not yet supported");
+      }
+      brave4.remoteEndpoint(zipkin.Endpoint.builder()
+          .serviceName(endpoint.service_name)
+          .ipv4(endpoint.ipv4)
+          .ipv6(endpoint.ipv6)
+          .port(endpoint.port)
+          .build());
+    }
+
+    @Override void tag(Span span, String key, String value) {
+      brave4(span).tag(key, value);
+    }
+
+    @Override void finish(Span span, long timestamp) {
+      brave4(span).finish(timestamp);
+    }
+
+    @Override void flush(Span span) {
+      brave4(span).flush();
+    }
+
+    // If garbage becomes a concern, we can introduce caching or thread locals.
+    brave.Span brave4(Span span) {
+      return tracer.toSpan(toTraceContext(InternalSpan.instance.context(span)));
+    }
+
+    @Override public long currentTimeMicroseconds() {
+      return tracer.clock().currentTimeMicroseconds();
+    }
+  }
+
+  static SpanId toSpanId(TraceContext context) {
+    return SpanId.builder()
+        .traceIdHigh(context.traceIdHigh())
+        .traceId(context.traceId())
+        .parentId(context.parentId())
+        .spanId(context.spanId())
+        .debug(context.debug())
+        .sampled(context.sampled())
+        .shared(context.shared()).build();
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
@@ -1,0 +1,13 @@
+package com.github.kristofa.brave;
+
+import brave.Tracer;
+
+public class Brave4ClientTracerTest extends ClientTracerTest {
+  @Override Brave newBrave() {
+    return TracerAdapter.newBrave(Tracer.newBuilder()
+        .clock(new AnnotationSubmitter.DefaultClock()::currentTimeMicroseconds)
+        .localEndpoint(ZIPKIN_ENDPOINT)
+        .clock(clock::currentTimeMicroseconds)
+        .reporter(spans::add).build());
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
@@ -1,0 +1,19 @@
+package com.github.kristofa.brave;
+
+import brave.Tracer;
+
+public class Brave4LocalTracerTest extends LocalTracerTest {
+  @Override Brave newBrave() {
+    return TracerAdapter.newBrave(Tracer.newBuilder()
+        .clock(clock::currentTimeMicroseconds)
+        .localEndpoint(ZIPKIN_ENDPOINT)
+        .reporter(spans::add).build());
+  }
+
+  @Override Brave newBrave(ServerClientAndLocalSpanState state) {
+    return TracerAdapter.newBrave(Tracer.newBuilder()
+        .clock(clock::currentTimeMicroseconds)
+        .localEndpoint(ZIPKIN_ENDPOINT)
+        .reporter(spans::add).build(), state);
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
@@ -1,0 +1,11 @@
+package com.github.kristofa.brave;
+
+import brave.Tracer;
+
+public class Brave4ServerRequestInterceptorTest extends ServerRequestInterceptorTest {
+  @Override Brave newBrave() {
+    return TracerAdapter.newBrave(Tracer.newBuilder()
+        .localEndpoint(ZIPKIN_ENDPOINT)
+        .reporter(spans::add).build());
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
@@ -1,0 +1,12 @@
+package com.github.kristofa.brave;
+
+import brave.Tracer;
+
+public class Brave4ServerTracerTest extends ServerTracerTest {
+  @Override Brave newBrave() {
+    return TracerAdapter.newBrave(Tracer.newBuilder()
+        .clock(clock::currentTimeMicroseconds)
+        .localEndpoint(ZIPKIN_ENDPOINT)
+        .reporter(spans::add).build());
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4Test.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4Test.java
@@ -1,0 +1,22 @@
+package com.github.kristofa.brave;
+
+import brave.Tracer;
+
+public class Brave4Test extends BraveTest {
+
+  @Override protected Brave newBrave() {
+    return TracerAdapter.newBrave(Tracer.newBuilder().build());
+  }
+
+  @Override protected Brave newBrave(Sampler sampler) {
+    return TracerAdapter.newBrave(Tracer.newBuilder().sampler(new brave.sampler.Sampler() {
+      @Override public boolean isSampled(long traceId) {
+        return sampler.isSampled(traceId);
+      }
+    }).build());
+  }
+
+  @Override protected Brave newBraveWith128BitTraceIds() {
+    return TracerAdapter.newBrave(Tracer.newBuilder().traceId128Bit(true).build());
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
@@ -10,11 +10,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 public class BraveTest {
-  Brave brave = new Brave.Builder().build();
+  Brave brave = newBrave();
 
   @Before
   public void setup() {
     ThreadLocalServerClientAndLocalSpanState.clear();
+  }
+
+  protected Brave newBrave() {
+    return new Brave.Builder().build();
+  }
+
+  protected Brave newBrave(Sampler sampler) {
+    return new Brave.Builder().traceSampler(sampler).build();
+  }
+
+  protected Brave newBraveWith128BitTraceIds() {
+    return new Brave.Builder().traceId128Bit(true).build();
   }
 
   @Test
@@ -82,7 +94,8 @@ public class BraveTest {
 
   @Test
   public void newSpan_whenUnsampled() {
-    brave = new Brave.Builder().traceSampler(Sampler.NEVER_SAMPLE).build();
+    Sampler sampler = Sampler.NEVER_SAMPLE;
+    brave = newBrave(sampler);
 
     Span span = brave.serverTracer().spanFactory().nextSpan(null);
     assertThat(Brave.context(span).sampled()).isFalse();
@@ -103,7 +116,7 @@ public class BraveTest {
 
   @Test
   public void newSpan_rootSpanWith128bitTraceId() {
-    brave = new Brave.Builder().traceId128Bit(true).build();
+    brave = newBraveWith128BitTraceIds();
 
     Span span = brave.serverTracer().spanFactory().nextSpan(null);
     assertThat(span.getTrace_id_high()).isNotZero();

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -21,8 +21,8 @@ public class ClientTracerTest {
   private static final long TRACE_ID = 105;
   private static final SpanId PARENT_CONTEXT =
       SpanId.builder().traceId(TRACE_ID).spanId(103).build();
-  private static final Endpoint ENDPOINT = Endpoint.create("serviceName", 80);
-  private static final zipkin.Endpoint ZIPKIN_ENDPOINT = zipkin.Endpoint.create("serviceName", 80);
+  private static final Endpoint ENDPOINT = Endpoint.create("service", 80);
+  static final zipkin.Endpoint ZIPKIN_ENDPOINT = zipkin.Endpoint.create("service", 80);
   private static final zipkin.Span BASE_SPAN =
       DefaultSpanCodec.toZipkin(Brave.toSpan(SpanId.builder().spanId(TRACE_ID).build()));
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -1,17 +1,15 @@
 package com.github.kristofa.brave;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.twitter.zipkin.gen.Endpoint;
-import com.twitter.zipkin.gen.Span;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class LocalTracerTest {
     private static final long START_TIME_MICROSECONDS = System.currentTimeMillis() * 1000;
@@ -20,8 +18,8 @@ public class LocalTracerTest {
     private static final SpanId PARENT_CONTEXT = SpanId.builder().traceId(TRACE_ID).spanId(103).build();
     private static final String COMPONENT_NAME = "componentname";
     private static final String OPERATION_NAME = "operationname";
-    private static final Endpoint ENDPOINT = Endpoint.create("serviceName", 80);
-    private static final zipkin.Endpoint ZIPKIN_ENDPOINT = zipkin.Endpoint.create("serviceName", 80);
+    private static final Endpoint ENDPOINT = Endpoint.create("service", 80);
+    static final zipkin.Endpoint ZIPKIN_ENDPOINT = zipkin.Endpoint.create("service", 80);
 
     long timestamp = START_TIME_MICROSECONDS;
     AnnotationSubmitter.Clock clock = () -> timestamp;

--- a/brave-core/src/test/java/com/github/kristofa/brave/example/TracerAdapterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/example/TracerAdapterTest.java
@@ -1,0 +1,74 @@
+package com.github.kristofa.brave.example; // intentionally in a different package
+
+import brave.Tracer;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.TracerAdapter;
+import com.twitter.zipkin.gen.Span;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import zipkin.Constants;
+
+import static com.github.kristofa.brave.TracerAdapter.toSpan;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static zipkin.internal.Util.UTF_8;
+
+public class TracerAdapterTest {
+
+  List<zipkin.Span> spans = new ArrayList<>();
+  Tracer brave4 = Tracer.newBuilder().reporter(spans::add).build();
+  Brave brave3 = TracerAdapter.newBrave(brave4);
+
+  @Test public void startWithLocalTracerAndFinishWithTracer() {
+    SpanId spanId = brave3.localTracer().startNewSpan("codec", "encode", 1L);
+
+    brave.Span span = toSpan(brave4, spanId);
+
+    span.annotate(2L, "pump fake");
+    span.finish(3L);
+
+    checkSpanReportedToZipkin();
+  }
+
+  @Test public void startWithCurrentSpanAndFinishWithTracer() {
+    brave3.localTracer().startNewSpan("codec", "encode", 1L);
+
+    Span brave3Span = brave3.localSpanThreadBinder().getCurrentLocalSpan();
+
+    brave.Span span = toSpan(brave4, brave3Span);
+
+    span.annotate(2L, "pump fake");
+    span.finish(3L);
+
+    checkSpanReportedToZipkin();
+  }
+
+  @Test public void startWithTracerAndFinishWithLocalTracer() {
+    brave.Span brave4Span = brave4.newTrace().name("encode")
+        .tag(Constants.LOCAL_COMPONENT, "codec")
+        .start(1L);
+
+    com.twitter.zipkin.gen.Span brave3Span = toSpan(brave4Span.context());
+    brave3.localSpanThreadBinder().setCurrentSpan(brave3Span);
+
+    brave3.localTracer().submitAnnotation("pump fake", 2L);
+    brave3.localTracer().finishSpan(2L /* duration */);
+
+    checkSpanReportedToZipkin();
+  }
+
+  void checkSpanReportedToZipkin() {
+    assertThat(spans).first().satisfies(s -> {
+          assertThat(s.name).isEqualTo("encode");
+          assertThat(s.timestamp).isEqualTo(1L);
+          assertThat(s.annotations).extracting(a -> a.timestamp, a -> a.value)
+              .containsExactly(tuple(2L, "pump fake"));
+          assertThat(s.binaryAnnotations).extracting(b -> b.key, b -> new String(b.value, UTF_8))
+              .containsExactly(tuple(Constants.LOCAL_COMPONENT, "codec"));
+          assertThat(s.duration).isEqualTo(2L);
+        }
+    );
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
@@ -1,0 +1,10 @@
+package com.github.kristofa.brave.internal;
+
+import brave.Tracer;
+import com.github.kristofa.brave.TracerAdapter;
+
+public class Brave4MaybeAddClientAddressTest extends MaybeAddClientAddressTest {
+  public Brave4MaybeAddClientAddressTest() {
+    brave = TracerAdapter.newBrave(Tracer.newBuilder().reporter(spans::add).build());
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
@@ -25,9 +25,9 @@ import zipkin.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class MaybeAddClientAddressTest {
-  List<Span> spans = new ArrayList<>();
-  Brave brave = new Brave.Builder().reporter(spans::add).build();
+public class MaybeAddClientAddressTest {
+  protected List<Span> spans = new ArrayList<>();
+  protected Brave brave = new Brave.Builder().reporter(spans::add).build();
 
   @Before
   public void clearState() {

--- a/brave-cxf3/pom.xml
+++ b/brave-cxf3/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>brave-parent</artifactId>
     <groupId>io.zipkin.brave</groupId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>brave-cxf3</artifactId>
   <packaging>jar</packaging>

--- a/brave-grpc/pom.xml
+++ b/brave-grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>brave-grpc</artifactId>
     <packaging>jar</packaging>

--- a/brave-http-tests/pom.xml
+++ b/brave-http-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>brave-parent</artifactId>
     <groupId>io.zipkin.brave</groupId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>brave-http-tests</artifactId>
   <packaging>jar</packaging>

--- a/brave-http/pom.xml
+++ b/brave-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-parent</artifactId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>brave-http</artifactId>

--- a/brave-jaxrs2/pom.xml
+++ b/brave-jaxrs2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>brave-jaxrs2</artifactId>
     <packaging>jar</packaging>

--- a/brave-jersey/pom.xml
+++ b/brave-jersey/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
    <artifactId>brave-jersey</artifactId>
    <packaging>jar</packaging>

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>brave-jersey2</artifactId>
     <packaging>jar</packaging>

--- a/brave-mysql/pom.xml
+++ b/brave-mysql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
    <artifactId>brave-mysql</artifactId>
    <packaging>jar</packaging>

--- a/brave-okhttp/pom.xml
+++ b/brave-okhttp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>brave-parent</artifactId>
     <groupId>io.zipkin.brave</groupId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/brave-p6spy/pom.xml
+++ b/brave-p6spy/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>brave-p6spy</artifactId>
     <packaging>jar</packaging>

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -3,7 +3,7 @@
   <parent>
   	<groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>   
   
   <artifactId>brave-resteasy-spring</artifactId>

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -3,7 +3,7 @@
   <parent>
   	<groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>   
   
   <artifactId>brave-resteasy3-spring</artifactId>

--- a/brave-sampler-zookeeper/pom.xml
+++ b/brave-sampler-zookeeper/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>brave-sampler-zookeeper</artifactId>

--- a/brave-spancollector-http/pom.xml
+++ b/brave-spancollector-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-parent</artifactId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>brave-spancollector-http</artifactId>

--- a/brave-spancollector-kafka/pom.xml
+++ b/brave-spancollector-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-parent</artifactId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>brave-spancollector-kafka</artifactId>

--- a/brave-spancollector-local/pom.xml
+++ b/brave-spancollector-local/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.zipkin.brave</groupId>
         <artifactId>brave-parent</artifactId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>brave-spancollector-local</artifactId>

--- a/brave-spancollector-scribe/pom.xml
+++ b/brave-spancollector-scribe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
   	<groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>   
   
   <artifactId>brave-spancollector-scribe</artifactId>

--- a/brave-spring-resttemplate-interceptors/pom.xml
+++ b/brave-spring-resttemplate-interceptors/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>brave-spring-resttemplate-interceptors</artifactId>

--- a/brave-spring-web-servlet-interceptor/pom.xml
+++ b/brave-spring-web-servlet-interceptor/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>3.18.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>brave-spring-web-servlet-interceptor</artifactId>

--- a/brave-web-servlet-filter/pom.xml
+++ b/brave-web-servlet-filter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>brave-parent</artifactId>
         <groupId>io.zipkin.brave</groupId>
-        <version>3.18.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,0 +1,267 @@
+Brave Api (v4)
+==============
+
+Brave is a library used to capture and report latency information about
+distributed operations to Zipkin. Most users won't use Brave directly,
+rather libraries or frameworks than employ Brave on their behalf.
+
+This module includes tracer creates and joins spans that model the
+latency of potentially distributed work. It also includes libraries to
+propagate the trace context over network boundaries, for example, via
+http headers.
+
+## Basics
+The tracer creates and joins spans that model the latency of potentially
+distributed work. It can employ sampling to reduce overhead in process
+or to reduce the amount of data sent to Zipkin.
+
+Spans returned by a tracer report data to Zipkin when finished, or do
+nothing if unsampled. After starting a span, you can annotate events of
+interest or add tags containing details or lookup keys.
+
+Spans have a context which includes trace identifiers that place it at
+the correct spot in the tree representing the distributed operation.
+
+### Local Tracing
+
+When tracing local code, just run it inside a span.
+```java
+try (Span span = tracer.newTrace().name("encode").start()) {
+  doSomethingExpensive();
+}
+```
+
+In the above example, the span is the root of the trace. In many cases,
+you will be a part of an existing trace. When this is the case, call
+`newChild` instead of `newTrace`
+
+```java
+try (Span root = tracer.newTrace().name("2pc").start()) {
+  try (Span child = tracer.newChild(root.context()).name("prepare").start()) {
+    prepare();
+  }
+  try (Span child = tracer.newChild(root.context()).name("commit").start()) {
+    commit();
+  }
+}
+```
+
+Once you have a span, you can add tags to it, which can be used as lookup
+keys or details. For example, you might add a tag with your runtime version:
+
+```java
+span.tag("clnt/finagle.version", "6.36.0");
+```
+
+### RPC tracing
+RPC tracing is often done automatically by interceptors. Under the scenes,
+they add tags and events that relate to their role in an RPC operation.
+
+Here's an example of a client span:
+```java
+// before you send a request, add metadata that describes the operation
+span = tracer.newTrace().name("get").type(CLIENT);
+span.tag("clnt/finagle.version", "6.36.0");
+span.tag(TraceKeys.HTTP_PATH, "/api");
+span.remoteEndpoint(Endpoint.builder()
+    .serviceName("backend")
+    .ipv4(127 << 24 | 1)
+    .port(8080).build());
+
+// when the request is scheduled, start the span
+span.start();
+
+// if you have callbacks for when data is on the wire, note those events
+span.annotate(Constants.WIRE_SEND);
+span.annotate(Constants.WIRE_RECV);
+
+// when the response is complete, finish the span
+span.finish();
+```
+
+## Sampling
+Sampling may be employed to reduce the data collected and reported out
+of process. When a span isn't sampled, it adds no overhead (noop).
+
+Sampling is an up-front decision, meaning that the decision to report
+data is made at the first operation in a trace, and that decision is
+propagated downstream.
+
+By default, there's a global sampler that applies a single rate to all
+traced operations. `Tracer.Builder.sampler` is how you indicate this,
+and it defaults to trace every request.
+
+### Custom sampling
+
+You may want to apply different policies depending on what the operation
+is. For example, you might not want to trace requests to static resources
+such as images, or you might want to trace all requests to a new api.
+
+Most users will use a framework interceptor which automates this sort of
+policy. Here's how they might work internally.
+
+```java
+Span newTrace(Request input) {
+  SamplingFlags flags = SamplingFlags.NONE;
+  if (input.url().startsWith("/experimental")) {
+    flags = SamplingFlags.SAMPLED;
+  } else if (input.url().startsWith("/static")) {
+    flags = SamplingFlags.NOT_SAMPLED;
+  }
+  return tracer.newTrace(flags);
+}
+```
+
+## Propagation
+Propagation is needed to ensure activity originating from the same root
+are collected together in the same trace. The most common propagation
+approach is to copy a trace context from a client sending an RPC request
+to a server receiving it.
+
+For example, when an downstream Http call is made, its trace context is
+sent along with it, encoded as request headers:
+
+```
+   Client Span                                                Server Span
+┌──────────────────┐                                       ┌──────────────────┐
+│                  │                                       │                  │
+│   TraceContext   │           Http Request Headers        │   TraceContext   │
+│ ┌──────────────┐ │          ┌───────────────────┐        │ ┌──────────────┐ │
+│ │ TraceId      │ │          │ X─B3─TraceId      │        │ │ TraceId      │ │
+│ │              │ │          │                   │        │ │              │ │
+│ │ ParentSpanId │ │ Extract  │ X─B3─ParentSpanId │ Inject │ │ ParentSpanId │ │
+│ │              ├─┼─────────>│                   ├────────┼>│              │ │
+│ │ SpanId       │ │          │ X─B3─SpanId       │        │ │ SpanId       │ │
+│ │              │ │          │                   │        │ │              │ │
+│ │ Sampled      │ │          │ X─B3─Sampled      │        │ │ Sampled      │ │
+│ └──────────────┘ │          └───────────────────┘        │ └──────────────┘ │
+│                  │                                       │                  │
+└──────────────────┘                                       └──────────────────┘
+```
+
+The names above are from [B3 Propagation](https://github.com/openzipkin/b3-propagation),
+which is built-in to Brave and has implementations in many languages and
+frameworks.
+
+Most users will use a framework interceptor which automates propagation.
+Here's how they might work internally.
+
+```java
+// configure a function that injects a trace context into a request
+injector = Propagation.B3_STRING.injector(Request.Builder::addHeader);
+
+// before a request is sent, add the current span's context to it
+injector.inject(span.context(), request);
+
+// configure a function that extracts the trace context from a request
+extractor = Propagation.B3_STRING.extractor(Request::getHeader);
+
+// when a server receives a request, it joins or starts a new trace
+contextOrFlags = extractor.extract(request);
+span = contextOrFlags.context() != null
+    ? tracer.joinSpan(contextOrFlags.context())
+    : tracer.newTrace(contextOrFlags.samplingFlags());
+```
+
+## Performance
+Brave has been built with performance in mind. Using the core Span api,
+you can record spans in sub-microseconds. When a span is sampled, there's
+effectively no overhead (as it is a noop).
+
+Unlike previous implementations, Brave 4 only needs one timestamp per
+span. All annotations are recorded on an offset basis, using the less
+expensive and more precise `System.nanoTime()` function.
+
+## Upgrading from Brave 3
+Brave 4 was designed to live alongside Brave 3. Using `TracerAdapter`,
+you can navigate between apis, buying you time to update as appropriate.
+
+### Creating a Brave 3 instance
+If your code uses Brave 3 apis, all you need to do is use `TracerAdapter`
+to create a (Brave 3) .. Brave. You don't have to change anything else.
+
+```java
+Tracer brave4 = Tracer.newBuilder()...build();
+Brave brave3 = TracerAdapter.newBrave(brave4);
+```
+
+### Converting between types
+Those coding directly to both apis can use `TracerAdapter.toSpan` to
+navigate between span types.
+
+If you have a reference to a Brave 3 Span, you can convert like this:
+```java
+brave3Span = brave3.localSpanThreadBinder().getCurrentLocalSpan();
+brave4Span = TracerAdapter.toSpan(brave4, brave3Span);
+```
+
+You can also attach Brave 4 Span to a Brave 3 thread binder like this:
+```java
+brave3Span = TracerAdapter.toSpan(brave4Span.context());
+brave3.localSpanThreadBinder().setCurrentSpan(brave3Span);
+```
+
+### Dependencies
+`io.zipkin.brave:brave`(Brave 4) is an optional dependency of
+`io.zipkin.brave:brave-core`(Brave 3). To use `TracerAdapter`, you need
+to declare an explicit dependency, and ensure both libraries are of the
+same version.
+
+### Notes
+* Never mutate `com.twitter.zipkin.gen.Span` directly. Doing so will
+  break the above integration.
+* The above only works when `com.github.kristofa.brave.Brave` was
+  instantiated via `TracerAdapter.newBrave`
+
+## 128-bit trace IDs
+
+Traditionally, Zipkin trace IDs were 64-bit. Starting with Zipkin 1.14,
+128-bit trace identifiers are supported. This can be useful in sites that
+have very large traffic volume, persist traces forever, or are re-using
+externally generated 128-bit IDs.
+
+If you want Brave to generate 128-bit trace identifiers when starting new
+root spans, set `Tracer.Builder.traceId128Bit(true)`
+
+When 128-bit trace ids are propagated, they will be twice as long as
+before. For example, the `X-B3-TraceId` header will hold a 32-character
+value like `163ac35c9f6413ad48485a3953bb6124`.
+
+Before doing this, ensure your Zipkin setup is up-to-date, and downstream
+instrumented services can read the longer 128-bit trace IDs.
+
+Note: this only affects the trace ID, not span IDs. For example, span ids
+within a trace are always 64-bit.
+
+## Acknowledgements
+Brave 4's design lends from past experience and similar open source work.
+Quite a lot of decisions were driven by portability with Brave 3, and the
+dozens of individuals involved in that. There are notable new aspects
+that are borrowed or adapted from others.
+
+### Stateful Span object
+Brave 4 allows you to pass around a Span object which can report itself
+to Zipkin when finished. This is better than using thread contexts in
+some cases, particularly where many async hops are in use. The Span api
+is derived from OpenTracing, narrowed to more cleanly match Zipkin's
+abstraction. As a result, a bridge from Brave 4 to OpenTracing v0.20.2
+is relatively little code. It should be able to implement future
+versions of OpenTracing as well.
+
+### Recorder architecture
+Much of Brave 4's architecture is borrowed from Finagle, whose design
+implies a separation between the propagated trace context and the data
+collected in process. For example, Brave's MutableSpanMap is the same
+overall design as Finagle's. The internals of MutableSpanMap were adapted
+from [WeakConcurrentMap](https://github.com/raphw/weak-lock-free).
+
+### Propagation Api
+OpenTracing's Tracer type has methods to inject or extract a trace
+context from a carrier. While naming is similar, Brave optimizes for
+direct integration with carrier types (such as http request) vs routing
+through an intermediate (such as a map). Brave also considers propagation
+a separate api from the tracer.
+
+### Public namespace
+Brave 4's pubic namespace is more defensive that the past, using a package
+accessor design from [OkHttp](https://github.com/square/okhttp).

--- a/brave/bnd.bnd
+++ b/brave/bnd.bnd
@@ -1,0 +1,5 @@
+Export-Package: \
+	brave,\
+	brave.propagation,\
+	brave.sampler,\
+	brave.internal;braveinternal=true;mandatory:=braveinternal

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-parent</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>brave</artifactId>
+  <packaging>jar</packaging>
+
+  <name>brave</name>
+  <description>Brave</description>
+  <url>https://github.com/kristofa/brave</url>
+  <licenses>
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${zipkin-reporter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet</groupId>
+      <artifactId>animal-sniffer-annotation</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <!-- for value types... don't worry. this dependency is compile only! -->
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- to mock Platform calls -->
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>0.20.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/brave/src/main/java/brave/Clock.java
+++ b/brave/src/main/java/brave/Clock.java
@@ -1,0 +1,17 @@
+package brave;
+
+/**
+ * Epoch microseconds used for {@link zipkin.Span#timestamp} and {@link
+ * zipkin.Annotation#timestamp}.
+ *
+ * <p>This should use the most precise value possible. For example, {@code gettimeofday} or
+ * multiplying {@link System#currentTimeMillis} by 1000.
+ *
+ * <p>See <a href="http://zipkin.io/pages/instrumenting.html">Instrumenting a service</a> for
+ * more.
+ */
+// FunctionalInterface except Java language level 6
+public interface Clock {
+
+  long currentTimeMicroseconds();
+}

--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -1,0 +1,66 @@
+package brave;
+
+import brave.propagation.TraceContext;
+import zipkin.Endpoint;
+
+final class NoopSpan extends Span {
+  final TraceContext context;
+
+  NoopSpan(TraceContext context) {
+    this.context = context;
+  }
+
+  @Override public boolean isNoop() {
+    return true;
+  }
+
+  @Override public TraceContext context() {
+    return context;
+  }
+
+  @Override public Span start() {
+    return this;
+  }
+
+  @Override public Span start(long timestamp) {
+    return this;
+  }
+
+  @Override public Span name(String name) {
+    return this;
+  }
+
+  @Override public Span kind(Kind kind) {
+    return this;
+  }
+
+  @Override public Span annotate(String value) {
+    return this;
+  }
+
+  @Override public Span annotate(long timestamp, String value) {
+    return this;
+  }
+
+  @Override public Span remoteEndpoint(Endpoint endpoint) {
+    return this;
+  }
+
+  @Override public Span tag(String key, String value) {
+    return this;
+  }
+
+  @Override public void finish() {
+  }
+
+  @Override public void finish(long timestamp) {
+  }
+
+  @Override public void flush() {
+  }
+
+  @Override
+  public String toString() {
+    return "NoopSpan(" + context + ")";
+  }
+}

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -1,0 +1,82 @@
+package brave;
+
+import brave.internal.recorder.Recorder;
+import brave.propagation.TraceContext;
+import zipkin.Endpoint;
+
+/** This wraps the public api and guards access to a mutable span. */
+final class RealSpan extends Span {
+
+  final TraceContext context;
+  final Clock clock;
+  final Recorder recorder;
+
+  RealSpan(TraceContext context, Clock clock, Recorder recorder) {
+    this.context = context;
+    this.clock = clock;
+    this.recorder = recorder;
+  }
+
+  @Override public boolean isNoop() {
+    return false;
+  }
+
+  @Override public TraceContext context() {
+    return context;
+  }
+
+  @Override public Span start() {
+    return start(clock.currentTimeMicroseconds());
+  }
+
+  @Override public Span start(long timestamp) {
+    recorder.start(context, timestamp);
+    return this;
+  }
+
+  @Override public Span name(String name) {
+    recorder.name(context, name);
+    return this;
+  }
+
+  @Override public Span kind(Kind kind) {
+    recorder.kind(context, kind);
+    return this;
+  }
+
+  @Override public Span annotate(String value) {
+    return annotate(clock.currentTimeMicroseconds(), value);
+  }
+
+  @Override public Span annotate(long timestamp, String value) {
+    recorder.annotate(context, timestamp, value);
+    return this;
+  }
+
+  @Override public Span tag(String key, String value) {
+    recorder.tag(context, key, value);
+    return this;
+  }
+
+  @Override public Span remoteEndpoint(Endpoint remoteEndpoint) {
+    recorder.remoteEndpoint(context, remoteEndpoint);
+    return this;
+  }
+
+  @Override public void finish() {
+    finish(clock.currentTimeMicroseconds());
+  }
+
+  @Override public void finish(long timestamp) {
+    recorder.finish(context, timestamp);
+  }
+
+  @Override public void flush() {
+    recorder.flush(context);
+  }
+
+  @Override
+  public String toString() {
+    return "RealSpan(" + context + ")";
+  }
+}

--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -1,0 +1,124 @@
+package brave;
+
+import brave.propagation.TraceContext;
+import java.io.Closeable;
+import java.io.Flushable;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.TraceKeys;
+
+/**
+ * Used to model the latency of an operation.
+ *
+ * <p>For example, to trace a local function call.
+ * <pre>{@code
+ * try (Span span = tracer.newTrace().name("encode").start()) {
+ *   doSomethingExpensive();
+ * }
+ * }</pre>
+ * This captures duration of {@link #start()} until {@link #finish()} is called (implicitly via
+ * try-with-resources).
+ */
+// Implements closeable not auto-closable for JRE 6
+// Design note: this does not require a builder as the span is mutable anyway. Having a single
+// mutation interface is less code to maintain. Those looking to prepare a span before starting it
+// can simply call start when they are ready.
+public abstract class Span implements Closeable, Flushable {
+  public enum Kind {
+    CLIENT,
+    SERVER
+  }
+
+  /**
+   * When true, no recording is done and nothing is reported to zipkin. However, this span should
+   * still be injected into outgoing requests. Use this flag to avoid performing expensive
+   * computation.
+   */
+  public abstract boolean isNoop();
+
+  public abstract TraceContext context();
+
+  /**
+   * Starts the span with an implicit timestamp.
+   *
+   * <p>Spans can be modified before calling start. For example, you can add tags to the span and
+   * set its name without lock contention.
+   */
+  public abstract Span start();
+
+  /** Like {@link #start()}, except with a given timestamp in microseconds. */
+  public abstract Span start(long timestamp);
+
+  /**
+   * Sets the string name for the logical operation this span represents.
+   */
+  public abstract Span name(String name);
+
+  /**
+   * The kind of span is optional. When set, it affects how a span is reported. For example, if the
+   * kind is {@link Kind#SERVER}, the span's start timestamp is implicitly annotated as "sr"
+   * and that plus its duration as "ss".
+   */
+  public abstract Span kind(Kind kind);
+
+  /**
+   * Associates an event that explains latency with the current system time.
+   *
+   * <p>Implicitly {@link #start() starts} the span if needed.
+   *
+   * <p>Implicitly {@link #finish() finishes} the span when the value is special (ex. "ss" or "cr").
+   *
+   * @param value A short tag indicating the event, like "finagle.retry"
+   * @see Constants
+   */
+  public abstract Span annotate(String value);
+
+  /** Like {@link #annotate(String)}, except with a given timestamp in microseconds. */
+  public abstract Span annotate(long timestamp, String value);
+
+  /**
+   * Tags give your span context for search, viewing and analysis. For example, a key
+   * "your_app.version" would let you lookup spans by version. A tag {@link TraceKeys#SQL_QUERY}
+   * isn't searchable, but it can help in debugging when viewing a trace.
+   *
+   * @param key Name used to lookup spans, such as "your_app.version". See {@link TraceKeys} for
+   * standard ones.
+   * @param value String value, cannot be <code>null</code>.
+   */
+  public abstract Span tag(String key, String value);
+
+  /**
+   * For a client span, this would be the server's address.
+   *
+   * <p>It is often expensive to derive a remote address: always check {@link #isNoop()} first!
+   */
+  public abstract Span remoteEndpoint(Endpoint endpoint);
+
+  /** Reports the span complete, assigning the most precise duration possible. */
+  public abstract void finish();
+
+  /**
+   * Like {@link #finish()}, except with a given timestamp in microseconds.
+   *
+   * <p>{@link zipkin.Span#duration Zipkin's span duration} is derived by subtracting the start
+   * timestamp from this, and set when appropriate.
+   */
+  // Design note: This differs from Brave 3's LocalTracer which completes with a given duration.
+  // This was changed for a few use cases.
+  // * Finishing a one-way span on another host https://github.com/openzipkin/zipkin/issues/1243
+  //   * The other host will not be able to read the start timestamp, so can't calculate duration
+  // * Consistency in Api: All units and measures are epoch microseconds
+  //   * This can reduce accidents where people use duration when they mean a timestamp
+  // * Parity with OpenTracing
+  //   * OpenTracing close spans like this, and this makes a Brave bridge stateless wrt timestamps
+  public abstract void finish(long timestamp);
+
+  /** Convenience for use in try-with-resources, which calls {@link #finish()} */
+  @Override
+  public final void close() {
+    finish();
+  }
+
+  /** Reports the span, even if unfinished. */
+  @Override public abstract void flush();
+}

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -1,0 +1,237 @@
+package brave;
+
+import brave.internal.Internal;
+import brave.internal.Nullable;
+import brave.internal.Platform;
+import brave.internal.recorder.Recorder;
+import brave.propagation.Propagation;
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.Sampler;
+import zipkin.Endpoint;
+import zipkin.reporter.AsyncReporter;
+import zipkin.reporter.Reporter;
+import zipkin.reporter.Sender;
+
+/**
+ * Using a tracer, you can create a root span capturing the critical path of a request. Child
+ * spans can be created to allocate latency relating to outgoing requests.
+ *
+ * Here's a contrived example:
+ * <pre>{@code
+ * try (Span root = tracer.newTrace().name("2pc").start()) {
+ *   try (Span child = tracer.newChild(root.context()).name("prepare").start()) {
+ *     prepare();
+ *   }
+ *   try (Span child = tracer.newChild(root.context()).name("commit").start()) {
+ *     commit();
+ *   }
+ * }
+ * }</pre>
+ *
+ * @see Span
+ * @see Propagation
+ */
+public final class Tracer {
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    Endpoint localEndpoint;
+    Reporter<zipkin.Span> reporter;
+    Clock clock;
+    Sampler sampler = Sampler.ALWAYS_SAMPLE;
+    boolean traceId128Bit = false;
+
+    /**
+     * @param localEndpoint Endpoint of the local service being traced. Defaults to site local.
+     */
+    public Builder localEndpoint(Endpoint localEndpoint) {
+      if (localEndpoint == null) throw new NullPointerException("localEndpoint == null");
+      this.localEndpoint = localEndpoint;
+      return this;
+    }
+
+    /**
+     * Controls how spans are reported. Defaults to logging, but often an {@link AsyncReporter}
+     * which batches spans before sending to Zipkin.
+     *
+     * The {@link AsyncReporter} includes a {@link Sender}, which is a driver for transports like
+     * http, kafka and scribe.
+     *
+     * <p>For example, here's how to batch send spans via http:
+     *
+     * <pre>{@code
+     * reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
+     *                         .build();
+     *
+     * tracerBuilder.reporter(reporter);
+     * }</pre>
+     *
+     * <p>See https://github.com/openzipkin/zipkin-reporter-java
+     */
+    public Builder reporter(Reporter<zipkin.Span> reporter) {
+      if (reporter == null) throw new NullPointerException("reporter == null");
+      this.reporter = reporter;
+      return this;
+    }
+
+    /** See {@link Tracer#clock()} */
+    public Builder clock(Clock clock) {
+      if (clock == null) throw new NullPointerException("clock == null");
+      this.clock = clock;
+      return this;
+    }
+
+    /**
+     * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether
+     * the overhead of tracing will occur and/or if a trace will be reported to Zipkin.
+     */
+    public Builder sampler(Sampler sampler) {
+      this.sampler = sampler;
+      return this;
+    }
+
+    /** When true, new root spans will have 128-bit trace IDs. Defaults to false (64-bit) */
+    public Builder traceId128Bit(boolean traceId128Bit) {
+      this.traceId128Bit = traceId128Bit;
+      return this;
+    }
+
+    public Tracer build() {
+      if (clock == null) clock = Platform.get();
+      if (localEndpoint == null) localEndpoint = Platform.get().localEndpoint();
+      if (reporter == null) reporter = Platform.get();
+      return new Tracer(this);
+    }
+  }
+
+  static {
+    Internal.instance = new Internal() {
+      @Override public Long timestamp(Tracer tracer, TraceContext context) {
+        return tracer.recorder.timestamp(context);
+      }
+    };
+  }
+
+  final Clock clock;
+  final Endpoint localEndpoint;
+  final Recorder recorder;
+  final Sampler sampler;
+  final boolean traceId128Bit;
+
+  Tracer(Builder builder) {
+    this.clock = builder.clock;
+    this.localEndpoint = builder.localEndpoint;
+    this.recorder = new Recorder(localEndpoint, clock, builder.reporter);
+    this.sampler = builder.sampler;
+    this.traceId128Bit = builder.traceId128Bit;
+  }
+
+  /** Used internally by operations such as {@link Span#finish()}, exposed for convenience. */
+  public Clock clock() {
+    return clock;
+  }
+
+  /**
+   * Creates a new trace. If there is an existing trace, use {@link #newChild(TraceContext)}
+   * instead.
+   */
+  public Span newTrace() {
+    return ensureSampled(nextContext(null, SamplingFlags.EMPTY));
+  }
+
+  /**
+   * Joining is re-using the same trace and span ids extracted from an incoming request. Here, we
+   * ensure a sampling decision has been made. If the span passed sampling, we assume this is a
+   * shared span, one where the caller and the current tracer report to the same span IDs. If no
+   * sampling decision occurred yet, we have exclusive access to this span ID.
+   *
+   * <p>Here's an example of conditionally joining a span, depending on if a trace context was
+   * extracted from an incoming request.
+   *
+   * <pre>{@code
+   * contextOrFlags = extractor.extract(request);
+   * span = contextOrFlags.context() != null
+   *          ? tracer.joinSpan(contextOrFlags.context())
+   *          : tracer.newTrace(contextOrFlags.samplingFlags());
+   * }</pre>
+   *
+   * @see Propagation
+   * @see TraceContext.Extractor#extract(Object)
+   * @see TraceContextOrSamplingFlags#context()
+   */
+  public final Span joinSpan(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    // If we are joining a trace, we are sharing IDs with the caller
+    return ensureSampled(context.toBuilder().shared(true).build());
+  }
+
+  /**
+   * Like {@link #newTrace()}, but supports parameterized sampling, for example limiting on
+   * operation or url pattern.
+   *
+   * <p>For example, to sample all requests for a specific url:
+   * <pre>{@code
+   * Span newTrace(Request input) {
+   *   SamplingFlags flags = SamplingFlags.NONE;
+   *   if (input.url().startsWith("/experimental")) {
+   *     flags = SamplingFlags.SAMPLED;
+   *   } else if (input.url().startsWith("/static")) {
+   *     flags = SamplingFlags.NOT_SAMPLED;
+   *   }
+   *   return tracer.newTrace(flags);
+   * }
+   * }</pre>
+   */
+  public Span newTrace(SamplingFlags samplingFlags) {
+    return ensureSampled(nextContext(null, samplingFlags));
+  }
+
+  /** Converts the context as-is to a Span object */
+  public Span toSpan(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    if (context.sampled()) {
+      return new RealSpan(context, clock, recorder);
+    }
+    return new NoopSpan(context);
+  }
+
+  /**
+   * Creates a new span within an existing trace. If there is no existing trace, use {@link
+   * #newTrace()} instead.
+   */
+  public Span newChild(TraceContext parent) {
+    if (parent == null) throw new NullPointerException("parent == null");
+    if (Boolean.FALSE.equals(parent.sampled())) {
+      return new NoopSpan(parent);
+    }
+    return ensureSampled(nextContext(parent, parent));
+  }
+
+  Span ensureSampled(TraceContext context) {
+    // If the sampled flag was left unset, we need to make the decision here
+    if (context.sampled() == null) {
+      context = context.toBuilder()
+          .sampled(sampler.isSampled(context.traceId()))
+          .shared(false)
+          .build();
+    }
+    return toSpan(context);
+  }
+
+  TraceContext nextContext(@Nullable TraceContext parent, SamplingFlags samplingFlags) {
+    long nextId = Platform.get().randomLong();
+    if (parent != null) {
+      return parent.toBuilder().spanId(nextId).parentId(parent.spanId()).build();
+    }
+    return TraceContext.newBuilder()
+        .sampled(samplingFlags.sampled())
+        .debug(samplingFlags.debug())
+        .traceIdHigh(traceId128Bit ? Platform.get().randomLong() : 0L)
+        .traceId(nextId)
+        .spanId(nextId).build();
+  }
+}

--- a/brave/src/main/java/brave/internal/HexCodec.java
+++ b/brave/src/main/java/brave/internal/HexCodec.java
@@ -1,0 +1,86 @@
+package brave.internal;
+
+// code originally imported from zipkin.Util
+public final class HexCodec {
+
+  /**
+   * Parses a 1 to 32 character lower-hex string with no prefix into an unsigned long, tossing any
+   * bits higher than 64.
+   */
+  public static long lowerHexToUnsignedLong(String lowerHex) {
+    int length = lowerHex.length();
+    if (length < 1 || length > 32) throw isntLowerHexLong(lowerHex);
+
+    // trim off any high bits
+    int beginIndex = length > 16 ? length - 16 : 0;
+
+    return lowerHexToUnsignedLong(lowerHex, beginIndex);
+  }
+
+  /**
+   * Parses a 16 character lower-hex string with no prefix into an unsigned long, starting at the
+   * spe index.
+   */
+  public static long lowerHexToUnsignedLong(String lowerHex, int index) {
+    long result = 0;
+    for (int endIndex = Math.min(index + 16, lowerHex.length()); index < endIndex; index++) {
+      char c = lowerHex.charAt(index);
+      result <<= 4;
+      if (c >= '0' && c <= '9') {
+        result |= c - '0';
+      } else if (c >= 'a' && c <= 'f') {
+        result |= c - 'a' + 10;
+      } else {
+        throw isntLowerHexLong(lowerHex);
+      }
+    }
+    return result;
+  }
+
+  static NumberFormatException isntLowerHexLong(String lowerHex) {
+    throw new NumberFormatException(
+        lowerHex + " should be a 1 to 32 character lower-hex string with no prefix");
+  }
+
+  /** Returns 16 or 32 character hex string depending on if {@code high} is zero. */
+  public static String toLowerHex(long high, long low) {
+    char[] result = new char[high != 0 ? 32 : 16];
+    int pos = 0;
+    if (high != 0) {
+      writeHexLong(result, pos, high);
+      pos += 16;
+    }
+    writeHexLong(result, pos, low);
+    return new String(result);
+  }
+
+  /** Inspired by {@code okio.Buffer.writeLong} */
+  public static String toLowerHex(long v) {
+    char[] data = new char[16];
+    writeHexLong(data, 0, v);
+    return new String(data);
+  }
+
+  /** Inspired by {@code okio.Buffer.writeLong} */
+  public static void writeHexLong(char[] data, int pos, long v) {
+    writeHexByte(data, pos + 0, (byte) ((v >>> 56L) & 0xff));
+    writeHexByte(data, pos + 2, (byte) ((v >>> 48L) & 0xff));
+    writeHexByte(data, pos + 4, (byte) ((v >>> 40L) & 0xff));
+    writeHexByte(data, pos + 6, (byte) ((v >>> 32L) & 0xff));
+    writeHexByte(data, pos + 8, (byte) ((v >>> 24L) & 0xff));
+    writeHexByte(data, pos + 10, (byte) ((v >>> 16L) & 0xff));
+    writeHexByte(data, pos + 12, (byte) ((v >>> 8L) & 0xff));
+    writeHexByte(data, pos + 14, (byte) (v & 0xff));
+  }
+
+  static final char[] HEX_DIGITS =
+      {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+  static void writeHexByte(char[] data, int pos, byte b) {
+    data[pos + 0] = HEX_DIGITS[(b >> 4) & 0xf];
+    data[pos + 1] = HEX_DIGITS[b & 0xf];
+  }
+
+  HexCodec() {
+  }
+}

--- a/brave/src/main/java/brave/internal/Internal.java
+++ b/brave/src/main/java/brave/internal/Internal.java
@@ -1,0 +1,19 @@
+package brave.internal;
+
+import brave.Tracer;
+import brave.propagation.TraceContext;
+
+/**
+ * Allows internal classes outside the package {@code brave} to use non-public methods. This allows
+ * us access internal methods while also making obvious the hooks are not for public use. The only
+ * implementation of this interface is in {@link brave.Tracer}.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.Internal}
+ */
+public abstract class Internal {
+
+  // Used by Brave 3 apis
+  public abstract @Nullable Long timestamp(Tracer tracer, TraceContext context);
+
+  public static Internal instance;
+}

--- a/brave/src/main/java/brave/internal/Nullable.java
+++ b/brave/src/main/java/brave/internal/Nullable.java
@@ -1,0 +1,12 @@
+package brave.internal;
+
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * AutoValue will process any annotation named {@code Nullable}. This avoids a dependency on one of
+ * the many jsr305 jars.
+ */
+@java.lang.annotation.Documented
+@java.lang.annotation.Retention(RetentionPolicy.SOURCE)
+public @interface Nullable {
+}

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -1,0 +1,149 @@
+package brave.internal;
+
+import brave.Clock;
+import brave.Tracer;
+import com.google.auto.value.AutoValue;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Enumeration;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jvnet.animal_sniffer.IgnoreJRERequirement;
+import zipkin.Endpoint;
+import zipkin.reporter.Reporter;
+
+/**
+ * Access to platform-specific features and implements a default logging reporter.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.platform.Platform}
+ */
+public abstract class Platform implements Clock, Reporter<zipkin.Span> {
+  static final Logger logger = Logger.getLogger(Tracer.class.getName());
+
+  private static final Platform PLATFORM = findPlatform();
+
+  // currentTimeMicroseconds is derived by this
+  final long createTimestamp;
+  final long createTick;
+  volatile Endpoint localEndpoint;
+
+  Platform() {
+    createTimestamp = System.currentTimeMillis() * 1000;
+    createTick = System.nanoTime();
+  }
+
+  @Override public void report(zipkin.Span span) {
+    if (!logger.isLoggable(Level.INFO)) return;
+    if (span == null) throw new NullPointerException("span == null");
+    logger.info(span.toString());
+  }
+
+  public Endpoint localEndpoint() {
+    // uses synchronized variant of double-checked locking as getting the endpoint can be expensive
+    if (localEndpoint == null) {
+      synchronized (this) {
+        if (localEndpoint == null) {
+          localEndpoint = produceLocalEndpoint();
+        }
+      }
+    }
+    return localEndpoint;
+  }
+
+  Endpoint produceLocalEndpoint() {
+    Endpoint.Builder builder = Endpoint.builder().serviceName("unknown");
+    try {
+      Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
+      if (nics == null) return builder.build();
+      while (nics.hasMoreElements()) {
+        NetworkInterface nic = nics.nextElement();
+        Enumeration<InetAddress> addresses = nic.getInetAddresses();
+        while (addresses.hasMoreElements()) {
+          InetAddress address = addresses.nextElement();
+          if (address.isSiteLocalAddress()) {
+            byte[] addressBytes = address.getAddress();
+            if (addressBytes.length == 4) {
+              builder.ipv4(ByteBuffer.wrap(addressBytes).getInt());
+            } else if (addressBytes.length == 16) {
+              builder.ipv6(addressBytes);
+            }
+            break;
+          }
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      // don't crash the caller if there was a problem reading nics.
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "error reading nics", e);
+      }
+    }
+    return builder.build();
+  }
+
+  public static Platform get() {
+    return PLATFORM;
+  }
+
+  /** Attempt to match the host runtime to a capable Platform implementation. */
+  private static Platform findPlatform() {
+
+    Platform jre7 = Jre7.buildIfSupported();
+
+    if (jre7 != null) return jre7;
+
+    // compatible with JRE 6
+    return Jre6.build();
+  }
+
+  /**
+   * This class uses pseudo-random number generators to provision IDs.
+   *
+   * <p>This optimizes speed over full coverage of 64-bits, which is why it doesn't share a {@link
+   * SecureRandom}. It will use {@link java.util.concurrent.ThreadLocalRandom} unless used in JRE 6
+   * which doesn't have the class.
+   */
+  public abstract long randomLong();
+
+  /** gets a timestamp based on duration since the create tick. */
+  @Override
+  public long currentTimeMicroseconds() {
+    return ((System.nanoTime() - createTick) / 1000) + createTimestamp;
+  }
+
+  @AutoValue
+  static abstract class Jre7 extends Platform {
+
+    static Jre7 buildIfSupported() {
+      // Find JRE 7 new methods
+      try {
+        Class.forName("java.util.concurrent.ThreadLocalRandom");
+        return new AutoValue_Platform_Jre7();
+      } catch (ClassNotFoundException e) {
+        // pre JRE 7
+      }
+      return null;
+    }
+
+    @IgnoreJRERequirement
+    @Override public long randomLong() {
+      return java.util.concurrent.ThreadLocalRandom.current().nextLong();
+    }
+  }
+
+  @AutoValue
+  static abstract class Jre6 extends Platform {
+    abstract Random prng();
+
+    static Jre6 build() {
+      return new AutoValue_Platform_Jre6(new Random(System.nanoTime()));
+    }
+
+    @Override public long randomLong() {
+      return prng().nextLong();
+    }
+  }
+}

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -1,0 +1,151 @@
+package brave.internal.recorder;
+
+import brave.Span;
+import brave.internal.Nullable;
+import brave.propagation.TraceContext;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+
+import static zipkin.Constants.LOCAL_COMPONENT;
+
+final class MutableSpan {
+  final Endpoint localEndpoint;
+  final zipkin.Span.Builder span;
+  boolean shared;
+  // fields which are added late
+  long startTimestamp;
+  Endpoint remoteEndpoint;
+
+  // flags which help us know how to reassemble the span
+  Span.Kind kind;
+
+  int flags;
+  static final int FLAG_CS = 1 << 0;
+  static final int FLAG_SR = 1 << 1;
+  static final int FLAG_SS = 1 << 2;
+  static final int FLAG_CR = 1 << 3;
+  static final int FLAG_LOCAL_ENDPOINT = 1 << 4;
+
+  boolean finished;
+
+  // Since this is not exposed, this class could be refactored later as needed to act in a pool
+  // to reduce GC churn. This would involve calling span.clear and resetting the fields below.
+  MutableSpan(TraceContext context, Endpoint localEndpoint) {
+    this.localEndpoint = localEndpoint;
+    this.span = zipkin.Span.builder()
+        .traceIdHigh(context.traceIdHigh())
+        .traceId(context.traceId())
+        .parentId(context.parentId())
+        .id(context.spanId())
+        .debug(context.debug())
+        .name(""); // avoid a NPE
+    shared = context.shared();
+    startTimestamp = 0;
+    remoteEndpoint = null;
+    kind = null;
+    finished = false;
+  }
+
+  synchronized MutableSpan start(long timestamp) {
+    startTimestamp = timestamp;
+    return this;
+  }
+
+  synchronized MutableSpan name(String name) {
+    span.name(name);
+    return this;
+  }
+
+  synchronized MutableSpan kind(Span.Kind kind) {
+    this.kind = kind;
+    return this;
+  }
+
+  synchronized MutableSpan annotate(long timestamp, String value) {
+    span.addAnnotation(Annotation.create(timestamp, value, localEndpoint));
+    flags |= FLAG_LOCAL_ENDPOINT;
+    if (value.length() != 2) return this;
+    if (value.equals(Constants.CLIENT_SEND)) {
+      flags |= FLAG_CS;
+      kind = Span.Kind.CLIENT;
+    } else if (value.equals(Constants.SERVER_RECV)) {
+      flags |= FLAG_SR;
+      kind = Span.Kind.SERVER;
+    } else if (value.equals(Constants.SERVER_SEND)) {
+      flags |= FLAG_SS;
+      kind = Span.Kind.SERVER;
+    } else if (value.equals(Constants.CLIENT_RECV)) {
+      flags |= FLAG_CR;
+      kind = Span.Kind.CLIENT;
+    }
+    return this;
+  }
+
+  synchronized MutableSpan tag(String key, String value) {
+    span.addBinaryAnnotation(BinaryAnnotation.create(key, value, localEndpoint));
+    flags |= FLAG_LOCAL_ENDPOINT;
+    return this;
+  }
+
+  synchronized MutableSpan remoteEndpoint(Endpoint remoteEndpoint) {
+    this.remoteEndpoint = remoteEndpoint;
+    return this;
+  }
+
+  /** Completes and reports the span */
+  synchronized MutableSpan finish(@Nullable Long finishTimestamp) {
+    if (finished) return this;
+    finished = true;
+
+    if (startTimestamp != 0) {
+      span.timestamp(startTimestamp);
+      if (finishTimestamp != null) {
+        span.duration(Math.max(finishTimestamp - startTimestamp, 1));
+      }
+    }
+    if (kind != null) {
+      String remoteEndpointType;
+      String startAnnotation;
+      String finishAnnotation;
+      switch (kind) {
+        case CLIENT:
+          remoteEndpointType = Constants.SERVER_ADDR;
+          startAnnotation = (flags & FLAG_CS) == 0 ? Constants.CLIENT_SEND : null;
+          finishAnnotation = (flags & FLAG_CR) == 0 ? Constants.CLIENT_RECV : null;
+          break;
+        case SERVER:
+          remoteEndpointType = Constants.CLIENT_ADDR;
+          startAnnotation = (flags & FLAG_SR) == 0 ? Constants.SERVER_RECV : null;
+          finishAnnotation = (flags & FLAG_SS) == 0 ? Constants.SERVER_SEND : null;
+          break;
+        default:
+          throw new AssertionError("update kind mapping");
+      }
+      if (remoteEndpoint != null) {
+        span.addBinaryAnnotation(BinaryAnnotation.address(remoteEndpointType, remoteEndpoint));
+      }
+      if (startAnnotation != null && startTimestamp != 0) {
+        if (startAnnotation.equals(Constants.SERVER_RECV)) flags |= FLAG_SR;
+        span.addAnnotation(Annotation.create(startTimestamp, startAnnotation, localEndpoint));
+      }
+      if (finishAnnotation != null && finishTimestamp != null) {
+        span.addAnnotation(Annotation.create(finishTimestamp, finishAnnotation, localEndpoint));
+      }
+      flags |= FLAG_LOCAL_ENDPOINT;
+    }
+    // don't report server-side timestamp on shared-spans
+    if (shared && (flags & FLAG_SR) == FLAG_SR) {
+      span.timestamp(null).duration(null);
+    }
+    if ((flags & FLAG_LOCAL_ENDPOINT) == 0) { // create a small dummy annotation
+      span.addBinaryAnnotation(BinaryAnnotation.create(LOCAL_COMPONENT, "", localEndpoint));
+    }
+    return this;
+  }
+
+  synchronized zipkin.Span toSpan() {
+    return span.build();
+  }
+}

--- a/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
@@ -1,0 +1,144 @@
+package brave.internal.recorder;
+
+import brave.Clock;
+import brave.internal.Nullable;
+import brave.propagation.TraceContext;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import zipkin.Endpoint;
+import zipkin.reporter.Reporter;
+
+/**
+ * Similar to Finagle's deadline span map, except this is GC pressure as opposed to timeout driven.
+ * This means there's no bookkeeping thread required in order to flush orphaned spans.
+ *
+ * <p>Spans are weakly referenced by their owning context. When the keys are collected, they are
+ * transferred to a queue, waiting to be reported. A call to modify any span will implicitly flush
+ * orphans to Zipkin. Spans in this state will have a "brave.flush" annotation added to them.
+ *
+ * <p>The internal implementation is derived from WeakConcurrentMap by Rafael Winterhalter. See
+ * https://github.com/raphw/weak-lock-free/blob/master/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java
+ */
+final class MutableSpanMap extends ReferenceQueue<TraceContext> {
+  static final Logger logger = Logger.getLogger(MutableSpanMap.class.getName());
+
+  // Eventhough we only put by RealKey, we allow get and remove by LookupKey
+  final ConcurrentMap<Object, MutableSpan> delegate = new ConcurrentHashMap<>(64);
+  final Endpoint localEndpoint;
+  final Clock clock;
+  final Reporter<zipkin.Span> reporter;
+
+  MutableSpanMap(Endpoint localEndpoint, Clock clock, Reporter<zipkin.Span> reporter) {
+    this.localEndpoint = localEndpoint;
+    this.clock = clock;
+    this.reporter = reporter;
+  }
+
+  @Nullable MutableSpan get(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    reportOrphanedSpans();
+    return delegate.get(new LookupKey(context));
+  }
+
+  MutableSpan getOrCreate(TraceContext context) {
+    MutableSpan result = get(context);
+    if (result != null) return result;
+
+    MutableSpan newSpan = new MutableSpan(context, localEndpoint);
+    MutableSpan previousSpan = delegate.putIfAbsent(new RealKey(context, this), newSpan);
+    if (previousSpan != null) return previousSpan; // lost race
+    return newSpan;
+  }
+
+  @Nullable MutableSpan remove(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    MutableSpan result = delegate.remove(new LookupKey(context));
+    reportOrphanedSpans(); // also clears the reference relating to the recent remove
+    return result;
+  }
+
+  /** Reports spans orphaned by garbage collection. */
+  void reportOrphanedSpans() {
+    Reference<? extends TraceContext> reference;
+    while ((reference = poll()) != null) {
+      TraceContext context = reference.get();
+      MutableSpan value = delegate.remove(reference);
+      if (value == null) continue;
+      try {
+        value.annotate(clock.currentTimeMicroseconds(), "brave.flush");
+        reporter.report(value.toSpan());
+      } catch (RuntimeException e) {
+        // don't crash the caller if there was a problem reporting an unrelated span.
+        if (context != null && logger.isLoggable(Level.FINE)) {
+          logger.log(Level.FINE, "error flushing " + context, e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Real keys contain a reference to the real context associated with a span. This is a weak
+   * reference, so that we get notified on GC pressure.
+   *
+   * <p>Since {@linkplain TraceContext}'s hash code is final, it is used directly both here and in
+   * lookup keys.
+   */
+  static final class RealKey extends WeakReference<TraceContext> {
+    final int hashCode;
+
+    RealKey(TraceContext context, ReferenceQueue<TraceContext> queue) {
+      super(context, queue);
+      hashCode = context.hashCode();
+    }
+
+    @Override public String toString() {
+      TraceContext context = get();
+      return context != null ? "WeakReference(" + context + ")" : "ClearedReference()";
+    }
+
+    @Override public int hashCode() {
+      return this.hashCode;
+    }
+
+    /** Resolves hash code collisions */
+    @Override public boolean equals(Object other) {
+      TraceContext thisContext = get(), thatContext = ((RealKey) other).get();
+      if (thisContext == null) {
+        return thatContext == null;
+      } else {
+        return thisContext.equals(thatContext);
+      }
+    }
+  }
+
+  /**
+   * Lookup keys are cheaper than real keys as reference tracking is not involved. We cannot use
+   * {@linkplain TraceContext} directly as a lookup key, as eventhough it has the same hash code as
+   * the real key, it would fail in equals comparison.
+   */
+  static final class LookupKey {
+    final TraceContext context;
+
+    LookupKey(TraceContext context) {
+      this.context = context;
+    }
+
+    @Override public int hashCode() {
+      return context.hashCode();
+    }
+
+    /** Resolves hash code collisions */
+    @Override public boolean equals(Object other) {
+      return context.equals(((RealKey) other).get());
+    }
+  }
+
+  @Override public String toString() {
+    return "MutableSpanMap" + delegate.keySet();
+  }
+}

--- a/brave/src/main/java/brave/internal/recorder/Recorder.java
+++ b/brave/src/main/java/brave/internal/recorder/Recorder.java
@@ -1,0 +1,88 @@
+package brave.internal.recorder;
+
+import brave.Clock;
+import brave.Span;
+import brave.internal.Nullable;
+import brave.propagation.TraceContext;
+import zipkin.Endpoint;
+import zipkin.reporter.Reporter;
+
+/** Dispatches mutations on a span to a shared object per trace/span id. */
+public final class Recorder {
+
+  final MutableSpanMap spanMap;
+  final Reporter<zipkin.Span> reporter;
+
+  public Recorder(Endpoint localEndpoint, Clock clock, Reporter<zipkin.Span> reporter) {
+    this.spanMap = new MutableSpanMap(localEndpoint, clock, reporter);
+    this.reporter = reporter;
+  }
+
+  /**
+   * Hook needed for Brave 3's LocalTracer.finish(duration)
+   *
+   * @see Span#start()
+   */
+  @Nullable public Long timestamp(TraceContext context) {
+    MutableSpan span = spanMap.get(context);
+    if (span == null) return null;
+    return span.startTimestamp == 0 ? null : span.startTimestamp;
+  }
+
+  /** @see brave.Span#start(long) */
+  public void start(TraceContext context, long timestamp) {
+    spanMap.getOrCreate(context).start(timestamp);
+  }
+
+  /** @see brave.Span#name(String) */
+  public void name(TraceContext context, String name) {
+    if (name == null) throw new NullPointerException("name == null");
+    spanMap.getOrCreate(context).name(name);
+  }
+
+  /** @see brave.Span#kind(Span.Kind) */
+  public void kind(TraceContext context, Span.Kind kind) {
+    if (kind == null) throw new NullPointerException("kind == null");
+    spanMap.getOrCreate(context).kind(kind);
+  }
+
+  /** @see brave.Span#annotate(long, String) */
+  public void annotate(TraceContext context, long timestamp, String value) {
+    if (value == null) throw new NullPointerException("value == null");
+    spanMap.getOrCreate(context).annotate(timestamp, value);
+  }
+
+  /** @see brave.Span#tag(String, String) */
+  public void tag(TraceContext context, String key, String value) {
+    if (key == null) throw new NullPointerException("key == null");
+    if (key.isEmpty()) throw new IllegalArgumentException("key is empty");
+    if (value == null) throw new NullPointerException("value == null");
+    spanMap.getOrCreate(context).tag(key, value);
+  }
+
+  /** @see brave.Span#remoteEndpoint(Endpoint) */
+  public void remoteEndpoint(TraceContext context, Endpoint remoteEndpoint) {
+    if (remoteEndpoint == null) throw new NullPointerException("remoteEndpoint == null");
+    spanMap.getOrCreate(context).remoteEndpoint(remoteEndpoint);
+  }
+
+  /** @see Span#finish() */
+  public void finish(TraceContext context, long finishTimestamp) {
+    MutableSpan span = spanMap.remove(context);
+    if (span == null) return;
+    synchronized (span) {
+      span.finish(finishTimestamp);
+      reporter.report(span.toSpan());
+    }
+  }
+
+  /** @see Span#flush() */
+  public void flush(TraceContext context) {
+    MutableSpan span = spanMap.remove(context);
+    if (span == null) return;
+    synchronized (span) {
+      span.finish(null);
+      reporter.report(span.toSpan());
+    }
+  }
+}

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -1,0 +1,133 @@
+package brave.propagation;
+
+import brave.internal.HexCodec;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static brave.internal.HexCodec.lowerHexToUnsignedLong;
+
+/**
+ * Implements <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
+ */
+public final class B3Propagation<K> implements Propagation<K> {
+
+  public static <K> B3Propagation<K> create(KeyFactory<K> keyFactory) {
+    return new B3Propagation<>(keyFactory);
+  }
+
+  /**
+   * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
+   */
+  static final String TRACE_ID_NAME = "X-B3-TraceId";
+  /**
+   * 64-bit span ID lower-hex encoded into 16 characters (required)
+   */
+  static final String SPAN_ID_NAME = "X-B3-SpanId";
+  /**
+   * 64-bit parent span ID lower-hex encoded into 16 characters (absent on root span)
+   */
+  static final String PARENT_SPAN_ID_NAME = "X-B3-ParentSpanId";
+  /**
+   * "1" means report this span to the tracing system, "0" means do not. (absent means defer the
+   * decision to the receiver of this header).
+   */
+  static final String SAMPLED_NAME = "X-B3-Sampled";
+  /**
+   * "1" implies sampled and is a request to override collection-tier sampling policy.
+   */
+  static final String FLAGS_NAME = "X-B3-Flags";
+  final K traceIdKey;
+  final K spanIdKey;
+  final K parentSpanIdKey;
+  final K sampledKey;
+  final K debugKey;
+  final List<K> fields;
+
+  B3Propagation(KeyFactory<K> keyFactory) {
+    this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
+    this.spanIdKey = keyFactory.create(SPAN_ID_NAME);
+    this.parentSpanIdKey = keyFactory.create(PARENT_SPAN_ID_NAME);
+    this.sampledKey = keyFactory.create(SAMPLED_NAME);
+    this.debugKey = keyFactory.create(FLAGS_NAME);
+    this.fields = Collections.unmodifiableList(
+        Arrays.asList(traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey)
+    );
+  }
+
+  @Override public List<K> keys() {
+    return fields;
+  }
+
+  @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+    if (setter == null) throw new NullPointerException("setter == null");
+    return new B3Injector<>(this, setter);
+  }
+
+  static final class B3Injector<C, K> implements TraceContext.Injector<C> {
+    final B3Propagation<K> propagation;
+    final Setter<C, K> setter;
+
+    B3Injector(B3Propagation<K> propagation, Setter<C, K> setter) {
+      this.propagation = propagation;
+      this.setter = setter;
+    }
+
+    @Override public void inject(TraceContext traceContext, C carrier) {
+      setter.put(carrier, propagation.traceIdKey, traceContext.traceIdString());
+      setter.put(carrier, propagation.spanIdKey, HexCodec.toLowerHex(traceContext.spanId()));
+      if (traceContext.parentId() != null) {
+        setter.put(carrier, propagation.parentSpanIdKey,
+            HexCodec.toLowerHex(traceContext.parentId()));
+      }
+      if (traceContext.sampled() != null) {
+        setter.put(carrier, propagation.sampledKey, traceContext.sampled() ? "1" : "0");
+      }
+      if (traceContext.debug()) {
+        setter.put(carrier, propagation.debugKey, "1");
+      }
+    }
+  }
+
+  @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+    if (getter == null) throw new NullPointerException("getter == null");
+    return new B3Extractor(this, getter);
+  }
+
+  static final class B3Extractor<C, K> implements TraceContext.Extractor<C> {
+    final B3Propagation<K> propagation;
+    final Getter<C, K> getter;
+
+    B3Extractor(B3Propagation<K> propagation, Getter<C, K> getter) {
+      this.propagation = propagation;
+      this.getter = getter;
+    }
+
+    @Override public TraceContextOrSamplingFlags extract(C carrier) {
+      if (carrier == null) throw new NullPointerException("carrier == null");
+
+      String sampledString = getter.get(carrier, propagation.sampledKey);
+      // Official sampled value is 1, though some old instrumentation send true
+      Boolean sampled = sampledString != null
+          ? sampledString.equals("1") || sampledString.equalsIgnoreCase("true")
+          : null;
+      boolean debug = "1".equals(getter.get(carrier, propagation.debugKey));
+      String traceIdString = getter.get(carrier, propagation.traceIdKey);
+      TraceContext.Builder result = TraceContext.newBuilder().sampled(sampled).debug(debug);
+      if (traceIdString != null) {
+        result.traceIdHigh(
+            traceIdString.length() == 32 ? lowerHexToUnsignedLong(traceIdString, 0) : 0);
+        result.traceId(lowerHexToUnsignedLong(traceIdString));
+      }
+      String spanIdString = getter.get(carrier, propagation.spanIdKey);
+      if (spanIdString != null) {
+        result.spanId(lowerHexToUnsignedLong(spanIdString));
+      }
+      String parentSpanIdString = getter.get(carrier, propagation.parentSpanIdKey);
+      if (parentSpanIdString != null) {
+        result.parentId(lowerHexToUnsignedLong(parentSpanIdString));
+      }
+      return TraceContextOrSamplingFlags.create(result);
+    }
+  }
+}

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -1,0 +1,61 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import java.util.List;
+
+/**
+ * Injects and extracts {@link TraceContext trace identifiers} as text into carriers that travel
+ * in-band across process boundaries. Identifiers are often encoded as messaging or RPC request
+ * headers.
+ *
+ * <h3>Propagation example: Http</h3>
+ *
+ * <p>When using http, the carrier of propagated data on both the client (injector) and server
+ * (extractor) side is usually an http request. Propagation is usually implemented via library-
+ * specific request interceptors, where the client-side injects span identifiers and the server-side
+ * extracts them.
+ *
+ * @param <K> Usually, but not always a String
+ */
+public interface Propagation<K> {
+  Propagation<String> B3_STRING = Propagation.Factory.B3.create(Propagation.KeyFactory.STRING);
+
+  interface Factory {
+    Factory B3 = B3Propagation::create;
+
+    <K> Propagation<K> create(KeyFactory<K> keyFactory);
+  }
+
+  /** Creates keys for use in propagated contexts */
+  interface KeyFactory<K> {
+    KeyFactory<String> STRING = name -> name;
+
+    K create(String name);
+  }
+
+  /** Replaces a propagated key with the given value */
+  interface Setter<C, K> {
+    void put(C carrier, K key, String value);
+  }
+
+  /** The propagation fields defined */
+  // The use cases of this are:
+  // * allow pre-allocation of fields, especially in systems like gRPC Metadata
+  // * allow a single-pass over an iterator (ex OpenTracing has no getter in TextMap)
+  List<K> keys();
+
+  /**
+   * @param setter invoked for each propagation key to add.
+   */
+  <C> TraceContext.Injector<C> injector(Setter<C, K> setter);
+
+  /** Gets the first value of the given propagation key or returns null */
+  interface Getter<C, K> {
+    @Nullable String get(C carrier, K key);
+  }
+
+  /**
+   * @param getter invoked for each propagation key to get.
+   */
+  <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter);
+}

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -1,0 +1,75 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+
+public abstract class SamplingFlags {
+  public static final SamplingFlags EMPTY = new SamplingFlagsImpl(null, false);
+  public static final SamplingFlags SAMPLED = new SamplingFlagsImpl(true, false);
+  public static final SamplingFlags NOT_SAMPLED = new SamplingFlagsImpl(false, false);
+  public static final SamplingFlags DEBUG = new SamplingFlagsImpl(true, true);
+
+  /**
+   * Should we sample this request or not? True means sample, false means don't, null means we defer
+   * decision to someone further down in the stack.
+   */
+  @Nullable public abstract Boolean sampled();
+
+  /**
+   * True is a request to store this span even if it overrides sampling policy. Defaults to false.
+   */
+  public abstract boolean debug();
+
+  public static final class Builder {
+    Boolean sampled;
+    boolean debug = false;
+
+    public Builder() {
+      // public constructor instead of static newBuilder which would clash with TraceContext's
+    }
+
+    public Builder sampled(@Nullable Boolean sampled) {
+      this.sampled = sampled;
+      return this;
+    }
+
+    public Builder debug(boolean debug) {
+      this.debug = debug;
+      if (debug) sampled(true);
+      return this;
+    }
+
+    public SamplingFlags build() {
+      if (debug) {
+        return DEBUG;
+      } else if (sampled != null) {
+        return sampled ? SAMPLED : NOT_SAMPLED;
+      }
+      return EMPTY;
+    }
+  }
+
+  static final class SamplingFlagsImpl extends SamplingFlags {
+    final Boolean sampled;
+    final boolean debug;
+
+    SamplingFlagsImpl(Boolean sampled, boolean debug) {
+      this.sampled = sampled;
+      this.debug = debug;
+    }
+
+    @Override public Boolean sampled() {
+      return sampled;
+    }
+
+    @Override public boolean debug() {
+      return debug;
+    }
+
+    @Override public String toString() {
+      return "SamplingFlags(sampled=" + sampled + ", debug=" + debug + ")";
+    }
+  }
+
+  SamplingFlags() {
+  }
+}

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -1,0 +1,149 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import com.google.auto.value.AutoValue;
+
+import static brave.internal.HexCodec.writeHexLong;
+
+/**
+ * Contains trace identifiers and sampling data propagated in and out-of-process.
+ *
+ * <p>Particularly, this includes trace identifiers and sampled state.
+ *
+ * <p>The implementation was originally {@code com.github.kristofa.brave.SpanId}, which was a
+ * port of {@code com.twitter.finagle.tracing.TraceId}. Unlike these mentioned, this type does not
+ * expose a single binary representation. That's because propagation forms can now vary.
+ */
+@AutoValue
+public abstract class TraceContext extends SamplingFlags {
+
+  /**
+   * Used to send the trace context downstream. For example, as http headers.
+   */
+  public interface Injector<C> {
+    /**
+     * Usually calls a setter for each propagation field to send downstream.
+     *
+     * @param traceContext possibly unsampled.
+     * @param carrier holds propagation fields. For example, an outgoing message or http request.
+     */
+    void inject(TraceContext traceContext, C carrier);
+  }
+
+  /**
+   * Used to join an incoming trace. For example, by reading http headers.
+   *
+   * @see brave.Tracer#joinSpan
+   */
+  public interface Extractor<C> {
+
+    /**
+     * Returns either a trace context or sampling flags parsed from the carrier. If nothing was
+     * parsable, sampling flags will be set to {@link SamplingFlags#EMPTY}.
+     *
+     * @param carrier holds propagation fields. For example, an incoming message or http request.
+     */
+    TraceContextOrSamplingFlags extract(C carrier);
+  }
+
+  public static Builder newBuilder() {
+    return new AutoValue_TraceContext.Builder().traceIdHigh(0L).debug(false).shared(false);
+  }
+
+  /** When non-zero, the trace containing this span uses 128-bit trace identifiers. */
+  public abstract long traceIdHigh();
+
+  /** Unique 8-byte identifier for a trace, set on all spans within it. */
+  public abstract long traceId();
+
+  /** The parent's {@link #spanId} or null if this the root span in a trace. */
+  @Nullable public abstract Long parentId();
+
+  // override as auto-value can't currently read the super-class's nullable annotation.
+  @Override @Nullable public abstract Boolean sampled();
+
+  /**
+   * Unique 8-byte identifier of this span within a trace.
+   *
+   * <p>A span is uniquely identified in storage by ({@linkplain #traceId}, {@linkplain #spanId}).
+   */
+  public abstract long spanId();
+
+  /**
+   * True if we are contributing to a span started by another tracer (ex on a different host).
+   * Defaults to false.
+   *
+   * <p>When an RPC trace is client-originated, it will be sampled and the same span ID is used for
+   * the server side. However, the server shouldn't set span.timestamp or duration since it didn't
+   * start the span.
+   */
+  public abstract boolean shared();
+
+  public abstract Builder toBuilder();
+
+  /** Returns the hex representation of the span's trace ID */
+  public String traceIdString() {
+    if (traceIdHigh() != 0) {
+      char[] result = new char[32];
+      writeHexLong(result, 0, traceIdHigh());
+      writeHexLong(result, 16, traceId());
+      return new String(result);
+    }
+    char[] result = new char[16];
+    writeHexLong(result, 0, traceId());
+    return new String(result);
+  }
+
+  /** Returns {@code $traceId/$spanId} */
+  @Override
+  public String toString() {
+    boolean traceHi = traceIdHigh() != 0;
+    char[] result = new char[((traceHi ? 3 : 2) * 16) + 1]; // 2 ids and the delimiter
+    int pos = 0;
+    if (traceHi) {
+      writeHexLong(result, pos, traceIdHigh());
+      pos += 16;
+    }
+    writeHexLong(result, pos, traceId());
+    pos += 16;
+    result[pos++] = '/';
+    writeHexLong(result, pos, spanId());
+    return new String(result);
+  }
+
+  @AutoValue.Builder
+  public static abstract class Builder {
+    /** @see TraceContext#traceIdHigh() */
+    public abstract Builder traceIdHigh(long traceIdHigh);
+
+    /** @see TraceContext#traceId() */
+    public abstract Builder traceId(long traceId);
+
+    /** @see TraceContext#parentId */
+    public abstract Builder parentId(@Nullable Long parentId);
+
+    /** @see TraceContext#spanId */
+    public abstract Builder spanId(long spanId);
+
+    /** @see TraceContext#sampled */
+    public abstract Builder sampled(Boolean nullableSampled);
+
+    /** @see TraceContext#debug() */
+    public abstract Builder debug(boolean debug);
+
+    /** @see TraceContext#shared() */
+    public abstract Builder shared(boolean shared);
+
+    public abstract TraceContext build();
+
+    abstract Boolean sampled();
+
+    abstract boolean debug();
+
+    Builder() { // no external implementations
+    }
+  }
+
+  TraceContext() { // no external implementations
+  }
+}

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -1,0 +1,36 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import com.google.auto.value.AutoValue;
+
+/**
+ * Union type that contains either a trace context or sampling flags, but not both.
+ *
+ * <p>This is a port of {@code com.github.kristofa.brave.TraceData}, which served the same purpose.
+ *
+ * @see TraceContext.Extractor
+ */
+@AutoValue
+public abstract class TraceContextOrSamplingFlags {
+
+  /** When present, create the span via {@link brave.Tracer#joinSpan(TraceContext)} */
+  @Nullable public abstract TraceContext context();
+
+  /** When present, create the span via {@link brave.Tracer#newTrace(SamplingFlags)} */
+  @Nullable public abstract SamplingFlags samplingFlags();
+
+  public static TraceContextOrSamplingFlags create(TraceContext.Builder builder) {
+    if (builder == null) throw new NullPointerException("builder == null");
+    try {
+      return new AutoValue_TraceContextOrSamplingFlags(builder.build(), null);
+    } catch (IllegalStateException e) { // no trace IDs, but it might have sampling flags
+      SamplingFlags flags = new SamplingFlags.Builder()
+          .sampled(builder.sampled())
+          .debug(builder.debug()).build();
+      return new AutoValue_TraceContextOrSamplingFlags(null, flags);
+    }
+  }
+
+  TraceContextOrSamplingFlags() { // no external implementations
+  }
+}

--- a/brave/src/main/java/brave/sampler/BoundarySampler.java
+++ b/brave/src/main/java/brave/sampler/BoundarySampler.java
@@ -1,0 +1,53 @@
+package brave.sampler;
+
+import java.util.Random;
+
+import static zipkin.internal.Util.checkArgument;
+
+/**
+ * This sampler is appropriate for high-traffic instrumentation (ex edge web servers that each
+ * receive >100K requests) who provision random trace ids, and make the sampling decision only once.
+ * It defends against nodes in the cluster selecting exactly the same ids.
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This uses modulo 10000 arithmetic, which allows a minimum sample rate of 0.01%. Trace id
+ * collision was noticed in practice in the Twitter front-end cluster. A random salt is here to
+ * defend against nodes in the same cluster sampling exactly the same subset of trace ids. The goal
+ * was full 64-bit coverage of trace IDs on multi-host deployments.
+ *
+ * <p>Based on https://github.com/twitter/finagle/blob/develop/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Sampler.scala#L68
+ */
+public final class BoundarySampler extends Sampler {
+  static final long SALT = new Random().nextLong();
+
+  /**
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is
+   * 0.0001, or 0.01% of traces
+   */
+  public static Sampler create(float rate) {
+    if (rate == 0) return Sampler.NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    checkArgument(rate >= 0.0001f && rate < 1, "rate should be between 0.0001 and 1: was %s", rate);
+    final long boundary = (long) (rate * 10000); // safe cast as less <= 1
+    return new BoundarySampler(boundary);
+  }
+
+  private final long boundary;
+
+  BoundarySampler(long boundary) {
+    this.boundary = boundary;
+  }
+
+  /** Returns true when {@code abs(traceId) <= boundary} */
+  @Override
+  public boolean isSampled(long traceId) {
+    long t = Math.abs(traceId ^ SALT);
+    return t % 10000 <= boundary;
+  }
+
+  @Override
+  public String toString() {
+    return "BoundaryTraceIdSampler(" + boundary + ")";
+  }
+}

--- a/brave/src/main/java/brave/sampler/CountingSampler.java
+++ b/brave/src/main/java/brave/sampler/CountingSampler.java
@@ -1,0 +1,77 @@
+package brave.sampler;
+
+import java.util.BitSet;
+import java.util.Random;
+
+import static zipkin.internal.Util.checkArgument;
+
+/**
+ * This sampler is appropriate for low-traffic instrumentation (ex servers that each receive <100K
+ * requests), or those who do not provision random trace ids. It not appropriate for collectors as
+ * the sampling decision isn't idempotent (consistent based on trace id).
+ *
+ * <h3>Implementation</h3>
+ *
+ * <p>This initializes a random bitset of size 100 (corresponding to 1% granularity). This means
+ * that it is accurate in units of 100 traces. At runtime, this loops through the bitset, returning
+ * the value according to a counter.
+ */
+public final class CountingSampler extends Sampler {
+
+  /**
+   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
+   * or 1% of traces
+   */
+  public static Sampler create(final float rate) {
+    if (rate == 0) return NEVER_SAMPLE;
+    if (rate == 1.0) return ALWAYS_SAMPLE;
+    checkArgument(rate >= 0.01f && rate < 1, "rate should be between 0.01 and 1: was %s", rate);
+    return new CountingSampler(rate);
+  }
+
+  private int i; // guarded by this
+  private final BitSet sampleDecisions;
+
+  /** Fills a bitset with decisions according to the supplied rate. */
+  CountingSampler(float rate) {
+    int outOf100 = (int) (rate * 100.0f);
+    this.sampleDecisions = randomBitSet(100, outOf100, new Random());
+  }
+
+  /** loops over the pre-canned decisions, resetting to zero when it gets to the end. */
+  @Override
+  public synchronized boolean isSampled(long traceIdIgnored) {
+    boolean result = sampleDecisions.get(i++);
+    if (i == 100) i = 0;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CountingSampler()";
+  }
+
+  /**
+   * Reservoir sampling algorithm borrowed from Stack Overflow.
+   *
+   * http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+   */
+  static BitSet randomBitSet(int size, int cardinality, Random rnd) {
+    BitSet result = new BitSet(size);
+    int[] chosen = new int[cardinality];
+    int i;
+    for (i = 0; i < cardinality; ++i) {
+      chosen[i] = i;
+      result.set(i);
+    }
+    for (; i < size; ++i) {
+      int j = rnd.nextInt(i + 1);
+      if (j < cardinality) {
+        result.clear(chosen[j]);
+        result.set(i);
+        chosen[j] = i;
+      }
+    }
+    return result;
+  }
+}

--- a/brave/src/main/java/brave/sampler/Sampler.java
+++ b/brave/src/main/java/brave/sampler/Sampler.java
@@ -1,8 +1,17 @@
 package brave.sampler;
 
-import brave.propagation.TraceContext;
-
-// TODO: replace with the existing sampler code once base code is merged.
+/**
+ * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether the
+ * overhead of tracing will occur and/or if a trace will be reported to the collection tier.
+ *
+ * <p>Zipkin v1 uses before-the-fact sampling. This means that the decision to keep or drop the
+ * trace is made before any work is measured, or annotations are added. As such, the input parameter
+ * to zipkin v1 samplers is the trace ID (64-bit random number).
+ *
+ * <p>The instrumentation sampling decision happens once, at the root of the trace, and is
+ * propagated downstream. For this reason, the decision needn't be consistent based on trace ID.
+ */
+// abstract for factory-method support on Java language level 7
 public abstract class Sampler {
 
   public static final Sampler ALWAYS_SAMPLE = new Sampler() {
@@ -15,10 +24,28 @@ public abstract class Sampler {
     }
   };
 
-  /**
-   * Returns true if the trace ID should be measured.
-   *
-   * @param traceId the {@link TraceContext#traceId() first 64-bits of the trace ID.
-   */
+  public static final Sampler NEVER_SAMPLE = new Sampler() {
+    @Override public boolean isSampled(long traceId) {
+      return false;
+    }
+
+    @Override public String toString() {
+      return "NeverSample";
+    }
+  };
+
+  /** Returns true if the trace ID should be measured. */
   public abstract boolean isSampled(long traceId);
+
+  /**
+   * Returns a sampler, given a rate expressed as a percentage.
+   *
+   * <p>The sampler returned is good for low volumes of traffic (<100K requests), as it is precise.
+   * If you have high volumes of traffic, consider {@link BoundarySampler}.
+   *
+   * @param rate minimum sample rate is 0.01, or 1% of traces
+   */
+  public static Sampler create(float rate) {
+    return CountingSampler.create(rate);
+  }
 }

--- a/brave/src/main/java/brave/sampler/Sampler.java
+++ b/brave/src/main/java/brave/sampler/Sampler.java
@@ -1,0 +1,24 @@
+package brave.sampler;
+
+import brave.propagation.TraceContext;
+
+// TODO: replace with the existing sampler code once base code is merged.
+public abstract class Sampler {
+
+  public static final Sampler ALWAYS_SAMPLE = new Sampler() {
+    @Override public boolean isSampled(long traceId) {
+      return true;
+    }
+
+    @Override public String toString() {
+      return "AlwaysSample";
+    }
+  };
+
+  /**
+   * Returns true if the trace ID should be measured.
+   *
+   * @param traceId the {@link TraceContext#traceId() first 64-bits of the trace ID.
+   */
+  public abstract boolean isSampled(long traceId);
+}

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -1,0 +1,40 @@
+package brave;
+
+import brave.sampler.Sampler;
+import org.junit.Test;
+import zipkin.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NoopSpanTest {
+  Tracer tracer = Tracer.newBuilder().sampler(Sampler.NEVER_SAMPLE)
+      .clock(() -> {
+        throw new AssertionError();
+      })
+      .reporter(s -> {
+        throw new AssertionError();
+      })
+      .build();
+  Span span = tracer.newTrace();
+
+  @Test public void isNoop() {
+    assertThat(span.isNoop()).isTrue();
+  }
+
+  @Test public void hasRealContext() {
+    assertThat(span.context().spanId()).isNotZero();
+  }
+
+  @Test public void doesNothing() {
+    // Since our clock and reporter throw, we know this is doing nothing
+    span.start();
+    span.start(1L);
+    span.annotate("foo");
+    span.annotate(2L, "foo");
+    span.tag("bar", "baz");
+    span.remoteEndpoint(Endpoint.create("lalala", 127 << 24 | 1));
+    span.finish(1L);
+    span.finish();
+    span.flush();
+  }
+}

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -1,0 +1,105 @@
+package brave;
+
+import brave.internal.Platform;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Endpoint;
+
+import static brave.Span.Kind.SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class RealSpanTest {
+  List<zipkin.Span> spans = new ArrayList();
+  Endpoint localEndpoint = Platform.get().localEndpoint();
+  Tracer tracer = Tracer.newBuilder().reporter(spans::add).build();
+  Span span = tracer.newTrace();
+
+  @Test public void isNotNoop() {
+    assertThat(span.isNoop()).isFalse();
+  }
+
+  @Test public void hasRealContext() {
+    assertThat(span.context().spanId()).isNotZero();
+  }
+
+  @Test public void start() {
+    span.start();
+    span.flush();
+
+    assertThat(spans).hasSize(1).first()
+        .extracting(s -> s.timestamp)
+        .isNotNull();
+  }
+
+  @Test public void start_timestamp() {
+    span.start(2);
+    span.flush();
+
+    assertThat(spans).hasSize(1).first()
+        .extracting(s -> s.timestamp)
+        .containsExactly(2L);
+  }
+
+  @Test public void finish() {
+    span.start();
+    span.finish();
+
+    assertThat(spans).hasSize(1).first()
+        .extracting(s -> s.duration)
+        .isNotNull();
+  }
+
+  @Test public void finish_timestamp() {
+    span.start(2);
+    span.finish(5);
+
+    assertThat(spans).hasSize(1).first()
+        .extracting(s -> s.duration)
+        .containsExactly(3L);
+  }
+
+  @Test public void annotate() {
+    span.annotate("foo");
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value, a -> a.endpoint)
+        .containsExactly(tuple("foo", localEndpoint));
+  }
+
+  @Test public void annotate_timestamp() {
+    span.annotate(2, "foo");
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.annotations)
+        .containsExactly(Annotation.create(2L, "foo", localEndpoint));
+  }
+
+  @Test public void tag() {
+    span.tag("foo", "bar");
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.binaryAnnotations)
+        .containsExactly(BinaryAnnotation.create("foo", "bar", localEndpoint));
+  }
+
+  @Test public void autoCloseOnTryFinally() {
+    try (Span span = tracer.newTrace().name("foo").start()) {
+      span.tag("holy", "toledo");
+    }
+
+    assertThat(spans).hasSize(1);
+  }
+
+  @Test public void autoCloseOnTryFinally_doesntDoubleClose() {
+    try (Span span = tracer.newTrace().kind(SERVER).name("getOrCreate").start()) {
+      span.finish(); // user closes and also auto-close closes
+    }
+
+    assertThat(spans).hasSize(1);
+  }
+}

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -1,0 +1,128 @@
+package brave;
+
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import brave.sampler.Sampler;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracerTest {
+  Tracer tracer = Tracer.newBuilder().build();
+
+  @Test public void sampler() {
+    Sampler sampler = new Sampler() {
+      @Override public boolean isSampled(long traceId) {
+        return false;
+      }
+    };
+
+    tracer = Tracer.newBuilder().sampler(sampler).build();
+
+    assertThat(tracer.sampler)
+        .isSameAs(sampler);
+  }
+
+  @Test public void clock() {
+    Clock clock = () -> 0L;
+    tracer = Tracer.newBuilder().clock(clock).build();
+
+    assertThat(tracer.clock())
+        .isSameAs(clock);
+  }
+
+  @Test public void newTrace_isRootSpan() {
+    assertThat(tracer.newTrace())
+        .satisfies(s -> assertThat(s.context().parentId()).isNull())
+        .isInstanceOf(RealSpan.class);
+  }
+
+  @Test public void newTrace_traceId128Bit() {
+    tracer = Tracer.newBuilder().traceId128Bit(true).build();
+
+    assertThat(tracer.newTrace().context().traceIdHigh())
+        .isNotZero();
+  }
+
+  @Test public void newTrace_unsampled_tracer() {
+    tracer = Tracer.newBuilder().sampler(Sampler.NEVER_SAMPLE).build();
+
+    assertThat(tracer.newTrace())
+        .isInstanceOf(NoopSpan.class);
+  }
+
+  @Test public void newTrace_sampled_flag() {
+    assertThat(tracer.newTrace(SamplingFlags.SAMPLED))
+        .isInstanceOf(RealSpan.class);
+  }
+
+  @Test public void newTrace_debug_flag() {
+    List<zipkin.Span> spans = new ArrayList<>();
+    tracer = Tracer.newBuilder().reporter(spans::add).build();
+
+    Span root = tracer.newTrace(SamplingFlags.DEBUG).start();
+    root.finish();
+
+    assertThat(spans).extracting(s -> s.debug)
+        .containsExactly(true);
+  }
+
+  @Test public void newTrace_notsampled_flag() {
+    assertThat(tracer.newTrace(SamplingFlags.NOT_SAMPLED))
+        .isInstanceOf(NoopSpan.class);
+  }
+
+  /** When we join a sampled request, we are sharing the same trace identifiers. */
+  @Test public void join_setsShared() {
+    TraceContext fromIncomingRequest = tracer.newTrace().context();
+
+    assertThat(tracer.joinSpan(fromIncomingRequest).context())
+        .isEqualTo(fromIncomingRequest.toBuilder().shared(true).build());
+  }
+
+  @Test public void join_ensuresSampling() {
+    TraceContext notYetSampled =
+        tracer.newTrace().context().toBuilder().sampled(null).build();
+
+    assertThat(tracer.joinSpan(notYetSampled).context())
+        .isEqualTo(notYetSampled.toBuilder().sampled(true).build());
+  }
+
+  @Test public void toSpan() {
+    TraceContext context = tracer.newTrace().context();
+
+    assertThat(tracer.toSpan(context))
+        .isInstanceOf(RealSpan.class)
+        .extracting(Span::context)
+        .containsExactly(context);
+  }
+
+  @Test public void toSpan_unsampledIsNoop() {
+    TraceContext unsampled =
+        tracer.newTrace().context().toBuilder().sampled(false).build();
+
+    assertThat(tracer.toSpan(unsampled))
+        .isInstanceOf(NoopSpan.class);
+  }
+
+  @Test public void newChild() {
+    TraceContext parent = tracer.newTrace().context();
+
+    assertThat(tracer.newChild(parent))
+        .satisfies(c -> {
+          assertThat(c.context().traceIdString()).isEqualTo(parent.traceIdString());
+          assertThat(c.context().parentId()).isEqualTo(parent.spanId());
+        })
+        .isInstanceOf(RealSpan.class);
+  }
+
+  @Test public void newChild_unsampledIsNoop() {
+    TraceContext unsampled =
+        tracer.newTrace().context().toBuilder().sampled(false).build();
+
+    assertThat(tracer.newChild(unsampled))
+        .isInstanceOf(NoopSpan.class);
+  }
+}

--- a/brave/src/test/java/brave/features/async/OneWaySpanTest.java
+++ b/brave/src/test/java/brave/features/async/OneWaySpanTest.java
@@ -1,0 +1,109 @@
+package brave.features.async;
+
+import brave.Span;
+import brave.Tracer;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContextOrSamplingFlags;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.Endpoint;
+import zipkin.storage.InMemoryStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.mock;
+import static zipkin.Constants.CLIENT_SEND;
+import static zipkin.Constants.SERVER_RECV;
+
+/**
+ * This is an example of a one-way span, which is possible by use of the {@link Span#flush()}
+ * operator.
+ */
+public class OneWaySpanTest {
+  @Rule public MockWebServer server = new MockWebServer();
+
+  InMemoryStorage storage = new InMemoryStorage();
+
+  /** Use different tracers for client and server as usually they are on different hosts. */
+  Tracer clientTracer = Tracer.newBuilder()
+      .localEndpoint(Endpoint.builder().serviceName("client").build())
+      .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
+      .build();
+  Tracer serverTracer = Tracer.newBuilder()
+      .localEndpoint(Endpoint.builder().serviceName("server").build())
+      .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
+      .build();
+
+  CountDownLatch flushedIncomingRequest = new CountDownLatch(1);
+
+  @Before public void setup() {
+    server.setDispatcher(new Dispatcher() {
+      @Override public MockResponse dispatch(RecordedRequest recordedRequest) {
+        // pull the context out of the incoming request
+        TraceContextOrSamplingFlags result =
+            Propagation.B3_STRING.extractor(RecordedRequest::getHeader).extract(recordedRequest);
+
+        // in real life, we'd guard result.context was set and start a new trace if not
+        serverTracer.joinSpan(result.context())
+            .name(recordedRequest.getMethod())
+            .annotate(SERVER_RECV).flush(); // record the timestamp of the server receive and flush
+
+        flushedIncomingRequest.countDown();
+        // eventhough the client doesn't read the response, we return one
+        return new MockResponse();
+      }
+    });
+  }
+
+  @Test
+  public void startWithOneTracerAndStopWithAnother() throws Exception {
+    // start a new span representing a request
+    Span span = clientTracer.newTrace();
+
+    // inject the trace context into the request
+    Request.Builder request = new Request.Builder().url(server.url("/"));
+    Propagation.B3_STRING.injector(Request.Builder::addHeader).inject(span.context(), request);
+
+    // fire off the request asynchronously, totally dropping any response
+    new OkHttpClient().newCall(request.build()).enqueue(mock(Callback.class));
+    span.annotate(CLIENT_SEND).flush(); // record the timestamp of the client send and flush
+
+    // block on the server handling the request, so we can run assertions
+    flushedIncomingRequest.await();
+
+    // zipkin doesn't backfill timestamp and duration when storing raw spans
+    List<zipkin.Span> spans = storage.spanStore().getRawTrace(span.context().traceId());
+    assertThat(spans).flatExtracting(s -> s.timestamp, s -> s.duration)
+        .allSatisfy(u -> assertThat(u).isNull());
+
+    // check that the client send arrived first
+    zipkin.Span clientSpan = spans.get(0);
+    assertThat(clientSpan.name).isEmpty();
+    assertThat(clientSpan.annotations)
+        .extracting(a -> a.value, a -> a.endpoint.serviceName)
+        .containsExactly(tuple(CLIENT_SEND, "client"));
+
+    // check that the server receive arrived last
+    zipkin.Span serverSpan = spans.get(1);
+    assertThat(serverSpan.name).isEqualTo("get");
+    assertThat(serverSpan.annotations)
+        .extracting(a -> a.value, a -> a.endpoint.serviceName)
+        .containsExactly(tuple(SERVER_RECV, "server"));
+
+    // Zipkin will backfill the timestamp and duration on normal getTrace used by the UI
+    assertThat(storage.spanStore().getTrace(clientSpan.traceId))
+        .flatExtracting(s -> s.timestamp, s -> s.duration)
+        .allSatisfy(u -> assertThat(u).isNotNull());
+  }
+}

--- a/brave/src/test/java/brave/features/async/package-info.java
+++ b/brave/src/test/java/brave/features/async/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * one-way, async or messaging spans are possible when you {@link brave.Span#flush()} a span after
+ * sending on one host and flush after receiving on the other. This requires an annotation on either
+ * side. Zipkin will backfill the transit time using the annotation timestamps.
+ */
+package brave.features.async;

--- a/brave/src/test/java/brave/features/opentracing/BraveSpan.java
+++ b/brave/src/test/java/brave/features/opentracing/BraveSpan.java
@@ -1,0 +1,97 @@
+package brave.features.opentracing;
+
+import io.opentracing.SpanContext;
+import java.util.Map;
+
+final class BraveSpan implements io.opentracing.Span {
+
+  static BraveSpan wrap(brave.Span span) {
+    if (span == null) throw new NullPointerException("span == null");
+    return new BraveSpan(span);
+  }
+
+  final brave.Span delegate;
+  final SpanContext context;
+
+  BraveSpan(brave.Span delegate) {
+    this.delegate = delegate;
+    this.context = new BraveSpanContext(delegate.context());
+  }
+
+  public final brave.Span unwrap() {
+    return delegate;
+  }
+
+  @Override public SpanContext context() {
+    return context;
+  }
+
+  @Override public void finish() {
+    delegate.finish();
+  }
+
+  @Override public void finish(long finishMicros) {
+    delegate.finish(finishMicros);
+  }
+
+  @Override public void close() {
+    finish();
+  }
+
+  @Override public io.opentracing.Span setTag(String key, String value) {
+    delegate.tag(key, value);
+    return this;
+  }
+
+  @Override public io.opentracing.Span setTag(String key, boolean value) {
+    return setTag(key, Boolean.toString(value));
+  }
+
+  @Override public io.opentracing.Span setTag(String key, Number value) {
+    return setTag(key, value.toString());
+  }
+
+  @Override public io.opentracing.Span log(Map<String, ?> fields) {
+    if (fields.isEmpty()) return this;
+    // in real life, do like zipkin-go-opentracing: "key1=value1 key2=value2"
+    return log(fields.toString());
+  }
+
+  @Override public io.opentracing.Span log(long timestampMicroseconds, Map<String, ?> fields) {
+    if (fields.isEmpty()) return this;
+    // in real life, do like zipkin-go-opentracing: "key1=value1 key2=value2"
+    return log(timestampMicroseconds, fields.toString());
+  }
+
+  @Override public io.opentracing.Span log(String event) {
+    delegate.annotate(event);
+    return this;
+  }
+
+  @Override public io.opentracing.Span log(long timestampMicroseconds, String event) {
+    delegate.annotate(timestampMicroseconds, event);
+    return this;
+  }
+
+  @Override public io.opentracing.Span setBaggageItem(String key, String value) {
+    return this;
+  }
+
+  @Override public String getBaggageItem(String key) {
+    return null;
+  }
+
+  @Override public io.opentracing.Span setOperationName(String operationName) {
+    delegate.name(operationName);
+    return this;
+  }
+
+  @Override public io.opentracing.Span log(String eventName, Object ignored) {
+    return log(eventName);
+  }
+
+  @Override
+  public io.opentracing.Span log(long timestampMicroseconds, String eventName, Object ignored) {
+    return log(timestampMicroseconds, eventName);
+  }
+}

--- a/brave/src/test/java/brave/features/opentracing/BraveSpanBuilder.java
+++ b/brave/src/test/java/brave/features/opentracing/BraveSpanBuilder.java
@@ -1,0 +1,74 @@
+package brave.features.opentracing;
+
+import brave.Span;
+import brave.propagation.TraceContext;
+import io.opentracing.References;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class BraveSpanBuilder implements Tracer.SpanBuilder {
+  final brave.Tracer tracer;
+  final String operationName;
+  final Map<String, String> tags = new LinkedHashMap<>();
+
+  long timestamp;
+  TraceContext parent;
+
+  BraveSpanBuilder(brave.Tracer tracer, String operationName) {
+    this.tracer = tracer;
+    this.operationName = operationName;
+  }
+
+  @Override public BraveSpanBuilder asChildOf(SpanContext spanContext) {
+    return addReference(References.CHILD_OF, spanContext);
+  }
+
+  @Override public BraveSpanBuilder asChildOf(io.opentracing.Span span) {
+    return asChildOf(span.context());
+  }
+
+  @Override public BraveSpanBuilder addReference(String reference, SpanContext spanContext) {
+    if (parent != null) return this;// yolo pick the first parent!
+    if (References.CHILD_OF.equals(reference) || References.FOLLOWS_FROM.equals(reference)) {
+      this.parent = ((BraveSpanContext) spanContext).context;
+    }
+    return this;
+  }
+
+  @Override public BraveSpanBuilder withTag(String key, String value) {
+    tags.put(key, value);
+    return this;
+  }
+
+  @Override public BraveSpanBuilder withTag(String key, boolean value) {
+    return withTag(key, Boolean.toString(value));
+  }
+
+  @Override public BraveSpanBuilder withTag(String key, Number value) {
+    return withTag(key, value.toString());
+  }
+
+  @Override public BraveSpanBuilder withStartTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  @Override public Iterable<Map.Entry<String, String>> baggageItems() {
+    return Collections.emptySet();
+  }
+
+  @Override public BraveSpan start() {
+    Span result = parent == null ? tracer.newTrace() : tracer.newChild(parent);
+    if (operationName != null) result.name(operationName);
+    for (Map.Entry<String, String> tag : tags.entrySet()) {
+      result.tag(tag.getKey(), tag.getValue());
+    }
+    if (timestamp != 0) {
+      return new BraveSpan(result.start(timestamp));
+    }
+    return new BraveSpan(result.start());
+  }
+}

--- a/brave/src/test/java/brave/features/opentracing/BraveSpanContext.java
+++ b/brave/src/test/java/brave/features/opentracing/BraveSpanContext.java
@@ -1,0 +1,28 @@
+package brave.features.opentracing;
+
+import brave.propagation.TraceContext;
+import io.opentracing.SpanContext;
+import java.util.Collections;
+import java.util.Map;
+
+final class BraveSpanContext implements SpanContext {
+
+  static BraveSpanContext wrap(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    return new BraveSpanContext(context);
+  }
+
+  final TraceContext context;
+
+  BraveSpanContext(TraceContext context) {
+    this.context = context;
+  }
+
+  final TraceContext unwrap() {
+    return context;
+  }
+
+  @Override public Iterable<Map.Entry<String, String>> baggageItems() {
+    return Collections.EMPTY_SET;
+  }
+}

--- a/brave/src/test/java/brave/features/opentracing/BraveTracer.java
+++ b/brave/src/test/java/brave/features/opentracing/BraveTracer.java
@@ -1,0 +1,84 @@
+package brave.features.opentracing;
+
+import brave.internal.Nullable;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class BraveTracer implements Tracer {
+
+  static BraveTracer wrap(brave.Tracer tracer) {
+    if (tracer == null) throw new NullPointerException("tracer == null");
+    return new BraveTracer(tracer);
+  }
+
+  static final List<String> PROPAGATION_KEYS = Propagation.B3_STRING.keys();
+  static final TraceContext.Injector<TextMap> INJECTOR =
+      Propagation.B3_STRING.injector(TextMap::put);
+  static final TraceContext.Extractor<TextMapView> EXTRACTOR =
+      Propagation.B3_STRING.extractor(TextMapView::get);
+
+  final brave.Tracer tracer;
+
+  BraveTracer(brave.Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override public BraveSpanBuilder buildSpan(String operationName) {
+    return new BraveSpanBuilder(tracer, operationName);
+  }
+
+  @Override public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+    if (format != Format.Builtin.HTTP_HEADERS) {
+      throw new UnsupportedOperationException(format + " != Format.Builtin.HTTP_HEADERS");
+    }
+    TraceContext traceContext = ((BraveSpanContext) spanContext).context;
+    INJECTOR.inject(traceContext, (TextMap) carrier);
+  }
+
+  @Override public <C> BraveSpanContext extract(Format<C> format, C carrier) {
+    if (format != Format.Builtin.HTTP_HEADERS) {
+      throw new UnsupportedOperationException(format.toString());
+    }
+    TraceContextOrSamplingFlags result =
+        EXTRACTOR.extract(new TextMapView(PROPAGATION_KEYS, (TextMap) carrier));
+    TraceContext context = result.context() != null
+        ? result.context().toBuilder().shared(true).build()
+        : tracer.newTrace(result.samplingFlags()).context();
+    return new BraveSpanContext(context);
+  }
+
+  /** Eventhough TextMap is named like Map, it doesn't have a retrieve-by-key method */
+  static final class TextMapView {
+    final Iterator<Map.Entry<String, String>> input;
+    final Map<String, String> cache = new LinkedHashMap<>();
+    final List<String> fields;
+
+    TextMapView(List<String> fields, TextMap input) {
+      this.fields = fields;
+      this.input = input.iterator();
+    }
+
+    @Nullable String get(String key) {
+      String result = cache.get(key);
+      if (result != null) return result;
+      while (input.hasNext()) {
+        Map.Entry<String, String> next = input.next();
+        if (next.getKey().equals(key)) {
+          return next.getValue();
+        } else if (fields.contains(next.getKey())) {
+          cache.put(next.getKey(), next.getValue());
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -1,0 +1,103 @@
+package brave.features.opentracing;
+
+import brave.Tracer;
+import brave.propagation.TraceContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import io.opentracing.propagation.TextMapInjectAdapter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import zipkin.Constants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.data.MapEntry.entry;
+import static zipkin.internal.Util.UTF_8;
+
+/**
+ * This shows how one might make an OpenTracing adapter for Brave, and how to navigate in and out
+ * of the core concepts.
+ */
+public class OpenTracingAdapterTest {
+  List<zipkin.Span> spans = new ArrayList<>();
+  Tracer brave = Tracer.newBuilder().reporter(spans::add).build();
+  BraveTracer opentracing = BraveTracer.wrap(brave);
+
+  @Test public void startWithOpenTracingAndFinishWithBrave() {
+    io.opentracing.Span openTracingSpan = opentracing.buildSpan("encode")
+        .withTag(Constants.LOCAL_COMPONENT, "codec")
+        .withStartTimestamp(1L).start();
+
+    brave.Span braveSpan = ((BraveSpan) openTracingSpan).unwrap();
+
+    braveSpan.annotate(2L, "pump fake");
+    braveSpan.finish(3L);
+
+    checkSpanReportedToZipkin();
+  }
+
+  @Test public void startWithBraveAndFinishWithOpenTracing() {
+    brave.Span braveSpan = brave.newTrace().name("encode")
+        .tag(Constants.LOCAL_COMPONENT, "codec")
+        .start(1L);
+
+    io.opentracing.Span openTracingSpan = BraveSpan.wrap(braveSpan);
+
+    openTracingSpan.log(2L, "pump fake");
+    openTracingSpan.finish(3L);
+
+    checkSpanReportedToZipkin();
+  }
+
+  @Test
+  public void extractTraceContext() throws Exception {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("X-B3-TraceId", "0000000000000001");
+    map.put("X-B3-SpanId", "0000000000000002");
+    map.put("X-B3-Sampled", "1");
+
+    BraveSpanContext openTracingContext =
+        opentracing.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(map));
+
+    assertThat(openTracingContext.unwrap())
+        .isEqualTo(TraceContext.newBuilder()
+            .traceId(1L)
+            .spanId(2L)
+            .shared(true)
+            .sampled(true).build());
+  }
+
+  @Test
+  public void injectTraceContext() throws Exception {
+    TraceContext context = TraceContext.newBuilder()
+        .traceId(1L)
+        .spanId(2L)
+        .sampled(true).build();
+
+    Map<String, String> map = new LinkedHashMap<>();
+    TextMapInjectAdapter carrier = new TextMapInjectAdapter(map);
+    opentracing.inject(BraveSpanContext.wrap(context), Format.Builtin.HTTP_HEADERS, carrier);
+
+    assertThat(map).containsExactly(
+        entry("X-B3-TraceId", "0000000000000001"),
+        entry("X-B3-SpanId", "0000000000000002"),
+        entry("X-B3-Sampled", "1")
+    );
+  }
+
+  void checkSpanReportedToZipkin() {
+    assertThat(spans).first().satisfies(s -> {
+          assertThat(s.name).isEqualTo("encode");
+          assertThat(s.timestamp).isEqualTo(1L);
+          assertThat(s.annotations).extracting(a -> a.timestamp, a -> a.value)
+              .containsExactly(tuple(2L, "pump fake"));
+          assertThat(s.binaryAnnotations).extracting(b -> b.key, b -> new String(b.value, UTF_8))
+              .containsExactly(tuple(Constants.LOCAL_COMPONENT, "codec"));
+          assertThat(s.duration).isEqualTo(2L);
+        }
+    );
+  }
+}

--- a/brave/src/test/java/brave/features/opentracing/package-info.java
+++ b/brave/src/test/java/brave/features/opentracing/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * It was difficult to implement OpenTracing directly within Brave 3, particularly as spans were
+ * spread across 3 different tracing abstractions. Now, {@link brave.Span} can implement {@link
+ * io.opentracing.Span} directly, at least the features that can be mapped to Zipkin.
+ */
+package brave.features.opentracing;

--- a/brave/src/test/java/brave/features/package-info.java
+++ b/brave/src/test/java/brave/features/package-info.java
@@ -1,0 +1,2 @@
+/** Contains tests of features driving the Brave api */
+package brave.features;

--- a/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
+++ b/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
@@ -1,0 +1,33 @@
+package brave.features.propagation;
+
+import brave.Tracer;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import io.grpc.Metadata;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** This shows propagation keys don't need to be Strings. For example, we can propagate over gRPC */
+public class NonStringPropagationKeysTest {
+  Propagation<Metadata.Key<String>> grpcPropagation = Propagation.Factory.B3.create(
+      name -> Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER)
+  );
+  TraceContext.Extractor<Metadata> extractor = grpcPropagation.extractor(Metadata::get);
+  TraceContext.Injector<Metadata> injector = grpcPropagation.injector(Metadata::put);
+
+  @Test
+  public void injectExtractTraceContext() throws Exception {
+    TraceContext context = Tracer.newBuilder().build().newTrace().context();
+
+    Metadata metadata = new Metadata();
+    injector.inject(context, metadata);
+
+    assertThat(metadata.keys())
+        .containsExactly("x-b3-traceid", "x-b3-spanid", "x-b3-sampled");
+
+          //.shared(sampled != null)
+    assertThat(extractor.extract(metadata).context())
+        .isEqualTo(context);
+  }
+}

--- a/brave/src/test/java/brave/features/propagation/package-info.java
+++ b/brave/src/test/java/brave/features/propagation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Before, we had the same algorithm for encoding B3 copy pasted a couple times. We now have a
+ * type {@link brave.propagation.Propagation} which supplies an implementation such as B3. This
+ * includes common functions such as how to extract and inject based on map-like carriers.
+ */
+package brave.features.propagation;

--- a/brave/src/test/java/brave/internal/HexCodecTest.java
+++ b/brave/src/test/java/brave/internal/HexCodecTest.java
@@ -1,0 +1,71 @@
+package brave.internal;
+
+import org.junit.Test;
+
+import static brave.internal.HexCodec.lowerHexToUnsignedLong;
+import static brave.internal.HexCodec.toLowerHex;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+// code originally imported from zipkin.UtilTest
+public class HexCodecTest {
+
+  @Test
+  public void lowerHexToUnsignedLong_downgrades128bitIdsByDroppingHighBits() {
+    assertThat(lowerHexToUnsignedLong("463ac35c9f6413ad48485a3953bb6124"))
+        .isEqualTo(lowerHexToUnsignedLong("48485a3953bb6124"));
+  }
+
+  @Test
+  public void lowerHexToUnsignedLongTest() {
+    assertThat(lowerHexToUnsignedLong("ffffffffffffffff")).isEqualTo(-1);
+    assertThat(lowerHexToUnsignedLong("0")).isEqualTo(0);
+    assertThat(lowerHexToUnsignedLong(Long.toHexString(Long.MAX_VALUE))).isEqualTo(Long.MAX_VALUE);
+
+    try {
+      lowerHexToUnsignedLong("fffffffffffffffffffffffffffffffff"); // too long
+      failBecauseExceptionWasNotThrown(NumberFormatException.class);
+    } catch (NumberFormatException e) {
+
+    }
+
+    try {
+      lowerHexToUnsignedLong(""); // too short
+      failBecauseExceptionWasNotThrown(NumberFormatException.class);
+    } catch (NumberFormatException e) {
+
+    }
+
+    try {
+      lowerHexToUnsignedLong("rs"); // bad charset
+      failBecauseExceptionWasNotThrown(NumberFormatException.class);
+    } catch (NumberFormatException e) {
+
+    }
+  }
+
+  @Test
+  public void toLowerHex_minValue() {
+    assertThat(toLowerHex(Long.MAX_VALUE)).isEqualTo("7fffffffffffffff");
+  }
+
+  @Test
+  public void toLowerHex_midValue() {
+    assertThat(toLowerHex(3405691582L)).isEqualTo("00000000cafebabe");
+  }
+
+  @Test
+  public void toLowerHex_fixedLength() {
+    assertThat(toLowerHex(0L)).isEqualTo("0000000000000000");
+  }
+
+  @Test public void toLowerHex_whenNotHigh_16Chars() {
+    assertThat(toLowerHex(0L, 12345678L))
+        .hasToString("0000000000bc614e");
+  }
+
+  @Test public void toLowerHex_whenHigh_32Chars() {
+    assertThat(toLowerHex(1234L, 5678L))
+        .hasToString("00000000000004d2000000000000162e");
+  }
+}

--- a/brave/src/test/java/brave/internal/InternalTest.java
+++ b/brave/src/test/java/brave/internal/InternalTest.java
@@ -1,0 +1,24 @@
+package brave.internal;
+
+import brave.Span;
+import brave.Tracer;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InternalTest {
+  Tracer tracer = Tracer.newBuilder().build();
+
+  /**
+   * Brave 3's LocalTracer.finish(duration) requires a read-back of the initial timestamp. While
+   * that api is in use, this hook is needed.
+   */
+  @Test public void readBackTimestamp() {
+    long timestamp = tracer.clock().currentTimeMicroseconds();
+
+    Span span = tracer.newTrace().name("foo").start(timestamp);
+
+    assertThat(Internal.instance.timestamp(tracer, span.context()))
+        .isEqualTo(timestamp);
+  }
+}

--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -1,0 +1,162 @@
+package brave.internal;
+
+import com.google.common.collect.Sets;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import zipkin.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+// Added to declutter console: tells power mock not to mess with implicit classes we aren't testing
+@PowerMockIgnore({"org.apache.logging.*", "javax.script.*"})
+@PrepareForTest({Platform.class, NetworkInterface.class})
+public class PlatformTest {
+  Endpoint unknownEndpoint = Endpoint.builder().serviceName("unknown").build();
+  Platform platform = Platform.Jre7.buildIfSupported();
+
+  @Test public void relativeTimestamp_incrementsAccordingToNanoTick() {
+    mockStatic(System.class);
+    when(System.currentTimeMillis()).thenReturn(0L);
+    when(System.nanoTime()).thenReturn(0L);
+
+    Platform platform = new Platform() {
+      @Override public long randomLong() {
+        return 1L;
+      }
+    };
+
+    when(System.nanoTime()).thenReturn(1000L); // 1 microsecond
+
+    assertThat(platform.currentTimeMicroseconds()).isEqualTo(1);
+  }
+
+  @Test public void localEndpoint_lazySet() {
+    assertThat(platform.localEndpoint).isNull(); // sanity check setup
+
+    assertThat(platform.localEndpoint())
+        .isNotNull();
+  }
+
+  @Test public void localEndpoint_sameInstance() {
+    assertThat(platform.localEndpoint())
+        .isSameAs(platform.localEndpoint());
+  }
+
+  @Test public void produceLocalEndpoint_exceptionReadingNics() throws Exception {
+    mockStatic(NetworkInterface.class);
+    when(NetworkInterface.getNetworkInterfaces()).thenThrow(SocketException.class);
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint);
+  }
+
+  /** possible albeit very unlikely */
+  @Test public void produceLocalEndpoint_noNics() throws Exception {
+    mockStatic(NetworkInterface.class);
+
+    when(NetworkInterface.getNetworkInterfaces())
+        .thenReturn(null);
+
+    assertThat(platform.localEndpoint())
+        .isEqualTo(unknownEndpoint);
+
+    when(NetworkInterface.getNetworkInterfaces())
+        .thenReturn(new Vector<NetworkInterface>().elements());
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint);
+  }
+
+  /** also possible albeit unlikely */
+  @Test public void produceLocalEndpoint_noAddresses() throws Exception {
+    nicWithAddress(null);
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint);
+  }
+
+  @Test public void produceLocalEndpoint_siteLocal_ipv4() throws Exception {
+    nicWithAddress(InetAddress.getByAddress("local", new byte[] {(byte) 192, (byte) 168, 0, 1}));
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint.toBuilder().ipv4(192 << 24 | 168 << 16 | 1).build());
+  }
+
+  @Test public void produceLocalEndpoint_siteLocal_ipv6() throws Exception {
+    InetAddress ipv6 = Inet6Address.getByName("fec0:db8::c001");
+    nicWithAddress(ipv6);
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint.toBuilder().ipv6(ipv6.getAddress()).build());
+  }
+
+  @Test public void produceLocalEndpoint_notSiteLocal_ipv4() throws Exception {
+    nicWithAddress(InetAddress.getByAddress("external", new byte[] {1, 2, 3, 4}));
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint);
+  }
+
+  @Test public void produceLocalEndpoint_notSiteLocal_ipv6() throws Exception {
+    nicWithAddress(Inet6Address.getByName("2001:db8::c001"));
+
+    assertThat(platform.produceLocalEndpoint())
+        .isEqualTo(unknownEndpoint);
+  }
+
+  /**
+   * Getting an endpoint is expensive. This tests it is provisioned only once.
+   *
+   * test inspired by dagger.internal.DoubleCheckTest
+   */
+  @Test
+  public void localEndpoint_provisionsOnce() throws Exception {
+    // create all the tasks up front so that they are executed with no delay
+    List<Callable<Endpoint>> tasks = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      tasks.add(() -> platform.localEndpoint());
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+    List<Future<Endpoint>> futures = executor.invokeAll(tasks);
+
+    // check there's only a single unique endpoint returned
+    Set<Object> results = Sets.newIdentityHashSet();
+    for (Future<Endpoint> future : futures) {
+      results.add(future.get());
+    }
+    assertThat(results).hasSize(1);
+
+    executor.shutdownNow();
+  }
+
+  static void nicWithAddress(@Nullable InetAddress address) throws SocketException {
+    mockStatic(NetworkInterface.class);
+    Vector<InetAddress> addresses = new Vector<>();
+    if (address != null) addresses.add(address);
+    NetworkInterface nic = PowerMockito.mock(NetworkInterface.class);
+    Vector<NetworkInterface> nics = new Vector<>();
+    nics.add(nic);
+    when(NetworkInterface.getNetworkInterfaces()).thenReturn(nics.elements());
+    when(nic.getInetAddresses()).thenReturn(addresses.elements());
+  }
+}

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
@@ -1,0 +1,218 @@
+package brave.internal.recorder;
+
+import brave.propagation.TraceContext;
+import brave.Tracer;
+import brave.internal.Platform;
+import java.lang.ref.Reference;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import zipkin.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MutableSpanMapTest {
+  Endpoint localEndpoint = Platform.get().localEndpoint();
+  List<zipkin.Span> spans = new ArrayList();
+  TraceContext context = Tracer.newBuilder().build().newTrace().context();
+  MutableSpanMap map = new MutableSpanMap(localEndpoint, () -> 0L, spans::add);
+
+  @Test
+  public void getOrCreate_lazyCreatesASpan() throws Exception {
+    MutableSpan span = map.getOrCreate(context);
+
+    assertThat(span).isNotNull();
+    assertThat(span.localEndpoint).isEqualTo(localEndpoint);
+  }
+
+  @Test
+  public void getOrCreate_cachesReference() throws Exception {
+    MutableSpan span = map.getOrCreate(context);
+    assertThat(map.getOrCreate(context)).isSameAs(span);
+  }
+
+  @Test
+  public void getOrCreate_resolvesHashCodeCollisions() throws Exception {
+    // intentionally clash on hashCode, but not equals
+    TraceContext context1 = context.toBuilder().spanId(1).build();
+    TraceContext context2 = context.toBuilder().spanId(-2L).build();
+
+    // sanity check
+    assertThat(context1.hashCode()).isEqualTo(context2.hashCode());
+    assertThat(context1).isNotEqualTo(context2);
+
+    assertThat(map.getOrCreate(context1)).isNotEqualTo(map.getOrCreate(context2));
+  }
+
+  @Test
+  public void remove_clearsReference() throws Exception {
+    map.getOrCreate(context);
+    map.remove(context);
+
+    assertThat(map.delegate).isEmpty();
+    assertThat(map.poll()).isNull();
+  }
+
+  @Test
+  public void remove_doesntReport() throws Exception {
+    map.getOrCreate(context);
+    map.remove(context);
+
+    assertThat(spans).isEmpty();
+  }
+
+  @Test
+  public void remove_okWhenDoesntExist() throws Exception {
+    MutableSpan span = map.remove(context);
+    assertThat(span).isNull();
+  }
+
+  @Test
+  public void remove_resolvesHashCodeCollisions() throws Exception {
+    // intentionally clash on hashCode, but not equals
+    TraceContext context1 = context.toBuilder().spanId(1).build();
+    TraceContext context2 = context.toBuilder().spanId(-2L).build();
+
+    // sanity check
+    assertThat(context1.hashCode()).isEqualTo(context2.hashCode());
+    assertThat(context1).isNotEqualTo(context2);
+
+    map.getOrCreate(context1);
+    map.getOrCreate(context2);
+
+    map.remove(context1);
+
+    assertThat(map.delegate.keySet()).extracting(o -> ((Reference) o).get())
+        .containsOnly(context2);
+  }
+
+  /** mainly ensures internals aren't dodgy on null */
+  @Test
+  public void remove_whenSomeReferencesAreCleared() throws Exception {
+    map.getOrCreate(context);
+    pretendGCHappened();
+    map.remove(context);
+
+    assertThat(map.delegate.keySet()).extracting(o -> ((Reference) o).get())
+        .hasSize(1)
+        .containsNull();
+  }
+
+  @Test
+  public void getOrCreate_whenSomeReferencesAreCleared() throws Exception {
+    map.getOrCreate(context);
+    pretendGCHappened();
+    map.getOrCreate(context);
+
+    // we'd expect two distinct entries.. the span would be reported twice, but merged zipkin-side
+    assertThat(map.delegate.keySet()).extracting(o -> ((Reference) o).get())
+        .containsExactlyInAnyOrder(null, context);
+  }
+
+  /**
+   * This is the key feature. Spans orphaned via GC are reported to zipkin on the next action.
+   *
+   * <p>This is a customized version of https://github.com/raphw/weak-lock-free/blob/master/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
+   */
+  @Test
+  public void reportOrphanedSpans_afterGC() throws Exception {
+    TraceContext context1 = context.toBuilder().spanId(1).build();
+    map.getOrCreate(context1);
+    TraceContext context2 = context.toBuilder().spanId(2).build();
+    map.getOrCreate(context2);
+    TraceContext context3 = context.toBuilder().spanId(3).build();
+    map.getOrCreate(context3);
+    TraceContext context4 = context.toBuilder().spanId(4).build();
+    map.getOrCreate(context4);
+
+    // By clearing strong references in this test, we are left with the weak ones in the map
+    context1 = context2 = null;
+    blockOnGC();
+
+    // After GC, we expect that the weak references of context1 and context2 to be cleared
+    assertThat(map.delegate.keySet()).extracting(o -> ((Reference) o).get())
+        .containsExactlyInAnyOrder(null, null, context3, context4);
+
+    map.reportOrphanedSpans();
+
+    // After reporting, we expect no the weak references of null
+    assertThat(map.delegate.keySet()).extracting(o -> ((Reference) o).get())
+        .containsExactlyInAnyOrder(context3, context4);
+
+    // We also expect the spans to have been reported
+    assertThat(spans).flatExtracting(s -> s.annotations).extracting(a -> a.value)
+        .containsExactly("brave.flush", "brave.flush");
+  }
+
+  /** We ensure that the implicit caller of reportOrphanedSpans doesn't crash on report failure */
+  @Test
+  public void reportOrphanedSpans_whenReporterDies() throws Exception {
+    MutableSpanMap map = new MutableSpanMap(localEndpoint, () -> 0, span ->
+    {
+      throw new RuntimeException("die!");
+    });
+
+    // We drop the reference to the context, which means the next GC should attempt to flush it
+    map.getOrCreate(context.toBuilder().build());
+
+    blockOnGC();
+
+    // Sanity check that the referent trace context cleared due to GC
+    assertThat(map.delegate.keySet()).extracting(o -> ((Reference) o).get())
+        .hasSize(1)
+        .containsNull();
+
+    // The innocent caller isn't killed due to the exception in implicitly reporting GC'd spans
+    map.remove(context);
+
+    // However, the reference queue has been cleared.
+    assertThat(map.delegate.keySet())
+        .isEmpty();
+  }
+
+  /** Debugging should show what the spans are, as well any references pending clear. */
+  @Test
+  public void toString_saysWhatReferentsAre() throws Exception {
+    assertThat(map.toString())
+        .isEqualTo("MutableSpanMap[]");
+
+    map.getOrCreate(context);
+
+    assertThat(map.toString())
+        .isEqualTo("MutableSpanMap[WeakReference(" + context + ")]");
+
+    pretendGCHappened();
+
+    assertThat(map.toString())
+        .isEqualTo("MutableSpanMap[ClearedReference()]");
+  }
+
+  @Test
+  public void realKey_equalToItself(){
+    MutableSpanMap.RealKey key = new MutableSpanMap.RealKey(context, map);
+    assertThat(key).isEqualTo(key);
+    key.clear();
+    assertThat(key).isEqualTo(key);
+  }
+
+  @Test
+  public void realKey_equalToEquivalent(){
+    MutableSpanMap.RealKey key = new MutableSpanMap.RealKey(context, map);
+    MutableSpanMap.RealKey key2 = new MutableSpanMap.RealKey(context, map);
+    assertThat(key).isEqualTo(key2);
+    key.clear();
+    assertThat(key).isNotEqualTo(key2);
+    key2.clear();
+    assertThat(key).isEqualTo(key2);
+  }
+
+  /** In reality, this clears a reference even if it is strongly held by the test! */
+  void pretendGCHappened() {
+    ((MutableSpanMap.RealKey) map.delegate.keySet().iterator().next()).clear();
+  }
+
+  static void blockOnGC() throws InterruptedException {
+    System.gc();
+    Thread.sleep(200L);
+  }
+}

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -1,0 +1,191 @@
+package brave.internal.recorder;
+
+import brave.Span;
+import brave.Tracer;
+import brave.internal.Platform;
+import brave.propagation.TraceContext;
+import org.junit.Test;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+
+import static brave.Span.Kind.CLIENT;
+import static brave.Span.Kind.SERVER;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.CLIENT_ADDR;
+import static zipkin.Constants.CLIENT_RECV;
+import static zipkin.Constants.CLIENT_SEND;
+import static zipkin.Constants.LOCAL_COMPONENT;
+import static zipkin.Constants.SERVER_ADDR;
+import static zipkin.Constants.SERVER_RECV;
+import static zipkin.Constants.SERVER_SEND;
+
+public class MutableSpanTest {
+  Endpoint localEndpoint = Platform.get().localEndpoint();
+  TraceContext context = Tracer.newBuilder().build().newTrace().context();
+
+  // zipkin needs one annotation or binary annotation so that the local endpoint can be read
+  @Test public void addsDefaultBinaryAnnotation() {
+    MutableSpan span = newSpan();
+
+    span.start(1L);
+    span.finish(2L);
+
+    assertThat(span.toSpan().binaryAnnotations.get(0)).isEqualTo(
+        BinaryAnnotation.create(LOCAL_COMPONENT, "", localEndpoint)
+    );
+  }
+
+  @Test public void minimumDurationIsOne() {
+    MutableSpan span = newSpan();
+
+    span.start(1L).finish(1L);
+
+    assertThat(span.toSpan().duration).isEqualTo(1L);
+  }
+
+  @Test public void doesntAddDefaultBinaryAnnotation() {
+    MutableSpan span = newSpan();
+
+    span.start(1L);
+    span.annotate(2L, "foo"); // this has an endpoint, so don't add a default binary annotation
+    span.finish(2L);
+
+    assertThat(span.toSpan().binaryAnnotations).isEmpty();
+  }
+
+  @Test public void clientAnnotationsImplicitlySetKind() {
+    for (String annotation : asList(Constants.CLIENT_SEND, Constants.CLIENT_RECV)) {
+      assertThat(newSpan().annotate(1L, annotation).kind)
+          .isEqualTo(Span.Kind.CLIENT);
+    }
+  }
+
+  @Test public void serverAnnotationsImplicitlySetKind() {
+    for (String annotation : asList(Constants.SERVER_RECV, Constants.SERVER_SEND)) {
+      assertThat(newSpan().annotate(1L, annotation).kind)
+          .isEqualTo(Span.Kind.SERVER);
+    }
+  }
+
+  @Test public void whenKindIsClient_addsCsCr() {
+    MutableSpan span = newSpan();
+
+    span.kind(CLIENT);
+    span.start(1L);
+    span.finish(2L);
+
+    assertThat(span.toSpan().annotations).extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test public void whenKindIsClient_addsCr() {
+    MutableSpan span = newSpan();
+
+    span.annotate(1L, CLIENT_SEND);
+    span.finish(2L);
+
+    assertThat(span.toSpan().annotations).extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test public void whenKindIsClient_addsCs() {
+    MutableSpan span = newSpan();
+
+    span.start(1L);
+    span.annotate(2L, CLIENT_RECV);
+    span.finish(null);
+
+    assertThat(span.toSpan().annotations).extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test public void whenKindIsClient_addsSa() {
+    MutableSpan span = newSpan();
+
+    Endpoint endpoint = Endpoint.create("server", 127 | 1);
+    span.kind(CLIENT);
+    span.remoteEndpoint(endpoint);
+    span.start(1L);
+    span.finish(2L);
+
+    assertThat(span.toSpan().binaryAnnotations.get(0)).isEqualTo(
+        BinaryAnnotation.address(SERVER_ADDR, endpoint)
+    );
+  }
+
+  // This prevents the server timestamp from overwriting the client one
+  @Test public void doesntReportServerTimestampOnSharedSpans() {
+    MutableSpan span = new MutableSpan(context.toBuilder().shared(true).build(), localEndpoint);
+
+    span.start(1L);
+    span.kind(SERVER);
+    span.finish(2L);
+
+    assertThat(span.toSpan()).extracting(s -> s.timestamp, s -> s.duration)
+        .allSatisfy(u -> assertThat(u).isNull());
+  }
+
+  @Test public void whenKindIsServer_addsSrSs() {
+    MutableSpan span = newSpan();
+
+    span.kind(SERVER);
+    span.start(1L);
+    span.finish(1L);
+
+    assertThat(span.toSpan().annotations).extracting(a -> a.value)
+        .containsExactly("sr", "ss");
+  }
+
+  @Test public void whenKindIsServer_addsSs() {
+    MutableSpan span = newSpan();
+
+    span.annotate(1L, SERVER_RECV);
+    span.finish(2L);
+
+    assertThat(span.toSpan().annotations).extracting(a -> a.value)
+        .containsExactly("sr", "ss");
+  }
+
+  @Test public void whenKindIsServer_addsSr() {
+    MutableSpan span = newSpan();
+
+    span.start(1L);
+    span.annotate(2L, SERVER_SEND);
+    span.finish(null);
+
+    assertThat(span.toSpan().annotations).extracting(a -> a.value)
+        .containsExactly("sr", "ss");
+  }
+
+  @Test public void whenKindIsServer_addsCa() {
+    MutableSpan span = newSpan();
+
+    Endpoint endpoint = Endpoint.create("caller", 127 | 1);
+    span.kind(SERVER);
+    span.remoteEndpoint(endpoint);
+    span.start(1L);
+    span.finish(2L);
+
+    assertThat(span.toSpan().binaryAnnotations.get(0)).isEqualTo(
+        BinaryAnnotation.address(CLIENT_ADDR, endpoint)
+    );
+  }
+
+  @Test public void flushUnstartedNeitherSetsTimestampNorDuration() {
+    zipkin.Span flushed = newSpan().finish(null).toSpan();
+    assertThat(flushed).extracting(s -> s.timestamp, s -> s.duration)
+        .allSatisfy(u -> assertThat(u).isNull());
+  }
+
+  /** We can't compute duration unless we started the span in the same tracer. */
+  @Test public void finishUnstartedIsSameAsFlush() {
+    assertThat(newSpan().finish(2L).toSpan())
+        .isEqualTo(newSpan().finish(null).toSpan());
+  }
+
+  MutableSpan newSpan() {
+    return new MutableSpan(context, localEndpoint);
+  }
+}

--- a/brave/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave/src/test/java/brave/propagation/B3PropagationTest.java
@@ -1,0 +1,224 @@
+package brave.propagation;
+
+import brave.internal.HexCodec;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+public class B3PropagationTest {
+
+  Propagation<String> propagation = Propagation.B3_STRING;
+  Map<String, String> map = new LinkedHashMap<>();
+  MapEntry mapEntry = new MapEntry();
+
+  TraceContext rootSpan = TraceContext.newBuilder()
+      .traceId(1L)
+      .spanId(1L)
+      .sampled(true).build();
+  TraceContext childSpan = rootSpan.toBuilder()
+      .parentId(rootSpan.spanId())
+      .spanId(2).build();
+
+  @Test
+  public void extractTraceContext_rootSpan() throws Exception {
+    map.put("X-B3-TraceId", "0000000000000001");
+    map.put("X-B3-SpanId", "0000000000000001");
+    map.put("X-B3-Sampled", "1");
+
+    TraceContext traceContext = propagation.extractor(mapEntry).extract(map).context();
+
+    assertThat(traceContext)
+        .isEqualTo(rootSpan);
+  }
+
+  @Test
+  public void extractTraceContext_128BitTrace() throws Exception {
+    String high64Bits = "463ac35c9f6413ad";
+    String low64Bits = "48485a3953bb6124";
+
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-TraceId", high64Bits + low64Bits);
+    map.put("X-B3-SpanId", low64Bits);
+    map.put("X-B3-Sampled", "1");
+
+    TraceContext traceContext = propagation.extractor(mapEntry).extract(map).context();
+
+    assertThat(traceContext.traceIdHigh())
+        .isEqualTo(HexCodec.lowerHexToUnsignedLong(high64Bits));
+    assertThat(traceContext.traceId())
+        .isEqualTo(HexCodec.lowerHexToUnsignedLong(low64Bits));
+  }
+
+  @Test
+  public void extractTraceContext_childSpan() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-TraceId", "0000000000000001");
+    map.put("X-B3-ParentSpanId", "0000000000000001");
+    map.put("X-B3-SpanId", "0000000000000002");
+    map.put("X-B3-Sampled", "1");
+
+    TraceContext traceContext = propagation.extractor(mapEntry).extract(map).context();
+
+    assertThat(traceContext)
+        .isEqualTo(childSpan);
+  }
+
+  @Test
+  public void extractTraceContext_notSampled() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-TraceId", "0000000000000001");
+    map.put("X-B3-ParentSpanId", "0000000000000001");
+    map.put("X-B3-SpanId", "0000000000000002");
+    map.put("X-B3-Sampled", "0");
+
+    TraceContext traceContext = propagation.extractor(mapEntry).extract(map).context();
+
+    assertThat(traceContext)
+        .isEqualTo(childSpan.toBuilder().sampled(false).build());
+  }
+
+  @Test
+  public void extractTraceContext_notSampled_noIds() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-Sampled", "0");
+
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test
+  public void extractTraceContext_sampledFalse() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-Sampled", "false");
+
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test
+  public void extractTraceContext_sampledFalseUpperCase() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-Sampled", "FALSE");
+
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test
+  public void extractTraceContext_sampledTrueNoOtherTraceHeaders() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-Sampled", "1");
+
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.SAMPLED);
+  }
+
+  @Test
+  public void extractTraceContext_debug() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-Flags", "1");
+
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.DEBUG);
+  }
+
+  @Test
+  public void extractTraceContext_empty() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  /**
+   * When the caller propagates IDs, but not a sampling decision, the local process should decide.
+   */
+  @Test
+  public void extractTraceContext_externallyProvidedIds() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-TraceId", "1");
+    map.put("X-B3-SpanId", "1");
+
+    TraceContext traceContext = propagation.extractor(mapEntry).extract(map).context();
+
+    assertThat(traceContext)
+        .isEqualTo(rootSpan.toBuilder().sampled(null).build());
+  }
+
+  @Test
+  public void injectTraceContext_rootSpan() throws Exception {
+    propagation.injector(mapEntry).inject(rootSpan, map);
+
+    assertThat(map).containsExactly(
+        entry("X-B3-TraceId", "0000000000000001"),
+        entry("X-B3-SpanId", "0000000000000001"),
+        entry("X-B3-Sampled", "1")
+    );
+  }
+
+  @Test
+  public void injectTraceContext_childSpan() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+    propagation.injector(mapEntry).inject(childSpan, map);
+
+    assertThat(map).containsExactly(
+        entry("X-B3-TraceId", "0000000000000001"),
+        entry("X-B3-SpanId", "0000000000000002"),
+        entry("X-B3-ParentSpanId", "0000000000000001"),
+        entry("X-B3-Sampled", "1")
+    );
+  }
+
+  @Test
+  public void injectTraceContext_rootSpan128bit() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+    propagation.injector(mapEntry)
+        .inject(rootSpan.toBuilder().traceIdHigh(3).traceId(1).build(), map);
+
+    assertThat(map).containsExactly(
+        entry("X-B3-TraceId", "00000000000000030000000000000001"),
+        entry("X-B3-SpanId", "0000000000000001"),
+        entry("X-B3-Sampled", "1")
+    );
+  }
+
+  @Test
+  public void injectTraceContext_unsampled() throws Exception {
+    MapEntry mapEntry = new MapEntry();
+    propagation.injector(mapEntry).inject(rootSpan.toBuilder().sampled(false).build(), map);
+
+    assertThat(map).containsExactly(
+        entry("X-B3-TraceId", "0000000000000001"),
+        entry("X-B3-SpanId", "0000000000000001"),
+        entry("X-B3-Sampled", "0")
+    );
+  }
+
+  static class MapEntry implements
+      Propagation.Getter<Map<String, String>, String>,
+      Propagation.Setter<Map<String, String>, String> {
+
+    @Override public void put(Map<String, String> carrier, String key, String value) {
+      carrier.put(key, value);
+    }
+
+    @Override public String get(Map<String, String> carrier, String key) {
+      return carrier.get(key);
+    }
+  }
+}

--- a/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
@@ -1,0 +1,44 @@
+package brave.propagation;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SamplingFlagsTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test public void defaultIsEmpty() {
+    SamplingFlags flags = new SamplingFlags.Builder().build();
+
+    assertThat(flags).isSameAs(SamplingFlags.EMPTY);
+    assertThat(flags.sampled()).isNull();
+    assertThat(flags.debug()).isFalse();
+  }
+
+  @Test public void debugImpliesSampled() {
+    SamplingFlags flags = new SamplingFlags.Builder().debug(true).build();
+
+    assertThat(flags).isSameAs(SamplingFlags.DEBUG);
+    assertThat(flags.sampled()).isTrue();
+    assertThat(flags.debug()).isTrue();
+  }
+
+  @Test public void sampled() {
+    SamplingFlags flags = new SamplingFlags.Builder().sampled(true).build();
+
+    assertThat(flags).isSameAs(SamplingFlags.SAMPLED);
+    assertThat(flags.sampled()).isTrue();
+    assertThat(flags.debug()).isFalse();
+  }
+
+  @Test public void notSampled() {
+    SamplingFlags flags = new SamplingFlags.Builder().sampled(false).build();
+
+    assertThat(flags).isSameAs(SamplingFlags.NOT_SAMPLED);
+    assertThat(flags.sampled()).isFalse();
+    assertThat(flags.debug()).isFalse();
+  }
+}

--- a/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
@@ -1,0 +1,58 @@
+package brave.propagation;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceContextOrSamplingFlagsTest {
+
+  @Test public void contextWhenIdsAreSet() {
+    TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).spanId(1L);
+    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+
+    assertThat(contextOrFlags.context())
+        .isEqualTo(builder.build());
+    assertThat(contextOrFlags.samplingFlags())
+        .isNull();
+  }
+
+  @Test public void contextWhenIdsAndSamplingAreSet() {
+    TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).spanId(1L).sampled(true);
+    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+
+    assertThat(contextOrFlags.context())
+        .isEqualTo(builder.build());
+    assertThat(contextOrFlags.samplingFlags())
+        .isNull();
+  }
+
+  @Test public void flagsWhenMissingTraceId() {
+    TraceContext.Builder builder = TraceContext.newBuilder().spanId(1L);
+    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+
+    assertThat(contextOrFlags.context())
+        .isNull();
+    assertThat(contextOrFlags.samplingFlags())
+        .isSameAs(SamplingFlags.EMPTY);
+  }
+
+  @Test public void flagsWhenMissingSpanId() {
+    TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).sampled(true);
+    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+
+    assertThat(contextOrFlags.context())
+        .isNull();
+    assertThat(contextOrFlags.samplingFlags())
+        .isSameAs(SamplingFlags.SAMPLED);
+  }
+
+  @Test public void flags() {
+    TraceContext.Builder builder = TraceContext.newBuilder().sampled(true);
+    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+
+    assertThat(contextOrFlags.context())
+        .isNull();
+    assertThat(contextOrFlags.samplingFlags())
+        .isSameAs(SamplingFlags.SAMPLED);
+  }
+}

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -1,0 +1,39 @@
+package brave.propagation;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceContextTest {
+
+  @Test public void compareUnequalIds() {
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(0L).build();
+
+    assertThat(context)
+        .isNotEqualTo(TraceContext.newBuilder().traceId(333L).spanId(1L).build());
+  }
+
+  @Test public void compareEqualIds() {
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(444L).build();
+
+    assertThat(context)
+        .isEqualTo(TraceContext.newBuilder().traceId(333L).spanId(444L).build());
+  }
+
+  @Test
+  public void testToString_lo() {
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(3).parentId(2L).build();
+
+    assertThat(context.toString())
+        .isEqualTo("000000000000014d/0000000000000003");
+  }
+
+  @Test
+  public void testToString() {
+    TraceContext context =
+        TraceContext.newBuilder().traceIdHigh(333L).traceId(444L).spanId(3).parentId(2L).build();
+
+    assertThat(context.toString())
+        .isEqualTo("000000000000014d00000000000001bc/0000000000000003");
+  }
+}

--- a/brave/src/test/java/brave/sampler/BoundarySamplerTest.java
+++ b/brave/src/test/java/brave/sampler/BoundarySamplerTest.java
@@ -1,0 +1,21 @@
+package brave.sampler;
+
+import org.assertj.core.data.Percentage;
+import org.junit.Test;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class BoundarySamplerTest extends SamplerTest {
+  @Override Sampler newSampler(float rate) {
+    return BoundarySampler.create(rate);
+  }
+
+  @Override Percentage expectedErrorRate() {
+    return withPercentage(10);
+  }
+
+  @Test
+  public void acceptsOneInTenThousandSampleRate() {
+    newSampler(0.0001f);
+  }
+}

--- a/brave/src/test/java/brave/sampler/CountingSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/CountingSamplerTest.java
@@ -1,0 +1,22 @@
+package brave.sampler;
+
+import org.assertj.core.data.Percentage;
+import org.junit.Test;
+
+import static org.assertj.core.data.Percentage.withPercentage;
+
+public class CountingSamplerTest extends SamplerTest {
+  @Override Sampler newSampler(float rate) {
+    return CountingSampler.create(rate);
+  }
+
+  @Override Percentage expectedErrorRate() {
+    return withPercentage(0);
+  }
+
+  @Test
+  public void sampleRateMinimumOnePercent() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    newSampler(0.0001f);
+  }
+}

--- a/brave/src/test/java/brave/sampler/SamplerTest.java
+++ b/brave/src/test/java/brave/sampler/SamplerTest.java
@@ -1,0 +1,72 @@
+package brave.sampler;
+
+import java.util.Random;
+import org.assertj.core.data.Percentage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Theories.class)
+public abstract class SamplerTest {
+  /**
+   * Zipkin trace ids are random 64bit numbers. This creates a relatively large input to avoid
+   * flaking out due to PRNG nuance.
+   */
+  static final int INPUT_SIZE = 100000;
+
+  abstract Sampler newSampler(float rate);
+
+  abstract Percentage expectedErrorRate();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @DataPoints
+  public static final float[] SAMPLE_RATES = {0.01f, 0.5f, 0.9f};
+
+  @Theory
+  public void retainsPerSampleRate(float sampleRate) {
+    final Sampler sampler = newSampler(sampleRate);
+
+    // parallel to ensure there aren't any unsynchronized race conditions
+    long passed = new Random().longs(INPUT_SIZE).parallel().filter(sampler::isSampled).count();
+
+    assertThat(passed)
+        .isCloseTo((long) (INPUT_SIZE * sampleRate), expectedErrorRate());
+  }
+
+  @Test
+  public void zeroMeansDropAllTraces() {
+    final Sampler sampler = newSampler(0.0f);
+
+    assertThat(new Random().longs(INPUT_SIZE).filter(sampler::isSampled).findAny()).isEmpty();
+  }
+
+  @Test
+  public void oneMeansKeepAllTraces() {
+    final Sampler sampler = newSampler(1.0f);
+
+    assertThat(new Random().longs(INPUT_SIZE).filter(sampler::isSampled).count()).isEqualTo(
+        INPUT_SIZE);
+  }
+
+  @Test
+  public void rateCantBeNegative() {
+    thrown.expect(IllegalArgumentException.class);
+
+    newSampler(-1.0f);
+  }
+
+  @Test
+  public void rateCantBeOverOne() {
+    thrown.expect(IllegalArgumentException.class);
+
+    newSampler(1.1f);
+  }
+}

--- a/brave/src/test/resources/log4j2.properties
+++ b/brave/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders = console
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level = warn
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.zipkin.brave</groupId>
   <artifactId>brave-parent</artifactId>
-  <version>3.18.1-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Brave (parent)</name>
@@ -71,6 +71,7 @@
   </properties>
 
   <modules>
+    <module>brave</module>
     <module>brave-core</module>
     <module>brave-benchmarks</module>
     <module>brave-http</module>


### PR DESCRIPTION
Brave Api (v4) (see #180)
==============

Brave is a library used to capture and report latency information about
distributed operations to Zipkin. Most users won't use Brave directly,
rather libraries or frameworks than employ Brave on their behalf.

This module includes tracer creates and joins spans that model the
latency of potentially distributed work. It also includes libraries to
propagate the trace context over network boundaries, for example, via
http headers.

## Basics
The tracer creates and joins spans that model the latency of potentially
distributed work. It can employ sampling to reduce overhead in process
or to reduce the amount of data sent to Zipkin.

Spans returned by a tracer report data to Zipkin when finished, or do
nothing if unsampled. After starting a span, you can annotate events of
interest or add tags containing details or lookup keys.

Spans have a context which includes trace identifiers that place it at
the correct spot in the tree representing the distributed operation.

### Local Tracing

When tracing local code, just run it inside a span.
```java
try (Span span = tracer.newTrace().name("encode").start()) {
  doSomethingExpensive();
}
```

In the above example, the span is the root of the trace. In many cases,
you will be a part of an existing trace. When this is the case, call
`newChild` instead of `newTrace`

```java
try (Span root = tracer.newTrace().name("2pc").start()) {
  try (Span child = tracer.newChild(root.context()).name("prepare").start()) {
    prepare();
  }
  try (Span child = tracer.newChild(root.context()).name("commit").start()) {
    commit();
  }
}
```

Once you have a span, you can add tags to it, which can be used as lookup
keys or details. For example, you might add a tag with your runtime version:

```java
span.tag("clnt/finagle.version", "6.36.0");
```

### RPC tracing
RPC tracing is often done automatically by interceptors. Under the scenes,
they add tags and events that relate to their role in an RPC operation.

Here's an example of a client span:
```java
// before you send a request, add metadata that describes the operation
span = tracer.newTrace().name("get").type(CLIENT);
span.tag("clnt/finagle.version", "6.36.0");
span.tag(TraceKeys.HTTP_PATH, "/api");
span.remoteEndpoint(Endpoint.builder()
    .serviceName("backend")
    .ipv4(127 << 24 | 1)
    .port(8080).build());

// when the request is scheduled, start the span
span.start();

// if you have callbacks for when data is on the wire, note those events
span.annotate(Constants.WIRE_SEND);
span.annotate(Constants.WIRE_RECV);

// when the response is complete, finish the span
span.finish();
```

## Sampling
Sampling may be employed to reduce the data collected and reported out
of process. When a span isn't sampled, it adds no overhead (noop).

Sampling is an up-front decision, meaning that the decision to report
data is made at the first operation in a trace, and that decision is
propagated downstream.

By default, there's a global sampler that applies a single rate to all
traced operations. `Tracer.Builder.sampler` is how you indicate this,
and it defaults to trace every request.

### Custom sampling

You may want to apply different policies depending on what the operation
is. For example, you might not want to trace requests to static resources
such as images, or you might want to trace all requests to a new api.

Most users will use a framework interceptor which automates this sort of
policy. Here's how they might work internally.

```java
Span newTrace(Request input) {
  SamplingFlags flags = SamplingFlags.NONE;
  if (input.url().startsWith("/experimental")) {
    flags = SamplingFlags.SAMPLED;
  } else if (input.url().startsWith("/static")) {
    flags = SamplingFlags.NOT_SAMPLED;
  }
  return tracer.newTrace(flags);
}
```

## Propagation
Brave has customizable support for in-band propagation of the trace
context. For example, it has built-in support for [B3](https://github.com/openzipkin/b3-propagation),
which has implementations in many languages and frameworks.

Most users will use a framework interceptor which automates propagation.
Here's how they might work internally.

```java
// configure a function that injects a trace context into a request
injector = Propagation.B3_STRING.injector(Request.Builder::addHeader);

// before a request is sent, add the current span's context to it
injector.inject(span.context(), request);

// configure a function that extracts the trace context from a request
extractor = Propagation.B3_STRING.extractor(Request::getHeader);

// when a server receives a request, it joins or starts a new trace
contextOrFlags = extractor.extract(request);
span = contextOrFlags.context() != null
    ? tracer.joinSpan(contextOrFlags.context())
    : tracer.newTrace(contextOrFlags.samplingFlags());
```

## Performance
Brave has been built with performance in mind. Using the core Span api,
you can record spans in sub-microseconds. When a span is sampled, there's
effectively no overhead (as it is a noop).

Unlike previous implementations, Brave 4 only needs one timestamp per
span. All annotations are recorded on an offset basis, using the less
expensive and more precise `System.nanoTime()` function.

## Upgrading from Brave 3
Brave 4 was designed to live alongside Brave 3. Using `TracerAdapter`,
you can navigate between apis, buying you time to update as appropriate.

### Creating a Brave 3 instance
To wire up a mixed-version application, first create a (Brave 4) Tracer.
Then, use `TracerAdapter` to create a (Brave 3) .. Brave.

```java
Tracer brave4 = Tracer.newBuilder()...build();
Brave brave3 = TracerAdapter.newBrave(brave4);
```

### Converting between types
`TracerAdapter.toSpan` is used to navigate between span types.

If you have a reference to a Brave 3 Span, you can convert like this:
```java
brave3Span = brave3.localSpanThreadBinder().getCurrentLocalSpan();
brave4Span = TracerAdapter.toSpan(brave4, brave3Span);
```

You can also attach Brave 4 Span to a Brave 3 thread binder like this:
```java
brave3Span = TracerAdapter.toSpan(brave4Span.context());
brave3.localSpanThreadBinder().setCurrentSpan(brave3Span);
```

### Dependencies
`io.zipkin.brave:brave`(Brave 4) is an optional dependency of
`io.zipkin.brave:brave-core`(Brave 3). To use `TracerAdapter`, you need
to declare an explicit dependency, and ensure both libraries are of the
same version.

### Notes
* Never mutate `com.twitter.zipkin.gen.Span` directly. Doing so will
  break the above integration.
* The above only works when `com.github.kristofa.brave.Brave` was
  instantiated via `TracerAdapter.newBrave`

## 128-bit trace IDs

Traditionally, Zipkin trace IDs were 64-bit. Starting with Zipkin 1.14,
128-bit trace identifiers are supported. This can be useful in sites that
have very large traffic volume, persist traces forever, or are re-using
externally generated 128-bit IDs.

If you want Brave to generate 128-bit trace identifiers when starting new
root spans, set `Tracer.Builder.traceId128Bit(true)`

When 128-bit trace ids are propagated, they will be twice as long as
before. For example, the `X-B3-TraceId` header will hold a 32-character
value like `163ac35c9f6413ad48485a3953bb6124`.

Before doing this, ensure your Zipkin setup is up-to-date, and downstream
instrumented services can read the longer 128-bit trace IDs.

Note: this only affects the trace ID, not span IDs. For example, span ids
within a trace are always 64-bit.

## Acknowledgements
Brave 4's design lends from past experience and similar open source work.
Quite a lot of decisions were driven by portability with Brave 3, and the
dozens of individuals involved in that. There are notable new aspects
that are borrowed or adapted from others.

### Stateful Span object
Brave 4 allows you to pass around a Span object which can report itself
to Zipkin when finished. This is better than using thread contexts in
some cases, particularly where many async hops are in use. The Span api
is derived from OpenTracing, narrowed to more cleanly match Zipkin's
abstraction. As a result, a bridge from Brave 4 to OpenTracing v0.20.2
is relatively little code. It should be able to implement future
versions of OpenTracing as well.

### Recorder architecture
Much of Brave 4's architecture is borrowed from Finagle, whose design
implies a separation between the propagated trace context and the data
collected in process. For example, Brave's MutableSpanMap is the same
overall design as Finagle's. The internals of MutableSpanMap were adapted
from [WeakConcurrentMap](https://github.com/raphw/weak-lock-free).

### Propagation Api
OpenTracing's Tracer type has methods to inject or extract a trace
context from a carrier. While naming is similar, Brave optimizes for
direct integration with carrier types (such as http request) vs routing
through an intermediate (such as a map). Brave also considers propagation
a separate api from the tracer.

### Public namespace
Brave 4's pubic namespace is more defensive that the past, using a package
accessor design from [OkHttp](https://github.com/square/okhttp).
