### PR TITLE
Moves clock responsibility to recorder

### DIFF
--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>io.zipkin.reporter</groupId>
       <artifactId>zipkin-reporter</artifactId>
-      <version>0.6.11</version>
+      <version>${zipkin-reporter.version}</version>
     </dependency>
     <!-- for value types... don't worry. this dependency is compile only! -->
     <dependency>

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -5,7 +5,6 @@ import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import java.util.Random;
-import zipkin.Constants;
 import zipkin.reporter.Reporter;
 
 /**
@@ -85,8 +84,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
 
         public final ClientTracer build() {
             return new AutoValue_ClientTracer(
-                clock,
-                new AutoValue_Recorder_Default(localEndpoint, reporter),
+                new AutoValue_Recorder_Default(localEndpoint, clock, reporter),
                 currentLocalSpan,
                 currentServerSpan,
                 currentSpan,
@@ -102,7 +100,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * Sets 'client sent' event for current thread.
      */
     public void setClientSent() {
-        submitStartAnnotation(Constants.CLIENT_SEND);
+        submitStartAnnotation(Recorder.SpanKind.CLIENT);
     }
 
     /**
@@ -112,8 +110,8 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * "unknown" if unknown.
      */
     public void setClientSent(Endpoint server) {
-        submitAddress(Constants.SERVER_ADDR, server);
-        submitStartAnnotation(Constants.CLIENT_SEND);
+        submitAddress(Recorder.SpanKind.CLIENT, server);
+        submitStartAnnotation(Recorder.SpanKind.CLIENT);
     }
 
     /**
@@ -137,7 +135,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * event means this span is finished.
      */
     public void setClientReceived() {
-        if (submitEndAnnotation(Constants.CLIENT_RECV)) {
+        if (submitEndAnnotation(Recorder.SpanKind.CLIENT)) {
             currentSpan().setCurrentSpan(null);
         }
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
@@ -1,30 +1,46 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.InternalSpan;
 import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
+import zipkin.Constants;
 import zipkin.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.DefaultSpanCodec.toZipkin;
 
 abstract class Recorder {
+  enum SpanKind {
+    CLIENT,
+    SERVER
+  }
+
   abstract void name(Span span, String name);
+
+  abstract void start(Span span);
+
+  abstract void start(Span span, SpanKind kind);
 
   abstract void start(Span span, long timestamp);
 
+  abstract void annotate(Span span, String value);
+
   abstract void annotate(Span span, long timestamp, String value);
 
-  abstract void address(Span span, String key, Endpoint endpoint);
+  abstract void remoteAddress(Span span, SpanKind kind, Endpoint endpoint);
 
   abstract void tag(Span span, String key, String value);
 
   /** Implicitly calls flush */
-  abstract void finishWithTimestamp(Span span, long endTimestamp);
+  abstract void finish(Span span);
 
   /** Implicitly calls flush */
-  abstract void finishWithDuration(Span span, long duration);
+  abstract void finish(Span span, SpanKind kind);
+
+  /** Implicitly calls flush */
+  abstract void finish(Span span, long duration);
 
   /** Reports whatever is present even if unfinished. */
   abstract void flush(Span span);
@@ -32,6 +48,8 @@ abstract class Recorder {
   @AutoValue
   static abstract class Default extends Recorder {
     abstract Endpoint localEndpoint();
+
+    abstract AnnotationSubmitter.Clock clock();
 
     abstract Reporter<zipkin.Span> reporter();
 
@@ -41,10 +59,46 @@ abstract class Recorder {
       }
     }
 
+    @Override void start(Span span) {
+      start(span, clock().currentTimeMicroseconds());
+    }
+
+    @Override void start(Span span, SpanKind kind) {
+      String value;
+      switch (kind) {
+        case CLIENT:
+          value = Constants.CLIENT_SEND;
+          break;
+        case SERVER:
+          value = Constants.SERVER_RECV;
+          break;
+        default:
+          throw new AssertionError(kind + " is not yet supported");
+      }
+      Long timestamp = clock().currentTimeMicroseconds();
+      Annotation annotation = Annotation.create(timestamp, value, localEndpoint());
+
+      // In the RPC span model, the client owns the timestamp and duration of the span. If we
+      // were propagated an id, we can assume that we shouldn't report timestamp or duration,
+      // rather let the client do that. Worst case we were propagated an unreported ID and
+      // Zipkin backfills timestamp and duration.
+      boolean serverHalf = InternalSpan.instance.context(span).shared && kind == SpanKind.SERVER;
+      if (serverHalf) timestamp = null;
+
+      synchronized (span) {
+        span.setTimestamp(timestamp);
+        span.addToAnnotations(annotation);
+      }
+    }
+
     @Override void start(Span span, long timestamp) {
       synchronized (span) {
         span.setTimestamp(timestamp);
       }
+    }
+
+    @Override void annotate(Span span, String value) {
+      annotate(span, clock().currentTimeMicroseconds(), value);
     }
 
     @Override void annotate(Span span, long timestamp, String value) {
@@ -54,8 +108,19 @@ abstract class Recorder {
       }
     }
 
-    @Override void address(Span span, String key, Endpoint endpoint) {
-      BinaryAnnotation ba = BinaryAnnotation.address(key, endpoint);
+    @Override void remoteAddress(Span span, SpanKind kind, Endpoint endpoint) {
+      String address;
+      switch (kind) {
+        case CLIENT:
+          address = Constants.SERVER_ADDR;
+          break;
+        case SERVER:
+          address = Constants.CLIENT_ADDR;
+          break;
+        default:
+          throw new AssertionError(kind + " is not yet supported");
+      }
+      BinaryAnnotation ba = BinaryAnnotation.address(address, endpoint);
       synchronized (span) {
         span.addToBinary_annotations(ba);
       }
@@ -68,7 +133,8 @@ abstract class Recorder {
       }
     }
 
-    @Override void finishWithTimestamp(Span span, long endTimestamp) {
+    @Override void finish(Span span) {
+      long endTimestamp = clock().currentTimeMicroseconds();
       synchronized (span) {
         Long startTimestamp = span.getTimestamp();
         if (startTimestamp != null) {
@@ -78,7 +144,32 @@ abstract class Recorder {
       flush(span);
     }
 
-    @Override void finishWithDuration(Span span, long duration) {
+    @Override void finish(Span span, SpanKind kind) {
+      String value;
+      switch (kind) {
+        case CLIENT:
+          value = Constants.CLIENT_RECV;
+          break;
+        case SERVER:
+          value = Constants.SERVER_SEND;
+          break;
+        default:
+          throw new AssertionError(kind + " is not yet supported");
+      }
+      long endTimestamp = clock().currentTimeMicroseconds();
+      Annotation annotation = Annotation.create(endTimestamp, value, localEndpoint());
+
+      synchronized (span) {
+        span.addToAnnotations(annotation);
+        Long startTimestamp = span.getTimestamp();
+        if (startTimestamp != null) {
+          span.setDuration(Math.max(1L, endTimestamp - startTimestamp));
+        }
+      }
+      flush(span);
+    }
+
+    @Override void finish(Span span, long duration) {
       synchronized (span) {
         span.setDuration(duration);
       }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -5,7 +5,6 @@ import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import java.util.Random;
-import zipkin.Constants;
 import zipkin.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.Util.checkNotBlank;
@@ -81,8 +80,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
 
         public final ServerTracer build() {
             return new AutoValue_ServerTracer(
-                clock,
-                new AutoValue_Recorder_Default(localEndpoint, reporter),
+                new AutoValue_Recorder_Default(localEndpoint, clock, reporter),
                 currentSpan,
                 spanFactoryBuilder.build()
             );
@@ -155,7 +153,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * {@link ServerTracer#setStateUnknown(String)}.
      */
     public void setServerReceived() {
-        submitStartAnnotation(Constants.SERVER_RECV);
+        submitStartAnnotation(Recorder.SpanKind.SERVER);
     }
 
     /**
@@ -166,8 +164,8 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * "unknown" if unknown.
      */
     public void setServerReceived(Endpoint client) {
-        submitAddress(Constants.CLIENT_ADDR, client);
-        submitStartAnnotation(Constants.SERVER_RECV);
+        submitAddress(Recorder.SpanKind.SERVER, client);
+        submitStartAnnotation(Recorder.SpanKind.SERVER);
     }
 
     /**
@@ -191,7 +189,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * Sets the server sent event for current thread.
      */
     public void setServerSend() {
-        if (submitEndAnnotation(Constants.SERVER_SEND)) {
+        if (submitEndAnnotation(Recorder.SpanKind.SERVER)) {
             currentSpan().setCurrentSpan(ServerSpan.EMPTY);
         }
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
@@ -38,8 +38,8 @@ public class ITAnnotationSubmitterConcurrency {
             return span;
         }
     };
-    Recorder recorder = new AutoValue_Recorder_Default(endpoint, Reporter.NOOP);
-    AnnotationSubmitter annotationSubmitter = AnnotationSubmitter.create(currentSpan, clock, recorder);
+    Recorder recorder = new AutoValue_Recorder_Default(endpoint, clock, Reporter.NOOP);
+    AnnotationSubmitter annotationSubmitter = AnnotationSubmitter.create(currentSpan, recorder);
 
     @Before
     public void setup() {

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <spring.version>4.3.4.RELEASE</spring.version>
     <jetty.version>8.1.22.v20160922</jetty.version>
     <zipkin.version>1.18.0</zipkin.version>
+    <zipkin-reporter.version>0.6.11</zipkin-reporter.version>
     <log4j.version>2.7</log4j.version>
     <okhttp.version>3.5.0</okhttp.version>
     <powermock.version>1.6.6</powermock.version>


### PR DESCRIPTION
This re-organizes the recorder component such that it is authoritative
with regards to timestamps. This change makes it easier to integrate
Brave 4.