### PR TITLE
Moves internal utility methods out of Span, adds context and hardening

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
@@ -1,11 +1,14 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
+import java.util.Random;
 import zipkin.reporter.Reporter;
 
+import static com.github.kristofa.brave.internal.DefaultSpanCodec.toZipkin;
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
@@ -32,15 +35,13 @@ public abstract class AnnotationSubmitter {
         long currentTimeMicroseconds();
     }
 
-    static AnnotationSubmitter create(SpanAndEndpoint spanAndEndpoint) {
-        return new AnnotationSubmitterImpl(spanAndEndpoint, DefaultClock.INSTANCE);
-    }
-
     public static AnnotationSubmitter create(SpanAndEndpoint spanAndEndpoint, Clock clock) {
         return new AnnotationSubmitterImpl(spanAndEndpoint, clock);
     }
 
     abstract SpanAndEndpoint spanAndEndpoint();
+    abstract Random randomGenerator();
+    abstract boolean traceId128Bit();
 
     /**
      * The implementation of Clock to use.
@@ -129,7 +130,7 @@ public abstract class AnnotationSubmitter {
                 span.setDuration(Math.max(1L, endTimestamp - startTimestamp));
             }
         }
-        reporter.report(span.toZipkin());
+        reporter.report(toZipkin(span));
         return true;
     }
 
@@ -186,6 +187,25 @@ public abstract class AnnotationSubmitter {
         }
     }
 
+    SpanId nextContext(@Nullable Span maybeParent) {
+        long newSpanId = randomGenerator().nextLong();
+        if (maybeParent == null) { // new trace
+            return SpanId.builder()
+                .spanId(newSpanId)
+                .traceIdHigh(traceId128Bit() ? randomGenerator().nextLong() : 0L).build();
+        } else if (maybeParent.context() != null) {
+            return maybeParent.context().toBuilder()
+                .parentId(maybeParent.getId())
+                .spanId(newSpanId).build();
+        }
+        // If we got here, some implementation of state passed a deprecated span
+        return SpanId.builder()
+            .traceIdHigh(maybeParent.getTrace_id_high())
+            .traceId(maybeParent.getTrace_id())
+            .parentId(maybeParent.getId())
+            .spanId(newSpanId).build();
+    }
+
     AnnotationSubmitter() {
     }
 
@@ -202,6 +222,14 @@ public abstract class AnnotationSubmitter {
         @Override
         SpanAndEndpoint spanAndEndpoint() {
             return spanAndEndpoint;
+        }
+
+        @Override Random randomGenerator() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override boolean traceId128Bit() {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -47,6 +47,12 @@ public class Brave {
         private AnnotationSubmitter.Clock clock = AnnotationSubmitter.DefaultClock.INSTANCE;
         private boolean traceId128Bit = false;
 
+        // visible for testing
+        Builder random(Random random) {
+            this.random = random;
+            return this;
+        }
+
         /**
          * Builder which initializes with serviceName = "unknown".
          * <p>
@@ -293,7 +299,7 @@ public class Brave {
         serverResponseInterceptor = new ServerResponseInterceptor(serverTracer);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
-        serverSpanAnnotationSubmitter = AnnotationSubmitter.create(SpanAndEndpoint.ServerSpanAndEndpoint.create(builder.state));
+        serverSpanAnnotationSubmitter = AnnotationSubmitter.create(SpanAndEndpoint.ServerSpanAndEndpoint.create(builder.state), builder.clock);
         serverSpanThreadBinder = new ServerSpanThreadBinder(builder.state);
         clientSpanThreadBinder = new ClientSpanThreadBinder(builder.state);
         localSpanThreadBinder = new LocalSpanThreadBinder(builder.state);

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
@@ -33,12 +33,12 @@ public class ClientRequestInterceptor {
      */
     public void handle(ClientRequestAdapter adapter) {
 
-        SpanId spanId = clientTracer.startNewSpan(adapter.getSpanName());
-        if (spanId == null) {
+        SpanId context = clientTracer.startNewSpan(adapter.getSpanName());
+        if (context == null) {
             // We will not trace this request.
             adapter.addSpanIdToRequest(null);
         } else {
-            adapter.addSpanIdToRequest(spanId);
+            adapter.addSpanIdToRequest(context);
             for (KeyValueAnnotation annotation : adapter.requestAnnotations()) {
                 clientTracer.submitBinaryAnnotation(annotation.getKey(), annotation.getValue());
             }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -40,7 +40,7 @@ public abstract class ServerSpan {
     static ServerSpan create(SpanId spanId, String name) {
         if (spanId == null) throw new NullPointerException("spanId == null");
         if (name == null) throw new NullPointerException("name == null");
-        return new AutoValue_ServerSpan(spanId, Span.fromSpanId(spanId).setName(name), true);
+        return new AutoValue_ServerSpan(spanId, Span.create(spanId).setName(name), true);
     }
 
     ServerSpan(){

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorReporterAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorReporterAdapter.java
@@ -1,9 +1,6 @@
 package com.github.kristofa.brave;
 
-import com.twitter.zipkin.gen.Annotation;
-import com.twitter.zipkin.gen.AnnotationType;
-import com.twitter.zipkin.gen.BinaryAnnotation;
-import com.twitter.zipkin.gen.Endpoint;
+import com.github.kristofa.brave.internal.DefaultSpanCodec;
 import com.twitter.zipkin.gen.Span;
 import zipkin.reporter.Reporter;
 
@@ -19,7 +16,7 @@ final class SpanCollectorReporterAdapter implements SpanCollector, Reporter<zipk
 
   @Override public void report(zipkin.Span span) {
     checkNotNull(span, "Null span");
-    collect(toBrave(span));
+    collect(DefaultSpanCodec.fromZipkin(span));
   }
 
   @Override
@@ -32,36 +29,5 @@ final class SpanCollectorReporterAdapter implements SpanCollector, Reporter<zipk
   @Override
   public void addDefaultAnnotation(String key, String value) {
     delegate.addDefaultAnnotation(key, value);
-  }
-
-  /** Changes this to a brave-native span object. */
-  static Span toBrave(zipkin.Span input) {
-    Span result = new Span();
-    result.setTrace_id_high(input.traceIdHigh);
-    result.setTrace_id(input.traceId);
-    result.setId(input.id);
-    result.setParent_id(input.parentId);
-    result.setName(input.name);
-    result.setTimestamp(input.timestamp);
-    result.setDuration(input.duration);
-    result.setDebug(input.debug);
-    for (zipkin.Annotation a : input.annotations) {
-      result.addToAnnotations(Annotation.create(a.timestamp, a.value, from(a.endpoint)));
-    }
-    for (zipkin.BinaryAnnotation a : input.binaryAnnotations) {
-      result.addToBinary_annotations(BinaryAnnotation.create(
-          a.key, a.value, AnnotationType.fromValue(a.type.value), from(a.endpoint)
-      ));
-    }
-    return result;
-  }
-
-  private static Endpoint from(zipkin.Endpoint endpoint) {
-    if (endpoint == null) return null;
-    return Endpoint.builder()
-        .ipv4(endpoint.ipv4)
-        .ipv6(endpoint.ipv6)
-        .port(endpoint.port)
-        .serviceName(endpoint.serviceName).build();
   }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.Nullable;
-import com.twitter.zipkin.gen.Span;
 import java.nio.ByteBuffer;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
@@ -279,22 +278,6 @@ public final class SpanId {
     return new String(result);
   }
 
-  /**
-   * @deprecated deprecated to avoid coupling with old classes. Use {@link
-   * Span#fromSpanId(SpanId)} instead.
-   */
-  @Deprecated
-  public Span toSpan() {
-    Span result = new Span();
-    result.setId(spanId);
-    result.setTrace_id_high(traceIdHigh);
-    result.setTrace_id(traceId);
-    result.setParent_id(nullableParentId());
-    result.setName(""); // avoid NPE on equals
-    if (debug()) result.setDebug(debug());
-    return result;
-  }
-
   public static final class Builder {
     long traceIdHigh = 0;
     Long traceId;
@@ -361,7 +344,7 @@ public final class SpanId {
       return this;
     }
 
-    /** @see SpanId#shared() */
+    /** @see SpanId#shared */
     public Builder shared(boolean shared) {
       this.shared = shared;
       return this;

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -28,7 +28,7 @@ public class AnnotationSubmitterTest {
 
     private Endpoint endpoint =
         Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
-    private Span span = new Span().setName("foo");
+    private Span span = Span.create(SpanId.builder().spanId(1).build()).setName("foo");
     private AnnotationSubmitter annotationSubmitter;
 
     @Before

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
@@ -30,14 +30,13 @@ import com.twitter.zipkin.gen.Span;
 public class ITAnnotationSubmitterConcurrency {
 
     private ExecutorService executorService;
-    private Span span;
+    Span span = Span.create(SpanId.builder().spanId(1L).build());
     private Endpoint endpoint =
         Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
 
     @Before
     public void setup() {
         executorService = Executors.newFixedThreadPool(4);
-        span = new Span();
     }
 
     @After
@@ -48,7 +47,7 @@ public class ITAnnotationSubmitterConcurrency {
     @Test
     public void testSubmitAnnotations() throws InterruptedException, ExecutionException {
 
-        final AnnotationSubmitter annotationSubmitter = AnnotationSubmitter.create(StaticSpanAndEndpoint.create(span, endpoint));
+        final AnnotationSubmitter annotationSubmitter = AnnotationSubmitter.create(StaticSpanAndEndpoint.create(span, endpoint), AnnotationSubmitter.DefaultClock.INSTANCE);
 
         final List<AnnotationSubmitThread> threadList =
             Arrays.asList(new AnnotationSubmitThread(1, 100, annotationSubmitter), new AnnotationSubmitThread(101, 200,

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -8,7 +8,6 @@ import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InOrder;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -16,9 +15,7 @@ import zipkin.Constants;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -29,25 +26,19 @@ public class ServerTracerTest {
 
     private static final long START_TIME_MICROSECONDS = System.currentTimeMillis() * 1000;
     private static final long TRACE_ID = 1;
-    private static final SpanId SPAN_ID = SpanId.builder().traceId(TRACE_ID).spanId(2).parentId(3L).build();
+    private static final SpanId CONTEXT = SpanId.builder().traceId(TRACE_ID).spanId(2).parentId(3L).build();
     private static final String SPAN_NAME = "span name";
 
     private ServerTracer serverTracer;
-    private ServerSpanState mockServerSpanState;
     private SpanCollector mockSpanCollector;
-    private ServerSpan mockServerSpan;
-    private Span mockSpan;
-    private Endpoint mockEndpoint = Endpoint.create("service", 0);
+    private Endpoint endpoint = Endpoint.create("service", 0);
     private Random mockRandom;
     private Sampler mockSampler;
+    private Span span = Span.create(CONTEXT);
 
     @Before
     public void setup() {
-        mockServerSpanState = mock(ServerSpanState.class);
         mockSpanCollector = mock(SpanCollector.class);
-        mockSpan = mock(Span.class);
-        mockServerSpan = mock(ServerSpan.class);
-
         mockRandom = mock(Random.class);
         mockSampler = mock(Sampler.class);
 
@@ -55,55 +46,46 @@ public class ServerTracerTest {
         PowerMockito.when(System.currentTimeMillis()).thenReturn(START_TIME_MICROSECONDS / 1000);
         PowerMockito.when(System.nanoTime()).thenReturn(0L);
 
-        serverTracer = ServerTracer.builder()
-            .state(mockServerSpanState)
-            .randomGenerator(mockRandom)
+        serverTracer = new Brave.Builder(endpoint)
+            .random(mockRandom)
             .spanCollector(mockSpanCollector)
             .traceSampler(mockSampler)
             .clock(new AnnotationSubmitter.DefaultClock())
             .traceId128Bit(false)
-            .build();
+            .build().serverTracer();
     }
 
     @Test
     public void testClearCurrentSpan() {
         serverTracer.clearCurrentSpan();
-        verify(mockServerSpanState).setCurrentServerSpan(null);
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
+        assertThat(serverTracer.spanAndEndpoint().span()).isNull();
     }
 
     @Test
     public void testSetStateCurrentTrace() {
-        serverTracer.setStateCurrentTrace(SPAN_ID, SPAN_NAME);
-        ServerSpan expectedServerSpan = ServerSpan.create(SPAN_ID, SPAN_NAME);
-        verify(mockServerSpanState).setCurrentServerSpan(expectedServerSpan);
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
+        serverTracer.setStateCurrentTrace(CONTEXT, SPAN_NAME);
+
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.create(CONTEXT, SPAN_NAME));
     }
 
     @Test
     public void testSetStateNoTracing() {
         serverTracer.setStateNoTracing();
-        verify(mockServerSpanState).setCurrentServerSpan(ServerSpan.NOT_SAMPLED);
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
+
+        assertThat(serverTracer.spanAndEndpoint().state().sample())
+            .isFalse();
     }
 
     @Test
     public void testSetStateUnknownSamplerTrue() {
-
         when(mockRandom.nextLong()).thenReturn(TRACE_ID);
         when(mockSampler.isSampled(TRACE_ID)).thenReturn(true);
 
         serverTracer.setStateUnknown(SPAN_NAME);
-        ServerSpan expectedServerSpan = ServerSpan.create(
-            SpanId.builder().spanId(TRACE_ID).build(), SPAN_NAME);
 
-        final InOrder inOrder = inOrder(mockSampler, mockRandom, mockServerSpanState);
-
-        inOrder.verify(mockRandom).nextLong();
-        inOrder.verify(mockSampler).isSampled(TRACE_ID);
-        inOrder.verify(mockServerSpanState).setCurrentServerSpan(expectedServerSpan);
-
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector, mockRandom);
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.create(SpanId.builder().spanId(TRACE_ID).build(), SPAN_NAME));
     }
 
     @Test
@@ -115,19 +97,12 @@ public class ServerTracerTest {
         when(mockSampler.isSampled(TRACE_ID)).thenReturn(true);
 
         serverTracer.setStateUnknown(SPAN_NAME);
-        ServerSpan expectedServerSpan = ServerSpan.create(SpanId.builder()
-            .traceIdHigh(TRACE_ID + 1)
-            .traceId(TRACE_ID)
-            .spanId(TRACE_ID).build(), SPAN_NAME);
 
-        final InOrder inOrder = inOrder(mockSampler, mockRandom, mockServerSpanState);
-
-        inOrder.verify(mockRandom).nextLong();
-        inOrder.verify(mockSampler).isSampled(TRACE_ID);
-        inOrder.verify(mockRandom).nextLong();
-        inOrder.verify(mockServerSpanState).setCurrentServerSpan(expectedServerSpan);
-
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector, mockRandom);
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.create(SpanId.builder()
+                .traceIdHigh(TRACE_ID + 1)
+                .traceId(TRACE_ID)
+                .spanId(TRACE_ID).build(), SPAN_NAME));
     }
 
     @Test
@@ -137,171 +112,149 @@ public class ServerTracerTest {
 
         serverTracer.setStateUnknown(SPAN_NAME);
 
-        final InOrder inOrder = inOrder(mockSampler, mockRandom, mockServerSpanState);
-
-        inOrder.verify(mockRandom).nextLong();
-        inOrder.verify(mockSampler).isSampled(TRACE_ID);
-        inOrder.verify(mockServerSpanState).setCurrentServerSpan(ServerSpan.NOT_SAMPLED);
-
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector, mockRandom);
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.NOT_SAMPLED);
     }
 
     @Test
     public void testSetServerReceivedNoServerSpan() {
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(null);
 
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
-        when(mockServerSpan.getSpan()).thenReturn(null);
         serverTracer.setServerReceived();
-        verify(mockServerSpanState).getCurrentServerSpan();
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
+
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.EMPTY);
     }
 
     @Test
     public void testSetServerReceived() {
-        Span serverRecv = new Span();
-        when(mockServerSpan.getSpan()).thenReturn(serverRecv);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
-        when(mockServerSpanState.endpoint()).thenReturn(mockEndpoint);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
+
         serverTracer.setServerReceived();
 
-        final Annotation expectedAnnotation = Annotation.create(
+        Annotation expectedAnnotation = Annotation.create(
             START_TIME_MICROSECONDS,
             Constants.SERVER_RECV,
-            mockEndpoint
+            endpoint
         );
 
-        verify(mockServerSpanState).getCurrentServerSpan();
-        verify(mockServerSpanState).endpoint();
-
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
-
-        assertEquals(START_TIME_MICROSECONDS, serverRecv.getTimestamp().longValue());
-        assertEquals(expectedAnnotation, serverRecv.getAnnotations().get(0));
+        assertEquals(START_TIME_MICROSECONDS, span.getTimestamp().longValue());
+        assertEquals(expectedAnnotation, span.getAnnotations().get(0));
     }
 
     @Test
     public void testSetServerReceivedSentClientAddress() {
-        Span serverRecv = new Span();
-        when(mockServerSpan.getSpan()).thenReturn(serverRecv);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
-        when(mockServerSpanState.endpoint()).thenReturn(mockEndpoint);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
+
         serverTracer.setServerReceived(Endpoint.builder()
             .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4)
             .port(9999)
             .serviceName("foobar").build());
 
-
-        final Annotation expectedAnnotation = Annotation.create(
+        Annotation expectedAnnotation = Annotation.create(
             START_TIME_MICROSECONDS,
             Constants.SERVER_RECV,
-            mockEndpoint
+            endpoint
         );
 
-        verify(mockServerSpanState, times(2)).getCurrentServerSpan();
-        verify(mockServerSpanState).endpoint();
-
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
-
-        assertEquals(START_TIME_MICROSECONDS, serverRecv.getTimestamp().longValue());
-        assertEquals(expectedAnnotation, serverRecv.getAnnotations().get(0));
+        assertEquals(START_TIME_MICROSECONDS, span.getTimestamp().longValue());
+        assertEquals(expectedAnnotation, span.getAnnotations().get(0));
 
         BinaryAnnotation serverAddress = BinaryAnnotation.address(
             Constants.CLIENT_ADDR,
             Endpoint.builder().serviceName("foobar").ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4).port(9999).build()
         );
-        assertEquals(serverAddress, serverRecv.getBinary_annotations().get(0));
+        assertEquals(serverAddress, span.getBinary_annotations().get(0));
     }
 
     @Test
     public void testSetServerReceivedSentClientAddress_noServiceName() {
-        Span serverRecv = new Span();
-        when(mockServerSpan.getSpan()).thenReturn(serverRecv);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
-        when(mockServerSpanState.endpoint()).thenReturn(mockEndpoint);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
+
         serverTracer.setServerReceived(1 << 24 | 2 << 16 | 3 << 8 | 4, 9999, null);
 
-        assertEquals("unknown", serverRecv.getBinary_annotations().get(0).host.service_name);
+        assertEquals("unknown", span.getBinary_annotations().get(0).host.service_name);
     }
 
     @Test
     public void testSetServerSendShouldNoServerSpan() {
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(null);
 
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
-        when(mockServerSpan.getSpan()).thenReturn(null);
         serverTracer.setServerSend();
-        verify(mockServerSpanState).getCurrentServerSpan();
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector, mockSpan);
+
+        verifyNoMoreInteractions(mockSpanCollector);
     }
 
     @Test
     public void testSetServerSend() {
-        Span serverSend = new Span().setName("foo").setTimestamp(100L);
-        when(mockServerSpan.getSpan()).thenReturn(serverSend);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
-        when(mockServerSpanState.endpoint()).thenReturn(mockEndpoint);
+        span.setTimestamp(100L);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
+
         serverTracer.setServerSend();
 
-        final Annotation expectedAnnotation = Annotation.create(
+        Annotation expectedAnnotation = Annotation.create(
             START_TIME_MICROSECONDS,
             Constants.SERVER_SEND,
-            mockEndpoint
+            endpoint
         );
 
-        verify(mockServerSpanState).getCurrentServerSpan();
-        verify(mockServerSpanState).endpoint();
+        verify(mockSpanCollector).collect(span);
 
-        verify(mockSpanCollector).collect(serverSend);
-        verify(mockServerSpanState).setCurrentServerSpan(null);
-        verifyNoMoreInteractions(mockServerSpanState, mockSpanCollector);
+        assertThat(serverTracer.spanAndEndpoint().state().getCurrentServerSpan())
+            .isEqualTo(ServerSpan.EMPTY);
 
-        assertEquals(START_TIME_MICROSECONDS - serverSend.getTimestamp().longValue(), serverSend.getDuration().longValue());
-        assertEquals(expectedAnnotation, serverSend.getAnnotations().get(0));
+        assertEquals(START_TIME_MICROSECONDS - span.getTimestamp().longValue(), span.getDuration().longValue());
+        assertEquals(expectedAnnotation, span.getAnnotations().get(0));
     }
 
     @Test
     public void setServerSend_skipsDurationWhenNoTimestamp() {
-        Span finished = new Span().setName("foo"); // duration unset due to client-originated trace
-        when(mockServerSpan.getSpan()).thenReturn(finished);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
+        // duration unset due to client-originated trace
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
 
         serverTracer.setServerSend();
 
-        verify(mockSpanCollector).collect(finished);
+        verify(mockSpanCollector).collect(span);
         verifyNoMoreInteractions(mockSpanCollector);
 
-        assertThat(finished.getDuration()).isNull();
+        assertThat(span.getDuration()).isNull();
     }
 
     @Test
     public void setServerSend_usesPreciseDuration() {
-        Span finished = new Span().setName("foo").setTimestamp(START_TIME_MICROSECONDS);
-        when(mockServerSpan.getSpan()).thenReturn(finished);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
+        span.setTimestamp(START_TIME_MICROSECONDS);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
 
         PowerMockito.when(System.nanoTime()).thenReturn(500000L);
 
         serverTracer.setServerSend();
 
-        verify(mockSpanCollector).collect(finished);
+        verify(mockSpanCollector).collect(span);
         verifyNoMoreInteractions(mockSpanCollector);
 
-        assertEquals(500L, finished.getDuration().longValue());
+        assertEquals(500L, span.getDuration().longValue());
     }
 
     /** Duration of less than one microsecond is confusing to plot and could coerce to null. */
     @Test
     public void setServerSend_lessThanMicrosRoundUp() {
-        Span finished = new Span().setName("foo").setTimestamp(START_TIME_MICROSECONDS);
-        when(mockServerSpan.getSpan()).thenReturn(finished);
-        when(mockServerSpanState.getCurrentServerSpan()).thenReturn(mockServerSpan);
+        span.setTimestamp(START_TIME_MICROSECONDS);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        serverTracer.spanAndEndpoint().state().setCurrentServerSpan(serverSpan);
 
         PowerMockito.when(System.nanoTime()).thenReturn(50L);
 
         serverTracer.setServerSend();
 
-        verify(mockSpanCollector).collect(finished);
+        verify(mockSpanCollector).collect(span);
         verifyNoMoreInteractions(mockSpanCollector);
 
-        assertEquals(1L, finished.getDuration().longValue());
+        assertEquals(1L, span.getDuration().longValue());
     }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/SpanIdTest.java
@@ -2,7 +2,6 @@ package com.github.kristofa.brave;
 
 import com.twitter.finagle.tracing.TraceId;
 import com.twitter.finagle.tracing.TraceId$;
-import com.twitter.zipkin.gen.Span;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -212,16 +211,5 @@ public class SpanIdTest {
 
     assertThat(SpanId.fromBytes(id.bytes()))
         .isEqualTo(id);
-  }
-
-  @Test
-  public void toSpan_128() {
-    SpanId id = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
-
-    Span span = Span.fromSpanId(id);
-    assertThat(span.getTrace_id_high()).isEqualTo(id.traceIdHigh);
-    assertThat(span.getTrace_id()).isEqualTo(id.traceId);
-    assertThat(span.getId()).isEqualTo(id.spanId);
-    assertThat(span.getParent_id()).isEqualTo(id.parentId);
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave.internal;
 
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
@@ -19,10 +20,8 @@ public class DefaultSpanCodecTest {
       .ipv6(sun.net.util.IPAddressUtil.textToNumericFormatV6("2001:db8::c001"))
       .port(80).build();
 
-  Span span = new Span() // browser calls web
-      .setTrace_id(-692101025335252320L)
+  Span span = Span.create(SpanId.builder().spanId(-692101025335252320L).build()) // browser calls web
       .setName("get")
-      .setId(-692101025335252320L)
       .setTimestamp(1444438900939000L)
       .setDuration(376000L)
       .addToAnnotations(Annotation.create(1444438900939000L, Constants.SERVER_RECV, web))
@@ -51,7 +50,7 @@ public class DefaultSpanCodecTest {
 
   @Test
   public void roundTripSpan_json_128() {
-    span.setTrace_id_high(3L);
+    span = Span.create(span.context().toBuilder().traceIdHigh(3L).build());
 
     byte[] encoded = DefaultSpanCodec.JSON.writeSpan(span);
     assertEquals(span, DefaultSpanCodec.JSON.readSpan(encoded));

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
@@ -16,6 +16,7 @@ package com.github.kristofa.brave.internal;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Span;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
@@ -35,7 +36,7 @@ public final class MaybeAddClientAddressTest {
 
   @Mock
   ServerSpan serverSpan;
-  Span span = new Span();
+  Span span = Span.create(SpanId.builder().spanId(1L).build());
   @Mock
   Brave brave;
   @Mock

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
@@ -1,7 +1,9 @@
 package com.twitter.zipkin.gen;
 
+import com.github.kristofa.brave.SpanId;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class SpanTest {
@@ -21,5 +23,16 @@ public class SpanTest {
         .setDuration(376000L);
 
     assertEquals("{\"traceId\":\"f66529c8cc356aa0\",\"id\":\"f66529c8cc356aa0\",\"name\":\"get\",\"timestamp\":1444438900939000,\"duration\":376000}", span.toString());
+  }
+
+  @Test
+  public void toSpan_128() {
+    SpanId id = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
+
+    Span span = Span.create(id);
+    assertThat(span.getTrace_id_high()).isEqualTo(id.traceIdHigh);
+    assertThat(span.getTrace_id()).isEqualTo(id.traceId);
+    assertThat(span.getId()).isEqualTo(id.spanId);
+    assertThat(span.getParent_id()).isEqualTo(id.parentId);
   }
 }

--- a/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
+++ b/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
@@ -12,6 +12,8 @@ import zipkin.storage.AsyncSpanConsumer;
 import zipkin.storage.Callback;
 import zipkin.storage.StorageComponent;
 
+import static com.github.kristofa.brave.internal.DefaultSpanCodec.toZipkin;
+
 /**
  * SpanCollector which submits spans directly to a Zipkin {@link StorageComponent}.
  *
@@ -77,7 +79,7 @@ public final class LocalSpanCollector extends FlushingSpanCollector {
     // Brave 3 doesn't use zipkin spans. Convert accordingly
     List<zipkin.Span> zipkinSpans = new ArrayList<zipkin.Span>(drained.size());
     for (Span input : drained) {
-      zipkinSpans.add(input.toZipkin());
+      zipkinSpans.add(toZipkin(input));
     }
     // This dereferences a lazy, which might throw an exception if the storage system is down.
     AsyncSpanConsumer asyncSpanConsumer = storageComponent.asyncSpanConsumer();


### PR DESCRIPTION
The "generated" span type is unfortunately exposed due to the way state
is managed. That said, it is an internal type as all interactions are
recorded via tracers.

Span now has a reference to its propagated context. This prepares for 
when we interact with a new version of Brave, as we need a stable lookup
key for mutations such as adding an annotation.

On that note, this eliminates or deprecates places where mutable state
is leaked.

See #300