### PR TITLE
Accepts span.name as empty; asserts against deprecated invocations

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -134,10 +134,10 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * Start a new span for a new client request that will be bound to current thread. The ClientTracer can decide to return
      * <code>null</code> in case this request should not be traced (eg sampling).
      *
-     * @param requestName Request name. Should be lowercase and not <code>null</code> or empty.
+     * @param requestName Request name. Should be lowercase. Null or empty will defer to the server's name of the operation.
      * @return Span id for new request or <code>null</code> in case we should not trace this new client request.
      */
-    public SpanId startNewSpan(String requestName) {
+    public SpanId startNewSpan(@Nullable String requestName) {
         // When a trace context is extracted from an incoming request, it may have only the
         // sampled header (no ids). If the header says unsampled, we must honor that. Since
         // we currently don't synthesize a fake span when a trace is unsampled, we have to

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static com.github.kristofa.brave.internal.Util.equal;
 
@@ -34,6 +35,7 @@ public class Span implements Serializable {
   /** @deprecated internally we call {@link Span#Span(SpanId)} because it sets the identity */
   @Deprecated
   public Span() {
+    assert false : "do not construct spans except via their context";
     context = null;
   }
 
@@ -63,6 +65,7 @@ public class Span implements Serializable {
   /** @deprecated do not modify the context of a span once created */
   @Deprecated
   public Span setTrace_id(long trace_id) {
+    assert false : "do not modify the context of a span once created";
     this.trace_id = trace_id;
     return this;
   }
@@ -80,6 +83,7 @@ public class Span implements Serializable {
   /** @deprecated do not modify the context of a span once created */
   @Deprecated
   public Span setTrace_id_high(long trace_id_high) {
+    assert false : "do not modify the context of a span once created";
     this.trace_id_high = trace_id_high;
     return this;
   }
@@ -99,10 +103,11 @@ public class Span implements Serializable {
    * Conventionally, when the span name isn't known, name = "unknown".
    */
   public Span setName(String name) {
-    if (name != null) {
-      name = name.toLowerCase();
+    if (name == null || name.isEmpty()) {
+      this.name = "";
+    } else {
+      this.name = name.toLowerCase(Locale.ROOT);
     }
-    this.name = name;
     return this;
   }
 
@@ -113,6 +118,7 @@ public class Span implements Serializable {
   /** @deprecated do not modify the context of a span once created */
   @Deprecated
   public Span setId(long id) {
+    assert false : "do not modify the context of a span once created";
     this.id = id;
     return this;
   }
@@ -124,6 +130,7 @@ public class Span implements Serializable {
   /** @deprecated do not modify the context of a span once created */
   @Deprecated
   public Span setParent_id(Long parent_id) {
+    assert false : "do not modify the context of a span once created";
     this.parent_id = parent_id;
     return this;
   }
@@ -171,6 +178,7 @@ public class Span implements Serializable {
   /** @deprecated do not modify the context of a span once created */
   @Deprecated
   public Span setDebug(Boolean debug) {
+    assert false : "do not modify the context of a span once created";
     this.debug = debug;
     return this;
   }

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -30,7 +30,7 @@ public class AnnotationSubmitterTest {
 
     private Endpoint endpoint =
         Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
-    private Span span = Span.create(SpanId.builder().spanId(1).build()).setName("foo");
+    private Span span = Span.create(SpanId.builder().spanId(1).build());
     private AnnotationSubmitter annotationSubmitter;
     private List<zipkin.Span> spans = new ArrayList<>();
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -114,7 +114,7 @@ public class ClientTracerTest {
 
     @Test
     public void testSetClientReceived() {
-        brave.clientSpanThreadBinder().setCurrentSpan(span.setName("foo").setTimestamp(100L));
+        brave.clientSpanThreadBinder().setCurrentSpan(span.setTimestamp(100L));
 
         brave.clientTracer().setClientReceived();
 
@@ -186,9 +186,7 @@ public class ClientTracerTest {
 
     @Test
     public void setClientReceived_usesPreciseDuration() {
-        brave.clientSpanThreadBinder().setCurrentSpan(
-            span.setName("foo").setTimestamp(START_TIME_MICROSECONDS)
-        );
+        brave.clientSpanThreadBinder().setCurrentSpan(span.setTimestamp(START_TIME_MICROSECONDS));
 
         PowerMockito.when(System.nanoTime()).thenReturn(500000L);
 
@@ -203,9 +201,7 @@ public class ClientTracerTest {
     /** Duration of less than one microsecond is confusing to plot and could coerce to null. */
     @Test
     public void setClientReceived_lessThanMicrosRoundUp() {
-        brave.clientSpanThreadBinder().setCurrentSpan(
-            span.setName("foo").setTimestamp(START_TIME_MICROSECONDS)
-        );
+        brave.clientSpanThreadBinder().setCurrentSpan(span.setTimestamp(START_TIME_MICROSECONDS));
 
         PowerMockito.when(System.nanoTime()).thenReturn(500L);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -121,9 +121,7 @@ public class LocalTracerTest {
      */
     @Test
     public void finishSpan() {
-        brave.localSpanThreadBinder().setCurrentSpan(
-            span.setName("foo").setTimestamp(START_TIME_MICROSECONDS)
-        );
+        brave.localSpanThreadBinder().setCurrentSpan(span.setTimestamp(START_TIME_MICROSECONDS));
 
         PowerMockito.when(System.nanoTime()).thenReturn(500000L);
 
@@ -138,9 +136,7 @@ public class LocalTracerTest {
     /** Duration of less than one microsecond is confusing to plot and could coerce to null. */
     @Test
     public void finishSpan_lessThanMicrosRoundUp() {
-        brave.localSpanThreadBinder().setCurrentSpan(
-            span.setName("foo").setTimestamp(START_TIME_MICROSECONDS)
-        );
+        brave.localSpanThreadBinder().setCurrentSpan(span.setTimestamp(START_TIME_MICROSECONDS));
 
         PowerMockito.when(System.nanoTime()).thenReturn(50L);
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
@@ -36,7 +36,7 @@ public class DefaultSpanCodecTest {
 
   @Test
   public void roundTripSpan_thrift_128() {
-    span.setTrace_id_high(3L);
+    span = Span.create(span.context().toBuilder().traceIdHigh(3L).build());
 
     byte[] encoded = DefaultSpanCodec.THRIFT.writeSpan(span);
     assertEquals(span, DefaultSpanCodec.THRIFT.readSpan(encoded));

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
@@ -7,18 +7,67 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class SpanTest {
+
+  @Test(expected = AssertionError.class)
+  public void deprecatedConstructor_throwsAssertionError() {
+    new Span();
+  }
+
+  @Test(expected = AssertionError.class)
+  public void setTrace_id_high_throwsAssertionError() {
+    Span.create(SpanId.builder().spanId(1L).build()).setTrace_id_high(1L);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void setTrace_id_throwsAssertionError() {
+    Span.create(SpanId.builder().spanId(1L).build()).setTrace_id(1L);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void setParent_id_throwsAssertionError() {
+    Span.create(SpanId.builder().spanId(1L).build()).setParent_id(1L);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void setId_throwsAssertionError() {
+    Span.create(SpanId.builder().spanId(1L).build()).setId(1L);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void setDebug_throwsAssertionError() {
+    Span.create(SpanId.builder().spanId(1L).build()).setDebug(false);
+  }
+
   @Test
   public void testNameLowercase() {
-    assertEquals("spanname", new Span().setName("SpanName").getName());
+    assertEquals("spanname", Span.create(SpanId.builder().spanId(1L).build())
+        .setName("SpanName").getName());
+  }
+
+  @Test
+  public void setName_coercesNullToEmptyString() {
+    Span span = Span.create(SpanId.builder().spanId(1L).build()).setName("foo");
+
+    assertThat(span.setName(null).getName()).isEqualTo("");
+  }
+
+  /** Use addToAnnotations as opposed to attempting to mutate the collection */
+  @Test(expected = UnsupportedOperationException.class)
+  public void getAnnotations_returnsUnmodifiable() {
+    Span.create(SpanId.builder().spanId(1L).build()).getAnnotations().add(null);
+  }
+
+  /** Use addToBinary_annotations as opposed to attempting to mutate the collection */
+  @Test(expected = UnsupportedOperationException.class)
+  public void getBinary_annotations_returnsUnmodifiable() {
+    Span.create(SpanId.builder().spanId(1L).build()).getBinary_annotations().add(null);
   }
 
   @Test
   public void toStringIsJson() {
     long traceId = -692101025335252320L;
-    Span span = new Span()
-        .setTrace_id(traceId)
+    Span span = Span.create(SpanId.builder().spanId(traceId).build())
         .setName("get")
-        .setId(traceId)
         .setTimestamp(1444438900939000L)
         .setDuration(376000L);
 

--- a/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
+++ b/brave-grpc/src/test/java/com/github/kristofa/brave/grpc/BraveGrpcInterceptorsTest.java
@@ -147,8 +147,9 @@ public class BraveGrpcInterceptorsTest {
 
     @Test
     public void propagatesAndReads128BitTraceId() throws Exception {
-        Span span =
-            new Span().setTrace_id_high(1).setTrace_id(2).setId(3).setParent_id(2L).setName("myop");
+        SpanId spanId = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
+
+        Span span = Span.create(spanId);
         brave.localSpanThreadBinder().setCurrentSpan(span);
         GreeterBlockingStub stub = GreeterGrpc.newBlockingStub(channel);
         //This call will be made using hte context of the localTracer as it's parent

--- a/brave-spancollector-http/src/test/java/com/github/kristofa/brave/http/HttpSpanCollectorTest.java
+++ b/brave-spancollector-http/src/test/java/com/github/kristofa/brave/http/HttpSpanCollectorTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.Span;
 import java.util.Arrays;
@@ -33,14 +34,14 @@ public class HttpSpanCollectorTest {
 
   @Test
   public void collectDoesntDoIO() throws Exception {
-    collector.collect(span(1L, "foo"));
+    collector.collect(span(1L));
 
     assertThat(zipkinRule.httpRequestCount()).isZero();
   }
 
   @Test
   public void collectIncrementsAcceptedMetrics() throws Exception {
-    collector.collect(span(1L, "foo"));
+    collector.collect(span(1L));
 
     assertThat(metrics.acceptedSpans.get()).isEqualTo(1);
     assertThat(metrics.droppedSpans.get()).isZero();
@@ -49,7 +50,7 @@ public class HttpSpanCollectorTest {
   @Test
   public void dropsWhenQueueIsFull() throws Exception {
     for (int i = 0; i < 1001; i++)
-      collector.collect(span(1L, "foo"));
+      collector.collect(span(1L));
 
     collector.flush(); // manually flush the spans
 
@@ -59,8 +60,8 @@ public class HttpSpanCollectorTest {
 
   @Test
   public void postsSpans() throws Exception {
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -69,8 +70,8 @@ public class HttpSpanCollectorTest {
 
     // Now, let's read back the spans we sent!
     assertThat(zipkinRule.getTraces()).containsExactly(
-        asList(zipkinSpan(1L, "foo")),
-        asList(zipkinSpan(2L, "bar"))
+        asList(zipkinSpan(1L)),
+        asList(zipkinSpan(2L))
     );
   }
 
@@ -89,7 +90,7 @@ public class HttpSpanCollectorTest {
 
       HttpSpanCollector collector = new HttpSpanCollector(zipkin.url("/").toString(), config, metrics);
 
-      collector.collect(span(1L, "foo")
+      collector.collect(span(1L)
           .addToAnnotations(Annotation.create(1111L, new String(annotation2K), null)));
 
       collector.flush(); // manually flush the span
@@ -106,8 +107,8 @@ public class HttpSpanCollectorTest {
   public void incrementsDroppedSpansWhenServerErrors() throws Exception {
     zipkinRule.enqueueFailure(HttpFailure.sendErrorResponse(500, "Server Error!"));
 
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -118,8 +119,8 @@ public class HttpSpanCollectorTest {
   public void incrementsDroppedSpansWhenServerDisconnects() throws Exception {
     zipkinRule.enqueueFailure(HttpFailure.disconnectDuringBody());
 
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -142,11 +143,11 @@ public class HttpSpanCollectorTest {
     }
   }
 
-  static Span span(long traceId, String spanName) {
-    return new Span().setTrace_id(traceId).setId(traceId).setName(spanName);
+  static Span span(long traceId) {
+    return Span.create(SpanId.builder().spanId(traceId).build());
   }
 
-  static zipkin.Span zipkinSpan(long traceId, String spanName) {
-    return zipkin.Span.builder().traceId(traceId).id(traceId).name(spanName).build();
+  static zipkin.Span zipkinSpan(long traceId) {
+    return zipkin.Span.builder().traceId(traceId).id(traceId).name("").build();
   }
 }

--- a/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/KafkaSpanCollectorTest.java
+++ b/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/KafkaSpanCollectorTest.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.kafka;
 
 import com.github.charithe.kafka.KafkaJunitRule;
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.kafka.KafkaSpanCollector.Config;
 import com.twitter.zipkin.gen.Span;
 import java.util.List;
@@ -41,14 +42,14 @@ public class KafkaSpanCollectorTest {
   @Test
   public void collectDoesntDoIO() throws Exception {
     thrown.expect(TimeoutException.class);
-    collector.collect(span(1L, "foo"));
+    collector.collect(span(1L));
 
     assertThat(readMessages()).isEmpty();
   }
 
   @Test
   public void collectIncrementsAcceptedMetrics() throws Exception {
-    collector.collect(span(1L, "foo"));
+    collector.collect(span(1L));
 
     assertThat(metrics.acceptedSpans.get()).isEqualTo(1);
     assertThat(metrics.droppedSpans.get()).isZero();
@@ -57,7 +58,7 @@ public class KafkaSpanCollectorTest {
   @Test
   public void dropsWhenQueueIsFull() throws Exception {
     for (int i = 0; i < 1001; i++)
-      collector.collect(span(1L, "foo"));
+      collector.collect(span(1L));
 
     collector.flush(); // manually flush the spans
 
@@ -67,8 +68,8 @@ public class KafkaSpanCollectorTest {
 
   @Test
   public void sendsSpans() throws Exception {
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -78,8 +79,8 @@ public class KafkaSpanCollectorTest {
 
     // Now, let's read back the spans we sent!
     assertThat(Codec.THRIFT.readSpans(messages.get(0))).containsExactly(
-        zipkinSpan(1L, "foo"),
-        zipkinSpan(2L, "bar")
+        zipkinSpan(1L),
+        zipkinSpan(2L)
     );
   }
 
@@ -87,14 +88,14 @@ public class KafkaSpanCollectorTest {
   public void submitMultipleSpansInParallel() throws Exception {
     Callable<Void> spanProducer1 = () -> {
       for (int i = 1; i <= 200; i++) {
-        collector.collect(span(i, "producer1_" + i));
+        collector.collect(span(i));
       }
       return null;
     };
 
     Callable<Void> spanProducer2 = () -> {
       for (int i = 1; i <= 200; i++) {
-        collector.collect(span(i, "producer2_" + i));
+        collector.collect(span(i));
       }
       return null;
     };
@@ -120,7 +121,7 @@ public class KafkaSpanCollectorTest {
   public void submitsSpansToCorrectTopic() throws Exception {
     Config config = Config.builder("localhost:" + kafka.kafkaBrokerPort()).topic("customzipkintopic").build();
     KafkaSpanCollector collector = new KafkaSpanCollector(config, metrics);
-    collector.collect(span(123, "myspan"));
+    collector.collect(span(123));
     List<byte[]> messages = readMessages("customzipkintopic");
     assertThat(messages).hasSize(1);
   }
@@ -141,12 +142,12 @@ public class KafkaSpanCollectorTest {
     }
   }
 
-  static Span span(long traceId, String spanName) {
-    return new Span().setTrace_id(traceId).setId(traceId).setName(spanName);
+  static Span span(long traceId) {
+    return Span.create(SpanId.builder().spanId(traceId).build());
   }
 
-  static zipkin.Span zipkinSpan(long traceId, String spanName) {
-    return zipkin.Span.builder().traceId(traceId).id(traceId).name(spanName).build();
+  static zipkin.Span zipkinSpan(long traceId) {
+    return zipkin.Span.builder().traceId(traceId).id(traceId).name("").build();
   }
 
   private List<byte[]> readMessages(String topic) throws TimeoutException {

--- a/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
+++ b/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.local;
 
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Span;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
@@ -25,7 +26,7 @@ public class LocalSpanCollectorTest {
       throw new AssertionError("spans should only report on flush!");
     });
 
-    collector.collect(span(1L, "foo"));
+    collector.collect(span(1L));
 
     assertThat(storage.spanStore().traceIds()).isEmpty();
   }
@@ -35,7 +36,7 @@ public class LocalSpanCollectorTest {
     LocalSpanCollector collector = newLocalSpanCollector((spans, callback) -> {
     });
 
-    collector.collect(span(1L, "foo"));
+    collector.collect(span(1L));
 
     assertThat(metrics.acceptedSpans.get()).isEqualTo(1);
     assertThat(metrics.droppedSpans.get()).isZero();
@@ -47,7 +48,7 @@ public class LocalSpanCollectorTest {
     });
 
     for (int i = 0; i < 1001; i++)
-      collector.collect(span(1L, "foo"));
+      collector.collect(span(1L));
 
     collector.flush(); // manually flush the spans
 
@@ -64,8 +65,8 @@ public class LocalSpanCollectorTest {
       messageCount.incrementAndGet();
     });
 
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -79,8 +80,8 @@ public class LocalSpanCollectorTest {
       throw new RuntimeException("couldn't store");
     });
 
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -92,8 +93,8 @@ public class LocalSpanCollectorTest {
     LocalSpanCollector collector = newLocalSpanCollector((spans, callback) ->
         callback.onError(new RuntimeException("couldn't store")));
 
-    collector.collect(span(1L, "foo"));
-    collector.collect(span(2L, "bar"));
+    collector.collect(span(1L));
+    collector.collect(span(2L));
 
     collector.flush(); // manually flush the spans
 
@@ -116,12 +117,12 @@ public class LocalSpanCollectorTest {
     }
   }
 
-  static Span span(long traceId, String spanName) {
-    return new Span().setTrace_id(traceId).setId(traceId).setName(spanName);
+  static Span span(long traceId) {
+    return Span.create(SpanId.builder().spanId(traceId).build());
   }
 
-  static zipkin.Span zipkinSpan(long traceId, String spanName) {
-    return zipkin.Span.builder().traceId(traceId).id(traceId).name(spanName).build();
+  static zipkin.Span zipkinSpan(long traceId) {
+    return zipkin.Span.builder().traceId(traceId).id(traceId).name("").build();
   }
 
   LocalSpanCollector newLocalSpanCollector(AsyncSpanConsumer consumer) {

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollector.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollector.java
@@ -3,6 +3,7 @@ package com.github.kristofa.brave.scribe;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.github.kristofa.brave.SpanId;
 import java.util.logging.Logger;
 
 import org.apache.thrift.transport.TTransportException;
@@ -20,7 +21,6 @@ public class ITScribeSpanCollector {
     private static final Logger LOGGER = Logger.getLogger(ITScribeSpanCollector.class.getName());
 
     private static final int PORT = FreePortProvider.getNewFreePort();
-    private static final String SPAN_NAME = "spanname";
 
     private static ScribeServer scribeServer;
 
@@ -89,12 +89,8 @@ public class ITScribeSpanCollector {
         }
     }
 
-    private Span span(long traceId) {
-        final Span span = new Span();
-        span.setId(traceId);
-        span.setTrace_id(traceId);
-        span.setName(SPAN_NAME);
-        return span;
+    static Span span(long traceId) {
+        return Span.create(SpanId.builder().spanId(traceId).build());
     }
 
 }

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorFailOnSetup.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorFailOnSetup.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.scribe;
 
 import static org.junit.Assert.assertEquals;
 
+import com.github.kristofa.brave.SpanId;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.Test;
 
@@ -12,7 +13,6 @@ public class ITScribeSpanCollectorFailOnSetup {
     private static final int PORT = FreePortProvider.getNewFreePort();
     private static final long SPAN_ID = 1;
     private static final long TRACE_ID = 2;
-    private static final String SPAN_NAME = "spanname";
 
     /**
      * Integration isSampled that checks failOnSetup = false. The isSampled basically shows that no exception is thrown when the server
@@ -26,10 +26,7 @@ public class ITScribeSpanCollectorFailOnSetup {
         final ScribeSpanCollectorParams params = new ScribeSpanCollectorParams();
         params.setFailOnSetup(false);
 
-        final Span span = new Span();
-        span.setId(SPAN_ID);
-        span.setTrace_id(TRACE_ID);
-        span.setName(SPAN_NAME);
+        final Span span = Span.create(SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).build());
 
         // Should not throw exception but log error.
         final ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT, params);

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorOfferTimeout.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorOfferTimeout.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave.scribe;
 
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Span;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.*;
@@ -18,7 +19,6 @@ public class ITScribeSpanCollectorOfferTimeout {
     private static final int PORT = FreePortProvider.getNewFreePort();
     private static final long SPAN_ID = 1;
     private static final long TRACE_ID = 2;
-    private static final String SPAN_NAME = "spanname";
 
     private static ScribeServer scribeServer;
 
@@ -62,11 +62,7 @@ public class ITScribeSpanCollectorOfferTimeout {
 
         final ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT, params);
         try {
-
-            final Span span = new Span();
-            span.setId(SPAN_ID);
-            span.setTrace_id(TRACE_ID);
-            span.setName(SPAN_NAME);
+            Span span = Span.create(SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).build());
 
             for (int i = 1; i <= hundredTen; i++) {
                 LOGGER.info("Submitting Span nr " + i + "/" + hundredTen);

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorMetricsTest.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorMetricsTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.scribe;
 
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Span;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.AfterClass;
@@ -17,7 +18,7 @@ public class ScribeSpanCollectorMetricsTest {
 
     private static final String HOST = "localhost";
     private static final int PORT = FreePortProvider.getNewFreePort();
-    private static final Span SPAN = new Span().setTrace_id(1).setId(2).setName("span name");
+    private static final Span SPAN = Span.create(SpanId.builder().traceId(1).spanId(2).build());
 
     private static ScribeServer scribeServer;
     private EventsHandler eventsHandler;

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorTest.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorTest.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.scribe;
 
 import static org.junit.Assert.assertEquals;
 
+import com.github.kristofa.brave.SpanId;
 import java.util.List;
 
 import org.apache.thrift.transport.TTransportException;
@@ -18,7 +19,6 @@ public class ScribeSpanCollectorTest {
     private static final int PORT = 9500;
     private static final long SPAN_ID = 1;
     private static final long TRACE_ID = 2;
-    private static final String SPAN_NAME = "spanname";
     private static final String KEY1 = "key1";
     private static final String VALUE1 = "value1";
 
@@ -50,10 +50,8 @@ public class ScribeSpanCollectorTest {
 
         final ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT);
         try {
-            final Span span = new Span();
-            span.setId(SPAN_ID);
-            span.setTrace_id(TRACE_ID);
-            span.setName(SPAN_NAME);
+            Span span = Span.create(SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).build());
+
             scribeSpanCollector.collect(span);
 
         } finally {
@@ -63,8 +61,6 @@ public class ScribeSpanCollectorTest {
         assertEquals(1, serverCollectedSpans.size());
         assertEquals(SPAN_ID, serverCollectedSpans.get(0).getId());
         assertEquals(TRACE_ID, serverCollectedSpans.get(0).getTrace_id());
-        assertEquals(SPAN_NAME, serverCollectedSpans.get(0).getName());
-
     }
 
     @Test
@@ -73,10 +69,8 @@ public class ScribeSpanCollectorTest {
         final ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT);
         scribeSpanCollector.addDefaultAnnotation(KEY1, VALUE1);
         try {
-            final Span span = new Span();
-            span.setId(SPAN_ID);
-            span.setTrace_id(TRACE_ID);
-            span.setName(SPAN_NAME);
+            Span span = Span.create(SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).build());
+
             scribeSpanCollector.collect(span);
 
         } finally {
@@ -87,7 +81,6 @@ public class ScribeSpanCollectorTest {
         final Span span = serverCollectedSpans.get(0);
         assertEquals(SPAN_ID, span.getId());
         assertEquals(TRACE_ID, span.getTrace_id());
-        assertEquals(SPAN_NAME, span.getName());
         final List<BinaryAnnotation> binary_annotations = span.getBinary_annotations();
         assertEquals("Expect default annotation to have been submitted.", 1, binary_annotations.size());
         final BinaryAnnotation binaryAnnotation = binary_annotations.get(0);

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
@@ -16,6 +16,7 @@ package com.github.kristofa.brave.servlet.internal;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
+import com.github.kristofa.brave.SpanId;
 import com.twitter.zipkin.gen.Span;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
@@ -39,7 +40,7 @@ public final class MaybeAddClientAddressFromRequestTest {
   HttpServletRequest request;
   @Mock
   ServerSpan serverSpan;
-  Span span = new Span();
+  Span span = Span.create(SpanId.builder().spanId(1L).build());
   @Mock
   Brave brave;
   @Mock


### PR DESCRIPTION
Current practice of client spans allows empty string as the span name.
When this is the case, the server's name will be preferred. Before, we
coerced null name to empty, but only in the constructor.

Span shouldn't be created or affected ad-hoc. This hardens span with
assertions as opposed to exceptions as the former won't break production
code.