### PR TITLE
Makes animalsniffer annotations provided

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -39,6 +39,8 @@
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
       <version>1.0</version>
+      <!-- annotations are not runtime rentition, so don't need a runtime dep -->
+      <scope>provided</scope>
     </dependency>
     <!-- for value types... don't worry. this dependency is compile only! -->
     <dependency>


### PR DESCRIPTION
Animal Sniffer annotations are class retention, which means they aren't
looked up reflectively and can be a provided dep.

fixes #335