### PR TITLE
Bumps to latest zipkin and removes redundant code

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/MaybeAddClientAddress.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/MaybeAddClientAddress.java
@@ -44,32 +44,7 @@ public abstract class MaybeAddClientAddress<T> {
     if (addressBytes.length == 4) {
       builder.ipv4(ByteBuffer.wrap(addressBytes).getInt());
     } else if (addressBytes.length == 16) {
-      // https://tools.ietf.org/html/rfc4291#section-2.5.5.2
-      boolean maybeIpv4Compat = true; // if it starts with 80 unset bits
-      boolean maybeLocalhost = true; // if it is ::1 (all zeros ending in 1)
-      for (int i = 0; i < 15; i++) {
-        if (i < 10 && addressBytes[i] != 0) {
-          maybeIpv4Compat = false;
-          maybeLocalhost = false;
-          break;
-        } else if (addressBytes[i] != 0) {
-          maybeLocalhost = false;
-          break;
-        }
-      }
-      if (maybeLocalhost && addressBytes[15] == 1) { // we found ::1
-        builder.ipv6(addressBytes);
-      } else if (maybeIpv4Compat) {
-        ByteBuffer buffer = ByteBuffer.wrap(addressBytes, 10, 6);
-        short flag = buffer.getShort();
-        if (flag == 0 || flag == -1) { // IPv4-Compatible or IPv4-Mapped
-          builder.ipv4(buffer.getInt());
-        } else {
-          builder.ipv6(addressBytes);
-        }
-      } else {
-        builder.ipv6(addressBytes);
-      }
+      builder.ipv6(addressBytes);
     } else {
       return; // invalid
     }

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
 
     <spring.version>4.3.4.RELEASE</spring.version>
     <jetty.version>8.1.22.v20160922</jetty.version>
-    <zipkin.version>1.18.0</zipkin.version>
-    <zipkin-reporter.version>0.6.11</zipkin-reporter.version>
+    <zipkin.version>1.19.2</zipkin.version>
+    <zipkin-reporter.version>0.6.12</zipkin-reporter.version>
     <log4j.version>2.7</log4j.version>
     <okhttp.version>3.5.0</okhttp.version>
     <grpc.version>1.0.3</grpc.version>


### PR DESCRIPTION
Latest zipkin release obviates code related to embedded IPv4 addresses.