### PR TITLE
Deprecates ServerTracer and ClientTracer.builder

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -260,7 +260,7 @@ public class Brave {
     }
 
     private Brave(Builder builder) {
-        serverTracer = ServerTracer.builder()
+        serverTracer = new AutoValue_ServerTracer.Builder()
                 .randomGenerator(builder.random)
                 .reporter(builder.reporter)
                 .state(builder.state)
@@ -269,7 +269,7 @@ public class Brave {
                 .traceId128Bit(builder.traceId128Bit)
                 .build();
 
-        clientTracer = ClientTracer.builder()
+        clientTracer = new AutoValue_ClientTracer.Builder()
                 .randomGenerator(builder.random)
                 .reporter(builder.reporter)
                 .state(builder.state)
@@ -278,7 +278,7 @@ public class Brave {
                 .traceId128Bit(builder.traceId128Bit)
                 .build();
 
-        localTracer = LocalTracer.builder()
+        localTracer = new AutoValue_LocalTracer.Builder()
                 .randomGenerator(builder.random)
                 .reporter(builder.reporter)
                 .allowNestedLocalSpans(builder.allowNestedLocalSpans)

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -27,18 +27,19 @@ import zipkin.reporter.Reporter;
 @AutoValue
 public abstract class ClientTracer extends AnnotationSubmitter {
 
+    /** @deprecated Don't build your own ClientTracer. Use {@link Brave#clientTracer()} */
+    @Deprecated
     public static Builder builder() {
         return new AutoValue_ClientTracer.Builder();
     }
-
-    // visible for testing
-    abstract Builder toBuilder();
 
     @Override
     abstract ClientSpanAndEndpoint spanAndEndpoint();
     abstract Reporter<zipkin.Span> reporter();
     abstract Sampler traceSampler();
 
+    /** @deprecated Don't build your own ClientTracer. Use {@link Brave#clientTracer()} */
+    @Deprecated
     @AutoValue.Builder
     public abstract static class Builder {
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -38,13 +38,6 @@ import static zipkin.Constants.LOCAL_COMPONENT;
 @AutoValue
 public abstract class LocalTracer extends AnnotationSubmitter {
 
-    static Builder builder() {
-        return new AutoValue_LocalTracer.Builder();
-    }
-
-    // visible for testing
-    abstract Builder toBuilder();
-
     @Override
     abstract LocalSpanAndEndpoint spanAndEndpoint();
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -28,18 +28,19 @@ import static com.github.kristofa.brave.internal.Util.checkNotBlank;
 @AutoValue
 public abstract class ServerTracer extends AnnotationSubmitter {
 
+    /** @deprecated Don't build your own ServerTracer. Use {@link Brave#serverTracer()} */
+    @Deprecated
     public static Builder builder() {
         return new AutoValue_ServerTracer.Builder();
     }
-
-    // visible for testing
-    abstract Builder toBuilder();
 
     @Override
     abstract ServerSpanAndEndpoint spanAndEndpoint();
     abstract Reporter<zipkin.Span> reporter();
     abstract Sampler traceSampler();
 
+    /** @deprecated Don't build your own ServerTracer. Use {@link Brave#serverTracer()} */
+    @Deprecated
     @AutoValue.Builder
     public abstract static class Builder {
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
@@ -26,6 +26,13 @@ public final class ThreadLocalServerClientAndLocalSpanState implements ServerCli
 
     private final Endpoint endpoint;
 
+    // visible for testing
+    static void clear() {
+        currentServerSpan.remove();
+        currentClientSpan.remove();
+        currentLocalSpan.remove();
+    }
+
     /**
      * Constructor
      *

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -47,12 +47,7 @@ public class ServerTracerTest {
         PowerMockito.when(System.currentTimeMillis()).thenReturn(START_TIME_MICROSECONDS / 1000);
         PowerMockito.when(System.nanoTime()).thenReturn(0L);
 
-        serverTracer = new Brave.Builder(endpoint)
-            .spanCollector(mockSpanCollector)
-            .traceSampler(mockSampler)
-            .clock(new AnnotationSubmitter.DefaultClock())
-            .traceId128Bit(false)
-            .build().serverTracer();
+        serverTracer = braveBuilder().build().serverTracer();
     }
 
     @Test
@@ -89,7 +84,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetStateUnknownSamplerTrue_128Bit() {
-        serverTracer = serverTracer.toBuilder().traceId128Bit(true).build();
+        serverTracer = braveBuilder().traceId128Bit(true).build().serverTracer();
 
         when(mockSampler.isSampled(anyLong())).thenReturn(true);
 
@@ -249,5 +244,11 @@ public class ServerTracerTest {
         verifyNoMoreInteractions(mockSpanCollector);
 
         assertEquals(1L, span.getDuration().longValue());
+    }
+
+    Brave.Builder braveBuilder() {
+        return new Brave.Builder(endpoint)
+            .spanCollector(mockSpanCollector)
+            .traceSampler(mockSampler);
     }
 }


### PR DESCRIPTION
ServerTracer and ClientTracer.builder were partially exposed, which will
interfere with our ability to upgrade Brave. This deprecates them so
that the we can backport code to Brave 4's api.

Users should prefer the accessors in Brave until then,

Ex. Brave.clientTracer()