### PR TITLE
Bumps dependency versions and switches brave deps to project references

### DIFF
--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -28,9 +28,9 @@
         <artifactId>httpcore</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-http</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -12,7 +12,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <jmh.version>1.12</jmh.version>
   </properties>
 
   <dependencies>
@@ -44,8 +43,8 @@
     <!-- for benchmarking SpanId -->
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-core_2.11</artifactId>
-      <version>6.35.0</version>
+      <artifactId>finagle-core_2.12</artifactId>
+      <version>6.41.0</version>
     </dependency>
   </dependencies>
 

--- a/brave-core-spring/pom.xml
+++ b/brave-core-spring/pom.xml
@@ -27,9 +27,9 @@
   </properties>
   <dependencies>
      <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-core</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
      </dependency>
      <dependency>
         <groupId>org.springframework</groupId>

--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -64,8 +64,8 @@
     <!-- for testing SpanId -->
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-core_2.11</artifactId>
-      <version>6.38.0</version>
+      <artifactId>finagle-core_2.12</artifactId>
+      <version>6.41.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/brave-cxf3/pom.xml
+++ b/brave-cxf3/pom.xml
@@ -22,12 +22,12 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cxf.version>3.1.8</cxf.version>
+    <cxf.version>3.1.9</cxf.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>io.zipkin.brave</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>brave-http</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/brave-grpc/pom.xml
+++ b/brave-grpc/pom.xml
@@ -22,7 +22,7 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <grpc.version>1.0.1</grpc.version>
+        <grpc.version>1.0.3</grpc.version>
         <protobuf.version>3.0.2</protobuf.version>
     </properties>
 
@@ -30,7 +30,7 @@
 
         <!-- brave-http contains propagation header keys (BraveHttpHeaders) -->
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-http</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/brave-http-tests/pom.xml
+++ b/brave-http-tests/pom.xml
@@ -24,7 +24,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.zipkin.brave</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>brave-http</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/brave-http/pom.xml
+++ b/brave-http/pom.xml
@@ -29,9 +29,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-core</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/brave-jaxrs2/pom.xml
+++ b/brave-jaxrs2/pom.xml
@@ -22,14 +22,13 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jersey.version>2.13</jersey.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-http</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -51,7 +50,6 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- to test the inject annotations -->

--- a/brave-jersey/pom.xml
+++ b/brave-jersey/pom.xml
@@ -26,14 +26,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-http</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-web-servlet-filter</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -22,14 +22,14 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jersey.version>2.13</jersey.version>
+        <jersey.version>2.25</jersey.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-jaxrs2</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/brave-mysql/pom.xml
+++ b/brave-mysql/pom.xml
@@ -26,14 +26,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-core</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.33</version>
+            <version>5.1.40</version>
         </dependency>
         <!-- TODO: use something different for property-based testing -->
         <dependency>

--- a/brave-p6spy/pom.xml
+++ b/brave-p6spy/pom.xml
@@ -23,15 +23,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <p6spy.version>3.0.0</p6spy.version>
-        <derby.version>10.12.1.1</derby.version>
+        <derby.version>10.13.1.1</derby.version>
+        <!-- Tests fail on connect exception using latest liquibase -->
         <liquibase.version>3.0.8</liquibase.version>
-        <jmh.version>1.12</jmh.version>
     </properties>
 
     <dependencies>
 
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -23,14 +23,15 @@
    </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <resteasy.version>2.3.5.Final</resteasy.version>
+    <!-- 2.3.10.Final has an unpublished dependency. This is the version prior to that -->
+    <resteasy.version>2.3.7.Final</resteasy.version>
   </properties>
   
   <dependencies>
     <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-http</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
     </dependency>
     <dependency>
 		<groupId>org.jboss.resteasy</groupId>

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -23,25 +23,24 @@
    </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <resteasy.version>3.0.8.Final</resteasy.version>
+    <resteasy.version>3.1.0.Final</resteasy.version>
   </properties>
   
   <dependencies>
     <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-http</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
     </dependency>
       <dependency>
-          <groupId>io.zipkin.brave</groupId>
-          <artifactId>brave-jaxrs2</artifactId>
-          <version>3.16.1-SNAPSHOT</version>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-jaxrs2</artifactId>
+        <version>${project.version}</version>
       </dependency>
     <!-- provided dep in brave-jaxrs2 -->
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0</version>
       <scope>provided</scope>
     </dependency>
 	<dependency>

