### PR TITLE
Locks down internal methods that create spans

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -1,7 +1,10 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.InternalSpan;
+import com.github.kristofa.brave.internal.Nullable;
 import com.github.kristofa.brave.internal.Util;
 import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
 import java.net.UnknownHostException;
 import java.util.List;
 import zipkin.reporter.AsyncReporter;
@@ -296,5 +299,19 @@ public class Brave {
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
         serverSpanAnnotationSubmitter = AnnotationSubmitter.create(serverSpanThreadBinder, localEndpoint, clock);
+    }
+
+    static {
+        new Span(); // ensure InternalSpan.instance points to a reference
+    }
+
+    /** Internal hook to create a new Span */
+    static Span newSpan(SpanId context) {
+        return InternalSpan.instance.newSpan(context);
+    }
+
+    /** Internal hook to create a new Span */
+    @Nullable static SpanId context(Span span) {
+        return InternalSpan.instance.context(span);
     }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -154,12 +154,12 @@ public abstract class ClientTracer extends AnnotationSubmitter {
             return null;
         }
 
-        Span newSpan = Span.create(nextContext).setName(requestName);
+        Span newSpan = Brave.newSpan(nextContext).setName(requestName);
         currentSpan().setCurrentSpan(newSpan);
         return nextContext;
     }
 
-    private SpanId maybeParent() {
+    @Nullable SpanId maybeParent() {
         Span parentSpan = currentLocalSpan().get();
         if (parentSpan == null) {
             Span serverSpan = currentServerSpan().get();
@@ -168,13 +168,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
             }
         }
         if (parentSpan == null) return null;
-        if (parentSpan.context() != null) return parentSpan.context();
-        // If we got here, some implementation of state passed a deprecated span
-        return SpanId.builder()
-            .traceIdHigh(parentSpan.getTrace_id_high())
-            .traceId(parentSpan.getTrace_id())
-            .parentId(parentSpan.getParent_id())
-            .spanId(parentSpan.getId()).build();
+        return Brave.context(parentSpan);
     }
 
     ClientTracer() {

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -100,13 +100,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
             }
         }
         if (parentSpan == null) return null;
