### PR TITLE
Extracts recorder, which centralizes mutation of spans

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
@@ -1,0 +1,92 @@
+package com.github.kristofa.brave;
+
+import com.google.auto.value.AutoValue;
+import com.twitter.zipkin.gen.Annotation;
+import com.twitter.zipkin.gen.BinaryAnnotation;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import zipkin.reporter.Reporter;
+
+import static com.github.kristofa.brave.internal.DefaultSpanCodec.toZipkin;
+
+abstract class Recorder {
+  abstract void name(Span span, String name);
+
+  abstract void start(Span span, long timestamp);
+
+  abstract void annotate(Span span, long timestamp, String value);
+
+  abstract void address(Span span, String key, Endpoint endpoint);
+
+  abstract void tag(Span span, String key, String value);
+
+  /** Implicitly calls flush */
+  abstract void finishWithTimestamp(Span span, long endTimestamp);
+
+  /** Implicitly calls flush */
+  abstract void finishWithDuration(Span span, long duration);
+
+  /** Reports whatever is present even if unfinished. */
+  abstract void flush(Span span);
+
+  @AutoValue
+  static abstract class Default extends Recorder {
+    abstract Endpoint localEndpoint();
+
+    abstract Reporter<zipkin.Span> reporter();
+
+    @Override void name(Span span, String name) {
+      synchronized (span) {
+        span.setName(name);
+      }
+    }
+
+    @Override void start(Span span, long timestamp) {
+      synchronized (span) {
+        span.setTimestamp(timestamp);
+      }
+    }
+
+    @Override void annotate(Span span, long timestamp, String value) {
+      Annotation annotation = Annotation.create(timestamp, value, localEndpoint());
+      synchronized (span) {
+        span.addToAnnotations(annotation);
+      }
+    }
+
+    @Override void address(Span span, String key, Endpoint endpoint) {
+      BinaryAnnotation ba = BinaryAnnotation.address(key, endpoint);
+      synchronized (span) {
+        span.addToBinary_annotations(ba);
+      }
+    }
+
+    @Override void tag(Span span, String key, String value) {
+      BinaryAnnotation ba = BinaryAnnotation.create(key, value, localEndpoint());
+      synchronized (span) {
+        span.addToBinary_annotations(ba);
+      }
+    }
+
+    @Override void finishWithTimestamp(Span span, long endTimestamp) {
+      synchronized (span) {
+        Long startTimestamp = span.getTimestamp();
+        if (startTimestamp != null) {
+          span.setDuration(Math.max(1L, endTimestamp - startTimestamp));
+        }
+      }
+      flush(span);
+    }
+
+    @Override void finishWithDuration(Span span, long duration) {
+      synchronized (span) {
+        span.setDuration(duration);
+      }
+      flush(span);
+    }
+
+    @Override void flush(Span span) {
+      reporter().report(toZipkin(span));
+    }
+  }
+}

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -38,12 +38,11 @@ public abstract class ServerSpan {
     public abstract Boolean getSample();
 
     /** Converts the input into a new server span or {@linkplain ServerSpan#NOT_SAMPLED}. */
-    static ServerSpan create(Span span, String spanName) {
+    static ServerSpan create(Span span) {
         SpanId context = Brave.context(span);
         if (Boolean.FALSE.equals(context.sampled())) {
             return ServerSpan.NOT_SAMPLED;
         }
-        span.setName(spanName);
         return new AutoValue_ServerSpan(context, span, context.sampled());
     }
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/Internal.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/Internal.java
@@ -1,0 +1,23 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.twitter.zipkin.gen.Endpoint;
+
+/**
+ * Allows internal classes outside the package {@code com.github.kristofa.brave} to use non-public
+ * methods. This allows us access internal methods while also making obvious the hooks are not for
+ * public use. The only implementation of this interface is in {@link Brave}.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.Internal}
+ */
+public abstract class Internal {
+
+  public static void initializeInstanceForTests() {
+    // Needed in tests to ensure that the instance is actually pointing to something.
+    new Brave.Builder().build();
+  }
+
+  public abstract void setClientAddress(Brave brave, Endpoint ca);
+
+  public static Internal instance;
+}

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import zipkin.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -149,21 +148,18 @@ public class AnnotationSubmitterTest {
             }
         };
         AnnotationSubmitter.DefaultClock clock = new AnnotationSubmitter.DefaultClock();
+        Recorder recorder = new AutoValue_Recorder_Default(endpoint, spans::add);
         return new AnnotationSubmitter(){
             @Override CurrentSpan currentSpan() {
                 return currentSpan;
-            }
-
-            @Override Endpoint endpoint() {
-                return endpoint;
             }
 
             @Override Clock clock() {
                 return clock;
             }
 
-            @Override Reporter<zipkin.Span> reporter() {
-                return spans::add;
+            @Override Recorder recorder() {
+                return recorder;
             }
         };
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritanceTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracingInheritanceTest.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -22,7 +21,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.twitter.zipkin.gen.Endpoint;
 import zipkin.reporter.Reporter;
 
-public class LocalTracingInheritenceTest {
+public class LocalTracingInheritanceTest {
 
     private Reporter<zipkin.Span> reporter;
     private Sampler sampler;
@@ -36,7 +35,7 @@ public class LocalTracingInheritenceTest {
         sampler = Sampler.ALWAYS_SAMPLE;
 
         final int ip = InetAddressUtilities.toInt(InetAddressUtilities.getLocalHostLANAddress());
-        final String serviceName = LocalTracingInheritenceTest.class.getSimpleName();
+        final String serviceName = LocalTracingInheritanceTest.class.getSimpleName();
         state = new InheritableServerClientAndLocalSpanState(Endpoint.create(serviceName, ip));
         brave = new Brave.Builder(state)
                 .reporter(reporter)
@@ -58,46 +57,6 @@ public class LocalTracingInheritenceTest {
         assertThat(localTracer.currentServerSpan().getCurrentServerSpan())
             .isSameAs(ServerSpan.EMPTY);
         assertThat(localTracer.currentSpan().get()).isNull();
-    }
-
-    @Test
-    public void testGetClientTracer() {
-        final ClientTracer clientTracer = brave.clientTracer();
-        assertNotNull(clientTracer);
-        assertSame("ClientTracer should be configured with the spanreportor we submitted.", reporter,
-                clientTracer.reporter());
-        assertSame("ClientTracer should be configured with the traceSampler we submitted.",
-                sampler, clientTracer.spanFactory().sampler());
-
-        final ClientTracer secondClientTracer = brave.clientTracer();
-        assertSame("It is important that each client tracer we get shares same state.",
-                clientTracer.currentSpan(), secondClientTracer.currentSpan());
-    }
-
-    @Test
-    public void testGetServerTracer() {
-        final ServerTracer serverTracer = brave.serverTracer();
-        assertNotNull(serverTracer);
-        assertSame(reporter, serverTracer.reporter());
-        assertSame("ServerTracer should be configured with the traceSampler we submitted.",
-                sampler, serverTracer.spanFactory().sampler());
-
-        final ServerTracer secondServerTracer = brave.serverTracer();
-        assertSame("It is important that each client tracer we get shares same state.",
-                serverTracer.currentSpan(), secondServerTracer.currentSpan());
-    }
-
-    @Test
-    public void testGetLocalTracer() {
-        final LocalTracer localTracer = brave.localTracer();
-        assertNotNull(localTracer);
-        assertSame(reporter, localTracer.reporter());
-        assertSame("LocalTracer should be configured with the traceSampler we submitted.",
-                sampler, localTracer.spanFactory().sampler());
-
-        final LocalTracer secondLocalTracer = brave.localTracer();
-        assertSame("It is important that each local tracer we get shares same state.",
-                localTracer.currentSpan(), secondLocalTracer.currentSpan());
     }
 
     @Test

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerSpanTest.java
@@ -1,6 +1,5 @@
 package com.github.kristofa.brave;
 
-import static com.github.kristofa.brave.Brave.newSpan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -14,9 +13,8 @@ public class ServerSpanTest {
     private static final long TRACE_ID = 1;
     private static final SpanId SPAN_ID =
         SpanId.builder().sampled(true).traceId(TRACE_ID).spanId(2).parentId(3L).build();
-    private static final String NAME = "name";
 
-    private ServerSpan serverSpan = ServerSpan.create(newSpan(SPAN_ID), NAME);
+    private ServerSpan serverSpan = ServerSpan.create(Brave.newSpan(SPAN_ID));
 
     @Test
     public void testGetSpan() {
@@ -25,14 +23,13 @@ public class ServerSpanTest {
         assertEquals(TRACE_ID, span.getTrace_id());
         assertEquals(SPAN_ID.spanId, span.getId());
         assertEquals(SPAN_ID.parentId, span.getParent_id().longValue());
-        assertEquals(NAME, span.getName());
         assertTrue(span.getAnnotations().isEmpty());
         assertTrue(span.getBinary_annotations().isEmpty());
     }
 
     @Test
     public void testGetSpan_128() {
-        serverSpan = ServerSpan.create(newSpan(SPAN_ID.toBuilder().traceIdHigh(5).build()), NAME);
+        serverSpan = ServerSpan.create(Brave.newSpan(SPAN_ID.toBuilder().traceIdHigh(5).build()));
 
         Span span = serverSpan.getSpan();
         assertEquals(5, span.getTrace_id_high());
@@ -47,19 +44,19 @@ public class ServerSpanTest {
     @Test
     public void testEqualsObject() {
 
-        ServerSpan equalServerSpan = ServerSpan.create(newSpan(SPAN_ID), NAME);
+        ServerSpan equalServerSpan = ServerSpan.create(Brave.newSpan(SPAN_ID));
         assertTrue(serverSpan.equals(equalServerSpan));
     }
 
     @Test
     public void testHashCode() {
-        ServerSpan equalServerSpan = ServerSpan.create(newSpan(SPAN_ID), NAME);
+        ServerSpan equalServerSpan = ServerSpan.create(Brave.newSpan(SPAN_ID));
         Assert.assertEquals(serverSpan.hashCode(), equalServerSpan.hashCode());
     }
 
     @Test
     public void createUnsampled() {
-        serverSpan = ServerSpan.create(newSpan(SPAN_ID.toBuilder().sampled(false).build()), NAME);
+        serverSpan = ServerSpan.create(Brave.newSpan(SPAN_ID.toBuilder().sampled(false).build()));
         assertEquals(serverSpan, ServerSpan.NOT_SAMPLED);
     }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanStateTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ThreadLocalServerClientAndLocalSpanStateTest.java
@@ -21,6 +21,7 @@ public class ThreadLocalServerClientAndLocalSpanStateTest {
 
     @Before
     public void setup() {
+        ThreadLocalServerClientAndLocalSpanState.clear();
         // -1062731775 = 192.168.0.1
         serverAndClientSpanState = new ThreadLocalServerClientAndLocalSpanState(-1062731775, PORT, SERVICE_NAME);
         mockServerSpan = mock(ServerSpan.class);

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/InternalTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/InternalTest.java
@@ -1,0 +1,44 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.ThreadLocalServerClientAndLocalSpanState;
+import com.twitter.zipkin.gen.Endpoint;
+import com.twitter.zipkin.gen.Span;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InternalTest {
+  static {
+    InternalSpan.initializeInstanceForTests();
+  }
+
+  SpanId context = SpanId.builder().spanId(1L).build();
+  Span span = InternalSpan.instance.newSpan(context);
+
+  List<zipkin.Span> spans = new ArrayList<>();
+  Brave brave = new Brave.Builder().reporter(spans::add).build();
+
+  @Before
+  public void setup() {
+    ThreadLocalServerClientAndLocalSpanState.clear();
+  }
+
+  @Test
+  public void addsClientAddress() {
+    brave.serverTracer().setStateCurrentTrace(context, "foo");
+
+    Endpoint ca = Endpoint.create("foo", 127 << 24 | 1);
+    Internal.instance.setClientAddress(brave, ca);
+
+    brave.serverTracer().setServerSend(); // flush
+
+    assertThat(spans.get(0).binaryAnnotations).containsExactly(
+        zipkin.BinaryAnnotation.address("ca", zipkin.Endpoint.create("foo", 127 << 24 | 1))
+    );
+  }
+}

--- a/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
+++ b/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
@@ -14,55 +14,43 @@
 package com.github.kristofa.brave.servlet.internal;
 
 import com.github.kristofa.brave.Brave;
-import com.github.kristofa.brave.ServerSpan;
-import com.github.kristofa.brave.ServerSpanThreadBinder;
-import com.github.kristofa.brave.SpanId;
-import com.github.kristofa.brave.internal.InternalSpan;
-import com.twitter.zipkin.gen.Span;
+import com.github.kristofa.brave.ThreadLocalServerClientAndLocalSpanState;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class MaybeAddClientAddressFromRequestTest {
-  static {
-    InternalSpan.initializeInstanceForTests();
-  }
-
-  @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule();
-
-  @Mock
-  HttpServletRequest request;
-  @Mock
-  ServerSpan serverSpan;
-  Span span = InternalSpan.instance.newSpan(SpanId.builder().spanId(1L).build());
-  @Mock
-  Brave brave;
-  @Mock
-  ServerSpanThreadBinder threadBinder;
-  MaybeAddClientAddressFromRequest addressFunction;
+  List<zipkin.Span> spans = new ArrayList<>();
+  Brave brave = new Brave.Builder().reporter(spans::add).build();
 
   @Before
-  public void setup() {
-    when(brave.serverSpanThreadBinder()).thenReturn(threadBinder);
-    addressFunction = new MaybeAddClientAddressFromRequest(brave);
+  public void clearState() {
+    ThreadLocalServerClientAndLocalSpanState.clear();
+  }
+
+  MaybeAddClientAddressFromRequest addressFunction = new MaybeAddClientAddressFromRequest(brave);
+
+  HttpServletRequest request;
+
+  @Before
+  public void setup(){
+    request = mock(HttpServletRequest.class);
   }
 
   @Test
   public void kickOutIfXForwardedForAndRemoteAddrAreInvalid() {
     for (String invalid : Arrays.asList(null, "unknown", "999.999.999")) {
-      when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-      when(serverSpan.getSpan()).thenReturn(span);
+      brave.serverTracer().setStateUnknown("get");
+
       when(request.getHeader("X-Forwarded-For")).thenReturn(invalid);
       when(request.getRemoteAddr()).thenReturn(invalid);
 
@@ -70,83 +58,83 @@ public final class MaybeAddClientAddressFromRequestTest {
       addressFunction.accept(request);
 
       // shouldn't add anything to the span
-      assertThat(span.getBinary_annotations())
-          .isEmpty();
+      brave.serverTracer().setServerSend();
+      assertThat(spans.get(0).binaryAnnotations).isEmpty();
     }
   }
 
   @Test
   public void fallbackToRemoteAddrWhenXForwardedForIsInvalid() {
-    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-    when(serverSpan.getSpan()).thenReturn(span);
+    brave.serverTracer().setStateUnknown("get");
     when(request.getHeader("X-Forwarded-For")).thenReturn("unknown");
     when(request.getRemoteAddr()).thenReturn("1.2.3.4");
 
     addressFunction.accept(request);
+    brave.serverTracer().setServerSend();
 
-    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
         .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
   }
 
   @Test
   public void prefersXForwardedFor() {
-    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-    when(serverSpan.getSpan()).thenReturn(span);
+    brave.serverTracer().setStateUnknown("get");
     when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
     when(request.getRemoteAddr()).thenReturn("5.6.7.8");
 
     addressFunction.accept(request);
+    brave.serverTracer().setServerSend();
 
-    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
         .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
   }
 
   @Test
   public void parsesIpv6() throws UnknownHostException {
-    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-    when(serverSpan.getSpan()).thenReturn(span);
+    brave.serverTracer().setStateUnknown("get");
     when(request.getHeader("X-Forwarded-For")).thenReturn("2001:db8::c001");
 
     addressFunction.accept(request);
+    brave.serverTracer().setServerSend();
 
-    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv6)
+    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv6)
         .containsExactly(Inet6Address.getByName("2001:db8::c001").getAddress());
   }
 
   @Test
   public void parsesIpv4MappedIpV6Address() {
-    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-    when(serverSpan.getSpan()).thenReturn(span);
+    brave.serverTracer().setStateUnknown("get");
     when(request.getHeader("X-Forwarded-For")).thenReturn("::ffff:1.2.3.4");
 
     addressFunction.accept(request);
+    brave.serverTracer().setServerSend();
 
-    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
         .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
   }
 
   @Test
   public void parsesIpv4CompatIpV6Address() {
-    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-    when(serverSpan.getSpan()).thenReturn(span);
+    brave.serverTracer().setStateUnknown("get");
     when(request.getHeader("X-Forwarded-For")).thenReturn("::0000:1.2.3.4");
 
     addressFunction.accept(request);
+    brave.serverTracer().setServerSend();
 
-    assertThat(span.getBinary_annotations()).extracting(b -> b.host.ipv4)
+    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
         .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
   }
 
   @Test
   public void addsRemotePort() {
-    when(threadBinder.getCurrentServerSpan()).thenReturn(serverSpan);
-    when(serverSpan.getSpan()).thenReturn(span);
+    brave.serverTracer().setStateUnknown("get");
     when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
     when(request.getRemotePort()).thenReturn(124);
 
     addressFunction.accept(request);
+    brave.serverTracer().setServerSend();
 
-    assertThat(span.getBinary_annotations()).extracting(b -> b.host.port)
+    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.port)
         .containsExactly((short) 124);
   }
 }


### PR DESCRIPTION
This is the last big step in preparation of Brave 4. This adds a package
protected internal type called Recorder, which mimicks the same api in
Brave 4, except that it uses existing logic.