### PR TITLE
Adds Brave 4 ServerTracer integration

### DIFF
--- a/brave-core/src/test/java/com/github/kristofa/brave/example/TracerAdapterTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/example/TracerAdapterTest.java
@@ -7,9 +7,12 @@ import com.github.kristofa.brave.TracerAdapter;
 import com.twitter.zipkin.gen.Span;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 import zipkin.Constants;
 
+import static com.github.kristofa.brave.TracerAdapter.getServerSpan;
+import static com.github.kristofa.brave.TracerAdapter.setServerSpan;
 import static com.github.kristofa.brave.TracerAdapter.toSpan;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -18,7 +21,9 @@ import static zipkin.internal.Util.UTF_8;
 public class TracerAdapterTest {
 
   List<zipkin.Span> spans = new ArrayList<>();
-  Tracer brave4 = Tracer.newBuilder().reporter(spans::add).build();
+  AtomicLong epochMicros = new AtomicLong();
+  Tracer brave4 =
+      Tracer.newBuilder().clock(epochMicros::incrementAndGet).reporter(spans::add).build();
   Brave brave3 = TracerAdapter.newBrave(brave4);
 
   @Test public void startWithLocalTracerAndFinishWithTracer() {
@@ -29,10 +34,10 @@ public class TracerAdapterTest {
     span.annotate(2L, "pump fake");
     span.finish(3L);
 
-    checkSpanReportedToZipkin();
+    checkLocalSpanReportedToZipkin();
   }
 
-  @Test public void startWithCurrentSpanAndFinishWithTracer() {
+  @Test public void startWithCurrentLocalSpanAndFinishWithTracer() {
     brave3.localTracer().startNewSpan("codec", "encode", 1L);
 
     Span brave3Span = brave3.localSpanThreadBinder().getCurrentLocalSpan();
@@ -42,7 +47,7 @@ public class TracerAdapterTest {
     span.annotate(2L, "pump fake");
     span.finish(3L);
 
-    checkSpanReportedToZipkin();
+    checkLocalSpanReportedToZipkin();
   }
 
   @Test public void startWithTracerAndFinishWithLocalTracer() {
@@ -56,10 +61,70 @@ public class TracerAdapterTest {
     brave3.localTracer().submitAnnotation("pump fake", 2L);
     brave3.localTracer().finishSpan(2L /* duration */);
 
-    checkSpanReportedToZipkin();
+    checkLocalSpanReportedToZipkin();
   }
 
-  void checkSpanReportedToZipkin() {
+  @Test public void startWithClientTracerAndFinishWithTracer() {
+    SpanId spanId = brave3.clientTracer().startNewSpan("get");
+    brave3.clientTracer().setClientSent();
+
+    brave.Span span = toSpan(brave4, spanId);
+
+    span.finish();
+
+    checkClientSpanReportedToZipkin();
+  }
+
+  @Test public void startWithCurrentClientSpanAndFinishWithTracer() {
+    brave3.clientTracer().startNewSpan("get");
+    brave3.clientTracer().setClientSent();
+
+    Span brave3Span = brave3.clientSpanThreadBinder().getCurrentClientSpan();
+
+    brave.Span span = toSpan(brave4, brave3Span);
+
+    span.finish();
+
+    checkClientSpanReportedToZipkin();
+  }
+
+  @Test public void startWithTracerAndFinishWithClientTracer() {
+    brave.Span brave4Span = brave4.newTrace().name("get")
+        .kind(brave.Span.Kind.CLIENT)
+        .start();
+
+    com.twitter.zipkin.gen.Span brave3Span = toSpan(brave4Span.context());
+    brave3.clientSpanThreadBinder().setCurrentSpan(brave3Span);
+
+    brave3.clientTracer().setClientReceived();
+
+    checkClientSpanReportedToZipkin();
+  }
+
+  @Test public void startWithCurrentServerSpanAndFinishWithTracer() {
+    brave3.serverTracer().setStateUnknown("get");
+    brave3.serverTracer().setServerReceived();
+
+    brave.Span span = getServerSpan(brave4, brave3.serverSpanThreadBinder());
+
+    span.finish();
+
+    checkServerSpanReportedToZipkin();
+  }
+
+  @Test public void startWithTracerAndFinishWithServerTracer() {
+    brave.Span brave4Span = brave4.newTrace().name("get")
+        .kind(brave.Span.Kind.SERVER)
+        .start();
+
+    setServerSpan(brave4Span.context(), brave3.serverSpanThreadBinder());
+
+    brave3.serverTracer().setServerSend();
+
+    checkServerSpanReportedToZipkin();
+  }
+
+  void checkLocalSpanReportedToZipkin() {
     assertThat(spans).first().satisfies(s -> {
           assertThat(s.name).isEqualTo("encode");
           assertThat(s.timestamp).isEqualTo(1L);
@@ -68,6 +133,32 @@ public class TracerAdapterTest {
           assertThat(s.binaryAnnotations).extracting(b -> b.key, b -> new String(b.value, UTF_8))
               .containsExactly(tuple(Constants.LOCAL_COMPONENT, "codec"));
           assertThat(s.duration).isEqualTo(2L);
+        }
+    );
+  }
+
+  void checkClientSpanReportedToZipkin() {
+    assertThat(spans).first().satisfies(s -> {
+          assertThat(s.name).isEqualTo("get");
+          assertThat(s.timestamp).isEqualTo(1L);
+          assertThat(s.duration).isEqualTo(1L);
+          assertThat(s.annotations).extracting(a -> a.timestamp, a -> a.value).containsExactly(
+              tuple(1L, "cs"),
+              tuple(2L, "cr")
+          );
+        }
+    );
+  }
+
+  void checkServerSpanReportedToZipkin() {
+    assertThat(spans).first().satisfies(s -> {
+          assertThat(s.name).isEqualTo("get");
+          assertThat(s.timestamp).isEqualTo(1L);
+          assertThat(s.duration).isEqualTo(1L);
+          assertThat(s.annotations).extracting(a -> a.timestamp, a -> a.value).containsExactly(
+              tuple(1L, "sr"),
+              tuple(2L, "ss")
+          );
         }
     );
   }


### PR DESCRIPTION
An oversight in the initial Brave 4 TracerAdapter was how server spans
wire differently than local and client ones. Particularly, they carry
sampling status to prevent downstream trace commands from creating
children when unsampled.

fixes #332

Brave 3's ServerTracer works slightly differently than Brave 3's client
or local tracers. Internally, it uses a `ServerSpan` which keeps track
of the original sample status. To interop with ServerTracer, use the
following hooks:

Use `TracerAdapter.getServerSpan` to get one of..
* a real span: when a sampled server request preceded this call
* a noop span: when a server request preceded this call, but was not sampled
* null: if no server request preceded this call

```java
brave4Span = TracerAdapter.getServerSpan(brave4, brave3.serverSpanThreadBinder());
// Since the current server span might be empty, you must check null
if (brave4Span != null) {
  // use or finish the span
}
```

If you have a reference to a Brave 4 span, and know it represents a server
request, use `TracerAdapter.setServerSpan` to attach it to Brave 3's thread
binder.
```java
TracerAdapter.setServerSpan(brave4Span.context(), brave3.serverSpanThreadBinder());
brave3.serverTracer().setServerSend(); // for example
```