-        if (parentSpan.context() != null) return parentSpan.context();
-        // If we got here, some implementation of state passed a deprecated span
-        return SpanId.builder()
-            .traceIdHigh(parentSpan.getTrace_id_high())
-            .traceId(parentSpan.getTrace_id())
-            .parentId(parentSpan.getParent_id())
-            .spanId(parentSpan.getId()).build();
+        return Brave.context(parentSpan);
     }
 
     /**
@@ -136,7 +130,7 @@ public abstract class LocalTracer extends AnnotationSubmitter {
             return null;
         }
 
-        Span newSpan = Span.create(nextContext);
+        Span newSpan = Brave.newSpan(nextContext);
         newSpan.setName(operation);
         newSpan.setTimestamp(timestamp);
         newSpan.addToBinary_annotations(BinaryAnnotation.create(LOCAL_COMPONENT, component, endpoint()));

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -40,7 +40,7 @@ public abstract class ServerSpan {
     static ServerSpan create(SpanId spanId, String name) {
         if (spanId == null) throw new NullPointerException("spanId == null");
         if (name == null) throw new NullPointerException("name == null");
-        return new AutoValue_ServerSpan(spanId, Span.create(spanId).setName(name), true);
+        return new AutoValue_ServerSpan(spanId, Brave.newSpan(spanId).setName(name), true);
     }
 
     ServerSpan(){

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/DefaultSpanCodec.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/DefaultSpanCodec.java
@@ -41,7 +41,7 @@ public final class DefaultSpanCodec implements SpanCodec {
   }
 
   public static Span fromZipkin(zipkin.Span in) {
-    Span result = Span.create(SpanId.builder()
+    Span result = newSpan(SpanId.builder()
         .traceIdHigh(in.traceIdHigh)
         .traceId(in.traceId)
         .spanId(in.id)
@@ -107,5 +107,9 @@ public final class DefaultSpanCodec implements SpanCodec {
         .ipv6(host.ipv6)
         .port(host.port)
         .serviceName(host.service_name).build();
+  }
+
+  static Span newSpan(SpanId context) {
+    return InternalSpan.instance.newSpan(context);
   }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/InternalSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/InternalSpan.java
@@ -1,0 +1,29 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+
+/**
+ * Allows internal classes outside the package {@code com.twitter.zipkin.gen} to use non-public
+ * methods. This allows us access internal methods while also making obvious the hooks are not for
+ * public use. The only implementation of this interface is in {@link com.twitter.zipkin.gen.Span}.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.Internal}
+ */
+public abstract class InternalSpan {
+
+  public static void initializeInstanceForTests() {
+    // Needed in tests to ensure that the instance is actually pointing to something.
+    new Span();
+  }
+
+  public abstract Span newSpan(SpanId context);
+
+  /**
+   * In normal course, this returns the context of a span created by one of the tracers. This can
+   * return null when an invalid span was set externally via a custom thread binder or span state.
+   */
+  public abstract @Nullable SpanId context(Span span);
+
+  public static InternalSpan instance;
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -30,7 +30,7 @@ public class AnnotationSubmitterTest {
 
     private Endpoint endpoint =
         Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
-    private Span span = Span.create(SpanId.builder().spanId(1).build());
+    private Span span = Brave.newSpan(SpanId.builder().spanId(1).build());
     private AnnotationSubmitter annotationSubmitter;
     private List<zipkin.Span> spans = new ArrayList<>();
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -34,7 +34,7 @@ public class ClientTracerTest {
     private static final Endpoint endpoint = Endpoint.create("serviceName", 80);
 
     private SpanCollector mockCollector;
-    private Span span = Span.create(SpanId.builder().spanId(TRACE_ID).build());
+    private Span span = Brave.newSpan(SpanId.builder().spanId(TRACE_ID).build());
     private Brave brave;
 
     @Before

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 public class ITAnnotationSubmitterConcurrency {
 
     private ExecutorService executorService;
-    Span span = Span.create(SpanId.builder().spanId(1L).build());
+    Span span = Brave.newSpan(SpanId.builder().spanId(1L).build());
     private Endpoint endpoint =
         Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -37,7 +37,7 @@ public class LocalTracerTest {
 
     private Reporter<zipkin.Span> mockReporter;
     private Brave brave;
-    private Span span = Span.create(SpanId.builder().spanId(TRACE_ID).build());
+    private Span span = Brave.newSpan(SpanId.builder().spanId(TRACE_ID).build());
 
     @Before
     public void setup() {

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -36,7 +36,7 @@ public class ServerTracerTest {
     private SpanCollector mockSpanCollector;
     private Endpoint endpoint = Endpoint.create("service", 0);
     private Sampler mockSampler;
-    private Span span = Span.create(CONTEXT);
+    private Span span = Brave.newSpan(CONTEXT);
 
     @Before
     public void setup() {
@@ -116,7 +116,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetServerReceived() {
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         serverTracer.setServerReceived();
@@ -133,7 +133,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetServerReceivedSentClientAddress() {
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         serverTracer.setServerReceived(Endpoint.builder()
@@ -159,7 +159,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetServerReceivedSentClientAddress_noServiceName() {
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         serverTracer.setServerReceived(1 << 24 | 2 << 16 | 3 << 8 | 4, 9999, null);
@@ -179,7 +179,7 @@ public class ServerTracerTest {
     @Test
     public void testSetServerSend() {
         span.setTimestamp(100L);
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         serverTracer.setServerSend();
@@ -202,7 +202,7 @@ public class ServerTracerTest {
     @Test
     public void setServerSend_skipsDurationWhenNoTimestamp() {
         // duration unset due to client-originated trace
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         serverTracer.setServerSend();
@@ -216,7 +216,7 @@ public class ServerTracerTest {
     @Test
     public void setServerSend_usesPreciseDuration() {
         span.setTimestamp(START_TIME_MICROSECONDS);
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         PowerMockito.when(System.nanoTime()).thenReturn(500000L);
@@ -233,7 +233,7 @@ public class ServerTracerTest {
     @Test
     public void setServerSend_lessThanMicrosRoundUp() {
         span.setTimestamp(START_TIME_MICROSECONDS);
-        ServerSpan serverSpan = new AutoValue_ServerSpan(span.context(), span, true);
+        ServerSpan serverSpan = new AutoValue_ServerSpan(CONTEXT, span, true);
         serverTracer.currentSpan().setCurrentSpan(serverSpan);
 
         PowerMockito.when(System.nanoTime()).thenReturn(50L);

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/DefaultSpanCodecTest.java
@@ -8,6 +8,7 @@ import com.twitter.zipkin.gen.Span;
 import org.junit.Test;
 import zipkin.Constants;
 
+import static com.github.kristofa.brave.internal.DefaultSpanCodec.newSpan;
 import static org.junit.Assert.assertEquals;
 
 public class DefaultSpanCodecTest {
@@ -20,7 +21,7 @@ public class DefaultSpanCodecTest {
       .ipv6(sun.net.util.IPAddressUtil.textToNumericFormatV6("2001:db8::c001"))
       .port(80).build();
 
-  Span span = Span.create(SpanId.builder().spanId(-692101025335252320L).build()) // browser calls web
+  Span span = newSpan(SpanId.builder().spanId(-692101025335252320L).build()) // browser calls web
       .setName("get")
       .setTimestamp(1444438900939000L)
       .setDuration(376000L)
@@ -36,7 +37,7 @@ public class DefaultSpanCodecTest {
 
   @Test
   public void roundTripSpan_thrift_128() {
-    span = Span.create(span.context().toBuilder().traceIdHigh(3L).build());
+    span = newSpan(SpanId.builder().traceIdHigh(1L).traceId(2L).spanId(3L).build());
 
     byte[] encoded = DefaultSpanCodec.THRIFT.writeSpan(span);
     assertEquals(span, DefaultSpanCodec.THRIFT.readSpan(encoded));
@@ -50,7 +51,7 @@ public class DefaultSpanCodecTest {
 
   @Test
   public void roundTripSpan_json_128() {
-    span = Span.create(span.context().toBuilder().traceIdHigh(3L).build());
+    span = newSpan(SpanId.builder().traceIdHigh(1L).traceId(2L).spanId(3L).build());
 
     byte[] encoded = DefaultSpanCodec.JSON.writeSpan(span);
     assertEquals(span, DefaultSpanCodec.JSON.readSpan(encoded));

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/InternalSpanTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/InternalSpanTest.java
@@ -1,0 +1,47 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InternalSpanTest {
+  static {
+    InternalSpan.initializeInstanceForTests();
+  }
+
+  SpanId spanId = SpanId.builder().traceIdHigh(1).traceId(2).parentId(3L).spanId(4L).build();
+
+  @Test
+  public void context_nullWhenSpanIsEmpty() {
+    // pretend someone created an invalid span explicitly or by some accident of codec
+    Span span = new Span();
+    assertThat(InternalSpan.instance.context(span))
+        .isNull();
+  }
+
+  @Test
+  public void context_returnsSameObjectWhenSet() {
+    Span span = InternalSpan.instance.newSpan(spanId);
+
+    assertThat(InternalSpan.instance.context(span))
+        .isSameAs(spanId);
+  }
+
+  @Test
+  public void context_backFillsSpan() {
+    Span span = InternalSpan.instance.newSpan(spanId);
+    // If someone created a span externally, the context field would be unset
+    // This is deprecated practice, so we shouldn't break.
+    Whitebox.setInternalState(span, "context", (Object) null);
+
+    SpanId backfilled = InternalSpan.instance.context(span);
+    assertThat(backfilled).isEqualTo(spanId);
+
+    // after the state is set, future calls will return the same reference
+    assertThat(InternalSpan.instance.context(span))
+        .isSameAs(backfilled);
+  }
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
@@ -36,7 +36,7 @@ public final class MaybeAddClientAddressTest {
 
   @Mock
   ServerSpan serverSpan;
-  Span span = Span.create(SpanId.builder().spanId(1L).build());
+  Span span = InternalSpan.instance.newSpan(SpanId.builder().spanId(1L).build());
   @Mock
   Brave brave;
   @Mock

--- a/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
+++ b/brave-core/src/test/java/com/twitter/zipkin/gen/SpanTest.java
@@ -9,44 +9,39 @@ import static org.junit.Assert.assertEquals;
 public class SpanTest {
 
   @Test(expected = AssertionError.class)
-  public void deprecatedConstructor_throwsAssertionError() {
-    new Span();
-  }
-
-  @Test(expected = AssertionError.class)
   public void setTrace_id_high_throwsAssertionError() {
-    Span.create(SpanId.builder().spanId(1L).build()).setTrace_id_high(1L);
+    new Span(SpanId.builder().spanId(1L).build()).setTrace_id_high(1L);
   }
 
   @Test(expected = AssertionError.class)
   public void setTrace_id_throwsAssertionError() {
-    Span.create(SpanId.builder().spanId(1L).build()).setTrace_id(1L);
+    new Span(SpanId.builder().spanId(1L).build()).setTrace_id(1L);
   }
 
   @Test(expected = AssertionError.class)
   public void setParent_id_throwsAssertionError() {
-    Span.create(SpanId.builder().spanId(1L).build()).setParent_id(1L);
+    new Span(SpanId.builder().spanId(1L).build()).setParent_id(1L);
   }
 
   @Test(expected = AssertionError.class)
   public void setId_throwsAssertionError() {
-    Span.create(SpanId.builder().spanId(1L).build()).setId(1L);
+    new Span(SpanId.builder().spanId(1L).build()).setId(1L);
   }
 
   @Test(expected = AssertionError.class)
   public void setDebug_throwsAssertionError() {
-    Span.create(SpanId.builder().spanId(1L).build()).setDebug(false);
+    new Span(SpanId.builder().spanId(1L).build()).setDebug(false);
   }
 
   @Test
   public void testNameLowercase() {
-    assertEquals("spanname", Span.create(SpanId.builder().spanId(1L).build())
+    assertEquals("spanname", new Span(SpanId.builder().spanId(1L).build())
         .setName("SpanName").getName());
   }
 
   @Test
   public void setName_coercesNullToEmptyString() {
-    Span span = Span.create(SpanId.builder().spanId(1L).build()).setName("foo");
+    Span span = new Span(SpanId.builder().spanId(1L).build()).setName("foo");
 
     assertThat(span.setName(null).getName()).isEqualTo("");
   }
@@ -54,19 +49,19 @@ public class SpanTest {
   /** Use addToAnnotations as opposed to attempting to mutate the collection */
   @Test(expected = UnsupportedOperationException.class)
   public void getAnnotations_returnsUnmodifiable() {
-    Span.create(SpanId.builder().spanId(1L).build()).getAnnotations().add(null);
+    new Span(SpanId.builder().spanId(1L).build()).getAnnotations().add(null);
   }
 
   /** Use addToBinary_annotations as opposed to attempting to mutate the collection */
   @Test(expected = UnsupportedOperationException.class)
   public void getBinary_annotations_returnsUnmodifiable() {
-    Span.create(SpanId.builder().spanId(1L).build()).getBinary_annotations().add(null);
+    new Span(SpanId.builder().spanId(1L).build()).getBinary_annotations().add(null);
   }
 
   @Test
   public void toStringIsJson() {
     long traceId = -692101025335252320L;
-    Span span = Span.create(SpanId.builder().spanId(traceId).build())
+    Span span = new Span(SpanId.builder().spanId(traceId).build())
         .setName("get")
         .setTimestamp(1444438900939000L)
         .setDuration(376000L);
@@ -78,7 +73,7 @@ public class SpanTest {
   public void toSpan_128() {
     SpanId id = SpanId.builder().traceIdHigh(1).traceId(2).spanId(3).parentId(2L).build();
 
-    Span span = Span.create(id);
+    Span span = new Span(id);
     assertThat(span.getTrace_id_high()).isEqualTo(id.traceIdHigh);
     assertThat(span.getTrace_id()).isEqualTo(id.traceId);
     assertThat(span.getId()).isEqualTo(id.spanId);

--- a/brave-spancollector-http/src/test/java/com/github/kristofa/brave/http/HttpSpanCollectorTest.java
+++ b/brave-spancollector-http/src/test/java/com/github/kristofa/brave/http/HttpSpanCollectorTest.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.http;
 
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.Span;
 import java.util.Arrays;
@@ -18,6 +19,9 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class HttpSpanCollectorTest {
+  static {
+    InternalSpan.initializeInstanceForTests();
+  }
 
   @Rule
   public final ZipkinRule zipkinRule = new ZipkinRule();
@@ -144,7 +148,7 @@ public class HttpSpanCollectorTest {
   }
 
   static Span span(long traceId) {
-    return Span.create(SpanId.builder().spanId(traceId).build());
+    return InternalSpan.instance.newSpan(SpanId.builder().spanId(traceId).build());
   }
 
   static zipkin.Span zipkinSpan(long traceId) {

--- a/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/KafkaSpanCollectorTest.java
+++ b/brave-spancollector-kafka/src/test/java/com/github/kristofa/brave/kafka/KafkaSpanCollectorTest.java
@@ -3,6 +3,7 @@ package com.github.kristofa.brave.kafka;
 import com.github.charithe.kafka.KafkaJunitRule;
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.github.kristofa.brave.kafka.KafkaSpanCollector.Config;
 import com.twitter.zipkin.gen.Span;
 import java.util.List;
@@ -23,6 +24,9 @@ import zipkin.Codec;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class KafkaSpanCollectorTest {
+  static {
+    InternalSpan.initializeInstanceForTests();
+  }
 
   @Rule
   public KafkaJunitRule kafka = new KafkaJunitRule();
@@ -143,7 +147,7 @@ public class KafkaSpanCollectorTest {
   }
 
   static Span span(long traceId) {
-    return Span.create(SpanId.builder().spanId(traceId).build());
+    return InternalSpan.instance.newSpan(SpanId.builder().spanId(traceId).build());
   }
 
   static zipkin.Span zipkinSpan(long traceId) {

--- a/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
+++ b/brave-spancollector-local/src/test/java/com/github/kristofa/brave/local/LocalSpanCollectorTest.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.local;
 
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.twitter.zipkin.gen.Span;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
@@ -14,6 +15,10 @@ import zipkin.storage.StorageComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalSpanCollectorTest {
+  static {
+    InternalSpan.initializeInstanceForTests();
+  }
+
   public final InMemoryStorage storage = new InMemoryStorage();
 
   TestMetricsHander metrics = new TestMetricsHander();
@@ -118,7 +123,7 @@ public class LocalSpanCollectorTest {
   }
 
   static Span span(long traceId) {
-    return Span.create(SpanId.builder().spanId(traceId).build());
+    return InternalSpan.instance.newSpan(SpanId.builder().spanId(traceId).build());
   }
 
   static zipkin.Span zipkinSpan(long traceId) {

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollector.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollector.java
@@ -1,9 +1,9 @@
 package com.github.kristofa.brave.scribe;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import java.util.logging.Logger;
 
 import org.apache.thrift.transport.TTransportException;
@@ -17,6 +17,9 @@ import com.twitter.zipkin.gen.Span;
  * @author kristof
  */
 public class ITScribeSpanCollector {
+    static {
+        InternalSpan.initializeInstanceForTests();
+    }
 
     private static final Logger LOGGER = Logger.getLogger(ITScribeSpanCollector.class.getName());
 
@@ -66,7 +69,6 @@ public class ITScribeSpanCollector {
         params.setQueueSize(100);
         params.setBatchSize(50);
 
-        long traceId = 1;
         try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT, params)) {
 
             submitSpans(scribeSpanCollector, firstBurstOfSpans);
@@ -90,7 +92,6 @@ public class ITScribeSpanCollector {
     }
 
     static Span span(long traceId) {
-        return Span.create(SpanId.builder().spanId(traceId).build());
+        return InternalSpan.instance.newSpan(SpanId.builder().spanId(traceId).build());
     }
-
 }

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorFailOnSetup.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorFailOnSetup.java
@@ -1,18 +1,20 @@
 package com.github.kristofa.brave.scribe;
 
-import static org.junit.Assert.assertEquals;
-
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
+import com.twitter.zipkin.gen.Span;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.Test;
 
-import com.twitter.zipkin.gen.Span;
+import static org.junit.Assert.assertEquals;
 
 public class ITScribeSpanCollectorFailOnSetup {
+    static {
+        InternalSpan.initializeInstanceForTests();
+    }
 
     private static final int PORT = FreePortProvider.getNewFreePort();
-    private static final long SPAN_ID = 1;
-    private static final long TRACE_ID = 2;
+    Span span = InternalSpan.instance.newSpan(SpanId.builder().traceId(1).spanId(2).build());
 
     /**
      * Integration isSampled that checks failOnSetup = false. The isSampled basically shows that no exception is thrown when the server
@@ -25,9 +27,6 @@ public class ITScribeSpanCollectorFailOnSetup {
     public void testFailOnSetupFalse() throws TTransportException, InterruptedException {
         final ScribeSpanCollectorParams params = new ScribeSpanCollectorParams();
         params.setFailOnSetup(false);
-
-        final Span span = Span.create(SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).build());
-
         // Should not throw exception but log error.
         final ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT, params);
 

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorOfferTimeout.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ITScribeSpanCollectorOfferTimeout.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.scribe;
 
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.twitter.zipkin.gen.Span;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.*;
@@ -12,13 +13,15 @@ import static org.junit.Assert.assertTrue;
 
 
 public class ITScribeSpanCollectorOfferTimeout {
+    static {
+        InternalSpan.initializeInstanceForTests();
+    }
 
     private static final Logger LOGGER = Logger.getLogger(ITScribeSpanCollector.class.getName());
     private static final int QUEUE_SIZE = 5;
 
     private static final int PORT = FreePortProvider.getNewFreePort();
-    private static final long SPAN_ID = 1;
-    private static final long TRACE_ID = 2;
+    Span span = InternalSpan.instance.newSpan(SpanId.builder().traceId(1).spanId(2).build());
 
     private static ScribeServer scribeServer;
 
@@ -62,8 +65,6 @@ public class ITScribeSpanCollectorOfferTimeout {
 
         final ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("localhost", PORT, params);
         try {
-            Span span = Span.create(SpanId.builder().traceId(TRACE_ID).spanId(SPAN_ID).build());
-
             for (int i = 1; i <= hundredTen; i++) {
                 LOGGER.info("Submitting Span nr " + i + "/" + hundredTen);
                 scribeSpanCollector.collect(span);

--- a/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorMetricsTest.java
+++ b/brave-spancollector-scribe/src/test/java/com/github/kristofa/brave/scribe/ScribeSpanCollectorMetricsTest.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.scribe;
 
 import com.github.kristofa.brave.SpanCollectorMetricsHandler;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.twitter.zipkin.gen.Span;
 import org.apache.thrift.transport.TTransportException;
 import org.junit.AfterClass;
@@ -15,10 +16,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ScribeSpanCollectorMetricsTest {
+    static {
+        InternalSpan.initializeInstanceForTests();
+    }
 
     private static final String HOST = "localhost";
     private static final int PORT = FreePortProvider.getNewFreePort();
-    private static final Span SPAN = Span.create(SpanId.builder().traceId(1).spanId(2).build());
+    Span span = InternalSpan.instance.newSpan(SpanId.builder().traceId(1).spanId(2).build());
 
     private static ScribeServer scribeServer;
     private EventsHandler eventsHandler;
@@ -66,7 +70,7 @@ public class ScribeSpanCollectorMetricsTest {
 
         // when
         try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector(HOST, PORT, params)) {
-            scribeSpanCollector.collect(SPAN);
+            scribeSpanCollector.collect(span);
         }
 
         // then
@@ -85,9 +89,9 @@ public class ScribeSpanCollectorMetricsTest {
 
         // when
         try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector(HOST, PORT, params)) {
-            scribeSpanCollector.collect(SPAN);
-            scribeSpanCollector.collect(SPAN);
-            scribeSpanCollector.collect(SPAN);
+            scribeSpanCollector.collect(span);
+            scribeSpanCollector.collect(span);
+            scribeSpanCollector.collect(span);
         }
 
         // then
@@ -106,7 +110,7 @@ public class ScribeSpanCollectorMetricsTest {
 
         // when
         try (ScribeSpanCollector scribeSpanCollector = new ScribeSpanCollector("invalid-host", PORT, params)) {
-            scribeSpanCollector.collect(SPAN);
+            scribeSpanCollector.collect(span);
         }
 
         // then

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
@@ -17,6 +17,7 @@ import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
 import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.twitter.zipkin.gen.Span;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
@@ -33,6 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 public final class MaybeAddClientAddressFromRequestTest {
+  static {
+    InternalSpan.initializeInstanceForTests();
+  }
+
   @Rule
   public MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -40,7 +45,7 @@ public final class MaybeAddClientAddressFromRequestTest {
   HttpServletRequest request;
   @Mock
   ServerSpan serverSpan;
-  Span span = Span.create(SpanId.builder().spanId(1L).build());
+  Span span = InternalSpan.instance.newSpan(SpanId.builder().spanId(1L).build());
   @Mock
   Brave brave;
   @Mock


### PR DESCRIPTION
This locks down methods that create `c.t.z.gen.Span`, by forcing them
through the internal package. By doing so, we know if a span was created
in a deprecated way or not. We also remove temptation to use internal
hooks accidentally (by virtue of not reading docs).

This change works by making a package accessor `InternalSpan`, in the
same way as OkHttp works. In the rare cases we need to create spans for
test purposes, we need to set the reference using `initializeForTests()`

The majority of the code impact is old tests which don't need to create
spans explicitly, but would take effort to port to not do so.