### PR TITLE
Support Apache HttpAsyncClient "client received"

### DIFF
--- a/brave-apache-http-interceptors/README.md
+++ b/brave-apache-http-interceptors/README.md
@@ -1,6 +1,7 @@
 # brave-apache-http-interceptors #
 
-Http Request and Response interceptors that can be used with [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.3.x/index.html).
+HTTP request and response interceptors that can be used with [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html)
+and [Apache HttpAsyncClient](http://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html).
 
 Apache HttpClient is probably the most known and used Java Http client. These interceptors make it easy
 to integrate with brave to catch/trace client requests. The request interceptor will start a new
@@ -15,4 +16,5 @@ CloseableHttpClient httpclient = HttpClients.custom()
     .addInterceptorFirst(BraveHttpResponseInterceptor.create(brave))
     .build();
 ```
-It is tested with httpclient version 4.3.3.
+
+It is tested with httpclient version 4.4.1.

--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -42,5 +42,10 @@
         <artifactId>brave-http-tests</artifactId>
         <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpasyncclient</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
@@ -2,7 +2,9 @@ package com.github.kristofa.brave.httpclient;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.ClientSpanThreadBinder;
 import com.github.kristofa.brave.http.HttpClientResponseAdapter;
+import com.twitter.zipkin.gen.Span;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
@@ -39,17 +41,21 @@ public class BraveHttpResponseInterceptor implements HttpResponseInterceptor {
     }
 
     private final ClientResponseInterceptor responseInterceptor;
+    private final ClientSpanThreadBinder spanThreadBinder;
 
     BraveHttpResponseInterceptor(Builder b) { // intentionally hidden
         this.responseInterceptor = b.brave.clientResponseInterceptor();
+        this.spanThreadBinder = b.brave.clientSpanThreadBinder();
     }
 
     /**
-     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}
+     * @deprecated please use {@link #create(Brave)} or {@link #builder(Brave)}; using this constructor means that
+     * a "client received" event will not be sent when using {@code HttpAsyncClient}
      */
     @Deprecated
     public BraveHttpResponseInterceptor(final ClientResponseInterceptor responseInterceptor) {
         this.responseInterceptor = responseInterceptor;
+        this.spanThreadBinder = null;
     }
 
     /**
@@ -57,6 +63,16 @@ public class BraveHttpResponseInterceptor implements HttpResponseInterceptor {
      */
     @Override
     public void process(final HttpResponse response, final HttpContext context) throws HttpException, IOException {
+        // When using HttpAsyncClient, this interceptor does not run on the same thread as the request interceptor.
+        // So in that case, the current client span will be null. To still be able to submit "client received", we get
+        // the span from the HttpContext (where we put it in the request interceptor).
+        if (spanThreadBinder.getCurrentClientSpan() == null) {
+            Object span = context.getAttribute(BraveHttpRequestInterceptor.SPAN_ATTRIBUTE);
+            if (span instanceof Span) {
+                spanThreadBinder.setCurrentSpan((Span) span);
+            }
+        }
+
         final HttpClientResponseImpl httpClientResponse = new HttpClientResponseImpl(response);
         responseInterceptor.handle(new HttpClientResponseAdapter(httpClientResponse));
     }

--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveAsyncHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveAsyncHttpRequestInterceptor.java
@@ -1,0 +1,72 @@
+package com.github.kristofa.brave.httpclient;
+
+import com.github.kristofa.brave.http.ITHttpClient;
+import com.github.kristofa.brave.http.SpanNameProvider;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class ITBraveAsyncHttpRequestInterceptor extends ITHttpClient<CloseableHttpAsyncClient> {
+
+    @Override
+    protected CloseableHttpAsyncClient newClient(int port) {
+        return configureClient(BraveHttpRequestInterceptor.create(brave));
+    }
+
+    @Override
+    protected CloseableHttpAsyncClient newClient(int port, SpanNameProvider spanNameProvider) {
+        return configureClient(BraveHttpRequestInterceptor.builder(brave)
+                .spanNameProvider(spanNameProvider).build());
+    }
+
+    private CloseableHttpAsyncClient configureClient(BraveHttpRequestInterceptor requestInterceptor) {
+        CloseableHttpAsyncClient client = HttpAsyncClients.custom()
+                .addInterceptorFirst(requestInterceptor)
+                .addInterceptorFirst(BraveHttpResponseInterceptor.create(brave))
+                .build();
+        client.start();
+        return client;
+    }
+
+    @Override
+    protected void closeClient(CloseableHttpAsyncClient client) throws IOException {
+        client.close();
+    }
+
+    @Override
+    protected void get(CloseableHttpAsyncClient client, String pathIncludingQuery)
+            throws IOException {
+        getAsync(client, pathIncludingQuery);
+    }
+
+    @Override
+    protected void getAsync(CloseableHttpAsyncClient client, String pathIncludingQuery) {
+        try {
+            client.execute(new HttpGet(server.url(pathIncludingQuery).uri()), null).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    @Test(expected = AssertionError.class) // doesn't yet close a span on exception
+    public void addsErrorTagOnTransportException() throws Exception {
+        super.addsErrorTagOnTransportException();
+    }
+
+    @Override
+    @Test(expected = AssertionError.class) // base url is not logged in apache
+    public void httpUrlTagIncludesQueryParams() throws Exception {
+        super.httpUrlTagIncludesQueryParams();
+    }
+
+    @Override
+    @Test(expected = AssertionError.class) // doesn't yet close a span on exception
+    public void reportsSpanOnTransportException() throws Exception {
+        super.reportsSpanOnTransportException();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
             <version>${httpcomponents.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>4.1.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>


### PR DESCRIPTION
Before, BraveHttpResponseInterceptor would call
ClientResponseInterceptor and it would call setClientReceived. But it
would not submit the end annotation because the current client span was
null. This is because the response interceptor is not called on the same
thread as the request interceptor.

This can be solved by storing the client span as an attribute on the
HttpContext instead.