### PR TITLE
Consolidates span creation code

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -42,7 +42,7 @@ public class Brave {
 
         private final ServerClientAndLocalSpanState state;
         private Reporter reporter = new LoggingReporter();
-        private final SpanIdFactory.Builder spanIdFactoryBuilder = SpanIdFactory.builder();
+        private final SpanFactory.Builder spanFactoryBuilder = SpanFactory.builder();
         private boolean allowNestedLocalSpans = false;
         private AnnotationSubmitter.Clock clock;
 
@@ -115,7 +115,7 @@ public class Brave {
         }
 
         public Builder traceSampler(Sampler sampler) {
-            this.spanIdFactoryBuilder.sampler(sampler);
+            this.spanFactoryBuilder.sampler(sampler);
             return this;
         }
 
@@ -157,7 +157,7 @@ public class Brave {
 
         /** When true, new root spans will have 128-bit trace IDs. Defaults to false (64-bit) */
         public Builder traceId128Bit(boolean traceId128Bit) {
-            this.spanIdFactoryBuilder.traceId128Bit(traceId128Bit);
+            this.spanFactoryBuilder.traceId128Bit(traceId128Bit);
             return this;
         }
 
@@ -256,7 +256,7 @@ public class Brave {
     }
 
     private Brave(Builder builder) {
-        SpanIdFactory spanIdFactory = builder.spanIdFactoryBuilder.build();
+        SpanFactory spanFactory = builder.spanFactoryBuilder.build();
         AnnotationSubmitter.Clock clock = builder.clock != null
             ? builder.clock
             : new AnnotationSubmitter.DefaultClock();
@@ -267,7 +267,7 @@ public class Brave {
 
         Endpoint localEndpoint = builder.state.endpoint();
         serverTracer = new AutoValue_ServerTracer.Builder()
-                .spanIdFactory(spanIdFactory)
+                .spanFactory(spanFactory)
                 .reporter(builder.reporter)
                 .currentSpan(serverSpanThreadBinder)
                 .endpoint(localEndpoint)
@@ -275,7 +275,7 @@ public class Brave {
                 .build();
 
         clientTracer = new AutoValue_ClientTracer.Builder()
-                .spanIdFactory(spanIdFactory)
+                .spanFactory(spanFactory)
                 .reporter(builder.reporter)
                 .currentLocalSpan(localSpanThreadBinder)
                 .currentServerSpan(serverSpanThreadBinder)
@@ -285,7 +285,7 @@ public class Brave {
                 .build();
 
         localTracer = new AutoValue_LocalTracer.Builder()
-                .spanIdFactory(spanIdFactory)
+                .spanFactory(spanFactory)
                 .reporter(builder.reporter)
                 .allowNestedLocalSpans(builder.allowNestedLocalSpans)
                 .currentServerSpan(serverSpanThreadBinder)
@@ -310,7 +310,7 @@ public class Brave {
         return InternalSpan.instance.newSpan(context);
     }
 
-    /** Internal hook to create a new Span */
+    /** Internal hook to retrieve the context associated with a Span */
     @Nullable static SpanId context(Span span) {
         return InternalSpan.instance.context(span);
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/CommonSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/CommonSpanState.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.Nullable;
 import com.twitter.zipkin.gen.Endpoint;
 
 /**
@@ -12,16 +13,9 @@ import com.twitter.zipkin.gen.Endpoint;
  */
 public interface CommonSpanState {
 
-    /**
-     * Indicates if we should sample current request.
-     * <p/>
-     * Should be thread-aware to support multiple parallel requests.
-     * 
-     * @return <code>null</code> in case there is no indication if we should sample or not. <code>true</code> in case we got
-     *         the indication we should sample current request, <code>false</code> in case we should not sample the current
-     *         request.
-     */
-    Boolean sample();
+    /** @deprecated alias for the sampled flag on {@link ServerSpanState#getCurrentServerSpan()}. */
+    @Deprecated
+    @Nullable Boolean sample();
 
     /**
      * Gets the Endpoint (ip, port, service name) for this service.

--- a/brave-core/src/main/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanState.java
@@ -45,6 +45,7 @@ public final class InheritableServerClientAndLocalSpanState implements ServerCli
         this.endpoint = Util.checkNotNull(endpoint, "Endpoint must be specified.");
     }
 
+    /** Never returns null: {@code setCurrentServerSpan(null)} coerces to {@link ServerSpan#EMPTY} */
     @Override
     public ServerSpan getCurrentServerSpan() {
         return currentServerSpan.get();

--- a/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LocalTracer.java
@@ -43,11 +43,11 @@ public abstract class LocalTracer extends AnnotationSubmitter {
 
     abstract boolean allowNestedLocalSpans();
 
-    abstract SpanIdFactory spanIdFactory();
+    abstract SpanFactory spanFactory();
 
     @AutoValue.Builder
     abstract static class Builder {
-        abstract Builder spanIdFactory(SpanIdFactory spanIdFactory);
+        abstract Builder spanFactory(SpanFactory spanFactory);
 
         abstract Builder endpoint(Endpoint endpoint);
 
@@ -124,13 +124,13 @@ public abstract class LocalTracer extends AnnotationSubmitter {
             return null;
         }
 
-        SpanId nextContext = spanIdFactory().next(maybeParent());
+        Span newSpan = spanFactory().newSpan(maybeParent());
+        SpanId nextContext = Brave.context(newSpan);
         if (Boolean.FALSE.equals(nextContext.sampled())) {
             currentSpan().setCurrentSpan(null);
             return null;
         }
 
-        Span newSpan = Brave.newSpan(nextContext);
         newSpan.setName(operation);
         newSpan.setTimestamp(timestamp);
         newSpan.addToBinary_annotations(BinaryAnnotation.create(LOCAL_COMPONENT, component, endpoint()));

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -37,10 +37,14 @@ public abstract class ServerSpan {
     @Nullable
     public abstract Boolean getSample();
 
-    static ServerSpan create(SpanId spanId, String name) {
-        if (spanId == null) throw new NullPointerException("spanId == null");
-        if (name == null) throw new NullPointerException("name == null");
-        return new AutoValue_ServerSpan(spanId, Brave.newSpan(spanId).setName(name), true);
+    /** Converts the input into a new server span or {@linkplain ServerSpan#NOT_SAMPLED}. */
+    static ServerSpan create(Span span, String spanName) {
+        SpanId context = Brave.context(span);
+        if (Boolean.FALSE.equals(context.sampled())) {
+            return ServerSpan.NOT_SAMPLED;
+        }
+        span.setName(spanName);
+        return new AutoValue_ServerSpan(context, span, context.sampled());
     }
 
     ServerSpan(){

--- a/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanState.java
@@ -67,9 +67,7 @@ public final class ThreadLocalServerClientAndLocalSpanState implements ServerCli
         this.endpoint = endpoint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** Never returns null: {@code setCurrentServerSpan(null)} coerces to {@link ServerSpan#EMPTY} */
     @Override
     public ServerSpan getCurrentServerSpan() {
         return currentServerSpan.get();

--- a/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/BraveTest.java
@@ -31,7 +31,7 @@ public class BraveTest {
         assertSame("ClientTracer should be configured with the reporter we submitted.", fakeReporter,
             clientTracer.reporter());
         assertSame("ClientTracer should be configured with the traceSampler we submitted.",
-            mockSampler, clientTracer.spanIdFactory().sampler());
+            mockSampler, clientTracer.spanFactory().sampler());
 
         final ClientTracer secondClientTracer =
             brave.clientTracer();
@@ -45,7 +45,7 @@ public class BraveTest {
         assertNotNull(serverTracer);
         assertSame(fakeReporter, serverTracer.reporter());
         assertSame("ServerTracer should be configured with the traceSampler we submitted.",
-            mockSampler, serverTracer.spanIdFactory().sampler());
+            mockSampler, serverTracer.spanFactory().sampler());
 
         final ServerTracer secondServerTracer = brave.serverTracer();
         assertSame("It is important that each server tracer we get shares same state.",
@@ -70,7 +70,7 @@ public class BraveTest {
         assertNotNull(localTracer);
         assertSame(fakeReporter, localTracer.reporter());
         assertSame("LocalTracer should be configured with the traceSampler we submitted.",
-                mockSampler, localTracer.spanIdFactory().sampler());
+                mockSampler, localTracer.spanFactory().sampler());
 
         final LocalTracer secondLocalTracer =
                 brave.localTracer();

--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -158,7 +158,7 @@ public class ClientTracerTest {
 
     @Test
     public void testStartNewSpanSampleTruePartOfExistingSpan() {
-        final ServerSpan parentSpan = ServerSpan.create(PARENT_CONTEXT, "name");
+        final ServerSpan parentSpan = ServerSpan.create(Brave.newSpan(PARENT_CONTEXT), "name");
         brave.serverSpanThreadBinder().setCurrentSpan(parentSpan);
 
         SpanId newContext = brave.clientTracer().startNewSpan(REQUEST_NAME);
@@ -216,7 +216,7 @@ public class ClientTracerTest {
     @Test
     public void startNewSpan_whenParentHas128bitTraceId() {
         ServerSpan parentSpan = ServerSpan.create(
-            PARENT_CONTEXT.toBuilder().traceIdHigh(3).build(), "name");
+            Brave.newSpan(PARENT_CONTEXT.toBuilder().traceIdHigh(3).build()), "name");
         brave.serverSpanThreadBinder().setCurrentSpan(parentSpan);
 
         SpanId newContext = brave.clientTracer().startNewSpan(REQUEST_NAME);

--- a/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/InheritableServerClientAndLocalSpanStateTest.java
@@ -35,10 +35,16 @@ public class InheritableServerClientAndLocalSpanStateTest {
         mockSpan = mock(Span.class);
     }
 
+    @Test
+    public void setCurrentServerSpanNullRevertsToEmpty() {
+        state.setCurrentServerSpan(null);
+        assertEquals(ServerSpan.EMPTY, state.getCurrentServerSpan());
+    }
+
     @After
     public void tearDown() {
         state.setCurrentClientSpan(null);
-        state.setCurrentServerSpan(null);
+        state.setCurrentServerSpan(ServerSpan.EMPTY);
         Span localSpan;
         int depth = 0;
         while ((localSpan = state.getCurrentLocalSpan()) != null) {
@@ -111,7 +117,7 @@ public class InheritableServerClientAndLocalSpanStateTest {
         assertThat(currentParentSpan(state)).isSameAs(mockServerSpan.getSpan());
         assertThat(currentParentSpan(state)).isNotEqualTo(mockSpan);
 
-        state.setCurrentServerSpan(null);
+        state.setCurrentServerSpan(ServerSpan.EMPTY);
         assertThat(currentParentSpan(state)).isNull();
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -62,7 +62,7 @@ public class LocalTracerTest {
      */
     @Test
     public void startNewSpan() {
-        brave.serverSpanThreadBinder().setCurrentSpan(ServerSpan.create(PARENT_CONTEXT, "name"));
+        brave.serverTracer().setStateCurrentTrace(PARENT_CONTEXT, "name");
 
         PowerMockito.when(System.nanoTime()).thenReturn(500L);
 
@@ -95,7 +95,7 @@ public class LocalTracerTest {
      */
     @Test
     public void startSpan_userSuppliedTimestamp() {
-        brave.serverSpanThreadBinder().setCurrentSpan(ServerSpan.create(PARENT_CONTEXT, "name"));
+        brave.serverTracer().setStateCurrentTrace(PARENT_CONTEXT, "name");
 
         brave.localTracer().startNewSpan(COMPONENT_NAME, OPERATION_NAME, 1000L);
 
@@ -156,7 +156,7 @@ public class LocalTracerTest {
         LocalTracer localTracer = brave.localTracer();
 
         assertNull(localTracer.maybeParent());
-        state.setCurrentServerSpan(ServerSpan.create(PARENT_CONTEXT, "name"));
+        brave.serverTracer().setStateCurrentTrace(PARENT_CONTEXT, "name");
 
         SpanId span1 = localTracer.startNewSpan(COMPONENT_NAME, OPERATION_NAME);
         assertEquals(PARENT_CONTEXT.toBuilder().spanId(span1.spanId).parentId(PARENT_CONTEXT.spanId).build(), span1);
@@ -175,9 +175,8 @@ public class LocalTracerTest {
 
     @Test
     public void startNewSpan_whenParentHas128bitTraceId() {
-        ServerSpan parentSpan = ServerSpan.create(
-            PARENT_CONTEXT.toBuilder().traceIdHigh(3).build(), "name");
-        brave.serverSpanThreadBinder().setCurrentSpan(parentSpan);
+        brave.serverTracer()
+            .setStateCurrentTrace(PARENT_CONTEXT.toBuilder().traceIdHigh(3).build(), "name");
 
         SpanId newContext = brave.localTracer().startNewSpan(COMPONENT_NAME, OPERATION_NAME);
         assertEquals(3, newContext.traceIdHigh);

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritenceTest.java
@@ -67,7 +67,7 @@ public class LocalTracingInheritenceTest {
         assertSame("ClientTracer should be configured with the spanreportor we submitted.", reporter,
                 clientTracer.reporter());
         assertSame("ClientTracer should be configured with the traceSampler we submitted.",
-                sampler, clientTracer.spanIdFactory().sampler());
+                sampler, clientTracer.spanFactory().sampler());
 
         final ClientTracer secondClientTracer = brave.clientTracer();
         assertSame("It is important that each client tracer we get shares same state.",
@@ -80,7 +80,7 @@ public class LocalTracingInheritenceTest {
         assertNotNull(serverTracer);
         assertSame(reporter, serverTracer.reporter());
         assertSame("ServerTracer should be configured with the traceSampler we submitted.",
-                sampler, serverTracer.spanIdFactory().sampler());
+                sampler, serverTracer.spanFactory().sampler());
 
         final ServerTracer secondServerTracer = brave.serverTracer();
         assertSame("It is important that each client tracer we get shares same state.",
@@ -93,7 +93,7 @@ public class LocalTracingInheritenceTest {
         assertNotNull(localTracer);
         assertSame(reporter, localTracer.reporter());
         assertSame("LocalTracer should be configured with the traceSampler we submitted.",
-                sampler, localTracer.spanIdFactory().sampler());
+                sampler, localTracer.spanFactory().sampler());
 
         final LocalTracer secondLocalTracer = brave.localTracer();
         assertSame("It is important that each local tracer we get shares same state.",

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanTest.java
@@ -1,26 +1,22 @@
 package com.github.kristofa.brave;
 
+import static com.github.kristofa.brave.Brave.newSpan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.twitter.zipkin.gen.Span;
 
 public class ServerSpanTest {
     private static final long TRACE_ID = 1;
-    private static final SpanId SPAN_ID = SpanId.builder().traceId(TRACE_ID).spanId(2).parentId(3L).build();
+    private static final SpanId SPAN_ID =
+        SpanId.builder().sampled(true).traceId(TRACE_ID).spanId(2).parentId(3L).build();
     private static final String NAME = "name";
 
-    private ServerSpan serverSpan;
-
-    @Before
-    public void setup() {
-        serverSpan = ServerSpan.create(SPAN_ID, NAME);
-    }
+    private ServerSpan serverSpan = ServerSpan.create(newSpan(SPAN_ID), NAME);
 
     @Test
     public void testGetSpan() {
@@ -36,7 +32,7 @@ public class ServerSpanTest {
 
     @Test
     public void testGetSpan_128() {
-        serverSpan = ServerSpan.create(SPAN_ID.toBuilder().traceIdHigh(5).build(), NAME);
+        serverSpan = ServerSpan.create(newSpan(SPAN_ID.toBuilder().traceIdHigh(5).build()), NAME);
 
         Span span = serverSpan.getSpan();
         assertEquals(5, span.getTrace_id_high());
@@ -51,14 +47,19 @@ public class ServerSpanTest {
     @Test
     public void testEqualsObject() {
 
-        ServerSpan equalServerSpan = ServerSpan.create(SPAN_ID, NAME);
+        ServerSpan equalServerSpan = ServerSpan.create(newSpan(SPAN_ID), NAME);
         assertTrue(serverSpan.equals(equalServerSpan));
     }
 
     @Test
     public void testHashCode() {
-        ServerSpan equalServerSpan = ServerSpan.create(SPAN_ID, NAME);
+        ServerSpan equalServerSpan = ServerSpan.create(newSpan(SPAN_ID), NAME);
         Assert.assertEquals(serverSpan.hashCode(), equalServerSpan.hashCode());
     }
 
+    @Test
+    public void createUnsampled() {
+        serverSpan = ServerSpan.create(newSpan(SPAN_ID.toBuilder().sampled(false).build()), NAME);
+        assertEquals(serverSpan, ServerSpan.NOT_SAMPLED);
+    }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanThreadBinderTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanThreadBinderTest.java
@@ -45,9 +45,9 @@ public class ServerSpanThreadBinderTest {
     }
 
     @Test
-    public void testSetCurrentSpanNull() {
-        binder.setCurrentSpan(null);
-        verify(mockServerSpanState).setCurrentServerSpan(null);
+    public void testSetCurrentSpanEmpty() {
+        binder.setCurrentSpan(ServerSpan.EMPTY);
+        verify(mockServerSpanState).setCurrentServerSpan(ServerSpan.EMPTY);
         verifyNoMoreInteractions(mockServerSpanState);
     }
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -29,7 +29,8 @@ public class ServerTracerTest {
 
     private static final long START_TIME_MICROSECONDS = System.currentTimeMillis() * 1000;
     private static final long TRACE_ID = 1;
-    private static final SpanId CONTEXT = SpanId.builder().traceId(TRACE_ID).spanId(2).parentId(3L).build();
+    private static final SpanId CONTEXT =
+        SpanId.builder().sampled(true).traceId(TRACE_ID).spanId(2).parentId(3L).build();
     private static final String SPAN_NAME = "span name";
 
     private ServerTracer serverTracer;
@@ -61,7 +62,7 @@ public class ServerTracerTest {
         serverTracer.setStateCurrentTrace(CONTEXT, SPAN_NAME);
 
         assertThat(serverTracer.currentSpan().getCurrentServerSpan())
-            .isEqualTo(ServerSpan.create(CONTEXT, SPAN_NAME));
+            .isEqualTo(ServerSpan.create(Brave.newSpan(CONTEXT), SPAN_NAME));
     }
 
     @Test
@@ -106,7 +107,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetServerReceivedNoServerSpan() {
-        serverTracer.currentSpan().setCurrentSpan(null);
+        serverTracer.currentSpan().setCurrentSpan(ServerSpan.EMPTY);
 
         serverTracer.setServerReceived();
 
@@ -169,7 +170,7 @@ public class ServerTracerTest {
 
     @Test
     public void testSetServerSendShouldNoServerSpan() {
-        serverTracer.currentSpan().setCurrentSpan(null);
+        serverTracer.currentSpan().setCurrentSpan(ServerSpan.EMPTY);
 
         serverTracer.setServerSend();
 

--- a/brave-core/src/test/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanStateTest.java
@@ -30,7 +30,13 @@ public class ThreadLocalServerClientAndLocalSpanStateTest {
     @After
     public void tearDown() {
         serverAndClientSpanState.setCurrentClientSpan(null);
+        serverAndClientSpanState.setCurrentServerSpan(ServerSpan.EMPTY);
+    }
+
+    @Test
+    public void setCurrentServerSpanNullRevertsToEmpty() {
         serverAndClientSpanState.setCurrentServerSpan(null);
+        assertEquals(ServerSpan.EMPTY, serverAndClientSpanState.getCurrentServerSpan());
     }
 
     @Test

--- a/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/BraveServerInInterceptor.java
+++ b/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/BraveServerInInterceptor.java
@@ -2,6 +2,7 @@ package com.github.kristofa.brave.cxf3;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerRequestInterceptor;
+import com.github.kristofa.brave.ServerSpan;
 import com.github.kristofa.brave.ServerSpanThreadBinder;
 import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.http.HttpServerRequestAdapter;
@@ -63,7 +64,7 @@ public final class BraveServerInInterceptor extends AbstractPhaseInterceptor<Mes
           new HttpServerRequestAdapter(new HttpMessage.ServerRequest(message), spanNameProvider));
       message.getExchange().put(BRAVE_SERVER_SPAN, threadBinder.getCurrentServerSpan());
     } finally {
-      threadBinder.setCurrentSpan(null);
+      threadBinder.setCurrentSpan(ServerSpan.EMPTY);
     }
   }
 }

--- a/brave-spring-web-servlet-interceptor/src/main/java/com/github/kristofa/brave/spring/ServletHandlerInterceptor.java
+++ b/brave-spring-web-servlet-interceptor/src/main/java/com/github/kristofa/brave/spring/ServletHandlerInterceptor.java
@@ -97,7 +97,7 @@ public class ServletHandlerInterceptor extends HandlerInterceptorAdapter {
     @Override
     public void afterConcurrentHandlingStarted(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
         request.setAttribute(HTTP_SERVER_SPAN_ATTRIBUTE, serverThreadBinder.getCurrentServerSpan());
-        serverThreadBinder.setCurrentSpan(null);
+        serverThreadBinder.setCurrentSpan(ServerSpan.EMPTY);
     }
 
     @Override

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ServletHandlerInterceptorTest.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ServletHandlerInterceptorTest.java
@@ -74,6 +74,6 @@ public class ServletHandlerInterceptorTest {
 
         assertSame(serverSpan, request.getAttribute(ServletHandlerInterceptor.HTTP_SERVER_SPAN_ATTRIBUTE));
 
-        verify(serverThreadBinder).setCurrentSpan(null);
+        verify(serverThreadBinder).setCurrentSpan(ServerSpan.EMPTY);
     }
 }


### PR DESCRIPTION
This consolidates span creation code into SpanFactory, and clarifies
the ServerSpan type. Particularly, we never explicitly set a ServerSpan
to null, since the initial value is actually ServerSpan.EMPTY. Note that
eventhough the javadoc say don't set to null we've never enforced that!