### PR TITLE
Adds internal CurrentSpan type and deprecates SpanAndEndpoint

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientSpanThreadBinder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientSpanThreadBinder.java
@@ -13,7 +13,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * In the callback method, call {@link #setCurrentSpan} before calling {@link com.github.kristofa.brave.ClientTracer#setClientReceived()}
  * @author hzhao on 8/11/14.
  */
-public final class ClientSpanThreadBinder {
+public final class ClientSpanThreadBinder extends CurrentSpan {
 
     private final ClientSpanState state;
 
@@ -47,5 +47,9 @@ public final class ClientSpanThreadBinder {
     public void setCurrentSpan(Span span)
     {
         state.setCurrentClientSpan(span);
+    }
+
+    @Override Span get() {
+        return getCurrentClientSpan();
     }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/CurrentSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/CurrentSpan.java
@@ -1,0 +1,17 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Span;
+
+abstract class CurrentSpan { // intentionally not public
+
+  /**
+   * Returns the implicit span associated with the current context, or null if there is none.
+   *
+   * <p>This is used by {@linkplain LocalTracer}, {@linkplain LocalTracer}
+   *
+   * @return Span to which to add annotations. Can be <code>null</code>. In that case the different
+   * submit methods will not do anything.
+   */
+  @Nullable abstract Span get(); // intentionally package protected
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalSpanThreadBinder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalSpanThreadBinder.java
@@ -14,7 +14,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * variable) In the callback method, call {@link #setCurrentSpan} before calling {@link
  * LocalTracer#finishSpan()}
  */
-public final class LocalSpanThreadBinder {
+public final class LocalSpanThreadBinder extends CurrentSpan {
 
   private final LocalSpanState state;
 
@@ -46,5 +46,9 @@ public final class LocalSpanThreadBinder {
    */
   public void setCurrentSpan(Span span) {
     state.setCurrentLocalSpan(span);
+  }
+
+  @Override Span get() {
+    return getCurrentLocalSpan();
   }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
@@ -65,7 +65,7 @@ public class ServerRequestInterceptor {
         // rather let the client do that. Worst case we were propagated an unreported ID and
         // Zipkin backfills timestamp and duration.
         if (context.shared) {
-            Span span = serverTracer.spanAndEndpoint().span();
+            Span span = serverTracer.currentSpan().get();
             synchronized (span) {
                 span.setTimestamp(null);
             }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanThreadBinder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanThreadBinder.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.Nullable;
+import com.twitter.zipkin.gen.Span;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
@@ -14,7 +15,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * 
  * @author kristof
  */
-public class ServerSpanThreadBinder {
+public class ServerSpanThreadBinder extends CurrentSpan {
 
     private final ServerSpanState state;
 
@@ -49,5 +50,15 @@ public class ServerSpanThreadBinder {
      */
     public void setCurrentSpan(final ServerSpan span) {
         state.setCurrentServerSpan(span);
+    }
+
+    @Override Span get() {
+        ServerSpan result = getCurrentServerSpan();
+        return result != null ? result.getSpan(): null;
+    }
+
+    Boolean sampled() {
+        ServerSpan result = getCurrentServerSpan();
+        return result != null ? result.getSample(): null;
     }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanAndEndpoint.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanAndEndpoint.java
@@ -5,6 +5,11 @@ import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 
+/**
+ * @deprecated this type was only used for {@link AnnotationSubmitter#create(SpanAndEndpoint,
+ * AnnotationSubmitter.Clock)}, which is deprecated.
+ */
+@Deprecated
 public interface SpanAndEndpoint {
 
     /**
@@ -23,6 +28,11 @@ public interface SpanAndEndpoint {
      */
     Endpoint endpoint();
 
+    /**
+     * @deprecated this type was only used for {@link AnnotationSubmitter#create(SpanAndEndpoint,
+     * AnnotationSubmitter.Clock)}, which is deprecated.
+     */
+    @Deprecated
     @AutoValue
     abstract class ServerSpanAndEndpoint implements SpanAndEndpoint {
         abstract ServerSpanState state();
@@ -48,6 +58,11 @@ public interface SpanAndEndpoint {
         }
     }
 
+    /**
+     * @deprecated this type was only used for {@link AnnotationSubmitter#create(SpanAndEndpoint,
+     * AnnotationSubmitter.Clock)}, which is deprecated.
+     */
+    @Deprecated
     @AutoValue
     abstract class ClientSpanAndEndpoint implements SpanAndEndpoint {
         abstract ServerClientAndLocalSpanState state();
@@ -73,6 +88,11 @@ public interface SpanAndEndpoint {
         }
     }
 
+    /**
+     * @deprecated this type was only used for {@link AnnotationSubmitter#create(SpanAndEndpoint,
+     * AnnotationSubmitter.Clock)}, which is deprecated.
+     */
+    @Deprecated
     @AutoValue
     abstract class LocalSpanAndEndpoint implements SpanAndEndpoint {
         abstract ServerClientAndLocalSpanState state();

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -143,19 +143,19 @@ public class AnnotationSubmitterTest {
     }
 
     AnnotationSubmitter newAnnotationSubmitter() {
-        SpanAndEndpoint spanAndEndpoint = new SpanAndEndpoint() {
-            @Override public Span span() {
+        CurrentSpan currentSpan = new CurrentSpan() {
+            @Override Span get() {
                 return span;
-            }
-
-            @Override public Endpoint endpoint() {
-                return endpoint;
             }
         };
         AnnotationSubmitter.DefaultClock clock = new AnnotationSubmitter.DefaultClock();
         return new AnnotationSubmitter(){
-            @Override SpanAndEndpoint spanAndEndpoint() {
-                return spanAndEndpoint;
+            @Override CurrentSpan currentSpan() {
+                return currentSpan;
+            }
+
+            @Override Endpoint endpoint() {
+                return endpoint;
             }
 
             @Override Clock clock() {

--- a/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
@@ -36,7 +36,7 @@ public class BraveTest {
         final ClientTracer secondClientTracer =
             brave.clientTracer();
         assertSame("It is important that each client tracer we get shares same state.",
-                   clientTracer.spanAndEndpoint().state(), secondClientTracer.spanAndEndpoint().state());
+                   clientTracer.currentSpan(), secondClientTracer.currentSpan());
     }
 
     @Test
@@ -47,10 +47,9 @@ public class BraveTest {
         assertSame("ServerTracer should be configured with the traceSampler we submitted.",
             mockSampler, serverTracer.spanIdFactory().sampler());
 
-        final ServerTracer secondServerTracer =
-            brave.serverTracer();
+        final ServerTracer secondServerTracer = brave.serverTracer();
         assertSame("It is important that each server tracer we get shares same state.",
-                   serverTracer.spanAndEndpoint().state(), secondServerTracer.spanAndEndpoint().state());
+                   serverTracer.currentSpan(), secondServerTracer.currentSpan());
     }
 
     @Test
@@ -60,8 +59,8 @@ public class BraveTest {
         final ServerTracer serverTracer =
             brave.serverTracer();
 
-        assertSame("Client and server tracers should share same state.", clientTracer.spanAndEndpoint().state(),
-            serverTracer.spanAndEndpoint().state());
+        assertSame("Client and server tracers should share same state.", clientTracer.currentServerSpan(),
+            serverTracer.currentSpan());
 
     }
 
@@ -76,7 +75,7 @@ public class BraveTest {
         final LocalTracer secondLocalTracer =
                 brave.localTracer();
         assertSame("It is important that each local tracer we get shares same state.",
-                localTracer.spanAndEndpoint().state(), secondLocalTracer.spanAndEndpoint().state());
+                localTracer.currentSpan(), secondLocalTracer.currentSpan());
     }
 
     @Test

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
@@ -1,9 +1,8 @@
 package com.github.kristofa.brave;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import com.github.kristofa.brave.AnnotationSubmitter.DefaultClock;
 import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,12 +11,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.twitter.zipkin.gen.Span;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This isSampled proves that we have proper synchronisation when submitted annotations for the same span. Without proper
@@ -45,16 +44,13 @@ public class ITAnnotationSubmitterConcurrency {
 
     @Test
     public void testSubmitAnnotations() throws InterruptedException, ExecutionException {
-
-        final AnnotationSubmitter annotationSubmitter = AnnotationSubmitter.create(new SpanAndEndpoint() {
-            @Override public Span span() {
+        CurrentSpan currentSpan = new CurrentSpan() {
+            @Override Span get() {
                 return span;
             }
-
-            @Override public Endpoint endpoint() {
-                return endpoint;
-            }
-        }, new AnnotationSubmitter.DefaultClock());
+        };
+        final AnnotationSubmitter annotationSubmitter =
+            AnnotationSubmitter.create(currentSpan, endpoint, new DefaultClock());
 
         final List<AnnotationSubmitThread> threadList =
             Arrays.asList(new AnnotationSubmitThread(1, 100, annotationSubmitter), new AnnotationSubmitThread(101, 200,

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -3,7 +3,6 @@ package com.github.kristofa.brave;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -56,11 +55,9 @@ public class LocalTracingInheritenceTest {
 
     private void checkState() {
         LocalTracer localTracer = brave.localTracer();
-        ServerClientAndLocalSpanState state = localTracer.spanAndEndpoint().state();
-        assertThat(state.getCurrentServerSpan()).isSameAs(ServerSpan.EMPTY);
-        assertThat(state.getCurrentClientSpan()).isNull();
-        assertThat(state.getCurrentLocalSpan()).isNull();
-        assertThat(localTracer.spanAndEndpoint().span()).isNull();
+        assertThat(localTracer.currentServerSpan().getCurrentServerSpan())
+            .isSameAs(ServerSpan.EMPTY);
+        assertThat(localTracer.currentSpan().get()).isNull();
     }
 
     @Test
@@ -74,7 +71,7 @@ public class LocalTracingInheritenceTest {
 
         final ClientTracer secondClientTracer = brave.clientTracer();
         assertSame("It is important that each client tracer we get shares same state.",
-                clientTracer.spanAndEndpoint().state(), secondClientTracer.spanAndEndpoint().state());
+                clientTracer.currentSpan(), secondClientTracer.currentSpan());
     }
 
     @Test
@@ -87,7 +84,7 @@ public class LocalTracingInheritenceTest {
 
         final ServerTracer secondServerTracer = brave.serverTracer();
         assertSame("It is important that each client tracer we get shares same state.",
-                serverTracer.spanAndEndpoint().state(), secondServerTracer.spanAndEndpoint().state());
+                serverTracer.currentSpan(), secondServerTracer.currentSpan());
     }
 
     @Test
@@ -100,7 +97,7 @@ public class LocalTracingInheritenceTest {
 
         final LocalTracer secondLocalTracer = brave.localTracer();
         assertSame("It is important that each local tracer we get shares same state.",
-                localTracer.spanAndEndpoint().state(), secondLocalTracer.spanAndEndpoint().state());
+                localTracer.currentSpan(), secondLocalTracer.currentSpan());
     }
 
     @Test
@@ -109,14 +106,14 @@ public class LocalTracingInheritenceTest {
         final ServerTracer serverTracer = brave.serverTracer();
         final LocalTracer localTracer = brave.localTracer();
 
-        assertSame("Client and server tracers should share same state.", clientTracer.spanAndEndpoint().state(),
-                serverTracer.spanAndEndpoint().state());
+        assertSame("Client and server tracers should share same state.", clientTracer.currentServerSpan(),
+                serverTracer.currentSpan());
 
-        assertSame("Client and local tracers should share same state.", clientTracer.spanAndEndpoint().state(),
-                localTracer.spanAndEndpoint().state());
+        assertSame("Client and local tracers should share same state.", clientTracer.currentLocalSpan(),
+                localTracer.currentSpan());
 
-        assertSame("Server and local tracers should share same state.", serverTracer.spanAndEndpoint().state(),
-                localTracer.spanAndEndpoint().state());
+        assertSame("Server and local tracers should share same state.", serverTracer.currentSpan(),
+                localTracer.currentServerSpan());
     }
 
     @Test


### PR DESCRIPTION
SpanAndEndpoint was only exposed for a historical method factory on
AnnotationSubmitter. In fact, `Brave.annotationSubmitter()` is
functionally equivalent to `Brave.serverTracer()`. This change
deprecates both the redundant `Brave.annotationSubmitter()` method
and also the `SpanAndEndpoint` type.

In its place are the following:

* new `CurrentSpan` type, retrofitted to the thread binders. This is
  not exposed publicly, as there's no reason to at this point.
* eager resolution of the localEndpoint (which is currently passed
  into the thread state classes). In almost all cases, this will have
  no effect since constructors eagerly resolve this anyway.

These changes make it more clear what's going on, particularly around
logic that decides whether to create a new trace or not. It also makes
replacing logic simpler, which is needed for Brave 4.