--- a/brave-sampler-zookeeper/pom.xml
+++ b/brave-sampler-zookeeper/pom.xml
@@ -26,20 +26,20 @@
   </properties>
   <dependencies>
     <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-core</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-framework</artifactId>
-        <version>2.8.0</version>
+        <version>2.11.1</version>
     </dependency>
     <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>2.8.0</version>
-        <scope>test</scope>  
+        <version>2.11.1</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/brave-spancollector-http/pom.xml
+++ b/brave-spancollector-http/pom.xml
@@ -27,9 +27,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-core</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/brave-spancollector-kafka/pom.xml
+++ b/brave-spancollector-kafka/pom.xml
@@ -30,15 +30,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-core</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/brave-spancollector-local/pom.xml
+++ b/brave-spancollector-local/pom.xml
@@ -27,7 +27,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/brave-spancollector-scribe/pom.xml
+++ b/brave-spancollector-scribe/pom.xml
@@ -27,15 +27,9 @@
  
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.10</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-core</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>com.google.auto.value</groupId>

--- a/brave-spring-resttemplate-interceptors/pom.xml
+++ b/brave-spring-resttemplate-interceptors/pom.xml
@@ -15,9 +15,9 @@
 
   <dependencies>
      <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-http</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
      </dependency>
 
      <dependency>

--- a/brave-spring-web-servlet-interceptor/pom.xml
+++ b/brave-spring-web-servlet-interceptor/pom.xml
@@ -15,9 +15,9 @@
 
     <dependencies>
      <dependency>
-        <groupId>io.zipkin.brave</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-web-servlet-filter</artifactId>
-        <version>3.16.1-SNAPSHOT</version>
+        <version>${project.version}</version>
      </dependency>
      <dependency>
         <groupId>org.springframework</groupId>

--- a/brave-web-servlet-filter/pom.xml
+++ b/brave-web-servlet-filter/pom.xml
@@ -16,9 +16,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.zipkin.brave</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-http</artifactId>
-            <version>3.16.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,20 +45,20 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <spring.version>4.3.2.RELEASE</spring.version>
-    <jetty.version>8.1.20.v20160902</jetty.version>
+    <spring.version>4.3.4.RELEASE</spring.version>
+    <jetty.version>8.1.22.v20160922</jetty.version>
     <zipkin.version>1.18.0</zipkin.version>
     <log4j.version>2.7</log4j.version>
-    <httpcomponents.version>4.4.1</httpcomponents.version>
     <okhttp.version>3.5.0</okhttp.version>
-    <powermock.version>1.6.5</powermock.version>
+    <powermock.version>1.6.6</powermock.version>
+    <jmh.version>1.17.3</jmh.version>
 
     <maven-plugin.version>0.3.3</maven-plugin.version>
-    <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-    <maven-source-plugin.version>3.0.0</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
     <centralsync-maven-plugin.version>0.1.0</centralsync-maven-plugin.version>
@@ -175,22 +175,22 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.5</version>
         </dependency>
+        <!-- The httpcomponents group do not share versions within it -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>${httpcomponents.version}</version>
+            <version>4.4.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>${httpcomponents.version}</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <!-- The async client does not share a version with the other httpcomponents -->
             <version>4.1.2</version>
         </dependency>
         <dependency>
@@ -231,7 +231,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.2.0</version>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -477,7 +482,7 @@
 
           <plugin>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.18.1</version>
+              <version>2.19.1</version>
               <configuration>
                   <systemPropertyVariables>
                       <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
@@ -487,7 +492,7 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-eclipse-plugin</artifactId>
-              <version>2.9</version>
+              <version>2.10</version>
               <configuration>
                   <downloadSources>true</downloadSources>
                   <downloadJavadocs>true</downloadJavadocs>
@@ -496,7 +501,7 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-failsafe-plugin</artifactId>
-              <version>2.14</version>
+              <version>2.19.1</version>
               <executions>
                   <execution>
                       <id>integration-test</id>


### PR DESCRIPTION
This bumps common dependencies, noting those that are rev-locked. It
also switches inter-module references to project variables, so that they
don't drift on each release.