### PR TITLE
Prefers end timestamp vs duration in Recorder

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
@@ -42,7 +42,7 @@ public abstract class AnnotationSubmitter {
     public void submitAnnotation(String value) {
         Span span = currentSpan().get();
         if (span == null) return;
-        recorder().annotate(span, value);
+        recorder().annotate(span, recorder().currentTimeMicroseconds(), value);
     }
 
     /**
@@ -61,11 +61,13 @@ public abstract class AnnotationSubmitter {
     }
 
     /** This adds an annotation that corresponds with {@link Span#getTimestamp()} */
-    void submitStartAnnotation(Recorder.SpanKind spanKind) {
+    void submitStartAnnotation(String startAnnotation) {
         Span span = currentSpan().get();
         if (span == null) return;
 
-        recorder().start(span, spanKind);
+        long timestamp = recorder().currentTimeMicroseconds();
+        recorder().annotate(span, timestamp, startAnnotation);
+        recorder().start(span, timestamp);
     }
 
     /**
@@ -74,20 +76,22 @@ public abstract class AnnotationSubmitter {
      *
      * @return true if a span was sent for collection.
      */
-    boolean submitEndAnnotation(Recorder.SpanKind spanKind) {
+    boolean submitEndAnnotation(String finishAnnotation) {
         Span span = currentSpan().get();
         if (span == null) return false;
 
-        recorder().finish(span, spanKind);
+        long timestamp = recorder().currentTimeMicroseconds();
+        recorder().annotate(span, timestamp, finishAnnotation);
+        recorder().finish(span, timestamp);
         return true;
     }
 
     /** Internal api for submitting an address. */
-    void submitAddress(Recorder.SpanKind spanKind, Endpoint endpoint) {
+    void submitAddress(String key, Endpoint endpoint) {
         Span span = currentSpan().get();
         if (span == null) return;
 
-        recorder().remoteAddress(span, spanKind, endpoint);
+        recorder().address(span, key, endpoint);
     }
 
     /**

--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -10,6 +10,7 @@ import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import java.net.UnknownHostException;
 import java.util.List;
+import zipkin.Constants;
 import zipkin.reporter.AsyncReporter;
 import zipkin.reporter.Reporter;
 import zipkin.reporter.Sender;
@@ -319,7 +320,7 @@ public class Brave {
             @Override public void setClientAddress(Brave brave, Endpoint ca) {
                 Span span = brave.serverSpanThreadBinder().get();
                 if (span == null) return;
-                brave.serverTracer.recorder().remoteAddress(span, Recorder.SpanKind.SERVER, ca);
+                brave.serverTracer.recorder().address(span, Constants.CLIENT_ADDR, ca);
             }
         };
         new Span(); // ensure InternalSpan.instance points to a reference

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -5,6 +5,7 @@ import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import java.util.Random;
+import zipkin.Constants;
 import zipkin.reporter.Reporter;
 
 /**
@@ -100,7 +101,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * Sets 'client sent' event for current thread.
      */
     public void setClientSent() {
-        submitStartAnnotation(Recorder.SpanKind.CLIENT);
+        submitStartAnnotation(Constants.CLIENT_SEND);
     }
 
     /**
@@ -110,8 +111,8 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * "unknown" if unknown.
      */
     public void setClientSent(Endpoint server) {
-        submitAddress(Recorder.SpanKind.CLIENT, server);
-        submitStartAnnotation(Recorder.SpanKind.CLIENT);
+        submitAddress(Constants.SERVER_ADDR, server);
+        submitStartAnnotation(Constants.CLIENT_SEND);
     }
 
     /**
@@ -135,7 +136,7 @@ public abstract class ClientTracer extends AnnotationSubmitter {
      * event means this span is finished.
      */
     public void setClientReceived() {
-        if (submitEndAnnotation(Recorder.SpanKind.CLIENT)) {
+        if (submitEndAnnotation(Constants.CLIENT_RECV)) {
             currentSpan().setCurrentSpan(null);
         }
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -5,6 +5,7 @@ import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import java.util.Random;
+import zipkin.Constants;
 import zipkin.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.Util.checkNotBlank;
@@ -153,7 +154,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * {@link ServerTracer#setStateUnknown(String)}.
      */
     public void setServerReceived() {
-        submitStartAnnotation(Recorder.SpanKind.SERVER);
+        submitStartAnnotation(Constants.SERVER_RECV);
     }
 
     /**
@@ -164,8 +165,8 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * "unknown" if unknown.
      */
     public void setServerReceived(Endpoint client) {
-        submitAddress(Recorder.SpanKind.SERVER, client);
-        submitStartAnnotation(Recorder.SpanKind.SERVER);
+        submitAddress(Constants.CLIENT_ADDR, client);
+        submitStartAnnotation(Constants.SERVER_RECV);
     }
 
     /**
@@ -189,7 +190,7 @@ public abstract class ServerTracer extends AnnotationSubmitter {
      * Sets the server sent event for current thread.
      */
     public void setServerSend() {
-        if (submitEndAnnotation(Recorder.SpanKind.SERVER)) {
+        if (submitEndAnnotation(Constants.SERVER_SEND)) {
             currentSpan().setCurrentSpan(ServerSpan.EMPTY);
         }
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import zipkin.Constants;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,7 +111,7 @@ public class AnnotationSubmitterTest {
 
     @Test
     public void doesntSetDurationWhenTimestampUnset() {
-        annotationSubmitter.submitEndAnnotation(Recorder.SpanKind.SERVER);
+        annotationSubmitter.submitEndAnnotation(Constants.SERVER_SEND);
         assertThat(spans).allSatisfy(
             span -> {
                 assertThat(span.timestamp).isNull();
@@ -123,8 +124,8 @@ public class AnnotationSubmitterTest {
     public void setsDurationWhenTimestampPresentButStartTickAbsent() {
         span.setTimestamp(START_TIME_MICROSECONDS - 1);
 
-        annotationSubmitter.submitStartAnnotation(Recorder.SpanKind.SERVER);
-        annotationSubmitter.submitEndAnnotation(Recorder.SpanKind.SERVER);
+        annotationSubmitter.submitStartAnnotation(Constants.SERVER_RECV);
+        annotationSubmitter.submitEndAnnotation(Constants.SERVER_SEND);
         assertThat(spans).extracting(s -> s.duration)
             .containsExactly(1L);
     }
@@ -135,8 +136,8 @@ public class AnnotationSubmitterTest {
 
         PowerMockito.when(System.nanoTime()).thenReturn(787L);
 
-        annotationSubmitter.submitStartAnnotation(Recorder.SpanKind.SERVER);
-        annotationSubmitter.submitEndAnnotation(Recorder.SpanKind.SERVER);
+        annotationSubmitter.submitStartAnnotation(Constants.SERVER_RECV);
+        annotationSubmitter.submitEndAnnotation(Constants.SERVER_SEND);
         assertThat(spans).extracting(s -> s.duration)
             .containsExactly(1L);
     }

--- a/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LocalTracerTest.java
@@ -115,7 +115,7 @@ public class LocalTracerTest {
      */
     @Test
     public void finishSpan() {
-        recorder.start(span);
+        recorder.start(span, START_TIME_MICROSECONDS);
         brave.localSpanThreadBinder().setCurrentSpan(span);
 
         timestamp = START_TIME_MICROSECONDS + 500;

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -19,11 +19,12 @@ public class ServerRequestInterceptorTest {
     private final static long SPAN_ID = 43435;
     private final static long PARENT_SPAN_ID = 44334435;
     private static final Endpoint ENDPOINT = Endpoint.create("serviceName", 80);
+    static final zipkin.Endpoint ZIPKIN_ENDPOINT = zipkin.Endpoint.create("service", 80);
     private static final KeyValueAnnotation ANNOTATION1 = KeyValueAnnotation.create(zipkin.TraceKeys.HTTP_URL, "/orders/user/4543");
     private static final KeyValueAnnotation ANNOTATION2 = KeyValueAnnotation.create("http.code", "200");
 
     List<zipkin.Span> spans = new ArrayList<>();
-    Brave brave = new Brave.Builder(ENDPOINT).reporter(spans::add).build();
+    Brave brave = newBrave();
     Recorder recorder = brave.serverTracer().recorder();
     ServerRequestInterceptor interceptor = new ServerRequestInterceptor(brave.serverTracer());
 
@@ -32,6 +33,10 @@ public class ServerRequestInterceptorTest {
     @Before
     public void setup() {
         ThreadLocalServerClientAndLocalSpanState.clear();
+    }
+
+    Brave newBrave() {
+        return new Brave.Builder(ENDPOINT).reporter(spans::add).build();
     }
 
     @Test


### PR DESCRIPTION
The only user api that specifies a duration is LocalTracer, which is
intended for spans that start and stop without leaving the process.

Since we've recently changed clocks to use an offset approach, we can
get precise duration using start and stop timestamps. We always have
the start timestamp in a local span (as it is required).

With the above in mind, we can safely change internals to use timestamps
to calcuate durations for all spans, not just remote ones. This really
simplifies logic and also makes bridging to OpenTracing easier too, as
its api doesn't accept duration.

The only cost to this approach is short-term, which is that in order
to support the existing LocalTracer.finishSpan(duration), we need to be
able to read-back the span's start timestamp.