### PR TITLE
Remove developers section from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,13 @@
     <developerConnection>scm:git:https://github.com/openzipkin/brave.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-   <developers>
-   		<developer>
-      		<id>kristofa</id>
-      		<name>Kristof Adriaenssens</name>
-      		<email>kr_adr@yahoo.co.uk</email>
-    	</developer>
-   </developers>
-
+  <developers>
+    <developer>
+      <id>zipkin-dev</id>
+      <name>Zipkin developers google group</name>
+      <url>https://groups.google.com/forum/#!forum/zipkin-dev</url>
+    </developer>
+  </developers>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Developers section content is outdated and doesn't
need to be maintained in pom.xml