### PR TITLE
Moves offset-logic into the default clock type

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
@@ -76,7 +76,6 @@ public class ServerRequestInterceptor {
             Span span = serverTracer.spanAndEndpoint().span();
             synchronized (span) {
                 span.setTimestamp(null);
-                span.startTick = null;
             }
         }
     }

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -20,11 +20,6 @@ public class Span implements Serializable {
 
   static final long serialVersionUID = 1L;
 
-  /**
-   * Internal field, used for deriving duration with {@link System#nanoTime()}.
-   */
-  public volatile Long startTick;
-
   private long trace_id; // required
   private long trace_id_high; // optional (default to zero)
   private String name; // required

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -96,7 +96,6 @@ public class ServerRequestInterceptorTest {
         // don't log timestamp when span is client-originated
         Span span = state.getCurrentServerSpan().getSpan();
         assertThat(span.getTimestamp()).isNull();
-        assertThat(span.startTick).isNull();
     }
 
     @Test
@@ -113,7 +112,6 @@ public class ServerRequestInterceptorTest {
         // We originated the trace, so we should set the timestamp
         Span span = state.getCurrentServerSpan().getSpan();
         assertThat(span.getTimestamp()).isNotNull();
-        assertThat(span.startTick).isNotNull();
     }
 
     @Test

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
@@ -1,7 +1,6 @@
 package com.twitter.zipkin.gen;
 
 import org.junit.Test;
-import zipkin.Constants;
 
 import static org.junit.Assert.assertEquals;
 
@@ -22,11 +21,5 @@ public class SpanTest {
         .setDuration(376000L);
 
     assertEquals("{\"traceId\":\"f66529c8cc356aa0\",\"id\":\"f66529c8cc356aa0\",\"name\":\"get\",\"timestamp\":1444438900939000,\"duration\":376000}", span.toString());
-  }
-
-  @Test
-  public void canStoreNanoTimeForDurationCalculation() {
-    Span span = new Span();
-    span.startTick = System.nanoTime();
   }
 }

--- a/brave-okhttp/pom.xml
+++ b/brave-okhttp/pom.xml
@@ -41,18 +41,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-http-tests</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Before, we repeated offset logic in each of the 3 tracers plus an
internal tick holder. This centralizes it into the default clock, which
dramatically simplifies the code and eliminates the need to expose a
tick anywhere. If anyone doesn't like offset-based approach, they can
easily replace the clock, too.