### PR TITLE
Consolidates internal code that affects SpanId

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
@@ -47,16 +47,8 @@ public class ServerRequestInterceptor {
             return;
         }
 
-        // If the sampled flag was left unset, we need to make the decision here
-        if (context.sampled() == null) {
-            context = context.toBuilder()
-                .sampled(serverTracer.traceSampler().isSampled(context.traceId))
-                .shared(false)
-                .build();
-        } else if (context.sampled()) {
-            // We know an instrumented caller initiated the trace if they sampled it
-            context = context.toBuilder().shared(true).build();
-        }
+        // We are now joining the span propagated to us, by re-using the trace and span ids here.
+        context = serverTracer.spanIdFactory().join(context);
 
         // At this point, we have inherited a sampling decision or made one explicitly
         if (!context.sampled()) {

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanIdFactory.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanIdFactory.java
@@ -1,0 +1,74 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+import com.google.auto.value.AutoValue;
+import java.util.Random;
+
+/** Internal code that affects the {@linkplain SpanId} type. */
+@AutoValue
+abstract class SpanIdFactory {
+
+  static Builder builder() {
+    return new AutoValue_SpanIdFactory.Builder()
+        .traceId128Bit(false)
+        .randomGenerator(new Random())
+        .sampler(Sampler.ALWAYS_SAMPLE);
+  }
+
+  abstract Builder toBuilder();
+
+  @AutoValue.Builder interface Builder {
+    Builder randomGenerator(Random randomGenerator);
+
+    Builder traceId128Bit(boolean traceId128Bit);
+
+    Builder sampler(Sampler sampler);
+
+    SpanIdFactory build();
+  }
+
+  abstract Random randomGenerator();
+
+  abstract boolean traceId128Bit();
+
+  abstract Sampler sampler();
+
+  /** Returns the next span ID derived from the input, or a new trace if null. */
+  SpanId next(@Nullable SpanId maybeParent) {
+    long newSpanId = randomGenerator().nextLong();
+    if (maybeParent == null) { // new trace
+      return SpanId.builder()
+          .traceIdHigh(traceId128Bit() ? randomGenerator().nextLong() : 0L)
+          .traceId(newSpanId)
+          .spanId(newSpanId)
+          .sampled(sampler().isSampled(newSpanId))
+          .build();
+    }
+    return maybeParent.toBuilder()
+        .parentId(maybeParent.spanId)
+        .spanId(newSpanId)
+        .shared(false)
+        .build();
+  }
+
+  /**
+   * Joining is re-using the same trace and span ids extracted from an incoming request. Here, we
+   * ensure a sampling decision has been made. If the span passed sampling, we assume this is a
+   * shared span, one where the caller and the current tracer report to the same span IDs. If no
+   * sampling decision occurred yet, we have exclusive access to this span ID.
+   */
+  SpanId join(SpanId context) {
+    // If the sampled flag was left unset, we need to make the decision here
+    if (context.sampled() == null) {
+      return context.toBuilder()
+          .sampled(sampler().isSampled(context.traceId))
+          .shared(false)
+          .build();
+    } else if (context.sampled()) {
+      // We know an instrumented caller initiated the trace if they sampled it
+      return context.toBuilder().shared(true).build();
+    } else {
+      return context;
+    }
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
@@ -2,7 +2,6 @@ package com.github.kristofa.brave;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
@@ -29,11 +28,10 @@ public class BraveTest {
     public void testGetClientTracer() {
         final ClientTracer clientTracer = brave.clientTracer();
         assertNotNull(clientTracer);
-        assertTrue("We expect instance of ClientTracer", clientTracer instanceof ClientTracer);
         assertSame("ClientTracer should be configured with the reporter we submitted.", fakeReporter,
             clientTracer.reporter());
         assertSame("ClientTracer should be configured with the traceSampler we submitted.",
-            mockSampler, clientTracer.traceSampler());
+            mockSampler, clientTracer.spanIdFactory().sampler());
 
         final ClientTracer secondClientTracer =
             brave.clientTracer();
@@ -47,8 +45,7 @@ public class BraveTest {
         assertNotNull(serverTracer);
         assertSame(fakeReporter, serverTracer.reporter());
         assertSame("ServerTracer should be configured with the traceSampler we submitted.",
-            mockSampler, serverTracer
-            .traceSampler());
+            mockSampler, serverTracer.spanIdFactory().sampler());
 
         final ServerTracer secondServerTracer =
             brave.serverTracer();
@@ -74,8 +71,7 @@ public class BraveTest {
         assertNotNull(localTracer);
         assertSame(fakeReporter, localTracer.reporter());
         assertSame("LocalTracer should be configured with the traceSampler we submitted.",
-                mockSampler, localTracer
-                        .traceSampler());
+                mockSampler, localTracer.spanIdFactory().sampler());
 
         final LocalTracer secondLocalTracer =
                 brave.localTracer();

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -164,11 +164,11 @@ public class LocalTracerTest {
 
         SpanId span1 = localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME);
         assertEquals(PARENT_CONTEXT.toBuilder().spanId(span1.spanId).parentId(PARENT_CONTEXT.spanId).build(), span1);
-        assertEquals(span1.spanId, localTracer.maybeParent().getId());
+        assertEquals(span1.spanId, localTracer.maybeParent().spanId);
 
         SpanId span2 = localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME);
         assertEquals(PARENT_CONTEXT.toBuilder().spanId(span2.spanId).parentId(span1.spanId).build(), span2);
-        assertEquals(span2.spanId, localTracer.maybeParent().getId());
+        assertEquals(span2.spanId, localTracer.maybeParent().spanId);
 
         assertEquals(span2.spanId, state.getCurrentLocalSpan().getId());
         localTracer.finishSpan();

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -67,11 +67,10 @@ public class LocalTracingInheritenceTest {
     public void testGetClientTracer() {
         final ClientTracer clientTracer = brave.clientTracer();
         assertNotNull(clientTracer);
-        assertTrue("We expect instance of ClientTracer", clientTracer instanceof ClientTracer);
         assertSame("ClientTracer should be configured with the spanreportor we submitted.", reporter,
                 clientTracer.reporter());
         assertSame("ClientTracer should be configured with the traceSampler we submitted.",
-                sampler, clientTracer.traceSampler());
+                sampler, clientTracer.spanIdFactory().sampler());
 
         final ClientTracer secondClientTracer = brave.clientTracer();
         assertSame("It is important that each client tracer we get shares same state.",
@@ -84,7 +83,7 @@ public class LocalTracingInheritenceTest {
         assertNotNull(serverTracer);
         assertSame(reporter, serverTracer.reporter());
         assertSame("ServerTracer should be configured with the traceSampler we submitted.",
-                sampler, serverTracer.traceSampler());
+                sampler, serverTracer.spanIdFactory().sampler());
 
         final ServerTracer secondServerTracer = brave.serverTracer();
         assertSame("It is important that each client tracer we get shares same state.",
@@ -97,7 +96,7 @@ public class LocalTracingInheritenceTest {
         assertNotNull(localTracer);
         assertSame(reporter, localTracer.reporter());
         assertSame("LocalTracer should be configured with the traceSampler we submitted.",
-                sampler, localTracer.traceSampler());
+                sampler, localTracer.spanIdFactory().sampler());
 
         final LocalTracer secondLocalTracer = brave.localTracer();
         assertSame("It is important that each local tracer we get shares same state.",


### PR DESCRIPTION
This consolidates common code used across tracers into `SpanIdFactory`,
in preparation of brave 4's `Tracer` which will absorb this
responsibility.