### PR TITLE
Documents one-way span modeling

### DIFF
--- a/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ClientTracerTest.java
@@ -53,6 +53,7 @@ public class ClientTracerTest {
     assertThat(spans).matches(s -> s.isEmpty() || s.contains(BASE_SPAN));
   }
 
+  @Test
   public void setClientSent_doesntFlush() {
     brave.clientSpanThreadBinder().setCurrentSpan(span);
     brave.clientTracer().setClientSent();
@@ -66,7 +67,6 @@ public class ClientTracerTest {
     brave.clientTracer().setClientSent();
 
     recorder.flush(brave.clientSpanThreadBinder().get());
-    assertThat(spans.get(0).timestamp).isEqualTo(START_TIME_MICROSECONDS);
     assertThat(spans.get(0).annotations).containsExactly(
         zipkin.Annotation.create(START_TIME_MICROSECONDS,
             Constants.CLIENT_SEND,

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -115,7 +115,9 @@ public class ServerRequestInterceptorTest {
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
 
         interceptor.handle(adapter);
-        recorder.flush(brave.serverTracer().currentSpan().get());
+        // simulate completion of the span (which happens in the response adapter)
+        recorder.finish(brave.serverTracer().currentSpan().get(),
+            brave.clock().currentTimeMicroseconds());
 
         // We originated the trace, so we should set the timestamp
         assertThat(spans.get(0).timestamp).isNotNull();

--- a/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/ServerTracerTest.java
@@ -111,7 +111,6 @@ public class ServerTracerTest {
     brave.serverTracer().setServerReceived();
 
     recorder.flush(span);
-    assertThat(spans.get(0).timestamp).isEqualTo(START_TIME_MICROSECONDS);
     assertThat(spans.get(0).annotations).containsExactly(
         zipkin.Annotation.create(START_TIME_MICROSECONDS,
             Constants.SERVER_RECV,
@@ -162,6 +161,7 @@ public class ServerTracerTest {
 
     brave.serverTracer().setServerSend();
 
+    assertThat(spans.get(0).timestamp).isEqualTo(100L);
     assertThat(spans.get(0).duration).isEqualTo(START_TIME_MICROSECONDS - 100L);
     assertThat(spans.get(0).annotations).contains(
         zipkin.Annotation.create(START_TIME_MICROSECONDS,

--- a/brave/src/test/java/brave/features/async/OneWaySpanTest.java
+++ b/brave/src/test/java/brave/features/async/OneWaySpanTest.java
@@ -57,7 +57,8 @@ public class OneWaySpanTest {
         // in real life, we'd guard result.context was set and start a new trace if not
         serverTracer.joinSpan(result.context())
             .name(recordedRequest.getMethod())
-            .annotate(SERVER_RECV).flush(); // record the timestamp of the server receive and flush
+            .kind(Span.Kind.SERVER)
+            .start().flush(); // start the server side and flush instead of processing a response
 
         flushedIncomingRequest.countDown();
         // eventhough the client doesn't read the response, we return one
@@ -77,7 +78,8 @@ public class OneWaySpanTest {
 
     // fire off the request asynchronously, totally dropping any response
     new OkHttpClient().newCall(request.build()).enqueue(mock(Callback.class));
-    span.annotate(CLIENT_SEND).flush(); // record the timestamp of the client send and flush
+    // start the client side and flush instead of processing a response
+    span.kind(Span.Kind.CLIENT).start().flush();
 
     // block on the server handling the request, so we can run assertions
     flushedIncomingRequest.await();

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -185,6 +185,23 @@ public class MutableSpanTest {
         .isEqualTo(newSpan().finish(null).toSpan());
   }
 
+  @Test public void oneWaySpan() {
+    MutableSpan client = newSpan().kind(Span.Kind.CLIENT).start(1L).finish(null);
+
+    assertThat(client.toSpan()).satisfies(s -> {
+      assertThat(s.timestamp).isNull();
+      assertThat(s.annotations).extracting(a -> a.value)
+          .containsExactly("cs");
+    });
+
+    MutableSpan server = newSpan().kind(Span.Kind.SERVER).start(1L).finish(null);
+    assertThat(server.toSpan()).satisfies(s -> {
+      assertThat(s.timestamp).isNull();
+      assertThat(s.annotations).extracting(a -> a.value)
+          .containsExactly("sr");
+    });
+  }
+
   MutableSpan newSpan() {
     return new MutableSpan(context, localEndpoint);
   }


### PR DESCRIPTION
This documents the simplest possible api for one-way RPC tracing, which is to use `flush` instead of `finish`

---
Sometimes you need to model an asynchronous operation, where there is a
request, but no response. In normal RPC tracing, you use `span.finish()`
which indicates the response was received. In one-way tracing, you use
`span.flush()` instead, as you don't expect a response.

Here's how a client might model a one-way operation
```java
// start a new span representing a client request
oneWaySend = tracer.newSpan(parent).kind(Span.Kind.CLIENT);

// Add the trace context to the request, so it can be propagated in-band
Propagation.B3_STRING.injector(Request::addHeader)
                     .inject(oneWaySend.context(), request);

// fire off the request asynchronously, totally dropping any response
request.execute();

// start the client side and flush instead of finish
oneWaySend.start().flush();
```

And here's how a server might handle this..
```java
// pull the context out of the incoming request
contextOrFlags =
    Propagation.B3_STRING.extractor(Request::getHeader).extract(request);

// convert that context to a span which you can name and add tags to
oneWayReceive = tracer.joinSpan(contextOrFlags.context())
    .name("process-request")
    .kind(SERVER)
    ... add tags etc.

// start the server side and flush instead of finish
oneWayReceive.start().flush();

// you should not modify this span anymore as it is complete. However,
// you can create children to represent follow-up work.
next = tracer.newSpan(oneWayReceive.context).name("step2").start();
```