### PR TITLE
Adds Tracer.Builder.localServiceName for porting from Brave.Builder

### DIFF
--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -6,6 +6,7 @@ import brave.sampler.Sampler;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
+import zipkin.Endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,6 +24,27 @@ public class TracerTest {
 
     assertThat(tracer.sampler)
         .isSameAs(sampler);
+  }
+
+  @Test public void localServiceName() {
+    tracer = Tracer.newBuilder().localServiceName("my-foo").build();
+
+    assertThat(tracer.localEndpoint.serviceName)
+        .isEqualTo("my-foo");
+  }
+
+  @Test public void localServiceName_defaultIsUnknown() {
+    assertThat(tracer.localEndpoint.serviceName)
+        .isEqualTo("unknown");
+  }
+
+  @Test public void localServiceName_ignoredWhenGivenLocalEndpoint() {
+    Endpoint localEndpoint = Endpoint.create("my-bar", 127 << 24 | 1);
+    tracer = Tracer.newBuilder().localServiceName("my-foo")
+        .localEndpoint(localEndpoint).build();
+
+    assertThat(tracer.localEndpoint)
+        .isSameAs(localEndpoint);
   }
 
   @Test public void clock() {


### PR DESCRIPTION
`Brave.Builder` had a convenience constructor to control the service
name of the tracer while defaulting to a site-local IP address. Before
this change, you could only create `brave.Tracer` specifying an endpoint
or accepting a default with name "unknown". This allows you to control
the service name of the default local endpoint.

Ex.

```
new Brave.Builder("foo")
// is equivalent to
Tracer.newBuilder().localServiceName("foo")
```

Note the local prefix matches the existing `localEndpoint` naming
convention.