### PR TITLE
Brave 4.x modernization

### DIFF
--- a/brave-sparkjava/pom.xml
+++ b/brave-sparkjava/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.sparkjava</groupId>
       <artifactId>spark-core</artifactId>
-      <version>2.5.5</version>
+      <version>${sparkjava.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/brave/src/main/java/brave/http/HttpAdapter.java
+++ b/brave/src/main/java/brave/http/HttpAdapter.java
@@ -1,0 +1,45 @@
+package brave.http;
+
+import brave.internal.Nullable;
+import java.net.URI;
+import zipkin.TraceKeys;
+
+public abstract class HttpAdapter<Req, Resp> {
+
+  /**
+   * The HTTP method, or verb, such as "GET" or "POST" or null if unreadable.
+   *
+   * @see TraceKeys#HTTP_METHOD
+   */
+  @Nullable public abstract String method(Req request);
+
+  /**
+   * The absolute http path, without any query parameters or null if unreadable. Ex.
+   * "/objects/abcd-ff"
+   *
+   * @see TraceKeys#HTTP_PATH
+   */
+  @Nullable public String path(Req request) {
+    return URI.create(url(request)).getPath(); // TODO benchmark
+  }
+
+  /**
+   * The entire URL, including the scheme, host and query parameters if available  or null if
+   * unreadable.
+   *
+   * @see TraceKeys#HTTP_URL
+   */
+  @Nullable public abstract String url(Req request);
+
+  /**
+   * Returns one value corresponding to the specified header, or null.
+   */
+  @Nullable public abstract String requestHeader(Req request, String name);
+
+  /**
+   * The HTTP status code or null if unreadable.
+   *
+   * @see TraceKeys#HTTP_STATUS_CODE
+   */
+  @Nullable public abstract Integer statusCode(Resp response);
+}

--- a/brave/src/main/java/brave/http/HttpClientHandler.java
+++ b/brave/src/main/java/brave/http/HttpClientHandler.java
@@ -1,0 +1,48 @@
+package brave.http;
+
+import brave.Span;
+import zipkin.Constants;
+
+public class HttpClientHandler<Req, Resp> {
+  final HttpAdapter<Req, Resp> adapter;
+  final HttpClientParser parser;
+
+  public HttpClientHandler(HttpAdapter<Req, Resp> adapter, HttpClientParser parser) {
+    this.adapter = adapter;
+    this.parser = parser;
+  }
+
+  public Req handleSend(Req request, Span span) {
+    if (span.isNoop()) return request;
+
+    // all of the parsing here occur before a timestamp is recorded on the span
+    span.kind(Span.Kind.CLIENT).name(parser.spanName(adapter, request));
+    parser.requestTags(adapter, request, span);
+    span.start();
+    return request;
+  }
+
+  public Resp handleReceive(Resp response, Span span) {
+    if (span.isNoop()) return response;
+
+    try {
+      parser.responseTags(adapter, response, span);
+    } finally {
+      span.finish();
+    }
+    return response;
+  }
+
+  public <T extends Throwable> T handleError(T throwable, Span span) {
+    if (span.isNoop()) return throwable;
+
+    try {
+      String message = throwable.getMessage();
+      if (message == null) message = throwable.getClass().getSimpleName();
+      span.tag(Constants.ERROR, message);
+      return throwable;
+    } finally {
+      span.finish();
+    }
+  }
+}

--- a/brave/src/main/java/brave/http/HttpClientParser.java
+++ b/brave/src/main/java/brave/http/HttpClientParser.java
@@ -1,0 +1,21 @@
+package brave.http;
+
+import brave.Span;
+import zipkin.TraceKeys;
+
+public class HttpClientParser {
+  public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+    return adapter.method(req);
+  }
+
+  public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Span span) {
+    span.tag(TraceKeys.HTTP_PATH, adapter.path(req));
+  }
+
+  public <Resp> void responseTags(HttpAdapter<?, Resp> adapter, Resp res, Span span) {
+    Integer httpStatus = adapter.statusCode(res);
+    if (httpStatus != null && (httpStatus < 200 || httpStatus > 299)) {
+      span.tag(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
+    }
+  }
+}

--- a/brave/src/main/java/brave/http/HttpServerHandler.java
+++ b/brave/src/main/java/brave/http/HttpServerHandler.java
@@ -1,0 +1,48 @@
+package brave.http;
+
+import brave.Span;
+import zipkin.Constants;
+
+public class HttpServerHandler<Req, Resp> {
+  final HttpAdapter<Req, Resp> adapter;
+  final HttpServerParser parser;
+
+  public HttpServerHandler(HttpAdapter<Req, Resp> adapter, HttpServerParser parser) {
+    this.adapter = adapter;
+    this.parser = parser;
+  }
+
+  public Req handleReceive(Req request, Span span) {
+    if (span.isNoop()) return request;
+
+    // all of the parsing here occur before a timestamp is recorded on the span
+    span.kind(Span.Kind.SERVER).name(parser.spanName(adapter, request));
+    parser.requestTags(adapter, request, span);
+    span.start();
+    return request;
+  }
+
+  public Resp handleSend(Resp response, Span span) {
+    if (span.isNoop()) return response;
+
+    try {
+      parser.responseTags(adapter, response, span);
+    } finally {
+      span.finish();
+    }
+    return response;
+  }
+
+  public <T extends Throwable> T handleError(T throwable, Span span) {
+    if (span.isNoop()) return throwable;
+
+    try {
+      String message = throwable.getMessage();
+      if (message == null) message = throwable.getClass().getSimpleName();
+      span.tag(Constants.ERROR, message);
+      return throwable;
+    } finally {
+      span.finish();
+    }
+  }
+}

--- a/brave/src/main/java/brave/http/HttpServerParser.java
+++ b/brave/src/main/java/brave/http/HttpServerParser.java
@@ -1,0 +1,21 @@
+package brave.http;
+
+import brave.Span;
+import zipkin.TraceKeys;
+
+public class HttpServerParser {
+  public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+    return adapter.method(req);
+  }
+
+  public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Span span) {
+    span.tag(TraceKeys.HTTP_PATH, adapter.path(req));
+  }
+
+  public <Resp> void responseTags(HttpAdapter<?, Resp> adapter, Resp res, Span span) {
+    Integer httpStatus = adapter.statusCode(res);
+    if (httpStatus != null && (httpStatus < 200 || httpStatus > 299)) {
+      span.tag(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
+    }
+  }
+}

--- a/brave/src/main/java/brave/http/HttpTracing.java
+++ b/brave/src/main/java/brave/http/HttpTracing.java
@@ -1,0 +1,70 @@
+package brave.http;
+
+import brave.Tracing;
+import com.google.auto.value.AutoValue;
+import zipkin.Endpoint;
+
+@AutoValue
+public abstract class HttpTracing {
+  public static HttpTracing create(Tracing tracing) {
+    return newBuilder(tracing).build();
+  }
+
+  public static Builder newBuilder(Tracing tracing) {
+    return new AutoValue_HttpTracing.Builder()
+        .tracing(tracing)
+        .serverName("")
+        .clientParser(new HttpClientParser())
+        .serverParser(new HttpServerParser());
+  }
+
+  public abstract Tracing tracing();
+
+  public abstract HttpClientParser clientParser();
+
+  /**
+   * Used by http clients to indicate the name of the destination service.
+   *
+   * Defaults to "", which will not show in the zipkin UI or end up in the dependency graph.
+   *
+   * <p>When present, a link from {@link Tracing.Builder#localServiceName(String)} to this name will
+   * increment for each traced client call.
+   *
+   * <p>As this is endpoint-specific, it is typical to create a scoped instance of {@linkplain
+   * HttpTracing} to assign this value.
+   *
+   * For example:
+   * <pre>{@code
+   * github = TracingHttpClientBuilder.create(
+   *   httpTracing.toBuilder().serverName("github").build()
+   * ).build();
+   * }</pre>
+   *
+   * @see zipkin.Constants#SERVER_ADDR
+   * @see brave.Span#remoteEndpoint(Endpoint)
+   */
+  public abstract String serverName();
+
+  public abstract HttpServerParser serverParser();
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public static abstract class Builder {
+    public abstract Builder tracing(Tracing tracing);
+
+    public abstract Builder clientParser(HttpClientParser clientParser);
+
+    public abstract Builder serverName(String serverName);
+
+    public abstract Builder serverParser(HttpServerParser serverParser);
+
+    public abstract HttpTracing build();
+
+    Builder() {
+    }
+  }
+
+  HttpTracing() {
+  }
+}

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,10 @@
 machine:
   java:
     version: openjdk8
+  services:
+    - mysql
+  environment:
+    MYSQL_USER: root
 
 dependencies:
   override:

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -1,0 +1,64 @@
+# brave-instrumentation
+This module a redo of all major instrumentation libraries since Brave 3.
+Artifacts have the naming convention "brave-instrumentation-XXX": for
+example, the directory "servlet" includes the artifact "brave-instrumentation-servlet".
+
+Notably, this adds a more `HttpTracing` component to configure http client
+and server tracing. It also adds support for async servlet and apache http
+client, and tests edge cases like multiple servlet versions. Finally, it
+tests and benchmarks every http component, so that people are aware of
+overhead is involved in tracing.
+
+Here's an example of configuring OkHttp. Note that all instrumentation
+have the same naming policy TracingXXX, where XXX is usually the same
+as the type returned.
+
+```java
+tracing = Tracing.newBuilder()
+                 .localServiceName("my-service")
+                 .reporter(reporter)
+                 .build();
+httpTracing = HttpTracing.newBuilder(tracing).serverName("github").build();
+okhttp = TracingCallFactory.create(httpTracing, new OkHttpClient());
+```
+
+### Http tracing
+Most instrumentation are based on http communication. For this reason,
+we have specialized handlers for http clients and servers. All of these
+are configured with `HttpTracing`.
+
+The `HttpTracing` class holds a reference to a tracing component and also
+includes instructions on what to put into http spans.
+
+By default, the following is added for both http clients and servers:
+* Span.name as the http method in lowercase: ex "get"
+* Tags/binary annotations:
+  * "http.path", which does not include query parameters.
+  * "http.status_code" when the status us not success.
+* Remote IP and port information
+
+Naming and tags are configurable in a library-agnostic way. For example,
+the same `HttpTracing` component configures OkHttp or Apache HttpClient
+identically.
+
+For example, to change the span and tag naming policy for clients, you
+can do something like this:
+
+```java
+httpTracing = httpTracing.toBuilder()
+    .clientParser(new HttpClientParser() {
+      @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+        return adapter.method(req).toLowerCase() + " " + adapter.path(req);
+      }
+
+      @Override
+      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
+        span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // the whole url, not just the path
+      }
+    })
+    .serverName("remote-service") // assume both libraries are calling the same service
+    .build();
+
+apache = TracingHttpClientBuilder.create(httpTracing).build();
+okhttp = TracingCallFactory.create(httpTracing, new OkHttpClient());
+```

--- a/instrumentation/benchmarks/README.md
+++ b/instrumentation/benchmarks/README.md
@@ -1,0 +1,12 @@
+# brave-instrumentation-benchmarks
+
+This module includes [JMH](http://openjdk.java.net/projects/code-tools/jmh/)
+benchmarks for Brave instrumentation. You can use these to measure overhead
+of using Brave.
+
+=== Running the benchmark
+From the project directory, run `./mvnw install -pl instrumentation/benchmarks -am -DskipTests` to build the benchmarks, and the following to run them:
+
+```bash
+$ java -jar instrumentation/benchmarks/target/benchmarks.jar
+```

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -1,0 +1,167 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>brave-instrumentation-benchmarks</artifactId>
+  <name>Brave Instrumentation: Benchmarks (JMH)</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+    <undertow.version>1.4.14.Final</undertow.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-httpclient</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-httpasyncclient</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-spring-web</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-okhttp3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-jaxrs2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.ltgt.jaxrs</groupId>
+      <artifactId>resteasy-client-okhttp3</artifactId>
+      <version>1.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-servlet</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-sparkjava</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sparkjava</groupId>
+      <artifactId>spark-core</artifactId>
+      <version>${sparkjava.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.undertow</groupId>
+      <artifactId>undertow-core</artifactId>
+      <version>${undertow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.undertow</groupId>
+      <artifactId>undertow-servlet</artifactId>
+      <version>${undertow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-undertow</artifactId>
+      <version>${resteasy.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>benchmarks</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpClientBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpClientBenchmarks.java
@@ -1,0 +1,89 @@
+package brave.http;
+
+import brave.Tracing;
+import brave.sampler.Sampler;
+import io.undertow.Undertow;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import zipkin.reporter.Reporter;
+
+import static io.undertow.util.Headers.CONTENT_TYPE;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(2)
+@State(Scope.Benchmark)
+public abstract class HttpClientBenchmarks<C> {
+  protected abstract C newClient(HttpTracing httpTracing) throws Exception;
+
+  protected abstract C newClient() throws Exception;
+
+  protected abstract void get(C client) throws Exception;
+
+  protected abstract void close(C client) throws Exception;
+
+  Undertow server;
+  String baseUrl;
+  C client;
+  C tracedClient;
+  C unsampledClient;
+
+  protected String baseUrl() {
+    return baseUrl;
+  }
+
+  @Setup(Level.Trial) public void init() throws Exception {
+    server = Undertow.builder()
+        .addHttpListener(0, "127.0.0.1")
+        .setHandler(exchange -> {
+          exchange.getResponseHeaders().put(CONTENT_TYPE, "text/plain; charset=UTF-8");
+          exchange.getResponseSender().send("hello world");
+        }).build();
+    server.start();
+    baseUrl = "http://127.0.0.1:" +
+        ((InetSocketAddress) server.getListenerInfo().get(0).getAddress()).getPort();
+
+    client = newClient();
+    tracedClient = newClient(HttpTracing.create(
+        Tracing.newBuilder().reporter(Reporter.NOOP).build()
+    ));
+    unsampledClient = newClient(HttpTracing.create(
+        Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+    ));
+  }
+
+  @TearDown(Level.Trial) public void close() throws Exception {
+    close(client);
+    close(unsampledClient);
+    close(tracedClient);
+    server.stop();
+  }
+
+  @Benchmark public void client_get() throws Exception {
+    get(client);
+  }
+
+  @Benchmark public void unsampledClient_get() throws Exception {
+    get(unsampledClient);
+  }
+
+  @Benchmark public void tracedClient_get() throws Exception {
+    get(tracedClient);
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
@@ -1,0 +1,90 @@
+package brave.http;
+
+import io.undertow.Undertow;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.ServletException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(2)
+@State(Scope.Benchmark)
+public abstract class HttpServerBenchmarks {
+
+  Undertow server;
+  OkHttpClient client;
+  String baseUrl;
+
+  protected String baseUrl() {
+    return baseUrl;
+  }
+
+  @Setup(Level.Trial) public void init() throws Exception {
+    baseUrl = "http://127.0.0.1:" + initServer();
+    client = new OkHttpClient();
+  }
+
+  @TearDown(Level.Trial) public void close() throws Exception {
+    if (server != null) server.stop();
+    client.dispatcher().executorService().shutdown();
+  }
+
+  protected int initServer() throws ServletException {
+    DeploymentInfo servletBuilder = Servlets.deployment()
+        .setClassLoader(getClass().getClassLoader())
+        .setContextPath("/")
+        .setDeploymentName("test.war");
+
+    init(servletBuilder);
+
+    DeploymentManager manager = Servlets.defaultContainer().addDeployment(servletBuilder);
+    manager.deploy();
+    server = Undertow.builder()
+        .addHttpListener(0, "127.0.0.1")
+        .setHandler(manager.start()).build();
+    server.start();
+    return ((InetSocketAddress) server.getListenerInfo().get(0).getAddress()).getPort();
+  }
+
+  protected abstract void init(DeploymentInfo servletBuilder);
+
+  @Benchmark public void server_get() throws Exception {
+    get("/nottraced");
+  }
+
+  @Benchmark public void unsampledServer_get() throws Exception {
+    get("/unsampled");
+  }
+
+  @Benchmark public void tracedServer_get() throws Exception {
+    get("/traced");
+  }
+
+  void get(String path) throws IOException {
+    client.newCall(new Request.Builder().url(baseUrl() + path).build())
+        .execute()
+        .body().close();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/httpasyncclient/ApacheHttpAsyncClientBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/httpasyncclient/ApacheHttpAsyncClientBenchmarks.java
@@ -1,0 +1,46 @@
+package brave.httpasyncclient;
+
+import brave.http.HttpClientBenchmarks;
+import brave.http.HttpTracing;
+import java.io.IOException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.util.EntityUtils;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class ApacheHttpAsyncClientBenchmarks extends
+    HttpClientBenchmarks<CloseableHttpAsyncClient> {
+
+  @Override protected CloseableHttpAsyncClient newClient(HttpTracing httpTracing) {
+    CloseableHttpAsyncClient result = TracingHttpAsyncClientBuilder.create(httpTracing).build();
+    result.start();
+    return result;
+  }
+
+  @Override protected CloseableHttpAsyncClient newClient() {
+    CloseableHttpAsyncClient result = HttpAsyncClients.custom().build();
+    result.start();
+    return result;
+  }
+
+  @Override protected void get(CloseableHttpAsyncClient client) throws Exception {
+    EntityUtils.consume(client.execute(new HttpGet(baseUrl()), null).get().getEntity());
+  }
+
+  @Override protected void close(CloseableHttpAsyncClient client) throws IOException {
+    client.close();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + ApacheHttpAsyncClientBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/httpclient/ApacheHttpClientBenchmarks.disabled
+++ b/instrumentation/benchmarks/src/main/java/brave/httpclient/ApacheHttpClientBenchmarks.disabled
@@ -1,0 +1,42 @@
+package brave.httpclient;
+
+import brave.http.HttpClientBenchmarks;
+import brave.http.HttpTracing;
+import java.io.IOException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/** Disabled as it crashes on socket problems */
+public class ApacheHttpClientBenchmarks extends HttpClientBenchmarks<CloseableHttpClient> {
+
+  @Override protected CloseableHttpClient newClient(HttpTracing httpTracing) {
+    return TracingHttpClientBuilder.create(httpTracing)
+        .build();
+  }
+
+  @Override protected CloseableHttpClient newClient() {
+    return HttpClients.custom().build();
+  }
+
+  @Override protected void get(CloseableHttpClient client) throws Exception {
+    client.execute(new HttpGet(baseUrl())).close();
+  }
+
+  @Override protected void close(CloseableHttpClient client) throws IOException {
+    client.close();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + ApacheHttpClientBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/jaxrs2/JaxRs2ClientBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jaxrs2/JaxRs2ClientBenchmarks.java
@@ -1,0 +1,48 @@
+package brave.jaxrs2;
+
+import brave.http.HttpClientBenchmarks;
+import brave.http.HttpTracing;
+import java.io.IOException;
+import javax.ws.rs.client.Client;
+import net.ltgt.resteasy.client.okhttp3.OkHttpClientEngine;
+import okhttp3.OkHttpClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class JaxRs2ClientBenchmarks extends HttpClientBenchmarks<Client> {
+
+  OkHttpClient ok = new OkHttpClient();
+
+  @Override protected Client newClient(HttpTracing httpTracing) {
+    return new ResteasyClientBuilder()
+        .httpEngine(new OkHttpClientEngine(ok))
+        .register(TracingFeature.create(httpTracing))
+        .build();
+  }
+
+  @Override protected Client newClient() {
+    return new ResteasyClientBuilder()
+        .httpEngine(new OkHttpClientEngine(ok))
+        .build();
+  }
+
+  @Override protected void get(Client client) throws Exception {
+    client.target(baseUrl()).request().buildGet().invoke().close();
+  }
+
+  @Override protected void close(Client client) throws IOException {
+    ok.dispatcher().executorService().shutdown();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + JaxRs2ClientBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/jaxrs2/JaxRs2ServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jaxrs2/JaxRs2ServerBenchmarks.java
@@ -1,0 +1,95 @@
+package brave.jaxrs2;
+
+import brave.Tracing;
+import brave.http.HttpServerBenchmarks;
+import brave.sampler.Sampler;
+import io.undertow.Undertow;
+import io.undertow.servlet.api.DeploymentInfo;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.servlet.ServletException;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin.reporter.Reporter;
+
+public class JaxRs2ServerBenchmarks extends HttpServerBenchmarks {
+
+  @Path("")
+  public static class Resource {
+    @GET @Produces("text/plain; charset=UTF-8") public String get() {
+      return "hello world";
+    }
+  }
+
+  @ApplicationPath("/nottraced")
+  public static class App extends Application {
+    @Override public Set<Object> getSingletons() {
+      return Collections.singleton(new Resource());
+    }
+  }
+
+  @ApplicationPath("/unsampled")
+  public static class Unsampled extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
+          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+      )));
+    }
+  }
+
+  @ApplicationPath("/traced")
+  public static class TracedApp extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
+          Tracing.newBuilder().reporter(Reporter.NOOP).build()
+      )));
+    }
+  }
+
+  PortExposing server;
+
+  @Override protected int initServer() throws ServletException {
+    server = (PortExposing) new PortExposing()
+        .deploy(App.class)
+        .deploy(Unsampled.class)
+        .deploy(TracedApp.class)
+        .start(Undertow.builder().addHttpListener(8888, "127.0.0.1"));
+    return server.getPort();
+  }
+
+  static class PortExposing extends UndertowJaxrsServer {
+    int getPort() {
+      return ((InetSocketAddress) server.getListenerInfo().get(0).getAddress()).getPort();
+    }
+  }
+
+  @Override protected void init(DeploymentInfo servletBuilder) {
+  }
+
+  @TearDown(Level.Trial) @Override public void close() throws Exception {
+    server.stop();
+    super.close();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + JaxRs2ServerBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/okhttp3/OkHttpClientBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/okhttp3/OkHttpClientBenchmarks.java
@@ -1,0 +1,46 @@
+package brave.okhttp3;
+
+import brave.http.HttpClientBenchmarks;
+import brave.http.HttpTracing;
+import java.io.IOException;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class OkHttpClientBenchmarks extends HttpClientBenchmarks<Call.Factory> {
+
+  @Override protected Call.Factory newClient(HttpTracing httpTracing) {
+    return TracingCallFactory.create(httpTracing, new OkHttpClient());
+  }
+
+  @Override protected Call.Factory newClient() {
+    return new OkHttpClient();
+  }
+
+  @Override protected void get(Call.Factory client) throws Exception {
+    client.newCall(new Request.Builder().url(baseUrl()).build()).execute().body().close();
+  }
+
+  @Override protected void close(Call.Factory client) throws IOException {
+    OkHttpClient ok;
+    if (client instanceof OkHttpClient) {
+      ok = (OkHttpClient) client;
+    } else {
+      ok = ((TracingCallFactory) client).ok;
+    }
+    ok.dispatcher().executorService().shutdown();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + OkHttpClientBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/servlet/ServletBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/servlet/ServletBenchmarks.java
@@ -1,0 +1,86 @@
+package brave.servlet;
+
+import brave.Tracing;
+import brave.http.HttpServerBenchmarks;
+import brave.sampler.Sampler;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.FilterInfo;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin.reporter.Reporter;
+
+import static javax.servlet.DispatcherType.REQUEST;
+
+public class ServletBenchmarks extends HttpServerBenchmarks {
+
+  static class HelloServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+        throws IOException {
+      resp.addHeader("Content-Type", "text/plain; charset=UTF-8");
+      resp.getWriter().println("hello world");
+    }
+  }
+
+  public static class Unsampled extends ForwardingTracingFilter {
+    public Unsampled() {
+      super(TracingFilter.create(
+          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+      ));
+    }
+  }
+
+  public static class Traced extends ForwardingTracingFilter {
+    public Traced() {
+      super(TracingFilter.create(Tracing.newBuilder().reporter(Reporter.NOOP).build()));
+    }
+  }
+
+  @Override protected void init(DeploymentInfo servletBuilder) {
+    servletBuilder.addFilter(new FilterInfo("Unsampled", Unsampled.class))
+        .addFilterUrlMapping("Unsampled", "/unsampled", REQUEST)
+        .addFilter(new FilterInfo("Traced", Traced.class))
+        .addFilterUrlMapping("Traced", "/traced", REQUEST)
+        .addServlets(Servlets.servlet("HelloServlet", HelloServlet.class).addMapping("/*"));
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + ServletBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  static class ForwardingTracingFilter implements Filter {
+    final Filter delegate;
+
+    public ForwardingTracingFilter(Filter delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+        FilterChain filterChain) throws IOException, ServletException {
+      delegate.doFilter(servletRequest, servletResponse, filterChain);
+    }
+
+    @Override public void destroy() {
+    }
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/sparkjava/SparkBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/sparkjava/SparkBenchmarks.java
@@ -1,0 +1,77 @@
+package brave.sparkjava;
+
+import brave.Tracing;
+import brave.http.HttpServerBenchmarks;
+import brave.sampler.Sampler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.FilterInfo;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+import spark.servlet.SparkApplication;
+import spark.servlet.SparkFilter;
+import zipkin.reporter.Reporter;
+
+import static javax.servlet.DispatcherType.REQUEST;
+
+public class SparkBenchmarks extends HttpServerBenchmarks {
+
+  public static class NotTraced implements SparkApplication {
+    @Override
+    public void init() {
+      Spark.get("/nottraced", (Request request, Response response) -> "hello world");
+    }
+  }
+
+  public static class Unsampled implements SparkApplication {
+    SparkTracing sparkTracing = SparkTracing.create(
+        Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+    );
+
+    @Override
+    public void init() {
+      Spark.before(sparkTracing.before());
+      Spark.get("/unsampled", (Request request, Response response) -> "hello world");
+      Spark.afterAfter(sparkTracing.afterAfter());
+    }
+  }
+
+  public static class Traced implements SparkApplication {
+    SparkTracing sparkTracing = SparkTracing.create(
+        Tracing.newBuilder().reporter(Reporter.NOOP).build()
+    );
+
+    @Override
+    public void init() {
+      Spark.before(sparkTracing.before());
+      Spark.get("/traced", (Request request, Response response) -> "hello world");
+      Spark.afterAfter(sparkTracing.afterAfter());
+    }
+  }
+
+  @Override protected void init(DeploymentInfo servletBuilder) {
+    servletBuilder
+        .addFilter(new FilterInfo("NotTraced", SparkFilter.class)
+            .addInitParam("applicationClass", NotTraced.class.getName()))
+        .addFilterUrlMapping("NotTraced", "/*", REQUEST)
+        .addFilter(new FilterInfo("Unsampled", SparkFilter.class)
+            .addInitParam("applicationClass", Unsampled.class.getName()))
+        .addFilterUrlMapping("Unsampled", "/unsampled", REQUEST)
+        .addFilter(new FilterInfo("Traced", SparkFilter.class)
+            .addInitParam("applicationClass", Traced.class.getName()))
+        .addFilterUrlMapping("Traced", "/traced", REQUEST);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + SparkBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/spring/web/RestTemplateBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/spring/web/RestTemplateBenchmarks.java
@@ -1,0 +1,48 @@
+package brave.spring.web;
+
+import brave.http.HttpClientBenchmarks;
+import brave.http.HttpTracing;
+import java.io.IOException;
+import java.util.Collections;
+import okhttp3.OkHttpClient;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+public class RestTemplateBenchmarks extends HttpClientBenchmarks<RestTemplate> {
+
+  OkHttpClient ok = new OkHttpClient();
+
+  @Override protected RestTemplate newClient(HttpTracing httpTracing) {
+    OkHttp3ClientHttpRequestFactory factory = new OkHttp3ClientHttpRequestFactory(ok);
+    RestTemplate result = new RestTemplate(factory);
+    result.setInterceptors(Collections.singletonList(
+        TracingClientHttpRequestInterceptor.create(httpTracing
+        )));
+    return result;
+  }
+
+  @Override protected RestTemplate newClient() {
+    return new RestTemplate(new OkHttp3ClientHttpRequestFactory(ok));
+  }
+
+  @Override protected void get(RestTemplate client) throws Exception {
+    client.getForObject(baseUrl(), String.class);
+  }
+
+  @Override protected void close(RestTemplate client) throws IOException {
+    ok.dispatcher().executorService().shutdown();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + RestTemplateBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/spring/webmvc/WebMvcBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/spring/webmvc/WebMvcBenchmarks.java
@@ -1,0 +1,78 @@
+package brave.spring.webmvc;
+
+import brave.Tracing;
+import brave.http.HttpServerBenchmarks;
+import brave.sampler.Sampler;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.ListenerInfo;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.handlers.DefaultServlet;
+import io.undertow.servlet.util.ImmediateInstanceHandle;
+import java.io.IOException;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.ContextLoaderListener;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import zipkin.reporter.Reporter;
+
+public class WebMvcBenchmarks extends HttpServerBenchmarks {
+
+  @Controller
+  public static class HelloController {
+    @RequestMapping("/nottraced")
+    public ResponseEntity<String> nottraced() throws IOException {
+      return ResponseEntity.ok("hello world");
+    }
+
+    @RequestMapping("/unsampled")
+    public ResponseEntity<String> unsampled() throws IOException {
+      return ResponseEntity.ok("hello world");
+    }
+
+    @RequestMapping("/traced")
+    public ResponseEntity<String> traced() throws IOException {
+      return ResponseEntity.ok("hello world");
+    }
+  }
+
+  @Configuration
+  @EnableWebMvc
+  static class SpringConfig extends WebMvcConfigurerAdapter {
+    @Override public void addInterceptors(InterceptorRegistry registry) {
+      registry.addInterceptor(TracingHandlerInterceptor.create(
+          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+      )).addPathPatterns("/unsampled");
+      registry.addInterceptor(TracingHandlerInterceptor.create(
+          Tracing.newBuilder().reporter(Reporter.NOOP).build()
+      )).addPathPatterns("/traced");
+    }
+  }
+
+  @Override protected void init(DeploymentInfo servletBuilder) {
+    AnnotationConfigWebApplicationContext appContext = new AnnotationConfigWebApplicationContext();
+    appContext.register(HelloController.class);
+    appContext.register(SpringConfig.class);
+    servletBuilder.addServlet(new ServletInfo("DispatcherServlet", DispatcherServlet.class,
+        () -> new ImmediateInstanceHandle(new DispatcherServlet(appContext))).addMapping("/*"));
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + WebMvcBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -1,0 +1,36 @@
+# brave-instrumentation-grpc
+This contains tracing client and server interceptors for [grpc](github.com/grpc/grpc-java).
+
+The client interceptor adds trace headers to outgoing requests. The
+server interceptor extracts trace state from incoming requests. Both
+report to Zipkin how long each request takes, along with relevant
+tags like the response status.
+
+To enable tracing for a gRPC application, add the interceptors when when
+constructing the client and server bindings:
+
+```java
+grpcTracing = GrpcTracing.create(tracing);
+
+Server server = ServerBuilder.forPort(serverPort)
+    .addService(ServerInterceptors.intercept(
+        GreeterGrpc.bindService(new GreeterImpl()), grpcTracing.newServerInterceptor()))
+    .build()
+    .start();
+
+ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", serverPort)
+    .intercept(grpcTracing.newClientInterceptor())
+    .usePlaintext(true)
+    .build();
+```
+
+## Development
+
+If you are working on this module, then you need to run `mvn install` to first compile the protos. Once the protos are compiled, then can be found in the directories:
+
+`
+./target/generated-test-sources/protobuf/grpc-java
+./target/generated-test-sources/protobuf/java
+`
+
+You may need to add the above directories as test sources in your IDE.

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-grpc</artifactId>
+  <name>Brave Instrumentation: gRPC</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-all</artifactId>
+      <version>${grpc.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-compile</goal>
+              <goal>test-compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/grpc/src/it/grpc12/README.md
+++ b/instrumentation/grpc/src/it/grpc12/README.md
@@ -1,0 +1,2 @@
+# grpc12
+This tests that GrpcTracing does not require Grpc >1.2

--- a/instrumentation/grpc/src/it/grpc12/pom.xml
+++ b/instrumentation/grpc/src/it/grpc12/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>@project.basedir@/..</relativePath>
+  </parent>
+
+  <artifactId>grpc12</artifactId>
+  <name>grpc12</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-all</artifactId>
+      <version>1.2.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-grpc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>@project.build.testSourceDirectory@</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <protoSourceRoot>@project.basedir@/src/test/proto</protoSourceRoot>
+        </configuration>
+      </plugin>
+    </plugins>
+    <testResources>
+      <testResource>
+        <directory>@project.basedir@/src/test/resources</directory>
+      </testResource>
+    </testResources>
+  </build>
+</project>

--- a/instrumentation/grpc/src/it/grpc12/src/test/java/brave/grpc12/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/it/grpc12/src/test/java/brave/grpc12/ITTracingClientInterceptor.java
@@ -1,0 +1,5 @@
+package brave.grpc12;
+
+public class ITTracingClientInterceptor extends brave.grpc.ITTracingClientInterceptor {
+
+}

--- a/instrumentation/grpc/src/it/grpc12/src/test/java/brave/grpc12/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/it/grpc12/src/test/java/brave/grpc12/ITTracingServerInterceptor.java
@@ -1,0 +1,5 @@
+package brave.grpc12;
+
+public class ITTracingServerInterceptor extends brave.grpc.ITTracingServerInterceptor {
+
+}

--- a/instrumentation/grpc/src/main/java/brave/grpc/AsciiMetadataKeyFactory.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/AsciiMetadataKeyFactory.java
@@ -1,0 +1,13 @@
+package brave.grpc;
+
+import brave.propagation.Propagation;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+
+enum AsciiMetadataKeyFactory implements Propagation.KeyFactory<Key<String>> {
+  INSTANCE;
+
+  @Override public Key<String> create(String name) {
+    return Key.of(name, Metadata.ASCII_STRING_MARSHALLER);
+  }
+}

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcTracing.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcTracing.java
@@ -1,0 +1,29 @@
+package brave.grpc;
+
+import brave.Tracing;
+import io.grpc.ClientInterceptor;
+import io.grpc.ServerInterceptor;
+
+public final class GrpcTracing {
+
+  public static GrpcTracing create(Tracing tracing) {
+    return new GrpcTracing(tracing);
+  }
+
+  final Tracing tracing;
+
+  GrpcTracing(Tracing tracing) { // intentionally hidden
+    if (tracing == null) throw new NullPointerException("tracing == null");
+    this.tracing = tracing;
+  }
+
+  /** This interceptor traces outbound calls */
+  public ClientInterceptor newClientInterceptor() {
+    return new TracingClientInterceptor(tracing);
+  }
+
+  /** This interceptor traces inbound calls */
+  public ServerInterceptor newServerInterceptor() {
+    return new TracingServerInterceptor(tracing);
+  }
+}

--- a/instrumentation/grpc/src/main/java/brave/grpc/TracingClientInterceptor.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TracingClientInterceptor.java
@@ -1,0 +1,67 @@
+package brave.grpc;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import zipkin.Constants;
+
+// not exposed directly as implementation notably changes between versions 1.2 and 1.3
+final class TracingClientInterceptor implements ClientInterceptor {
+
+  final Tracer tracer;
+  final TraceContext.Injector<Metadata> injector;
+
+  TracingClientInterceptor(Tracing tracing) {
+    tracer = tracing.tracer();
+    injector = tracing.propagationFactory().create(AsciiMetadataKeyFactory.INSTANCE)
+        .injector(new Propagation.Setter<Metadata, Metadata.Key<String>>() { // retrolambda no like
+          @Override public void put(Metadata metadata, Metadata.Key<String> key, String value) {
+            metadata.put(key, value);
+          }
+        });
+  }
+
+  /**
+   * This sets as span in scope both for the interception and for the start of the request. It does
+   * not set a span in scope during the response listener as it is unexpected it would be used at
+   * that fine granularity. If users want access to the span in a response listener, they will need
+   * to wrap the executor with one that's aware of the current context.
+   */
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions,
+      final Channel next) {
+    Span span = tracer.nextSpan();
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          span.kind(Span.Kind.CLIENT).name(method.getFullMethodName()).start();
+          injector.inject(span.context(), headers);
+          try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+            super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+              @Override public void onClose(Status status, Metadata trailers) {
+                if (!status.getCode().equals(Status.Code.OK)) {
+                  span.tag(Constants.ERROR, String.valueOf(status.getCode()));
+                }
+                span.finish();
+                super.onClose(status, trailers);
+              }
+            }, headers);
+          }
+        }
+      };
+    }
+  }
+}

--- a/instrumentation/grpc/src/main/java/brave/grpc/TracingServerInterceptor.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TracingServerInterceptor.java
@@ -1,0 +1,57 @@
+package brave.grpc;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import io.grpc.ForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import zipkin.Constants;
+
+// not exposed directly as implementation notably changes between versions 1.2 and 1.3
+final class TracingServerInterceptor implements ServerInterceptor {
+  final Tracer tracer;
+  final TraceContext.Extractor<Metadata> extractor;
+
+  TracingServerInterceptor(Tracing tracing) {
+    tracer = tracing.tracer();
+    extractor = tracing.propagationFactory().create(AsciiMetadataKeyFactory.INSTANCE)
+        .extractor(new Propagation.Getter<Metadata, Metadata.Key<String>>() { // retrolambda no like
+          @Override public String get(Metadata metadata, Metadata.Key<String> key) {
+            return metadata.get(key);
+          }
+        });
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call,
+      final Metadata requestHeaders, final ServerCallHandler<ReqT, RespT> next) {
+    Span span = tracer.nextSpan(extractor, requestHeaders);
+    return next.startCall(new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+      @Override
+      public void request(int numMessages) {
+        try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+          span.kind(Span.Kind.SERVER).name(call.getMethodDescriptor().getFullMethodName()).start();
+          super.request(numMessages);
+        }
+      }
+
+      @Override
+      public void close(Status status, Metadata trailers) {
+        try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+          if (!status.getCode().equals(Status.Code.OK)) {
+            span.tag(Constants.ERROR, String.valueOf(status.getCode()));
+          }
+          super.close(status, trailers);
+        } finally {
+          span.finish();
+        }
+      }
+    }, requestHeaders);
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/GreeterImpl.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GreeterImpl.java
@@ -1,0 +1,22 @@
+package brave.grpc;
+
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.stub.StreamObserver;
+
+class GreeterImpl extends GreeterGrpc.GreeterImplBase {
+  static final HelloRequest HELLO_REQUEST = HelloRequest.newBuilder()
+      .setName("tracer")
+      .build();
+
+  @Override public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
+    if (req.getName().equals("bad")) {
+      responseObserver.onError(new IllegalArgumentException());
+      return;
+    }
+    HelloReply reply = HelloReply.newBuilder().setMessage("Hello " + req.getName()).build();
+    responseObserver.onNext(reply);
+    responseObserver.onCompleted();
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
@@ -1,0 +1,258 @@
+package brave.grpc;
+
+import brave.Tracer;
+import brave.Tracing;
+import brave.internal.StrictCurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.Sampler;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import io.grpc.examples.helloworld.GraterGrpc;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.internal.Util;
+import zipkin.storage.InMemoryStorage;
+
+import static brave.grpc.GreeterImpl.HELLO_REQUEST;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.junit.Assume.assumeTrue;
+
+public class ITTracingClientInterceptor {
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  Tracing tracing;
+  TestServer server = new TestServer();
+  ManagedChannel client;
+
+  @Before public void setup() throws IOException {
+    server.start();
+    tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+    client = newClient();
+  }
+
+  @After public void close() throws Exception {
+    closeClient(client);
+    server.stop();
+  }
+
+  ManagedChannel newClient() {
+    return newClient(GrpcTracing.create(tracing).newClientInterceptor());
+  }
+
+  ManagedChannel newClient(ClientInterceptor... clientInterceptors) {
+    return ManagedChannelBuilder.forAddress("localhost", server.port())
+        .intercept(clientInterceptors)
+        .usePlaintext(true)
+        .build();
+  }
+
+  void closeClient(ManagedChannel client) throws Exception {
+    client.shutdown();
+    client.awaitTermination(1, TimeUnit.SECONDS);
+  }
+
+  @Test public void propagatesSpan() throws Exception {
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    TraceContext context = server.takeRequest().context();
+    assertThat(context.parentId()).isNull();
+    assertThat(context.sampled()).isTrue();
+  }
+
+  @Test public void makesChildOfCurrentSpan() throws Exception {
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+    } finally {
+      parent.finish();
+    }
+
+    TraceContext context = server.takeRequest().context();
+    assertThat(context.traceId())
+        .isEqualTo(parent.context().traceId());
+    assertThat(context.parentId())
+        .isEqualTo(parent.context().spanId());
+  }
+
+  /**
+   * This tests that the parent is determined at the time the request was made, not when the request
+   * was executed.
+   */
+  @Test public void usesParentFromInvocationTime() throws Exception {
+    server.enqueueDelay(TimeUnit.SECONDS.toMillis(1));
+    GreeterGrpc.GreeterFutureStub futureStub = GreeterGrpc.newFutureStub(client);
+
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      futureStub.sayHello(HELLO_REQUEST);
+      futureStub.sayHello(HELLO_REQUEST);
+    } finally {
+      parent.finish();
+    }
+
+    brave.Span otherSpan = tracing.tracer().newTrace().name("test2").start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(otherSpan)) {
+      for (int i = 0; i < 2; i++) {
+        TraceContext context = server.takeRequest().context();
+        assertThat(context.traceId())
+            .isEqualTo(parent.context().traceId());
+        assertThat(context.parentId())
+            .isEqualTo(parent.context().spanId());
+      }
+    } finally {
+      otherSpan.finish();
+    }
+  }
+
+  /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
+  @Test public void propagates_sampledFalse() throws Exception {
+    tracing = tracingBuilder(Sampler.NEVER_SAMPLE).build();
+    closeClient(client);
+    client = newClient();
+
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    TraceContextOrSamplingFlags context = server.takeRequest();
+    assertThat(context.context().sampled()).isFalse();
+  }
+
+  @Test public void reportsClientAnnotationsToZipkin() throws Exception {
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test public void defaultSpanNameIsMethodName() throws Exception {
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("helloworld.greeter/sayhello");
+  }
+
+  @Test public void reportsSpanOnTransportException() throws Exception {
+    server.stop();
+
+    try {
+      GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+      failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+    } catch (StatusRuntimeException e) {
+    }
+
+    assertThat(collectedSpans()).hasSize(1);
+  }
+
+  @Test public void addsErrorTag_onUnimplemented() throws Exception {
+
+    try {
+      GraterGrpc.newBlockingStub(client).seyHallo(HELLO_REQUEST);
+      failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+    } catch (StatusRuntimeException e) {
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(a -> a.key.equals(Constants.ERROR))
+        .extracting(a -> new String(a.value, Util.UTF_8))
+        .containsExactly("UNIMPLEMENTED");
+  }
+
+  @Test public void addsErrorTag_onTransportException() throws Exception {
+    reportsSpanOnTransportException();
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(a -> a.key.equals(Constants.ERROR))
+        .extracting(a -> new String(a.value, Util.UTF_8))
+        .containsExactly("UNAVAILABLE");
+  }
+
+  @Test public void addsErrorTag_onCanceledFuture() throws Exception {
+    server.enqueueDelay(TimeUnit.SECONDS.toMillis(1));
+
+    ListenableFuture<HelloReply> resp = GreeterGrpc.newFutureStub(client).sayHello(HELLO_REQUEST);
+    assumeTrue("lost race on cancel", resp.cancel(true));
+
+    close(); // blocks until the cancel finished
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(a -> a.key.equals(Constants.ERROR))
+        .extracting(a -> new String(a.value, Util.UTF_8))
+        .containsExactly("CANCELLED");
+  }
+
+  /**
+   * NOTE: for this to work, the brave interceptor must be last (so that it executes first)
+   *
+   * <p>Also notice that we are only making the current context available in the request side. The
+   */
+  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+    Map<String, String> scopes = new ConcurrentHashMap<>();
+    closeClient(client);
+
+    client = newClient(
+        new ClientInterceptor() {
+          @Override public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+              MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            scopes.put("before", tracing.currentTraceContext().get().traceIdString());
+            return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                next.newCall(method, callOptions)) {
+              @Override
+              public void start(Listener<RespT> responseListener, Metadata headers) {
+                scopes.put("start", tracing.currentTraceContext().get().traceIdString());
+                super.start(responseListener, headers);
+              }
+            };
+          }
+        },
+        GrpcTracing.create(tracing).newClientInterceptor()
+    );
+
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(scopes)
+        .containsKeys("before", "start");
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .localEndpoint(local)
+        .sampler(sampler);
+  }
+
+  List<Span> collectedSpans() {
+    List<List<Span>> result = storage.spanStore().getRawTraces();
+    assertThat(result).hasSize(1);
+    return result.get(0);
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
@@ -1,0 +1,174 @@
+package brave.grpc;
+
+import brave.Tracing;
+import brave.internal.HexCodec;
+import brave.internal.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptors;
+import io.grpc.StatusRuntimeException;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloRequest;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.storage.InMemoryStorage;
+
+import static brave.grpc.GreeterImpl.HELLO_REQUEST;
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class ITTracingServerInterceptor {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  Tracing tracing;
+  Server server;
+  ManagedChannel client;
+
+  @Before public void setup() throws Exception {
+    tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+    init();
+  }
+
+  void init() throws Exception {
+    stop();
+
+    server = ServerBuilder.forPort(PickUnusedPort.get())
+        .addService(ServerInterceptors.intercept(new GreeterImpl(),
+            GrpcTracing.create(tracing).newServerInterceptor()))
+        .build().start();
+
+    client = ManagedChannelBuilder.forAddress("localhost", server.getPort())
+        .usePlaintext(true)
+        .build();
+  }
+
+  @After
+  public void stop() throws Exception {
+    if (client != null) {
+      client.shutdown();
+      client.awaitTermination(1, TimeUnit.SECONDS);
+    }
+    if (server != null) {
+      server.shutdown();
+      server.awaitTermination();
+    }
+  }
+
+  @Test
+  public void usesExistingTraceId() throws Exception {
+    final String traceId = "463ac35c9f6413ad";
+    final String parentId = traceId;
+    final String spanId = "48485a3953bb6124";
+
+    Channel channel = ClientInterceptors.intercept(client, new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+          @Override
+          public void start(Listener<RespT> responseListener, Metadata headers) {
+            headers.put(Key.of("X-B3-TraceId", ASCII_STRING_MARSHALLER), traceId);
+            headers.put(Key.of("X-B3-ParentSpanId", ASCII_STRING_MARSHALLER), parentId);
+            headers.put(Key.of("X-B3-SpanId", ASCII_STRING_MARSHALLER), spanId);
+            super.start(responseListener, headers);
+          }
+        };
+      }
+    });
+
+    GreeterGrpc.newBlockingStub(channel).sayHello(HELLO_REQUEST);
+
+    assertThat(collectedSpans()).allSatisfy(s -> {
+      assertThat(HexCodec.toLowerHex(s.traceId)).isEqualTo(traceId);
+      assertThat(HexCodec.toLowerHex(s.parentId)).isEqualTo(parentId);
+      assertThat(HexCodec.toLowerHex(s.id)).isEqualTo(spanId);
+    });
+  }
+
+  @Test
+  public void samplingDisabled() throws Exception {
+    tracing = tracingBuilder(Sampler.NEVER_SAMPLE).build();
+    init();
+
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(collectedSpans())
+        .isEmpty();
+  }
+
+  @Test
+  public void reportsServerAnnotationsToZipkin() throws Exception {
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("sr", "ss");
+  }
+
+  @Test
+  public void defaultSpanNameIsMethodName() throws Exception {
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("helloworld.greeter/sayhello");
+  }
+
+  @Test
+  public void addsErrorTagOnException() throws Exception {
+    try {
+      GreeterGrpc.newBlockingStub(client)
+          .sayHello(HelloRequest.newBuilder().setName("bad").build());
+      failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+    } catch (StatusRuntimeException e) {
+      assertThat(collectedSpans())
+          .flatExtracting(s -> s.binaryAnnotations)
+          .contains(
+              BinaryAnnotation.create(Constants.ERROR, e.getStatus().getCode().toString(), local));
+    }
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .localEndpoint(local)
+        .sampler(sampler);
+  }
+
+  List<Span> collectedSpans() {
+    List<List<Span>> result = storage.spanStore().getRawTraces();
+    if (result.isEmpty()) return Collections.emptyList();
+    assertThat(result).hasSize(1);
+    return result.get(0);
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/PickUnusedPort.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/PickUnusedPort.java
@@ -1,0 +1,17 @@
+package brave.grpc;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+class PickUnusedPort {
+  static int get() {
+    try {
+      ServerSocket serverSocket = new ServerSocket(0);
+      int port = serverSocket.getLocalPort();
+      serverSocket.close();
+      return port;
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
@@ -1,0 +1,64 @@
+package brave.grpc;
+
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+class TestServer {
+  BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
+  BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
+  TraceContext.Extractor<Metadata> extractor =
+      Propagation.Factory.B3.create(AsciiMetadataKeyFactory.INSTANCE).extractor(Metadata::get);
+
+  Server server = ServerBuilder.forPort(PickUnusedPort.get())
+      .addService(ServerInterceptors.intercept(new GreeterImpl(), new ServerInterceptor() {
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+            Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+          Long delay = delayQueue.poll();
+          if (delay != null) {
+            try {
+              Thread.sleep(delay);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new AssertionError("interrupted sleeping " + delay);
+            }
+          }
+          requestQueue.add(extractor.extract(headers));
+          return next.startCall(call, headers);
+        }
+      }))
+      .build();
+
+  void start() throws IOException {
+    server.start();
+  }
+
+  void stop() throws InterruptedException {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  int port() {
+    return server.getPort();
+  }
+
+  TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
+    return requestQueue.take();
+  }
+
+  void enqueueDelay(long millis) {
+    this.delayQueue.add(millis);
+  }
+}

--- a/instrumentation/grpc/src/test/proto/helloworld.proto
+++ b/instrumentation/grpc/src/test/proto/helloworld.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (HelloRequest) returns (HelloReply) {
+    }
+}
+
+// intentionally different to test service not found
+service Grater {
+    // Sends a greeting
+    rpc SeyHallo (HelloRequest) returns (HelloReply) {
+    }
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+    string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+    string message = 1;
+}
+

--- a/instrumentation/grpc/src/test/resources/log4j2.properties
+++ b/instrumentation/grpc/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/http-tests/README.md
+++ b/instrumentation/http-tests/README.md
@@ -1,0 +1,4 @@
+# brave-instrumentation-http-tests
+
+This module contains test base classes used to ensure instrumentation
+work portably.

--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-http-tests</artifactId>
+  <name>Brave Instrumentation: Http Tests</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -1,0 +1,317 @@
+package brave.http;
+
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.internal.HexCodec;
+import brave.internal.StrictCurrentTraceContext;
+import brave.propagation.CurrentTraceContext;
+import brave.sampler.Sampler;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.TraceKeys;
+import zipkin.internal.Util;
+import zipkin.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class ITHttpClient<C> {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Rule public MockWebServer server = new MockWebServer();
+
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  protected CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  protected HttpTracing httpTracing;
+  protected C client;
+
+  @Before public void setup() {
+    httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+    client = newClient(server.getPort());
+  }
+
+  /** Make sure the client you return has retries disabled. */
+  protected abstract C newClient(int port);
+
+  protected abstract void closeClient(C client) throws IOException;
+
+  protected abstract void get(C client, String pathIncludingQuery) throws Exception;
+
+  protected abstract void post(C client, String pathIncludingQuery, String body) throws Exception;
+
+  protected abstract void getAsync(C client, String pathIncludingQuery) throws Exception;
+
+  @After public void close() throws IOException {
+    closeClient(client);
+  }
+
+  @Test public void propagatesSpan() throws Exception {
+    server.enqueue(new MockResponse());
+    get(client, "/foo");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeaders().toMultimap())
+        .containsKeys("x-b3-traceId", "x-b3-spanId")
+        .containsEntry("x-b3-sampled", asList("1"));
+  }
+
+  @Test public void makesChildOfCurrentSpan() throws Exception {
+    Tracer tracer = httpTracing.tracing().tracer();
+    server.enqueue(new MockResponse());
+
+    brave.Span parent = tracer.newTrace().name("test").start();
+    try (SpanInScope ws = tracer.withSpanInScope(parent)) {
+      get(client, "/foo");
+    } finally {
+      parent.finish();
+    }
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(parent.context().traceIdString());
+    assertThat(request.getHeader("x-b3-parentspanid"))
+        .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+  }
+
+  /**
+   * This tests that the parent is determined at the time the request was made, not when the request
+   * was executed.
+   */
+  @Test public void usesParentFromInvocationTime() throws Exception {
+    Tracer tracer = httpTracing.tracing().tracer();
+    server.enqueue(new MockResponse().setBodyDelay(1, TimeUnit.SECONDS));
+    server.enqueue(new MockResponse());
+
+    brave.Span parent = tracer.newTrace().name("test").start();
+    try (SpanInScope ws = tracer.withSpanInScope(parent)) {
+      getAsync(client, "/foo");
+      getAsync(client, "/foo");
+    } finally {
+      parent.finish();
+    }
+
+    brave.Span otherSpan = tracer.newTrace().name("test2").start();
+    try (SpanInScope ws = tracer.withSpanInScope(otherSpan)) {
+      for (int i = 0; i < 2; i++) {
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("x-b3-traceId"))
+            .isEqualTo(parent.context().traceIdString());
+        assertThat(request.getHeader("x-b3-parentspanid"))
+            .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+      }
+    } finally {
+      otherSpan.finish();
+    }
+  }
+
+  /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
+  @Test public void propagates_sampledFalse() throws Exception {
+    close();
+    httpTracing = HttpTracing.create(tracingBuilder(Sampler.NEVER_SAMPLE).build());
+    client = newClient(server.getPort());
+
+    server.enqueue(new MockResponse());
+    get(client, "/foo");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeaders().toMultimap())
+        .containsKeys("x-b3-traceId", "x-b3-spanId")
+        .doesNotContainKey("x-b3-parentSpanId")
+        .containsEntry("x-b3-sampled", asList("0"));
+  }
+
+  @Test public void reportsClientAnnotationsToZipkin() throws Exception {
+    server.enqueue(new MockResponse());
+    get(client, "/foo");
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test
+  public void reportsServerAddress() throws Exception {
+    server.enqueue(new MockResponse());
+    get(client, "/foo");
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(Constants.SERVER_ADDR))
+        .extracting(b -> b.endpoint)
+        .containsExactly(Endpoint.builder()
+            .serviceName("")
+            .ipv4(127 << 24 | 1)
+            .port(server.getPort()).build()
+        );
+  }
+
+  @Test public void defaultSpanNameIsMethodName() throws Exception {
+    server.enqueue(new MockResponse());
+    get(client, "/foo");
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("get");
+  }
+
+  @Test public void supportsPortableCustomization() throws Exception {
+    String uri = "/foo?z=2&yAA=1";
+
+    close();
+httpTracing = httpTracing.toBuilder()
+    .clientParser(new HttpClientParser() {
+      @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+        return adapter.method(req).toLowerCase() + " " + adapter.path(req);
+      }
+
+      @Override
+      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
+        span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
+      }
+    })
+    .serverName("remote-service")
+    .build();
+
+    client = newClient(server.getPort());
+    server.enqueue(new MockResponse());
+    get(client, uri);
+
+    List<Span> collectedSpans = collectedSpans();
+    assertThat(collectedSpans)
+        .extracting(s -> s.name)
+        .containsExactly("get /foo");
+
+    assertThat(collectedSpans)
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(Constants.SERVER_ADDR))
+        .extracting(b -> b.endpoint.serviceName)
+        .containsExactly("remote-service");
+
+    assertThat(collectedSpans)
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(TraceKeys.HTTP_URL))
+        .extracting(b -> new String(b.value, Util.UTF_8))
+        .containsExactly(url(uri));
+  }
+
+  @Test public void addsStatusCodeWhenNotOk() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    try {
+      get(client, "/foo");
+    } catch (RuntimeException e) {
+      // some clients think 404 is an error
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .contains(BinaryAnnotation.create(TraceKeys.HTTP_STATUS_CODE, "404", local));
+  }
+
+  @Test public void redirect() throws Exception {
+    Tracer tracer = httpTracing.tracing().tracer();
+    server.enqueue(new MockResponse().setResponseCode(302)
+        .addHeader("Location: " + url("/bar")));
+    server.enqueue(new MockResponse().setResponseCode(404)); // hehe to a bad location!
+
+    brave.Span parent = tracer.newTrace().name("test").start();
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(parent)) {
+      get(client, "/foo");
+    } catch (RuntimeException e) {
+      // some think 404 is an exception
+    } finally {
+      parent.finish();
+    }
+
+    assertThat(collectedSpans())
+        .hasSize(3) // parent and two HTTP spans
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(TraceKeys.HTTP_PATH))
+        .extracting(b -> new String(b.value, Util.UTF_8))
+        .containsExactly("/foo", "/bar");
+  }
+
+  @Test public void post() throws Exception {
+    String path = "/post";
+    String body = "body";
+    server.enqueue(new MockResponse());
+
+    post(client, path, body);
+
+    assertThat(server.takeRequest().getBody().readUtf8())
+        .isEqualTo(body);
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("post");
+  }
+
+  @Test public void reportsSpanOnTransportException() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+    try {
+      get(client, "/foo");
+    } catch (Exception e) {
+      // ok, but the span should include an error!
+    }
+
+    assertThat(collectedSpans()).hasSize(1);
+  }
+
+  @Test public void addsErrorTagOnTransportException() throws Exception {
+    reportsSpanOnTransportException();
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key)
+        .contains(Constants.ERROR);
+  }
+
+  @Test public void httpPathTagExcludesQueryParams() throws Exception {
+    String path = "/foo?z=2&yAA=1";
+
+    server.enqueue(new MockResponse());
+    get(client, path);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(TraceKeys.HTTP_PATH))
+        .extracting(b -> new String(b.value, Util.UTF_8))
+        .containsExactly("/foo");
+  }
+
+  protected String url(String pathIncludingQuery) {
+    return "http://127.0.0.1:" + server.getPort() + pathIncludingQuery;
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
+        .currentTraceContext(currentTraceContext)
+        .localEndpoint(local)
+        .sampler(sampler);
+  }
+
+  List<Span> collectedSpans() {
+    List<List<Span>> result = storage.spanStore().getRawTraces();
+    assertThat(result).hasSize(1);
+    return result.get(0);
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
@@ -1,0 +1,329 @@
+package brave.http;
+
+import brave.Tracing;
+import brave.internal.HexCodec;
+import brave.internal.StrictCurrentTraceContext;
+import brave.propagation.CurrentTraceContext;
+import brave.sampler.Sampler;
+import java.util.Collections;
+import java.util.List;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.TraceKeys;
+import zipkin.internal.Util;
+import zipkin.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+public abstract class ITHttpServer {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  public OkHttpClient client = new OkHttpClient();
+
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  protected CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  protected HttpTracing httpTracing;
+
+  @Before
+  public void setup() throws Exception {
+    httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+    init();
+  }
+
+  /** recreate the server if needed */
+  protected abstract void init() throws Exception;
+
+  protected abstract String url(String path);
+
+  @Test
+  public void usesExistingTraceId() throws Exception {
+    String path = "/foo";
+
+    final String traceId = "463ac35c9f6413ad";
+    final String parentId = traceId;
+    final String spanId = "48485a3953bb6124";
+
+    Request request = new Request.Builder().url(url(path))
+        .header("X-B3-TraceId", traceId)
+        .header("X-B3-ParentSpanId", parentId)
+        .header("X-B3-SpanId", spanId)
+        .header("X-B3-Sampled", "1")
+        .build();
+
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans()).allSatisfy(s -> {
+      assertThat(HexCodec.toLowerHex(s.traceId)).isEqualTo(traceId);
+      assertThat(HexCodec.toLowerHex(s.parentId)).isEqualTo(parentId);
+      assertThat(HexCodec.toLowerHex(s.id)).isEqualTo(spanId);
+    });
+  }
+
+  @Test
+  public void samplingDisabled() throws Exception {
+    httpTracing = HttpTracing.create(tracingBuilder(Sampler.NEVER_SAMPLE).build());
+    init();
+
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .isEmpty();
+  }
+
+  /**
+   * Tests that the span propagates between under asynchronous callbacks (even if explicitly)
+   */
+  @Test
+  public void async() throws Exception {
+    String path = "/async";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      if (response.code() == 404) throw new AssumptionViolatedException(path + " not supported");
+      assertThat(response.isSuccessful()).isTrue();
+    } catch (AssumptionViolatedException e) {
+      throw e;
+    }
+
+    List<Span> trace = collectedSpans();
+    assertThat(trace).hasSize(1);
+  }
+
+  /**
+   * This ensures thread-state is propagated from trace interceptors to user code. The endpoint
+   * "/child" is expected to create a local span. When this works, it should be a child of the
+   * "current span", in this case the span representing an incoming server request. When thread
+   * state isn't managed properly, the child span will appear as a new trace.
+   */
+  @Test
+  public void createsChildSpan() throws Exception {
+    String path = "/child";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      if (response.code() == 404) throw new AssumptionViolatedException(path + " not supported");
+    } catch (AssumptionViolatedException e) {
+      throw e;
+    } catch (Exception e) {
+      // ok, but the span should include an error!
+    }
+
+    List<Span> trace = collectedSpans();
+    assertThat(trace).hasSize(2);
+
+    Span child = trace.get(0);
+    Span parent = trace.get(1);
+
+    assertThat(parent.traceId).isEqualTo(child.traceId);
+    assertThat(parent.id).isEqualTo(child.parentId);
+    assertThat(parent.timestamp).isLessThan(child.timestamp);
+    assertThat(parent.duration).isGreaterThan(child.duration);
+  }
+
+  @Test
+  public void reportsClientAddress() throws Exception {
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key)
+        .contains(Constants.CLIENT_ADDR);
+  }
+
+  @Test
+  public void reportsClientAddress_XForwardedFor() throws Exception {
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path))
+        .header("X-Forwarded-For", "1.2.3.4")
+        .build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key, b -> b.endpoint.ipv4)
+        .contains(tuple(Constants.CLIENT_ADDR, 1 << 24 | 2 << 16 | 3 << 8 | 4));
+  }
+
+  @Test
+  public void reportsServerAnnotationsToZipkin() throws Exception {
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("sr", "ss");
+  }
+
+  @Test
+  public void defaultSpanNameIsMethodName() throws Exception {
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("get");
+  }
+
+  @Test
+  public void supportsPortableCustomization() throws Exception {
+    String uri = "/foo?z=2&yAA=1";
+
+    httpTracing = httpTracing.toBuilder().serverParser(new HttpServerParser() {
+      @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+        return adapter.method(req).toLowerCase() + " " + adapter.path(req);
+      }
+
+      @Override
+      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
+        span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
+      }
+    }).build();
+    init();
+
+    Request request = new Request.Builder().url(url(uri)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    List<Span> collectedSpans = collectedSpans();
+    assertThat(collectedSpans)
+        .extracting(s -> s.name)
+        .containsExactly("get /foo");
+
+    assertThat(collectedSpans)
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(TraceKeys.HTTP_URL))
+        .extracting(b -> new String(b.value, Util.UTF_8))
+        .containsExactly(url(uri));
+  }
+
+  @Test
+  public void addsStatusCode_badRequest() throws Exception {
+    String path = "/badrequest";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+    } catch (RuntimeException e) {
+      // some servers think 400 is an error
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .contains(BinaryAnnotation.create(TraceKeys.HTTP_STATUS_CODE, "400", local));
+  }
+
+  @Test
+  public void reportsSpanOnException() throws Exception {
+    reportsSpanOnException("/exception");
+  }
+
+  @Test
+  public void reportsSpanOnException_async() throws Exception {
+    reportsSpanOnException("/exceptionAsync");
+  }
+
+  private void reportsSpanOnException(String path) {
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      if (response.code() == 404) throw new AssumptionViolatedException(path + " not supported");
+    } catch (AssumptionViolatedException e) {
+      throw e;
+    } catch (Exception e) {
+      // ok, but the span should include an error!
+    }
+
+    assertThat(collectedSpans()).hasSize(1);
+  }
+
+  @Test
+  public void addsErrorTagOnException() throws Exception {
+    addsErrorTagOnException("/exception");
+  }
+
+  @Test
+  public void addsErrorTagOnException_async() throws Exception {
+    addsErrorTagOnException("/exceptionAsync");
+  }
+
+  private void addsErrorTagOnException(String path) {
+    reportsSpanOnException(path);
+    try {
+      Thread.sleep(1000L);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key)
+        .contains(Constants.ERROR);
+  }
+
+  @Test
+  public void httpPathTagExcludesQueryParams() throws Exception {
+    String uri = "/foo?z=2&yAA=1";
+
+    Request request = new Request.Builder().url(url(uri)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals(TraceKeys.HTTP_PATH))
+        .extracting(b -> new String(b.value, Util.UTF_8))
+        .containsExactly("/foo");
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
+        .currentTraceContext(currentTraceContext)
+        .localEndpoint(local)
+        .sampler(sampler);
+  }
+
+  protected List<Span> collectedSpans() {
+    List<List<Span>> result = storage.spanStore().getRawTraces();
+    if (result.isEmpty()) return Collections.emptyList();
+    assertThat(result).hasSize(1);
+    return result.get(0);
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITServlet25Container.java
@@ -1,0 +1,100 @@
+package brave.http;
+
+import brave.Tracer;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class ITServlet25Container extends ITServletContainer {
+
+  static class StatusServlet extends HttpServlet {
+    final int status;
+
+    StatusServlet(int status) {
+      this.status = status;
+    }
+
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      resp.setStatus(status);
+    }
+  }
+
+  static class ChildServlet extends HttpServlet {
+    final Tracer tracer;
+
+    ChildServlet(HttpTracing httpTracing) {
+      this.tracer = httpTracing.tracing().tracer();
+    }
+
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      tracer.nextSpan().name("child").start().finish();
+      resp.setStatus(200);
+    }
+  }
+
+  static class ExceptionServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      throw new IOException(); // null exception message!
+    }
+  }
+
+  Filter userFilter = new Filter() {
+    @Override public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+      String traceId = currentTraceContext.get().traceIdString();
+      ((HttpServletResponse) response).setHeader("my-id", traceId);
+      chain.doFilter(request, response);
+    }
+
+    @Override public void destroy() {
+    }
+  };
+
+  @Test public void currentSpanVisibleToOtherFilters() throws Exception {
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+      String idString = collectedSpans().iterator().next().idString();
+      assertThat(idString).startsWith(response.header("my-id"));
+    }
+  }
+
+  @Override
+  public void init(ServletContextHandler handler) {
+    // add servlets for the test resource
+    handler.addServlet(new ServletHolder(new StatusServlet(200)), "/foo");
+    handler.addServlet(new ServletHolder(new StatusServlet(400)), "/badrequest");
+    handler.addServlet(new ServletHolder(new ChildServlet(httpTracing)), "/child");
+    handler.addServlet(new ServletHolder(new ExceptionServlet()), "/exception");
+
+    // add the trace filter
+    addFilter(handler, newTracingFilter());
+    // add a user filter
+    addFilter(handler, userFilter);
+  }
+
+  protected abstract Filter newTracingFilter();
+
+  protected abstract void addFilter(ServletContextHandler handler, Filter filter);
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITServlet3Container.java
@@ -1,0 +1,44 @@
+package brave.http;
+
+import java.io.IOException;
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+public abstract class ITServlet3Container extends ITServlet25Container {
+
+  static class AsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      AsyncContext ctx = req.startAsync();
+      ctx.start(ctx::complete);
+    }
+  }
+
+  static class ExceptionAsyncServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      AsyncContext ctx = req.startAsync();
+      ctx.setTimeout(1);
+      ctx.start(() -> {
+        try {
+          Thread.sleep(10L);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          ctx.complete();
+        }
+      });
+    }
+  }
+
+  @Override
+  public void init(ServletContextHandler handler) {
+    super.init(handler);
+    // add servlet 3.0+
+    handler.addServlet(new ServletHolder(new AsyncServlet()), "/async");
+    handler.addServlet(new ServletHolder(new ExceptionAsyncServlet()), "/exceptionAsync");
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITServletContainer.java
@@ -1,0 +1,55 @@
+package brave.http;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.bio.SocketConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.After;
+
+/** Starts a jetty server which runs a servlet container */
+public abstract class ITServletContainer extends ITHttpServer {
+  int port = 0; // initially get a port, later reuse one
+  Server server;
+
+  /** recreates the server so that it uses the supplied trace configuration */
+  @Override protected final void init() {
+    stop();
+    SocketConnector connector = new SocketConnector();
+    connector.setMaxIdleTime(1000 * 60 * 60);
+    connector.setPort(port);
+    server = new Server();
+    server.setConnectors(new Connector[] {connector});
+
+    ServletContextHandler context = new ServletContextHandler();
+    context.setContextPath("/");
+    server.setHandler(context);
+
+    init(context);
+
+    try {
+      server.start();
+      port = server.getConnectors()[0].getLocalPort();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to start server.", e);
+    }
+  }
+
+  @Override protected final String url(String path) {
+    return "http://localhost:" + port + path;
+  }
+
+  /** Implement by registering a servlet for the test resource and anything needed for tracing */
+  public abstract void init(ServletContextHandler handler);
+
+  @After
+  public void stop() {
+    if (server == null) return;
+    try {
+      server.stop();
+      server.join();
+      server = null;
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/instrumentation/httpasyncclient/README.md
+++ b/instrumentation/httpasyncclient/README.md
@@ -1,0 +1,11 @@
+# brave-instrumentation-httpasyncclient
+This module contains a tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+.
+`TracingAsyncHttpClientBuilder` adds trace headers to outgoing requests. It
+then reports to Zipkin how long each request takes, along with relevant
+tags like the http url.
+
+To enable tracing, create your client using `TracingHttpAsyncClientBuilder`.
+
+```java
+httpasyncclient = TracingAsyncHttpClientBuilder.create(tracing).build();
+```

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-httpasyncclient</artifactId>
+  <name>Brave Instrumentation: Apache HttpClient v4.3+</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -1,0 +1,257 @@
+package brave.httpasyncclient;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import java.util.concurrent.Future;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpMessage;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.client.methods.HttpRequestWrapper;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.apache.http.protocol.HttpContext;
+import zipkin.Endpoint;
+
+public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
+
+  public static HttpAsyncClientBuilder create(Tracing tracing) {
+    return new TracingHttpAsyncClientBuilder(HttpTracing.create(tracing));
+  }
+
+  public static HttpAsyncClientBuilder create(HttpTracing httpTracing) {
+    return new TracingHttpAsyncClientBuilder(httpTracing);
+  }
+
+  final Tracer tracer;
+  final TraceContext.Injector<HttpMessage> injector;
+  final HttpClientHandler<HttpRequest, HttpResponse> handler;
+  final String remoteServiceName;
+
+  TracingHttpAsyncClientBuilder(HttpTracing httpTracing) { // intentionally hidden
+    if (httpTracing == null) throw new NullPointerException("httpTracing == null");
+    this.tracer = httpTracing.tracing().tracer();
+    this.remoteServiceName = httpTracing.serverName();
+    this.handler = new HttpClientHandler<>(new HttpAdapter(), httpTracing.clientParser());
+    this.injector = httpTracing.tracing().propagation().injector(HttpMessage::setHeader);
+  }
+
+  @Override public CloseableHttpAsyncClient build() {
+    super.addInterceptorFirst((HttpRequestInterceptor) (request, context) -> {
+      TraceContext parent = (TraceContext) context.getAttribute(TraceContext.class.getName());
+      Span span = parent == null ? tracer.newTrace() : tracer.newChild(parent);
+
+      HttpHost host = HttpClientContext.adapt(context).getTargetHost();
+      if (!span.isNoop() && host != null) {
+        parseServerAddress(host, span);
+        handler.handleSend(HttpRequestWrapper.wrap(request, host), span);
+      } else {
+        handler.handleSend(request, span);
+      }
+
+      injector.inject(span.context(), request);
+      context.setAttribute(Span.class.getName(), span);
+      context.setAttribute(SpanInScope.class.getName(), tracer.withSpanInScope(span));
+    });
+    super.addInterceptorLast((HttpRequestInterceptor) (request, context) -> {
+      SpanInScope scope = (SpanInScope) context.getAttribute(SpanInScope.class.getName());
+      if (scope != null) {
+        context.removeAttribute(SpanInScope.class.getName());
+        scope.close();
+      }
+    });
+    super.addInterceptorLast((HttpResponseInterceptor) (response, context) -> {
+      Span span = (Span) context.getAttribute(Span.class.getName());
+      handler.handleReceive(response, span);
+    });
+    return new TracingHttpAsyncClient(super.build());
+  }
+
+  void parseServerAddress(HttpHost host, Span span) {
+    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
+    if (!builder.parseIp(host.getAddress())) builder.parseIp(host.getHostName());
+    builder.port(host.getPort());
+    span.remoteEndpoint(builder.build());
+  }
+
+  static final class HttpAdapter extends brave.http.HttpAdapter<HttpRequest, HttpResponse> {
+    @Override public String method(HttpRequest request) {
+      return request.getRequestLine().getMethod();
+    }
+
+    @Override public String path(HttpRequest request) {
+      String result = request.getRequestLine().getUri();
+      int queryIndex = result.indexOf('?');
+      return queryIndex == -1 ? result : result.substring(0, queryIndex);
+    }
+
+    @Override public String url(HttpRequest request) {
+      if (request instanceof HttpRequestWrapper) {
+        HttpRequestWrapper wrapper = (HttpRequestWrapper) request;
+        HttpHost target = wrapper.getTarget();
+        if (target != null) return target.toURI() + wrapper.getURI();
+      }
+      return request.getRequestLine().getUri();
+    }
+
+    @Override public String requestHeader(HttpRequest request, String name) {
+      Header result = request.getFirstHeader(name);
+      return result != null ? result.getValue() : null;
+    }
+
+    @Override public Integer statusCode(HttpResponse response) {
+      return response.getStatusLine().getStatusCode();
+    }
+  }
+
+  final class TracingHttpAsyncClient extends CloseableHttpAsyncClient {
+    private final CloseableHttpAsyncClient delegate;
+
+    public TracingHttpAsyncClient(CloseableHttpAsyncClient delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public <T> Future<T> execute(HttpAsyncRequestProducer requestProducer,
+        HttpAsyncResponseConsumer<T> responseConsumer, HttpContext context,
+        FutureCallback<T> callback) {
+      Span span = tracer.currentSpan();
+      context.setAttribute(TraceContext.class.getName(), span != null ? span.context() : null);
+      return delegate.execute(
+          new TracingAsyncRequestProducer(requestProducer, context),
+          new TracingAsyncResponseConsumer<>(responseConsumer, context),
+          context,
+          callback
+      );
+    }
+
+    @Override public void close() throws IOException {
+      delegate.close();
+    }
+
+    @Override public boolean isRunning() {
+      return delegate.isRunning();
+    }
+
+    @Override public void start() {
+      delegate.start();
+    }
+  }
+
+  final class TracingAsyncRequestProducer implements HttpAsyncRequestProducer {
+    final HttpAsyncRequestProducer requestProducer;
+    final HttpContext context;
+
+    TracingAsyncRequestProducer(HttpAsyncRequestProducer requestProducer, HttpContext context) {
+      this.requestProducer = requestProducer;
+      this.context = context;
+    }
+
+    @Override public void close() throws IOException {
+      requestProducer.close();
+    }
+
+    @Override public HttpHost getTarget() {
+      return requestProducer.getTarget();
+    }
+
+    @Override public HttpRequest generateRequest() throws IOException, HttpException {
+      return requestProducer.generateRequest();
+    }
+
+    @Override public void produceContent(ContentEncoder encoder, IOControl io) throws IOException {
+      requestProducer.produceContent(encoder, io);
+    }
+
+    @Override public void requestCompleted(HttpContext context) {
+      requestProducer.requestCompleted(context);
+    }
+
+    @Override public void failed(Exception ex) {
+      Span currentSpan = (Span) context.getAttribute(Span.class.getName());
+      if (currentSpan != null) {
+        handler.handleError(ex, currentSpan);
+        context.removeAttribute(Span.class.getName());
+      }
+      requestProducer.failed(ex);
+    }
+
+    @Override public boolean isRepeatable() {
+      return requestProducer.isRepeatable();
+    }
+
+    @Override public void resetRequest() throws IOException {
+      requestProducer.resetRequest();
+    }
+  }
+
+  final class TracingAsyncResponseConsumer<T> implements HttpAsyncResponseConsumer<T> {
+    final HttpAsyncResponseConsumer<T> responseConsumer;
+    final HttpContext context;
+
+    TracingAsyncResponseConsumer(HttpAsyncResponseConsumer<T> responseConsumer,
+        HttpContext context) {
+      this.responseConsumer = responseConsumer;
+      this.context = context;
+    }
+
+    @Override public void responseReceived(HttpResponse response)
+        throws IOException, HttpException {
+      responseConsumer.responseReceived(response);
+    }
+
+    @Override public void consumeContent(ContentDecoder decoder, IOControl ioctrl)
+        throws IOException {
+      responseConsumer.consumeContent(decoder, ioctrl);
+    }
+
+    @Override public void responseCompleted(HttpContext context) {
+      responseConsumer.responseCompleted(context);
+    }
+
+    @Override public void failed(Exception ex) {
+      Span currentSpan = (Span) context.getAttribute(Span.class.getName());
+      if (currentSpan != null) {
+        handler.handleError(ex, currentSpan);
+        context.removeAttribute(Span.class.getName());
+      }
+      responseConsumer.failed(ex);
+    }
+
+    @Override public Exception getException() {
+      return responseConsumer.getException();
+    }
+
+    @Override public T getResult() {
+      return responseConsumer.getResult();
+    }
+
+    @Override public boolean isDone() {
+      return responseConsumer.isDone();
+    }
+
+    @Override public void close() throws IOException {
+      responseConsumer.close();
+    }
+
+    @Override public boolean cancel() {
+      return responseConsumer.cancel();
+    }
+  }
+}

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -1,0 +1,65 @@
+package brave.httpasyncclient;
+
+import brave.http.ITHttpClient;
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.nio.entity.NStringEntity;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingHttpAsyncClientBuilder extends ITHttpClient<CloseableHttpAsyncClient> {
+
+  @Override protected CloseableHttpAsyncClient newClient(int port) {
+    CloseableHttpAsyncClient result = TracingHttpAsyncClientBuilder.create(httpTracing).build();
+    result.start();
+    return result;
+  }
+
+  @Override protected void closeClient(CloseableHttpAsyncClient client) throws IOException {
+    client.close();
+  }
+
+  @Override protected void get(CloseableHttpAsyncClient client, String pathIncludingQuery)
+      throws Exception {
+    HttpGet get = new HttpGet(URI.create(url(pathIncludingQuery)));
+    EntityUtils.consume(client.execute(get, null).get().getEntity());
+  }
+
+  @Override
+  protected void post(CloseableHttpAsyncClient client, String pathIncludingQuery, String body)
+      throws Exception {
+    HttpPost post = new HttpPost(URI.create(url(pathIncludingQuery)));
+    post.setEntity(new NStringEntity(body));
+    EntityUtils.consume(client.execute(post, null).get().getEntity());
+  }
+
+  @Override protected void getAsync(CloseableHttpAsyncClient client, String pathIncludingQuery) {
+    client.execute(new HttpGet(URI.create(url(pathIncludingQuery))), null);
+  }
+
+  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+    server.enqueue(new MockResponse());
+
+    try (CloseableHttpAsyncClient client = TracingHttpAsyncClientBuilder.create(httpTracing)
+        .addInterceptorLast((HttpRequestInterceptor) (request, context) -> {
+          request.addHeader("my-id", currentTraceContext.get().traceIdString());
+        })
+        .build()) {
+      client.start();
+
+      get(client, "/foo");
+    }
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+}

--- a/instrumentation/httpasyncclient/src/test/resources/log4j2.properties
+++ b/instrumentation/httpasyncclient/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/httpclient/README.md
+++ b/instrumentation/httpclient/README.md
@@ -1,0 +1,11 @@
+# brave-instrumentation-httpclient
+This module contains a tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+.
+`TracingHttpClientBuilder` adds trace headers to outgoing requests. It
+then reports to Zipkin how long each request takes, along with relevant
+tags like the http url.
+
+To enable tracing, create your client using `TracingHttpClientBuilder`.
+
+```java
+httpclient = TracingHttpClientBuilder.create(tracing).build();
+```

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-httpclient</artifactId>
+  <name>Brave Instrumentation: Apache HttpClient v4.3+</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingHttpClientBuilder.java
@@ -1,0 +1,130 @@
+package brave.httpclient;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpMessage;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpRequestWrapper;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.execchain.ClientExecChain;
+import zipkin.Endpoint;
+
+public final class TracingHttpClientBuilder extends HttpClientBuilder {
+
+  public static HttpClientBuilder create(Tracing tracing) {
+    return new TracingHttpClientBuilder(HttpTracing.create(tracing));
+  }
+
+  public static HttpClientBuilder create(HttpTracing httpTracing) {
+    return new TracingHttpClientBuilder(httpTracing);
+  }
+
+  final Tracer tracer;
+  final TraceContext.Injector<HttpMessage> injector;
+  final HttpClientHandler<HttpRequestWrapper, HttpResponse> handler;
+  final String remoteServiceName;
+
+  TracingHttpClientBuilder(HttpTracing httpTracing) { // intentionally hidden
+    if (httpTracing == null) throw new NullPointerException("HttpTracing == null");
+    this.tracer = httpTracing.tracing().tracer();
+    this.remoteServiceName = httpTracing.serverName();
+    this.handler = new HttpClientHandler<>(new HttpAdapter(), httpTracing.clientParser());
+    this.injector = httpTracing.tracing().propagation().injector(HttpMessage::setHeader);
+  }
+
+  /**
+   * protocol exec is the second in the execution chain, so is invoked before a request is
+   * provisioned. We provision and scope a span here, so that application interceptors can see
+   * it via {@link Tracer#currentSpan()}.
+   */
+  @Override protected ClientExecChain decorateProtocolExec(ClientExecChain exec) {
+    return (route, request, context, execAware) -> {
+      Span next = tracer.nextSpan();
+      context.setAttribute(SpanInScope.class.getName(), tracer.withSpanInScope(next));
+      try {
+        return exec.execute(route, request, context, execAware);
+      } catch (IOException | HttpException | RuntimeException e) {
+        context.getAttribute(SpanInScope.class.getName(), SpanInScope.class).close();
+        throw e;
+      }
+    };
+  }
+
+  /**
+   * main exec is the first in the execution chain, so last to execute. This creates a concrete http
+   * request, so this is where the timing in the span occurs.
+   *
+   * <p>This ends the span (and scoping of it) created by {@link #decorateMainExec(ClientExecChain)}.
+   */
+  @Override protected ClientExecChain decorateMainExec(ClientExecChain exec) {
+    return (route, request, context, execAware) -> {
+      Span span = tracer.currentSpan();
+      try {
+        HttpHost host = HttpClientContext.adapt(context).getTargetHost();
+        if (!span.isNoop() && host != null) {
+          parseServerAddress(host, span);
+          handler.handleSend(HttpRequestWrapper.wrap(request, host), span);
+        } else {
+          handler.handleSend(request, span);
+        }
+
+        injector.inject(span.context(), request);
+
+        CloseableHttpResponse response = exec.execute(route, request, context, execAware);
+
+        handler.handleReceive(response, span);
+        return response;
+      } catch (IOException | HttpException | RuntimeException e) {
+        handler.handleError(e, span);
+        throw e;
+      } finally {
+        context.getAttribute(SpanInScope.class.getName(), SpanInScope.class).close();
+      }
+    };
+  }
+
+  void parseServerAddress(HttpHost host, Span span) {
+    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
+    if (!builder.parseIp(host.getAddress())) builder.parseIp(host.getHostName());
+    builder.port(host.getPort());
+    span.remoteEndpoint(builder.build());
+  }
+
+  static final class HttpAdapter extends brave.http.HttpAdapter<HttpRequestWrapper, HttpResponse> {
+    @Override public String method(HttpRequestWrapper request) {
+      return request.getRequestLine().getMethod();
+    }
+
+    @Override public String path(HttpRequestWrapper request) {
+      String result = request.getRequestLine().getUri();
+      int queryIndex = result.indexOf('?');
+      return queryIndex == -1 ? result : result.substring(0, queryIndex);
+    }
+
+    @Override public String url(HttpRequestWrapper request) {
+      HttpHost target = request.getTarget();
+      if (target != null) return target.toURI() + request.getURI();
+      return request.getRequestLine().getUri();
+    }
+
+    @Override public String requestHeader(HttpRequestWrapper request, String name) {
+      Header result = request.getFirstHeader(name);
+      return result != null ? result.getValue() : null;
+    }
+
+    @Override public Integer statusCode(HttpResponse response) {
+      return response.getStatusLine().getStatusCode();
+    }
+  }
+}

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -1,0 +1,63 @@
+package brave.httpclient;
+
+import brave.http.ITHttpClient;
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient> {
+
+  @Override protected CloseableHttpClient newClient(int port) {
+    return TracingHttpClientBuilder.create(httpTracing).disableAutomaticRetries().build();
+  }
+
+  @Override protected void closeClient(CloseableHttpClient client) throws IOException {
+    client.close();
+  }
+
+  @Override protected void get(CloseableHttpClient client, String pathIncludingQuery)
+      throws IOException {
+    client.execute(new HttpGet(URI.create(url(pathIncludingQuery)))).close();
+  }
+
+  @Override protected void post(CloseableHttpClient client, String pathIncludingQuery, String body)
+      throws Exception {
+    HttpPost post = new HttpPost(URI.create(url(pathIncludingQuery)));
+    post.setEntity(new StringEntity(body));
+    client.execute(post).close();
+  }
+
+  @Override protected void getAsync(CloseableHttpClient client, String pathIncludingQuery) {
+    throw new AssumptionViolatedException("This is not an async library");
+  }
+
+  @Test
+  public void currentSpanVisibleToUserInterceptors() throws Exception {
+    server.enqueue(new MockResponse());
+
+    try (CloseableHttpClient client = TracingHttpClientBuilder.create(httpTracing)
+        .disableAutomaticRetries()
+        .addInterceptorFirst((HttpRequestInterceptor) (request, context) -> {
+          request.addHeader("my-id",
+              currentTraceContext.get().traceIdString());
+        })
+        .build()) {
+
+      get(client, "/foo");
+    }
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+}

--- a/instrumentation/httpclient/src/test/resources/log4j2.properties
+++ b/instrumentation/httpclient/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/jaxrs2/README.md
+++ b/instrumentation/jaxrs2/README.md
@@ -1,0 +1,108 @@
+# brave-instrumentation-jaxrs2
+This module contains JAX-RS 2.x compatible tracing filters and a feature
+to automatically configure them.
+
+The `TracingClientFilter` adds trace headers to outgoing requests.
+`TracingContainerFilter` extracts trace state from incoming requests.
+Both report to Zipkin how long each request takes, along with relevant
+tags like the http url.
+
+## Configuration
+
+### Dependency Injection
+Tracing always needs an instance of type `brave.http.HttpTracing`
+configured. Make sure this is in place before proceeding.
+
+Then, configure `TracingFeature`, which sets up filters automatically.
+
+For example, this is how configuration looks with Jersey 2.x:
+
+
+In your web.xml:
+
+```xml
+<init-param>
+    <param-name>jersey.config.server.provider.packages</param-name>
+    <param-value>my.existing.packages,brave.jaxrs2</param-value>
+</init-param>
+```
+
+### Manual
+
+For server side setup, an Application class could look like this:
+
+```java
+public class MyApplication extends Application {
+
+  public Set<Object> getSingletons() {
+    Tracing tracing = Tracing.newBuilder().build();
+    TracingFeature tracingFeature = TracingFeature.create(tracing);
+    return new LinkedHashSet<>(Arrays.asList(tracingFeature));
+  }
+
+}
+```
+
+For client side setup, you just have to register the BraveTracingFeature
+with your `WebTarget` before you make your request:
+
+```java
+WebTarget target = target("/mytarget");
+target.register(TracingFeature.create(tracing));
+```
+
+## Exception handling
+`ContainerResponseFilter` has no means to handle uncaught exceptions.
+Unless you provide a catch-all exception mapper, requests that result in
+unhandled exceptions will leak until they are eventually flushed.
+
+Besides using framework-specific code, the only approach is to make a
+custom `ExceptionMapper`, similar to below, which ensures a request is
+sent back even when something unexpected happens.
+
+```java
+@Provider
+public static class CatchAllExceptions implements ExceptionMapper<Exception> {
+
+  @Override public Response toResponse(Exception e) {
+    if (e instanceof WebApplicationException) {
+      return ((WebApplicationException) e).getResponse();
+    }
+
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity("Internal error")
+        .type("text/plain")
+        .build();
+  }
+}
+```
+
+### Async Tasks
+
+Different frameworks require different means to control the thread pool
+asynchronous tasks operate on. Here's an example of how to configure
+Jersey 2+ to ensure traces propagate even when requests are completed
+asynchronously.
+
+```java
+
+@ClientAsyncExecutor
+class TracingExecutorServiceProvider implements ExecutorServiceProvider {
+
+  final ExecutorService service;
+
+  TracingExecutorServiceProvider(Tracing tracing, ExecutorService toWrap) {
+    this.service = tracing.currentTraceContext().executorService(toWrap);
+  }
+
+  @Override public ExecutorService getExecutorService() {
+    return service;
+  }
+  --snip--
+}
+
+// when you setup your client, register this provider when registering tracing
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.register(TracingFeature.create(httpTracing));
+clientConfig.register(new TracingExecutorServiceProvider(httpTracing.tracing(), executorService));
+```

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-jaxrs2</artifactId>
+  <name>Brave Instrumentation: JAX-RS v2</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <!-- indirectly depends on servlet 3.0.1 -->
+    <jersey.version>2.25.1</jersey.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- For Priority -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- For Inject -->
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- to test the inject annotations -->
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -1,0 +1,96 @@
+package brave.jaxrs2;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.net.URI;
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+import zipkin.Endpoint;
+
+import static javax.ws.rs.RuntimeType.CLIENT;
+
+/**
+ * This filter is set at highest priority which means it executes before other filters. The impact
+ * is that other filters can see the span created here via {@link Tracer#currentSpan()}. Another
+ * impact is that the span will not see modifications to the request made by downstream filters.
+ */
+// If tags for the request are added on response, they might include changes made by other filters..
+// However, the response callback isn't invoked on error, so this choice could be worse.
+@Provider
+@ConstrainedTo(CLIENT)
+@Priority(0) // to make the span in scope visible to other filters
+final class TracingClientFilter implements ClientRequestFilter, ClientResponseFilter {
+
+  final Tracer tracer;
+  final String remoteServiceName;
+  final HttpClientHandler<ClientRequestContext, ClientResponseContext> handler;
+  final TraceContext.Injector<MultivaluedMap> injector;
+
+  @Inject TracingClientFilter(HttpTracing httpTracing) {
+    if (httpTracing == null) throw new NullPointerException("HttpTracing == null");
+    tracer = httpTracing.tracing().tracer();
+    remoteServiceName = httpTracing.serverName();
+    handler = new HttpClientHandler<>(new HttpAdapter(), httpTracing.clientParser());
+    injector = httpTracing.tracing().propagation().injector(MultivaluedMap::putSingle);
+  }
+
+  @Override
+  public void filter(ClientRequestContext request) {
+    Span span = tracer.nextSpan();
+    parseServerAddress(request, span);
+    handler.handleSend(request, span);
+    injector.inject(span.context(), request.getHeaders());
+    request.setProperty(SpanInScope.class.getName(), tracer.withSpanInScope(span));
+  }
+
+  void parseServerAddress(ClientRequestContext request, Span span) {
+    if (span.isNoop()) return;
+    URI uri = request.getUri();
+    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
+    builder.parseIp(uri.getHost());
+    builder.port(uri.getPort());
+    span.remoteEndpoint(builder.build());
+  }
+
+  @Override
+  public void filter(ClientRequestContext request, ClientResponseContext response) {
+    SpanInScope spanInScope = (SpanInScope) request.getProperty(SpanInScope.class.getName());
+    if (spanInScope == null) return;
+    handler.handleReceive(response, tracer.currentSpan());
+    spanInScope.close();
+  }
+
+  static final class HttpAdapter
+      extends brave.http.HttpAdapter<ClientRequestContext, ClientResponseContext> {
+    @Override public String method(ClientRequestContext request) {
+      return request.getMethod();
+    }
+
+    @Override public String path(ClientRequestContext request) {
+      return request.getUri().getPath();
+    }
+
+    @Override public String url(ClientRequestContext request) {
+      return request.getUri().toString();
+    }
+
+    @Override public String requestHeader(ClientRequestContext request, String name) {
+      return request.getHeaderString(name);
+    }
+
+    @Override public Integer statusCode(ClientResponseContext response) {
+      return response.getStatus();
+    }
+  }
+}

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingContainerFilter.java
@@ -1,0 +1,135 @@
+package brave.jaxrs2;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.http.HttpServerHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.lang.annotation.Annotation;
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import zipkin.Constants;
+import zipkin.Endpoint;
+
+import static javax.ws.rs.RuntimeType.SERVER;
+
+// Currently not using PreMatching because we are attempting to detect if the method is async or not
+@Provider
+@Priority(0) // to make the span in scope visible to other filters
+@ConstrainedTo(SERVER) final class TracingContainerFilter
+    implements ContainerRequestFilter, ContainerResponseFilter {
+
+  final Tracer tracer;
+  final HttpServerHandler<ContainerRequestContext, ContainerResponseContext> handler;
+  final TraceContext.Extractor<ContainerRequestContext> extractor;
+
+  @Inject TracingContainerFilter(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    handler = new HttpServerHandler<>(new HttpAdapter(), httpTracing.serverParser());
+    extractor = httpTracing.tracing().propagation()
+        .extractor(ContainerRequestContext::getHeaderString);
+  }
+
+  /**
+   * This implementation peeks to see if the request is async or not, which means {@link
+   * PreMatching} cannot be used: pre-matching doesn't inject the resource info!
+   */
+  @Context ResourceInfo resourceInfo;
+
+  @Override public void filter(ContainerRequestContext context) {
+    Span span = startSpan(context);
+    if (shouldPutSpanInScope(resourceInfo)) {
+      context.setProperty(SpanInScope.class.getName(), tracer.withSpanInScope(span));
+    } else {
+      context.setProperty(Span.class.getName(), span);
+    }
+  }
+
+  private Span startSpan(ContainerRequestContext context) {
+    Span span = tracer.nextSpan(extractor, context);
+    parseClientAddress(context, span);
+    handler.handleReceive(context, span);
+    return span;
+  }
+
+  void parseClientAddress(ContainerRequestContext context, Span span) {
+    if (span.isNoop()) return;
+    Endpoint.Builder builder = Endpoint.builder().serviceName("");
+    if (builder.parseIp(context.getHeaderString("X-Forwarded-For"))) {
+      span.remoteEndpoint(builder.build());
+    }
+  }
+
+  @Override
+  public void filter(ContainerRequestContext request, ContainerResponseContext response) {
+    Span span = (Span) request.getProperty(Span.class.getName());
+    SpanInScope spanInScope = (SpanInScope) request.getProperty(SpanInScope.class.getName());
+    if (span != null) { // asynchronous response or we couldn't figure it out
+    } else if (spanInScope != null) { // synchronous response
+      span = tracer.currentSpan();
+      spanInScope.close();
+    } else if (response.getStatus() == 404) {
+      span = startSpan(request);
+    } else {
+      return; // unknown state
+    }
+
+    Response.StatusType statusInfo = response.getStatusInfo();
+    if (statusInfo.getFamily() == Response.Status.Family.SERVER_ERROR) {
+      span.tag(Constants.ERROR, statusInfo.getReasonPhrase());
+    }
+    handler.handleSend(response, span);
+  }
+
+  /**
+   * We shouldn't put a span in scope unless we know for sure the request is not async. That's
+   * because we cannot detach if from the calling thread when async is used.
+   */
+  // TODO: add benchmark and cache if slow
+  static boolean shouldPutSpanInScope(ResourceInfo resourceInfo) {
+    if (resourceInfo == null) return false;
+    for (Annotation[] annotations : resourceInfo.getResourceMethod().getParameterAnnotations()) {
+      for (Annotation annotation : annotations) {
+        if (annotation.annotationType().equals(Suspended.class)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  static final class HttpAdapter
+      extends brave.http.HttpAdapter<ContainerRequestContext, ContainerResponseContext> {
+    @Override public String method(ContainerRequestContext request) {
+      return request.getMethod();
+    }
+
+    @Override public String path(ContainerRequestContext request) {
+      return request.getUriInfo().getRequestUri().getPath();
+    }
+
+    @Override public String url(ContainerRequestContext request) {
+      return request.getUriInfo().getRequestUri().toString();
+    }
+
+    @Override public String requestHeader(ContainerRequestContext request, String name) {
+      return request.getHeaderString(name);
+    }
+
+    @Override public Integer statusCode(ContainerResponseContext response) {
+      return response.getStatus();
+    }
+  }
+}

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingFeature.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingFeature.java
@@ -1,0 +1,32 @@
+package brave.jaxrs2;
+
+import brave.Tracing;
+import brave.http.HttpTracing;
+import javax.inject.Inject;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public final class TracingFeature implements Feature {
+  public static Feature create(Tracing tracing) {
+    return new TracingFeature(HttpTracing.create(tracing));
+  }
+
+  public static Feature create(HttpTracing httpTracing) {
+    return new TracingFeature(httpTracing);
+  }
+
+  final HttpTracing httpTracing;
+
+  @Inject TracingFeature(HttpTracing httpTracing) { // intentionally hidden
+    this.httpTracing = httpTracing;
+  }
+
+  // TODO: figure out how to deal with when the client or server impl is also traced
+  @Override public boolean configure(FeatureContext context) {
+    context.register(new TracingClientFilter(httpTracing));
+    context.register(new TracingContainerFilter(httpTracing));
+    return true;
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
@@ -1,0 +1,83 @@
+package brave.jaxrs2;
+
+import brave.http.ITHttpClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.Entity;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingFeature_Client extends ITHttpClient<Client> {
+
+  ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @Override protected Client newClient(int port) {
+    return new ResteasyClientBuilder()
+        .asyncExecutor(httpTracing.tracing().currentTraceContext().executorService(executor))
+        .socketTimeout(1, TimeUnit.SECONDS)
+        .register(TracingFeature.create(httpTracing))
+        .build();
+  }
+
+  @Override protected void closeClient(Client client) throws IOException {
+    client.close();
+    executor.shutdown();
+  }
+
+  @Override protected void get(Client client, String pathIncludingQuery) throws IOException {
+    client.target(url(pathIncludingQuery)).request().buildGet().invoke().close();
+  }
+
+  @Override protected void post(Client client, String pathIncludingQuery, String body)
+      throws Exception {
+    client.target(url(pathIncludingQuery)).request()
+        .buildPost(Entity.text(body))
+        .invoke().close();
+  }
+
+  @Override protected void getAsync(Client client, String pathIncludingQuery) throws Exception {
+    client.target(url(pathIncludingQuery)).request().async().get();
+  }
+
+  @Test public void currentSpanVisibleToUserFilters() throws Exception {
+    server.enqueue(new MockResponse());
+    closeClient(client);
+
+    client = new ResteasyClientBuilder()
+        .asyncExecutor(httpTracing.tracing().currentTraceContext().executorService(executor))
+        .register(TracingFeature.create(httpTracing))
+        .register((ClientRequestFilter) requestContext ->
+            requestContext.getHeaders()
+                .putSingle("my-id", currentTraceContext.get().traceIdString())
+        ).build();
+
+    get(client, "/foo");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+
+  @Override @Test(expected = AssertionError.class)
+  public void redirect() throws Exception { // blind to the implementation of redirects
+    super.redirect();
+  }
+
+  @Override @Test(expected = AssertionError.class) // doesn't yet close a span on exception
+  public void reportsSpanOnTransportException() throws Exception {
+    super.reportsSpanOnTransportException();
+  }
+
+  @Override @Test(expected = AssertionError.class) // doesn't yet close a span on exception
+  public void addsErrorTagOnTransportException() throws Exception {
+    super.addsErrorTagOnTransportException();
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
@@ -1,0 +1,127 @@
+package brave.jaxrs2;
+
+import brave.Tracer;
+import brave.http.HttpTracing;
+import brave.http.ITServletContainer;
+import java.io.IOException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
+import org.jboss.resteasy.plugins.spring.SpringContextLoaderListener;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+public class ITTracingFeature_Container extends ITServletContainer {
+
+  @Override @Test public void reportsClientAddress() {
+    throw new AssumptionViolatedException("ContainerRequestContext doesn't include remote address");
+  }
+
+  @Path("")
+  public static class TestResource { // public for resteasy to inject
+    final Tracer tracer;
+
+    TestResource(HttpTracing httpTracing) {
+      this.tracer = httpTracing.tracing().tracer();
+    }
+
+    @GET
+    @Path("foo")
+    public Response get() {
+      return Response.status(200).build();
+    }
+
+    @GET
+    @Path("badrequest")
+    public Response badrequest() {
+      return Response.status(400).build();
+    }
+
+    @GET
+    @Path("child")
+    public Response child() {
+      tracer.nextSpan().name("child").start().finish();
+      return Response.status(200).build();
+    }
+
+    @GET
+    @Path("async")
+    public void async(@Suspended AsyncResponse response) throws IOException {
+      new Thread(() -> response.resume("ok")).start();
+    }
+
+    @GET
+    @Path("exception")
+    public Response disconnect() throws IOException {
+      throw new IOException();
+    }
+
+    @GET
+    @Path("exceptionAsync")
+    public void disconnectAsync(@Suspended AsyncResponse response) throws IOException {
+      new Thread(() -> response.resume(new IOException())).start();
+    }
+  }
+
+  /**
+   * {@link ContainerResponseFilter} has no means to handle uncaught exceptions. Unless you provide
+   * a catch-all exception mapper, requests that result in unhandled exceptions will leak until they
+   * are eventually flushed.
+   */
+  @Provider
+  public static class CatchAllExceptions implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception e) {
+      if (e instanceof WebApplicationException) {
+        return ((WebApplicationException) e).getResponse();
+      }
+
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("Internal error")
+          .type("text/plain")
+          .build();
+    }
+  }
+
+  /** Imports jaxrs2 filters used in resteasy3. */
+  @Configuration
+  @Import(TracingFeature.class)
+  public static class TracingFeatureConfiguration {
+  }
+
+  @Override public void init(ServletContextHandler handler) {
+    AnnotationConfigWebApplicationContext appContext =
+        new AnnotationConfigWebApplicationContext() {
+          // overriding this allows us to register dependencies of TracingFeature
+          // without passing static state to a configuration class.
+          @Override protected void loadBeanDefinitions(DefaultListableBeanFactory beanFactory) {
+            beanFactory.registerSingleton("httpTracing", httpTracing);
+            super.loadBeanDefinitions(beanFactory);
+          }
+        };
+
+    appContext.register(TestResource.class); // the test resource
+    appContext.register(CatchAllExceptions.class);
+    appContext.register(TracingFeatureConfiguration.class); // generic tracing setup
+
+    // resteasy + spring configuration, programmatically as opposed to using web.xml
+    handler.addServlet(new ServletHolder(new HttpServletDispatcher()), "/*");
+    handler.addEventListener(new ResteasyBootstrap());
+    handler.addEventListener(new SpringContextLoaderListener(appContext));
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
@@ -1,0 +1,35 @@
+package brave.jaxrs2;
+
+import brave.Tracing;
+import brave.http.HttpTracing;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** This ensures all filters can be injected, supplied with only {@linkplain HttpTracing}. */
+public class InjectionTest {
+
+  Injector injector = Guice.createInjector(new AbstractModule() {
+    @Override protected void configure() {
+      bind(HttpTracing.class).toInstance(HttpTracing.create(Tracing.newBuilder().build()));
+    }
+  });
+
+  @Test public void tracingClientFilter() throws Exception {
+    assertThat(injector.getInstance(TracingClientFilter.class))
+        .isNotNull();
+  }
+
+  @Test public void tracingContainerFilter() throws Exception {
+    assertThat(injector.getInstance(TracingContainerFilter.class))
+        .isNotNull();
+  }
+
+  @Test public void tracingFeature() throws Exception {
+    assertThat(injector.getInstance(TracingFeature.class))
+        .isNotNull();
+  }
+}

--- a/instrumentation/jaxrs2/src/test/resources/log4j2.properties
+++ b/instrumentation/jaxrs2/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/mysql/README.md
+++ b/instrumentation/mysql/README.md
@@ -1,0 +1,15 @@
+# brave-instrumentation-mysql
+
+This includes a MySQL statement interceptor that will report to Zipkin
+how long each statement takes, along with relevant tags like the query.
+
+To use it, append `?statementInterceptors=brave.mysql.TracingStatementInterceptor`
+to the end of the connection url.
+
+By default the service name corresponding to your database uses the format
+`mysql-${database}`, but you can append another property `zipkinServiceName` to customise it.
+
+`?statementInterceptors=brave.mysql.TracingStatementInterceptor&zipkinServiceName=myDatabaseService`
+
+The current tracing component is used at runtime. Until you have
+instantiated `brave.Tracing`, no traces will appear.

--- a/instrumentation/mysql/pom.xml
+++ b/instrumentation/mysql/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-mysql</artifactId>
+  <name>Brave Instrumentation: MySQL</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.41</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
@@ -1,0 +1,116 @@
+package brave.mysql;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import com.mysql.jdbc.Connection;
+import com.mysql.jdbc.PreparedStatement;
+import com.mysql.jdbc.ResultSetInternalMethods;
+import com.mysql.jdbc.Statement;
+import com.mysql.jdbc.StatementInterceptorV2;
+import java.net.InetAddress;
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.Properties;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.TraceKeys;
+
+/**
+ * A MySQL statement interceptor that will report to Zipkin how long each statement takes.
+ *
+ * <p>To use it, append <code>?statementInterceptors=brave.mysql.TracingStatementInterceptor</code>
+ * to the end of the connection url.
+ */
+public class TracingStatementInterceptor implements StatementInterceptorV2 {
+
+  @Override
+  public ResultSetInternalMethods preProcess(String sql, Statement interceptedStatement,
+      Connection connection) throws SQLException {
+    Tracer tracer = Tracing.currentTracer();
+    if (tracer == null) return null;
+
+    Span span = tracer.nextSpan();
+    // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
+    if (!span.isNoop()) {
+      // When running a prepared statement, sql will be null and we must fetch the sql from the statement itself
+      if (interceptedStatement instanceof PreparedStatement) {
+        sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
+      }
+      span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
+      span.tag(TraceKeys.SQL_QUERY, sql);
+      remoteEndpoint(connection, span);
+      span.start();
+    }
+
+    currentSpanInScope.set(tracer.withSpanInScope(span));
+
+    return null;
+  }
+
+  /**
+   * There's no attribute namespace shared across request and response. Hence, we need to save off
+   * a reference to the span in scope, so that we can close it in the response.
+   */
+  final ThreadLocal<Tracer.SpanInScope> currentSpanInScope = new ThreadLocal<>();
+
+  @Override
+  public ResultSetInternalMethods postProcess(String sql, Statement interceptedStatement,
+      ResultSetInternalMethods originalResultSet, Connection connection, int warningCount,
+      boolean noIndexUsed, boolean noGoodIndexUsed, SQLException statementException)
+      throws SQLException {
+    Tracer tracer = Tracing.currentTracer();
+    if (tracer == null) return null;
+
+    Tracer.SpanInScope spanInScope = currentSpanInScope.get();
+    if (spanInScope == null) return null;
+    Span span = tracer.currentSpan();
+    spanInScope.close();
+
+    if (statementException != null) {
+      span.tag(Constants.ERROR, Integer.toString(statementException.getErrorCode()));
+    }
+    span.finish();
+
+    return null;
+  }
+
+  /**
+   * MySQL exposes the host connecting to, but not the port. This attempts to get the port from the
+   * JDBC URL. Ex. 5555 from {@code jdbc:mysql://localhost:5555/isSampled}, or 3306 if absent.
+   */
+  static void remoteEndpoint(Connection connection, Span span) {
+    try {
+      URI url = URI.create(connection.getMetaData().getURL().substring(5)); // strip "jdbc:"
+      int port = url.getPort() == -1 ? 3306 : url.getPort();
+      String remoteServiceName = connection.getProperties().getProperty("zipkinServiceName");
+      if (remoteServiceName == null || "".equals(remoteServiceName)) {
+        String databaseName = connection.getCatalog();
+        if (databaseName != null && !databaseName.isEmpty()) {
+          remoteServiceName = "mysql-" + databaseName;
+        } else {
+          remoteServiceName = "mysql";
+        }
+      }
+      Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName).port(port);
+      if (!builder.parseIp(connection.getHost())) { // try for IP address
+        builder.parseIp(InetAddress.getByName(connection.getHost())); // nslookup
+      }
+      span.remoteEndpoint(builder.build());
+    } catch (Exception e) {
+      // remote address is optional
+    }
+  }
+
+  @Override public boolean executeTopLevelOnly() {
+    return true; // True means that we don't get notified about queries that other interceptors issue
+  }
+
+  @Override public void init(Connection conn, Properties props) throws SQLException {
+    // Don't care
+  }
+
+  @Override public void destroy() {
+    // Don't care
+  }
+}

--- a/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
@@ -1,0 +1,139 @@
+package brave.mysql;
+
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.internal.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.TraceKeys;
+import zipkin.internal.Util;
+import zipkin.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.Assume.assumeTrue;
+import static zipkin.internal.Util.envOr;
+
+public class ITTracingStatementInterceptor {
+  static final String QUERY = "select 'hello world'";
+
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+  Connection connection;
+
+  @Before public void init() throws SQLException {
+    StringBuilder url = new StringBuilder("jdbc:mysql://");
+    url.append(envOr("MYSQL_HOST", "127.0.0.1"));
+    url.append(":").append(envOr("MYSQL_TCP_PORT", 3306));
+    String db = envOr("MYSQL_DB", null);
+    if (db != null) url.append("/").append(db);
+    url.append("?statementInterceptors=").append(TracingStatementInterceptor.class.getName());
+    url.append("&zipkinServiceName=").append("myservice");
+
+    MysqlDataSource dataSource = new MysqlDataSource();
+    dataSource.setUrl(url.toString());
+
+    dataSource.setUser(System.getenv("MYSQL_USER"));
+    assumeTrue("Minimally, the environment variable MYSQL_USER must be set",
+        dataSource.getUser() != null);
+    dataSource.setPassword(envOr("MYSQL_PASS", ""));
+    connection = dataSource.getConnection();
+    storage.clear(); // clear any spans for test statements
+  }
+
+  @After public void close() throws SQLException {
+    Tracing.current().close();
+    if (connection != null) connection.close();
+  }
+
+  @Test
+  public void makesChildOfCurrentSpan() throws Exception {
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      prepareExecuteSelect(QUERY);
+    } finally {
+      parent.finish();
+    }
+
+    assertThat(collectedSpans())
+        .hasSize(2);
+  }
+
+  @Test
+  public void reportsClientAnnotationsToZipkin() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test
+  public void defaultSpanNameIsOperationName() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("select");
+  }
+
+  @Test
+  public void addsQueryTag() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(a -> a.key.equals(TraceKeys.SQL_QUERY))
+        .extracting(a -> new String(a.value, Util.UTF_8))
+        .containsExactly(QUERY);
+  }
+
+  @Test
+  public void reportsServerAddress() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key, b -> b.endpoint.serviceName)
+        .contains(tuple(Constants.SERVER_ADDR, "myservice"));
+  }
+
+  void prepareExecuteSelect(String query) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(query)) {
+      try (ResultSet resultSet = ps.executeQuery()) {
+        while (resultSet.next()) {
+          resultSet.getString(1);
+        }
+      }
+    }
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .localEndpoint(local)
+        .sampler(sampler);
+  }
+
+  List<Span> collectedSpans() {
+    List<List<Span>> result = storage.spanStore().getRawTraces();
+    assertThat(result).hasSize(1);
+    return result.get(0);
+  }
+}

--- a/instrumentation/mysql/src/test/resources/log4j2.properties
+++ b/instrumentation/mysql/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -1,0 +1,11 @@
+# brave-instrumentation-okhttp3
+This module contains a tracing decorator for [OkHttp](https://github.com/square/okhttp) 3.x.
+`TracingCallFactory` adds trace headers to outgoing requests. It
+then reports to Zipkin how long each request takes, along with relevant
+tags like the http url.
+
+To enable tracing, wrap your client using `TracingCallFactory`.
+
+```java
+callFactory = TracingCallFactory.create(tracing, okhttp);
+```

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-okhttp3</artifactId>
+  <name>Brave Instrumentation: OkHttp v3.x</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -1,0 +1,120 @@
+package brave.okhttp3;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import zipkin.Endpoint;
+
+/**
+ * This internally adds an interceptor which ensures whatever current span exists is available via
+ * {@link Tracer#currentSpan()}
+ */
+// NOTE: this is not an interceptor because the current span can get lost when there's a backlog.
+public final class TracingCallFactory implements Call.Factory {
+
+  public static Call.Factory create(Tracing tracing, OkHttpClient ok) {
+    return create(HttpTracing.create(tracing), ok);
+  }
+
+  public static Call.Factory create(HttpTracing httpTracing, OkHttpClient ok) {
+    return new TracingCallFactory(httpTracing, ok);
+  }
+
+  final Tracer tracer;
+  final String remoteServiceName;
+  final HttpClientHandler<Request, Response> handler;
+  final TraceContext.Injector<Request.Builder> injector;
+  final OkHttpClient ok;
+
+  TracingCallFactory(HttpTracing httpTracing, OkHttpClient ok) {
+    if (httpTracing == null) throw new NullPointerException("HttpTracing == null");
+    if (ok == null) throw new NullPointerException("OkHttpClient == null");
+    tracer = httpTracing.tracing().tracer();
+    remoteServiceName = httpTracing.serverName();
+    handler = new HttpClientHandler<>(new HttpAdapter(), httpTracing.clientParser());
+    injector = httpTracing.tracing().propagation().injector(Request.Builder::addHeader);
+    this.ok = ok;
+  }
+
+  @Override public Call newCall(Request request) {
+    Span currentSpan = tracer.currentSpan();
+    OkHttpClient.Builder b = ok.newBuilder();
+    if (currentSpan != null) b.interceptors().add(0, new SetParentSpanInScope(currentSpan));
+    b.networkInterceptors().add(0, new TracingNetworkInterceptor());
+    return b.build().newCall(request);
+  }
+
+  static final class HttpAdapter extends brave.http.HttpAdapter<Request, Response> {
+    @Override public String method(Request request) {
+      return request.method();
+    }
+
+    @Override public String path(Request request) {
+      return request.url().encodedPath();
+    }
+
+    @Override public String url(Request request) {
+      return request.url().toString();
+    }
+
+    @Override public String requestHeader(Request request, String name) {
+      return request.header(name);
+    }
+
+    @Override public Integer statusCode(Response response) {
+      return response.code();
+    }
+  }
+
+  /** In case a request is deferred due to a backlog, we re-apply the span that was in scope */
+  class SetParentSpanInScope implements Interceptor {
+    final Span previous;
+
+    SetParentSpanInScope(Span previous) {
+      this.previous = previous;
+    }
+
+    @Override public Response intercept(Chain chain) throws IOException {
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(previous)) {
+        return chain.proceed(chain.request());
+      }
+    }
+  }
+
+  class TracingNetworkInterceptor implements Interceptor {
+    @Override public Response intercept(Chain chain) throws IOException {
+      Span span = tracer.nextSpan();
+      parseServerAddress(chain.connection(), span);
+      Request request = chain.request();
+      handler.handleSend(request, span);
+      Request.Builder requestBuilder = request.newBuilder();
+      injector.inject(span.context(), requestBuilder);
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+        return handler.handleReceive(chain.proceed(requestBuilder.build()), span);
+      } catch (IOException | RuntimeException e) {
+        handler.handleError(e, span);
+        throw e;
+      }
+    }
+  }
+
+  void parseServerAddress(Connection connection, Span span) {
+    if (span.isNoop()) return;
+    InetSocketAddress remoteAddress = connection.route().socketAddress();
+    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
+    builder.parseIp(remoteAddress.getAddress());
+    builder.port(remoteAddress.getPort());
+    span.remoteEndpoint(builder.build());
+  }
+}

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -1,0 +1,83 @@
+package brave.okhttp3;
+
+import brave.Tracer;
+import brave.http.ITHttpClient;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingCallFactory extends ITHttpClient<Call.Factory> {
+
+  @Override protected Call.Factory newClient(int port) {
+    return TracingCallFactory.create(httpTracing, new OkHttpClient.Builder()
+        .connectTimeout(1, TimeUnit.SECONDS)
+        .readTimeout(1, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(false)
+        .build()
+    );
+  }
+
+  @Override protected void closeClient(Call.Factory client) throws IOException {
+    ((TracingCallFactory) client).ok.dispatcher().executorService().shutdownNow();
+  }
+
+  @Override protected void get(Call.Factory client, String pathIncludingQuery)
+      throws IOException {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
+        .execute();
+  }
+
+  @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
+      throws Exception {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery))
+        .post(RequestBody.create(MediaType.parse("text/plain"), body)).build())
+        .execute();
+  }
+
+  @Override protected void getAsync(Call.Factory client, String pathIncludingQuery)
+      throws Exception {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
+        .enqueue(new Callback() {
+          @Override public void onFailure(Call call, IOException e) {
+            e.printStackTrace();
+          }
+
+          @Override public void onResponse(Call call, Response response) throws IOException {
+          }
+        });
+  }
+
+  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+    Tracer tracer = httpTracing.tracing().tracer();
+    server.enqueue(new MockResponse());
+    closeClient(client);
+
+    client = TracingCallFactory.create(httpTracing, new OkHttpClient.Builder()
+        .addInterceptor(chain -> chain.proceed(chain.request().newBuilder()
+            .addHeader("my-id", currentTraceContext.get().traceIdString())
+            .build()))
+        .build());
+
+    brave.Span parent = tracer.newTrace().name("test").start();
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(parent)) {
+      get(client, "/foo");
+    } finally {
+      parent.finish();
+    }
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+}

--- a/instrumentation/okhttp3/src/test/resources/log4j2.properties
+++ b/instrumentation/okhttp3/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -1,0 +1,20 @@
+# brave-instrumentation-p6spy
+This includes a tracing [p6spy](https://github.com/p6spy/p6spy) module
+which is a proxy for calls to your JDBC driver. It reports to Zipkin how
+long each statement takes, along with relevant tags like the query.
+
+P6Spy requires a `spy.properties` in your application classpath
+(ex `src/main/resources`). `brave.p6spy.TracingP6Factory` must be in the
+`modulelist` to enable tracing.
+
+```
+modulelist=brave.p6spy.TracingP6Factory
+url=jdbc:p6spy:derby:memory:p6spy;create=true
+```
+
+By default the service name corresponding to your database is the name
+of the database, but you can add another property to `spy.properties`
+named `zipkinServiceName` to customise it.
+
+The current tracing component is used at runtime. Until you have
+instantiated `brave.Tracing`, no traces will appear.

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-p6spy</artifactId>
+  <name>Brave Instrumentation: P6Spy (JDBC)</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <p6spy.version>3.0.0</p6spy.version>
+    <derby.version>10.13.1.1</derby.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>p6spy</groupId>
+      <artifactId>p6spy</artifactId>
+      <version>${p6spy.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>${derby.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbyclient</artifactId>
+      <version>${derby.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -1,0 +1,88 @@
+package brave.p6spy;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import com.p6spy.engine.common.StatementInformation;
+import com.p6spy.engine.event.SimpleJdbcEventListener;
+import java.net.InetAddress;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.SQLException;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.TraceKeys;
+
+final class TracingJdbcEventListener extends SimpleJdbcEventListener {
+
+  final String remoteServiceName;
+
+  TracingJdbcEventListener(String remoteServiceName) {
+    this.remoteServiceName = remoteServiceName;
+  }
+
+  @Override public void onBeforeAnyExecute(StatementInformation info) {
+    Tracer tracer = Tracing.currentTracer();
+    if (tracer == null) return;
+
+    Span span = tracer.nextSpan();
+    // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
+    if (!span.isNoop()) {
+      String sql = info.getSql();
+      span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
+      span.tag(TraceKeys.SQL_QUERY, sql);
+      remoteEndpoint(info.getConnectionInformation().getConnection(), span);
+      span.start();
+    }
+
+    currentSpanInScope.set(tracer.withSpanInScope(span));
+  }
+
+  /**
+   * There's no attribute namespace shared across request and response. Hence, we need to save off
+   * a reference to the span in scope, so that we can close it in the response.
+   */
+  final ThreadLocal<Tracer.SpanInScope> currentSpanInScope = new ThreadLocal<>();
+
+  @Override public void onAfterAnyExecute(StatementInformation info, long elapsed, SQLException e) {
+    Tracer tracer = Tracing.currentTracer();
+    if (tracer == null) return;
+
+    Tracer.SpanInScope spanInScope = currentSpanInScope.get();
+    if (spanInScope == null) return;
+    Span span = tracer.currentSpan();
+    spanInScope.close();
+
+    if (e != null) {
+      span.tag(Constants.ERROR, Integer.toString(e.getErrorCode()));
+    }
+    span.finish();
+  }
+
+  /**
+   * This attempts to get the ip and port from the JDBC URL. Ex. localhost and 5555 from {@code
+   * jdbc:mysql://localhost:5555/isSampled}.
+   */
+  void remoteEndpoint(Connection connection, Span span) {
+    try {
+      URI url = URI.create(connection.getMetaData().getURL().substring(5)); // strip "jdbc:"
+      Endpoint.Builder builder = Endpoint.builder().port(url.getPort());
+      if (remoteServiceName == null || "".equals(remoteServiceName)) {
+        String databaseName = connection.getCatalog();
+        if (databaseName != null && !databaseName.isEmpty()) {
+          builder.serviceName(databaseName);
+        } else {
+          builder.serviceName("");
+        }
+      } else {
+        builder.serviceName(remoteServiceName);
+      }
+      if (!builder.parseIp(url.getHost())) { // try for IP address
+        builder.parseIp(InetAddress.getByName(url.getHost())); // nslookup
+      }
+      span.remoteEndpoint(builder.build());
+    } catch (Exception e) {
+      // remote address is optional
+    }
+  }
+}

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -1,0 +1,20 @@
+package brave.p6spy;
+
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.spy.P6Factory;
+import com.p6spy.engine.spy.P6LoadableOptions;
+import com.p6spy.engine.spy.option.P6OptionsRepository;
+
+/** Add this class name to the "moduleslist" in spy.properties */
+public final class TracingP6Factory implements P6Factory {
+
+  TracingP6SpyOptions options;
+
+  @Override public P6LoadableOptions getOptions(P6OptionsRepository repository) {
+    return options = new TracingP6SpyOptions(repository);
+  }
+
+  @Override public JdbcEventListener getJdbcEventListener() {
+    return new TracingJdbcEventListener(options.remoteServiceName());
+  }
+}

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
@@ -1,0 +1,25 @@
+package brave.p6spy;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.option.P6OptionsRepository;
+import java.util.Map;
+
+final class TracingP6SpyOptions extends P6SpyOptions {
+  static final String REMOTE_SERVICE_NAME = "remoteServiceName";
+
+  final P6OptionsRepository optionsRepository;
+
+  TracingP6SpyOptions(P6OptionsRepository optionsRepository) {
+    super(optionsRepository);
+    this.optionsRepository = optionsRepository;
+  }
+
+  @Override public void load(Map<String, String> options) {
+    super.load(options);
+    optionsRepository.set(String.class, REMOTE_SERVICE_NAME, options.get(REMOTE_SERVICE_NAME));
+  }
+
+  String remoteServiceName() {
+    return optionsRepository.get(String.class, REMOTE_SERVICE_NAME);
+  }
+}

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/DerbyUtils.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/DerbyUtils.java
@@ -1,0 +1,16 @@
+package brave.p6spy;
+
+import java.io.OutputStream;
+
+public class DerbyUtils {
+
+  //Get rid of the annoying derby.log file
+  public static void disableLog() {
+    System.setProperty("derby.stream.error.field", DerbyUtils.class.getName() + ".DEV_NULL");
+  }
+
+  public static final OutputStream DEV_NULL = new OutputStream() {
+    public void write(int b) {
+    }
+  };
+}

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -1,0 +1,130 @@
+package brave.p6spy;
+
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.internal.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.Span;
+import zipkin.TraceKeys;
+import zipkin.internal.Util;
+import zipkin.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class ITTracingP6Factory {
+  static final String URL = "jdbc:p6spy:derby:memory:p6spy;create=true";
+  static final String QUERY = "SELECT 1 FROM SYSIBM.SYSDUMMY1";
+
+  //Get rid of annoying derby.log
+  static {
+    DerbyUtils.disableLog();
+  }
+
+  Endpoint local = Endpoint.builder().serviceName("local").ipv4(127 << 24 | 1).port(100).build();
+  InMemoryStorage storage = new InMemoryStorage();
+
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+  Connection connection;
+
+  @Before
+  public void setup() throws Exception {
+    DriverManager.getDriver(URL);
+    connection = DriverManager.getConnection(URL, "foo", "bar");
+  }
+
+  @After
+  public void close() throws Exception {
+    Tracing.current().close();
+    connection.close();
+  }
+
+  @Test
+  public void makesChildOfCurrentSpan() throws Exception {
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      prepareExecuteSelect(QUERY);
+    } finally {
+      parent.finish();
+    }
+
+    assertThat(collectedSpans())
+        .hasSize(2);
+  }
+
+  @Test
+  public void reportsClientAnnotationsToZipkin() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test
+  public void defaultSpanNameIsOperationName() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .extracting(s -> s.name)
+        .containsExactly("select");
+  }
+
+  @Test
+  public void addsQueryTag() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(a -> a.key.equals(TraceKeys.SQL_QUERY))
+        .extracting(a -> new String(a.value, Util.UTF_8))
+        .containsExactly(QUERY);
+  }
+
+  @Test
+  public void reportsServerAddress() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key, b -> b.endpoint.serviceName)
+        .contains(tuple(Constants.SERVER_ADDR, "myservice"));
+  }
+
+  void prepareExecuteSelect(String query) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(query)) {
+      try (ResultSet resultSet = ps.executeQuery()) {
+        while (resultSet.next()) {
+          resultSet.getString(1);
+        }
+      }
+    }
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(s -> storage.spanConsumer().accept(asList(s)))
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .localEndpoint(local)
+        .sampler(sampler);
+  }
+
+  List<Span> collectedSpans() {
+    List<List<Span>> result = storage.spanStore().getRawTraces();
+    assertThat(result).hasSize(1);
+    return result.get(0);
+  }
+}

--- a/instrumentation/p6spy/src/test/resources/log4j2.properties
+++ b/instrumentation/p6spy/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/p6spy/src/test/resources/spy.properties
+++ b/instrumentation/p6spy/src/test/resources/spy.properties
@@ -1,0 +1,2 @@
+modulelist=brave.p6spy.TracingP6Factory
+remoteServiceName=myservice

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>brave-instrumentation-parent</artifactId>
+  <name>Brave: Instrumentation</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <protobuf.version>3.0.2</protobuf.version>
+  </properties>
+
+  <modules>
+    <module>http-tests</module>
+    <module>benchmarks</module>
+    <module>grpc</module>
+    <module>httpasyncclient</module>
+    <module>httpclient</module>
+    <module>jaxrs2</module>
+    <module>mysql</module>
+    <module>okhttp3</module>
+    <module>p6spy</module>
+    <module>servlet</module>
+    <module>sparkjava</module>
+    <module>spring-web</module>
+    <module>spring-webmvc</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>2.0.0</version>
+          <configuration>
+            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+            <settingsFile>${main.basedir}/src/it/settings.xml</settingsFile>
+            <profiles>
+              <profile>!release</profile>
+            </profiles>
+            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+            <postBuildHookScript>verify</postBuildHookScript>
+            <addTestClassPath>true</addTestClassPath>
+            <skipInvocation>${skipTests}</skipInvocation>
+            <streamLogs>true</streamLogs>
+          </configuration>
+          <executions>
+            <execution>
+              <id>integration-test</id>
+              <goals>
+                <goal>install</goal>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.xolstice.maven.plugins</groupId>
+          <artifactId>protobuf-maven-plugin</artifactId>
+          <version>0.5.0</version>
+          <configuration>
+            <protocArtifact>
+              com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+            </protocArtifact>
+            <pluginId>grpc-java</pluginId>
+            <pluginArtifact>
+              io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+            </pluginArtifact>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -1,0 +1,56 @@
+# brave-instrumentation-servlet
+This module contains a Servlet 2.5+ compatible tracing filter.
+`TracingFilter` extracts trace state from incoming requests. Then, it
+reports Zipkin how long each request takes, along with relevant tags
+like the http url.
+
+To enable tracing, you need to add the `TracingFilter`.
+
+Here's a Servlet 3+ example:
+```java
+public class TracingServletContextListener implements ServletContextListener {
+
+  @Override
+  public void contextInitialized(ServletContextEvent servletContextEvent) {
+    Tracing tracing = Tracing.newBuilder().localServiceName("myservicename").build();
+    servletContextEvent
+        .getServletContext()
+        .addFilter("TracingFilter", TracingFilter.create(tracing))
+        .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent servletContextEvent) {
+  }
+}
+```
+
+In Servlet 2.5, there's no `ServletContextListener`. Besides using tools
+like Spring or Guice, you can make a decorating `javax.servlet.Filter`
+that configures tracing, and add that to your web.xml.
+```java
+public class ServletContextTracingFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    Filter currentTracingFilter =
+        (Filter) request.getServletContext().getAttribute(TracingFilter.class.getName());
+    if (currentTracingFilter == null) {
+      chain.doFilter(request, response);
+    } else {
+      currentTracingFilter.doFilter(request, response, chain);
+    }
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+    Tracing tracing = Tracing.newBuilder().localServiceName("myservicename").build();
+    Filter tracingFilter = TracingFilter.create(tracing);
+    filterConfig.getServletContext().setAttribute(TracingFilter.class.getName(), tracingFilter);
+  }
+
+  @Override public void destroy() {
+  }
+}
+```

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-servlet</artifactId>
+  <name>Brave Instrumentation: Servlet</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <!-- compile dep on 3.0.1 runtime on 2.5 -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/servlet/src/it/servlet25/README.md
+++ b/instrumentation/servlet/src/it/servlet25/README.md
@@ -1,0 +1,2 @@
+# servlet-25
+This tests that TracingFilter does not rely on Servlet 3+ apis

--- a/instrumentation/servlet/src/it/servlet25/pom.xml
+++ b/instrumentation/servlet/src/it/servlet25/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>servlet25</artifactId>
+  <version>@project.version@</version>
+  <name>servlet25</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>@jetty-servlet25.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-servlet</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>@project.basedir@/src/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
+++ b/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
@@ -1,0 +1,21 @@
+package brave.servlet25;
+
+import brave.http.ITServlet25Container;
+import brave.servlet.TracingFilter;
+import java.util.EnumSet;
+import javax.servlet.Filter;
+import org.eclipse.jetty.server.DispatcherType;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+public class ITTracingFilter extends ITServlet25Container {
+
+  @Override
+  protected Filter newTracingFilter() {
+    return TracingFilter.create(httpTracing);
+  }
+
+  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
+    handler.addFilter(new FilterHolder(filter), "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+}

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletHandler.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletHandler.java
@@ -1,0 +1,62 @@
+package brave.servlet;
+
+import brave.Span;
+import brave.http.HttpAdapter;
+import brave.http.HttpServerHandler;
+import brave.http.HttpServerParser;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import zipkin.Endpoint;
+
+/**
+ * This is a generic handler which parses the remote IP of the client by default.
+ */
+public final class HttpServletHandler // public for others like sparkjava to use
+    extends HttpServerHandler<HttpServletRequest, HttpServletResponse> {
+
+  public HttpServletHandler(HttpServerParser parser) {
+    super(new HttpServletAdapter(), parser);
+  }
+
+  @Override public HttpServletRequest handleReceive(HttpServletRequest request, Span span) {
+    if (span.isNoop()) return request;
+    parseClientAddress(request, span);
+    return super.handleReceive(request, span);
+  }
+
+  void parseClientAddress(HttpServletRequest request, Span span) {
+    Endpoint.Builder builder = Endpoint.builder().serviceName("");
+    boolean parsed = builder.parseIp(request.getHeader("X-Forwarded-For"));
+    if (!parsed) parsed = builder.parseIp(request.getRemoteAddr());
+    if (parsed) span.remoteEndpoint(builder.port(request.getRemotePort()).build());
+  }
+
+  static final class HttpServletAdapter
+      extends HttpAdapter<HttpServletRequest, HttpServletResponse> {
+    final ServletRuntime servlet = ServletRuntime.get();
+
+    @Override public String method(HttpServletRequest request) {
+      return request.getMethod();
+    }
+
+    @Override public String path(HttpServletRequest request) {
+      return request.getRequestURI();
+    }
+
+    @Override public String url(HttpServletRequest request) {
+      StringBuffer url = request.getRequestURL();
+      if (request.getQueryString() != null && !request.getQueryString().isEmpty()) {
+        url.append('?').append(request.getQueryString());
+      }
+      return url.toString();
+    }
+
+    @Override public String requestHeader(HttpServletRequest request, String name) {
+      return request.getHeader(name);
+    }
+
+    @Override public Integer statusCode(HttpServletResponse response) {
+      return servlet.status(response);
+    }
+  }
+}

--- a/instrumentation/servlet/src/main/java/brave/servlet/ServletRuntime.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/ServletRuntime.java
@@ -1,0 +1,143 @@
+package brave.servlet;
+
+import brave.Span;
+import brave.internal.Nullable;
+import java.io.IOException;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import static zipkin.Constants.ERROR;
+
+/**
+ * Access to servlet version-specific features
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.platform.Platform}
+ */
+abstract class ServletRuntime {
+  private static final ServletRuntime SERVLET_RUNTIME = findServletRuntime();
+
+  HttpServletResponse httpResponse(ServletResponse response) {
+    return (HttpServletResponse) response;
+  }
+
+  abstract @Nullable Integer status(HttpServletResponse response);
+
+  abstract boolean isAsync(HttpServletRequest request);
+
+  abstract void handleAsync(HttpServletHandler handler, HttpServletRequest request, Span span);
+
+  ServletRuntime() {
+  }
+
+  static ServletRuntime get() {
+    return SERVLET_RUNTIME;
+  }
+
+  /** Attempt to match the host runtime to a capable Platform implementation. */
+  private static ServletRuntime findServletRuntime() {
+    // Find Servlet v3 new methods
+    try {
+      Class.forName("javax.servlet.AsyncEvent");
+      HttpServletRequest.class.getMethod("isAsyncStarted");
+      return new Servlet3();
+    } catch (NoSuchMethodException e) {
+      // pre Servlet v3
+    } catch (ClassNotFoundException e) {
+      // pre Servlet v3
+    }
+
+    // compatible with Servlet 2.5
+    return new Servlet25();
+  }
+
+  private static final class Servlet3 extends ServletRuntime {
+    @Override boolean isAsync(HttpServletRequest request) {
+      return request.isAsyncStarted();
+    }
+
+    @Override @Nullable Integer status(HttpServletResponse response) {
+      return response.getStatus();
+    }
+
+    @Override void handleAsync(HttpServletHandler handler, HttpServletRequest request, Span span) {
+      if (span.isNoop()) return; // don't add overhead when we aren't httpTracing
+      request.getAsyncContext().addListener(new AsyncListener() {
+        @Override public void onComplete(AsyncEvent e) throws IOException {
+          handler.handleSend((HttpServletResponse) e.getSuppliedResponse(), span);
+        }
+
+        @Override public void onTimeout(AsyncEvent e) throws IOException {
+          span.tag(ERROR, String.format("Timed out after %sms", e.getAsyncContext().getTimeout()));
+          handler.handleSend((HttpServletResponse) e.getSuppliedResponse(), span);
+        }
+
+        @Override public void onError(AsyncEvent e) throws IOException {
+          handler.handleError(e.getThrowable(), span);
+        }
+
+        @Override public void onStartAsync(AsyncEvent e) throws IOException {
+        }
+      });
+    }
+  }
+
+  private static final class Servlet25 extends ServletRuntime {
+    @Override HttpServletResponse httpResponse(ServletResponse response) {
+      return new Servlet25ServerResponseAdapter(response);
+    }
+
+    @Override boolean isAsync(HttpServletRequest request) {
+      return false;
+    }
+
+    @Override void handleAsync(HttpServletHandler handler, HttpServletRequest request, Span span) {
+      assert false : "this should never be called in Servlet 2.5";
+    }
+
+    @Override @Nullable Integer status(HttpServletResponse response) {
+      if (response instanceof Servlet25ServerResponseAdapter) {
+        // servlet 2.5 doesn't have get status
+        return ((Servlet25ServerResponseAdapter) response).getStatusInServlet25();
+      }
+      return null;
+    }
+  }
+
+  /** When deployed in Servlet 2.5 environment {@link #getStatus} is not available. */
+  static final class Servlet25ServerResponseAdapter extends HttpServletResponseWrapper {
+    // The Servlet spec says: calling setStatus is optional, if no status is set, the default is OK.
+    int httpStatus = HttpServletResponse.SC_OK;
+
+    Servlet25ServerResponseAdapter(ServletResponse response) {
+      super((HttpServletResponse) response);
+    }
+
+    @Override public void setStatus(int sc, String sm) {
+      httpStatus = sc;
+      super.setStatus(sc, sm);
+    }
+
+    @Override public void sendError(int sc) throws IOException {
+      httpStatus = sc;
+      super.sendError(sc);
+    }
+
+    @Override public void sendError(int sc, String msg) throws IOException {
+      httpStatus = sc;
+      super.sendError(sc, msg);
+    }
+
+    @Override public void setStatus(int sc) {
+      httpStatus = sc;
+      super.setStatus(sc);
+    }
+
+    public int getStatusInServlet25() {
+      return httpStatus;
+    }
+  }
+}

--- a/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
@@ -1,0 +1,67 @@
+package brave.servlet;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public final class TracingFilter implements Filter {
+  public static Filter create(Tracing tracing) {
+    return new TracingFilter(HttpTracing.create(tracing));
+  }
+
+  public static Filter create(HttpTracing httpTracing) {
+    return new TracingFilter(httpTracing);
+  }
+
+  final ServletRuntime servlet = ServletRuntime.get();
+  final Tracer tracer;
+  final HttpServletHandler handler;
+  final TraceContext.Extractor<HttpServletRequest> extractor;
+
+  TracingFilter(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    handler = new HttpServletHandler(httpTracing.serverParser());
+    extractor = httpTracing.tracing().propagation().extractor(HttpServletRequest::getHeader);
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = servlet.httpResponse(response);
+
+    Span span = tracer.nextSpan(extractor, httpRequest);
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      handler.handleReceive(httpRequest, span); // start the span
+
+      chain.doFilter(httpRequest, httpResponse); // any downstream filters see Tracer.currentSpan
+
+      if (servlet.isAsync(httpRequest)) { // we don't have the actual response, handle later
+        servlet.handleAsync(handler, httpRequest, span);
+      } else { // we have a synchronous response, so we can finish the span
+        handler.handleSend(httpResponse, span);
+      }
+    } catch (IOException | ServletException | RuntimeException e) {
+      handler.handleError(e, span);
+      throw e;
+    }
+  }
+
+  @Override public void destroy() {
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+  }
+}

--- a/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
@@ -1,0 +1,19 @@
+package brave.servlet;
+
+import brave.http.ITServlet3Container;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+public class ITTracingFilter extends ITServlet3Container {
+
+  @Override protected Filter newTracingFilter() {
+    return TracingFilter.create(httpTracing);
+  }
+
+  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
+    handler.addFilter(new FilterHolder(filter), "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+}

--- a/instrumentation/servlet/src/test/resources/log4j2.properties
+++ b/instrumentation/servlet/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/sparkjava/README.md
+++ b/instrumentation/sparkjava/README.md
@@ -1,0 +1,19 @@
+# brave-instrumentation-sparkjava
+
+This module contains SparkJava filters and exception handlers.
+The filters extract trace state from incoming requests. Then, they
+reports Zipkin how long each request takes, along with relevant tags
+like the http url. The exception handler ensures any errors are also
+sent to Zipkin.
+
+To enable tracing you need to add `before`, `exception` and `afterAfter`
+hooks:
+```java
+sparkTracing = SparkTracing.create(tracing);
+Spark.before(sparkTracing.before());
+Spark.exception(Exception.class, sparkTracing.exception(new ExceptionHandlerImpl()));
+Spark.afterAfter(sparkTracing.afterAfter());
+
+// any routes you add are now traced, such as the below
+Spark.get("/foo", (req, res) -> "bar");
+```

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-sparkjava</artifactId>
+  <name>Brave Instrumentation: Spark Framework</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.sparkjava</groupId>
+      <artifactId>spark-core</artifactId>
+      <version>${sparkjava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-servlet</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
+++ b/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
@@ -1,0 +1,56 @@
+package brave.sparkjava;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import brave.servlet.HttpServletHandler;
+import spark.ExceptionHandler;
+import spark.Filter;
+import spark.Request;
+
+public final class SparkTracing {
+  public static SparkTracing create(Tracing tracing) {
+    return new SparkTracing(HttpTracing.create(tracing));
+  }
+
+  public static SparkTracing create(HttpTracing httpTracing) {
+    return new SparkTracing(httpTracing);
+  }
+
+  final Tracer tracer;
+  final HttpServletHandler handler;
+  final TraceContext.Extractor<Request> extractor;
+
+  SparkTracing(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    handler = new HttpServletHandler(httpTracing.serverParser());
+    extractor = httpTracing.tracing().propagation().extractor(Request::headers);
+  }
+
+  public Filter before() {
+    return (request, response) -> {
+      Span span = tracer.nextSpan(extractor, request);
+      handler.handleReceive(request.raw(), span);
+      request.attribute(Tracer.SpanInScope.class.getName(), tracer.withSpanInScope(span));
+    };
+  }
+
+  public Filter afterAfter() {
+    return (request, response) -> {
+      Span span = tracer.currentSpan();
+      if (span == null) return;
+      ((Tracer.SpanInScope) request.attribute(Tracer.SpanInScope.class.getName())).close();
+      handler.handleSend(response.raw(), span);
+    };
+  }
+
+  public ExceptionHandler exception(ExceptionHandler delegate) {
+    return (exception, request, response) -> {
+      Span span = tracer.currentSpan();
+      if (span != null) handler.handleError(exception, span);
+      delegate.handle(exception, request, response);
+    };
+  }
+}

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -1,0 +1,64 @@
+package brave.sparkjava;
+
+import brave.http.ITHttpServer;
+import org.junit.After;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+import spark.Spark;
+
+public class ITSparkTracing extends ITHttpServer {
+
+  /**
+   * Async tests are ignored until https://github.com/perwendel/spark/issues/208
+   */
+  @Override
+  @Test(expected = ComparisonFailure.class)
+  public void async() throws Exception {
+    super.async();
+  }
+
+  @Override protected void init() throws Exception {
+    stop();
+
+    SparkTracing spark = SparkTracing.create(httpTracing);
+
+    Spark.before(spark.before());
+    Spark.exception(Exception.class, spark.exception(
+        (exception, request, response) -> response.body("exception"))
+    );
+    Spark.afterAfter(spark.afterAfter());
+
+    Spark.get("/foo", (req, res) -> "bar");
+    Spark.get("/badrequest", (req, res) -> {
+      res.status(400);
+      return res;
+    });
+    Spark.get("/child", (req, res) -> {
+      httpTracing.tracing().tracer().nextSpan().name("child").start().finish();
+      return "happy";
+    });
+    Spark.get("/exception", (req, res) -> {
+      throw new Exception();
+    });
+
+    Spark.awaitInitialization();
+  }
+
+  @Override
+  protected String url(String path) {//default port 4567
+    return "http://localhost:4567" + path;
+  }
+
+  /**
+   * Spark stop asynchronously but share one class Instance,
+   * so AddressAlreadyUsed Exception may happen.
+   * See:https://github.com/perwendel/spark/issues/705 .
+   * Just sleep 1 second to avoid this happens,
+   * after Spark.awaitStopped add,I will fix it.
+   */
+  @After
+  public void stop() throws InterruptedException {
+    Spark.stop();
+    Thread.sleep(1000);
+  }
+}

--- a/instrumentation/sparkjava/src/test/resources/log4j2.properties
+++ b/instrumentation/sparkjava/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/spring-web/README.md
+++ b/instrumentation/spring-web/README.md
@@ -1,0 +1,13 @@
+# brave-instrumentation-spring-web
+This module contains a tracing interceptor for [Spring RestTemplate](https://spring.io/guides/gs/consuming-rest/).
+`TracingClientHttpRequestInterceptor` adds trace headers to outgoing
+requests. It then reports to Zipkin how long each request takes, along
+with relevant tags like the http url.
+
+## Configuration
+
+Tracing always needs a bean of type `HttpTracing` configured. Make sure
+it is in place before proceeding.
+
+Then, wire `TracingClientHttpRequestInterceptor` and add it with the
+`RestTemplate.setInterceptors` method.

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-spring-web</artifactId>
+  <name>Brave Instrumentation: Spring Rest Template</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
@@ -1,0 +1,85 @@
+package brave.spring.web;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import java.net.URI;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import zipkin.Endpoint;
+
+public final class TracingClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+  public static ClientHttpRequestInterceptor create(Tracing tracing) {
+    return create(HttpTracing.create(tracing));
+  }
+
+  public static ClientHttpRequestInterceptor create(HttpTracing httpTracing) {
+    return new TracingClientHttpRequestInterceptor(httpTracing);
+  }
+
+  final Tracer tracer;
+  final String remoteServiceName;
+  final HttpClientHandler<HttpRequest, ClientHttpResponse> handler;
+  final TraceContext.Injector<HttpHeaders> injector;
+
+  TracingClientHttpRequestInterceptor(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    remoteServiceName = httpTracing.serverName();
+    handler = new HttpClientHandler<>(new HttpAdapter(), httpTracing.clientParser());
+    injector = httpTracing.tracing().propagation().injector(HttpHeaders::set);
+  }
+
+  @Override public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+      ClientHttpRequestExecution execution) throws IOException {
+    Span span = tracer.nextSpan();
+    parseServerAddress(request, span);
+    handler.handleSend(request, span);
+    injector.inject(span.context(), request.getHeaders());
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      return handler.handleReceive(execution.execute(request, body), span);
+    } catch (IOException | RuntimeException e) {
+      handler.handleError(e, span);
+      throw e;
+    }
+  }
+
+  void parseServerAddress(HttpRequest request, Span span) {
+    if (span.isNoop()) return;
+    URI uri = request.getURI();
+    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
+    builder.parseIp(uri.getHost());
+    builder.port(uri.getPort());
+    span.remoteEndpoint(builder.build());
+  }
+
+  static final class HttpAdapter extends
+      brave.http.HttpAdapter<HttpRequest, ClientHttpResponse> {
+    @Override public String method(HttpRequest request) {
+      return request.getMethod().name();
+    }
+
+    @Override public String url(HttpRequest request) {
+      return request.getURI().toString();
+    }
+
+    @Override public String requestHeader(HttpRequest request, String name) {
+      Object result = request.getHeaders().getFirst(name);
+      return result != null ? result.toString() : null;
+    }
+
+    @Override public Integer statusCode(ClientHttpResponse response) {
+      try {
+        return response.getRawStatusCode();
+      } catch (IOException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -1,0 +1,80 @@
+package brave.spring.web;
+
+import brave.http.ITHttpClient;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingClientHttpRequestInterceptor
+    extends ITHttpClient<OkHttp3ClientHttpRequestFactory> {
+
+  ClientHttpRequestInterceptor interceptor;
+
+  OkHttp3ClientHttpRequestFactory configureClient(
+      ClientHttpRequestInterceptor interceptor) {
+    OkHttp3ClientHttpRequestFactory factory = new OkHttp3ClientHttpRequestFactory();
+    factory.setReadTimeout(1000);
+    factory.setConnectTimeout(1000);
+    this.interceptor = interceptor;
+    return factory;
+  }
+
+  @Override protected OkHttp3ClientHttpRequestFactory newClient(int port) {
+    return configureClient(TracingClientHttpRequestInterceptor.create(httpTracing));
+  }
+
+  @Override protected void closeClient(OkHttp3ClientHttpRequestFactory client) throws IOException {
+    client.destroy();
+  }
+
+  @Override protected void get(OkHttp3ClientHttpRequestFactory client, String pathIncludingQuery)
+      throws Exception {
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.getForObject(url(pathIncludingQuery), String.class);
+  }
+
+  @Override
+  protected void post(OkHttp3ClientHttpRequestFactory client, String pathIncludingQuery,
+      String content) throws Exception {
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.postForObject(url(pathIncludingQuery), content, String.class);
+  }
+
+  @Override
+  protected void getAsync(OkHttp3ClientHttpRequestFactory client, String pathIncludingQuery) {
+    throw new AssumptionViolatedException("TODO: async rest template has its own interceptor");
+  }
+
+  @Test
+  public void currentSpanVisibleToUserInterceptors() throws Exception {
+    server.enqueue(new MockResponse());
+
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Arrays.asList(interceptor, (request, body, execution) -> {
+      request.getHeaders()
+          .add("my-id", currentTraceContext.get().traceIdString());
+      return execution.execute(request, body);
+    }));
+    restTemplate.getForObject(server.url("/foo").toString(), String.class);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+
+  @Override @Test(expected = AssertionError.class)
+  public void redirect() throws Exception { // blind to the implementation of redirects
+    super.redirect();
+  }
+}

--- a/instrumentation/spring-web/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-web/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/spring-webmvc/README.md
+++ b/instrumentation/spring-webmvc/README.md
@@ -1,0 +1,35 @@
+# brave-instrumentation-spring-webmvc
+This module contains a tracing interceptor for [Spring WebMVC](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html)
+`TracingHandlerInterceptor` extracts trace state from incoming requests.
+Then, it reports Zipkin how long each request takes, along with relevant
+tags like the http url.
+
+## Configuration
+
+Tracing always needs a bean of type `HttpTracing` configured. Make sure
+it is in place before proceeding.
+
+Then, configure `TracingHandlerInterceptor` in either XML or Java.
+
+```xml
+<mvc:interceptors>
+  <bean class="brave.spring.servlet.TracingHandlerInterceptor">
+  </bean>
+</mvc:interceptors>
+```
+
+```java
+@Configuration
+@Import(TracingHandlerInterceptor.class)
+public class WebConfig extends WebMvcConfigurerAdapter {
+
+    @Autowired
+    private TracingHandlerInterceptor interceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor);
+    }
+
+}
+```

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+  <name>Brave Instrumentation: Spring Web MVC</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-servlet</artifactId>
+    </dependency>
+    <!-- implicitly servlet 3.0.1 -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/spring-webmvc/src/it/servlet25/README.md
+++ b/instrumentation/spring-webmvc/src/it/servlet25/README.md
@@ -1,0 +1,2 @@
+# servlet-25
+This tests that TracingHandlerInterceptor does not rely on Servlet 3+ apis

--- a/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>spring-webmvc-servlet25</artifactId>
+  <version>@project.version@</version>
+  <name>spring-webmvc-servlet25</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>@spring.version@</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>@jetty-servlet25.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>@junit.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>@project.build.testSourceDirectory@</sourceDirectory>
+    <testResources>
+      <testResource>
+        <directory>@project.basedir@/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/spring-webmvc/src/it/servlet25/src/test/java/brave/spring/servlet25/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/servlet25/src/test/java/brave/spring/servlet25/ITTracingHandlerInterceptor.java
@@ -1,0 +1,22 @@
+package brave.spring.servlet25;
+
+import brave.servlet.TracingFilter;
+import org.junit.Test;
+
+public class ITTracingHandlerInterceptor extends brave.spring.webmvc.ITTracingHandlerInterceptor {
+
+  @Test(expected = AssertionError.class)
+  @Override public void async() throws Exception {
+    super.async();
+  }
+
+  /**
+   * {@code HttpServletRequest.getStatus()} was not added until Servlet 3.0. Unless we look
+   * reflectively for types that implement this even in Servlet 2.5 (like jetty and tomcat), this
+   * will not show the error code. Note that {@link TracingFilter} deals with this directlys.
+   */
+  @Test(expected = AssertionError.class)
+  @Override public void addsStatusCode_badRequest() throws Exception {
+    super.addsStatusCode_badRequest();
+  }
+}

--- a/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
@@ -1,0 +1,66 @@
+package brave.spring.webmvc;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import brave.servlet.HttpServletHandler;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+@Configuration // not final because of @Configuration
+public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
+
+  public static HandlerInterceptorAdapter create(Tracing tracing) {
+    return new TracingHandlerInterceptor(HttpTracing.create(tracing));
+  }
+
+  public static HandlerInterceptorAdapter create(HttpTracing httpTracing) {
+    return new TracingHandlerInterceptor(httpTracing);
+  }
+
+  final Tracer tracer;
+  final HttpServletHandler handler;
+  final TraceContext.Extractor<HttpServletRequest> extractor;
+
+  @Autowired TracingHandlerInterceptor(HttpTracing httpTracing) { // internal
+    tracer = httpTracing.tracing().tracer();
+    handler = new HttpServletHandler(httpTracing.serverParser());
+    extractor = httpTracing.tracing().propagation().extractor(HttpServletRequest::getHeader);
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) {
+    if (request.getAttribute(SpanInScope.class.getName()) != null) {
+      return true; // already handled (possibly due to async request)
+    }
+
+    Span span = tracer.nextSpan(extractor, request);
+    try {
+      this.handler.handleReceive(request, span);
+      request.setAttribute(SpanInScope.class.getName(), tracer.withSpanInScope(span));
+    } catch (RuntimeException e) {
+      throw this.handler.handleError(e, span);
+    }
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+      Object handler, Exception ex) {
+    Span span = tracer.currentSpan();
+    if (span == null) return;
+    ((SpanInScope) request.getAttribute(SpanInScope.class.getName())).close();
+    if (ex != null) {
+      this.handler.handleError(ex, span);
+    } else {
+      this.handler.handleSend(response, span);
+    }
+  }
+}

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
@@ -1,0 +1,95 @@
+package brave.spring.webmvc;
+
+import brave.Tracer;
+import brave.http.HttpTracing;
+import brave.http.ITServletContainer;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+public class ITTracingHandlerInterceptor extends ITServletContainer {
+
+  @Controller static class TestController {
+    final Tracer tracer;
+
+    @Autowired TestController(HttpTracing httpTracing) {
+      this.tracer = httpTracing.tracing().tracer();
+    }
+
+    @RequestMapping(value = "/foo")
+    public ResponseEntity<Void> foo() throws IOException {
+      return ResponseEntity.ok().build();
+    }
+
+    @RequestMapping(value = "/badrequest")
+    public ResponseEntity<Void> badrequest() throws IOException {
+      return ResponseEntity.badRequest().build();
+    }
+
+    @RequestMapping(value = "/child")
+    public ResponseEntity<Void> child() {
+      tracer.nextSpan().name("child").start().finish();
+      return ResponseEntity.ok().build();
+    }
+
+    @RequestMapping(value = "/async")
+    public Callable<ResponseEntity<Void>> async() throws IOException {
+      return () -> ResponseEntity.ok().build();
+    }
+
+    @RequestMapping(value = "/exception")
+    public ResponseEntity<Void> disconnect() throws IOException {
+      throw new IOException();
+    }
+
+    @RequestMapping(value = "/exceptionAsync")
+    public Callable<ResponseEntity<Void>> disconnectAsync() throws IOException {
+      return () -> {
+        throw new IOException();
+      };
+    }
+  }
+
+  @Configuration
+  @EnableWebMvc
+  @Import(TracingHandlerInterceptor.class)
+  static class TracingConfig extends WebMvcConfigurerAdapter {
+
+    @Autowired
+    private TracingHandlerInterceptor interceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+      registry.addInterceptor(interceptor).addPathPatterns();
+    }
+  }
+
+  @Override public void init(ServletContextHandler handler) {
+    AnnotationConfigWebApplicationContext appContext =
+        new AnnotationConfigWebApplicationContext() {
+          // overriding this allows us to register dependencies of TracingHandlerInterceptor
+          // without passing static state to a configuration class.
+          @Override protected void loadBeanDefinitions(DefaultListableBeanFactory beanFactory) {
+            beanFactory.registerSingleton("httpTracing", httpTracing);
+            super.loadBeanDefinitions(beanFactory);
+          }
+        };
+
+    appContext.register(TestController.class); // the test resource
+    appContext.register(TracingConfig.class); // generic tracing setup
+    handler.addServlet(new ServletHolder(new DispatcherServlet(appContext)), "/*");
+  }
+}

--- a/instrumentation/spring-webmvc/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-webmvc/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/pom.xml
+++ b/pom.xml
@@ -59,14 +59,18 @@
     <spring.version>4.3.4.RELEASE</spring.version>
     <!-- don't use apis not in jetty 7.6* else testing servlet 2.5 will imply duplication -->
     <jetty.version>8.1.22.v20160922</jetty.version>
+    <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.1.2.Final</resteasy.version>
     <zipkin.version>1.24.0</zipkin.version>
     <zipkin-reporter.version>0.7.1</zipkin-reporter.version>
     <finagle.version>6.44.0</finagle.version>
     <log4j.version>2.8.1</log4j.version>
-    <okhttp.version>3.6.0</okhttp.version>
-    <grpc.version>1.2.0</grpc.version>
+    <okhttp.version>3.7.0</okhttp.version>
+    <grpc.version>1.3.0</grpc.version>
+    <sparkjava.version>2.5.5</sparkjava.version>
+    <junit.version>4.12</junit.version>
+    <assertj.version>3.6.2</assertj.version>
     <powermock.version>1.6.6</powermock.version>
     <jmh.version>1.19</jmh.version>
 
@@ -88,6 +92,7 @@
   <modules>
     <module>brave</module>
     <module>context</module>
+    <module>instrumentation</module>
     <module>brave-core</module>
     <module>brave-benchmarks</module>
     <module>brave-http</module>
@@ -163,6 +168,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brave-instrumentation-http-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brave-instrumentation-servlet</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.zipkin.java</groupId>
             <artifactId>zipkin</artifactId>
             <version>${zipkin.version}</version>
@@ -212,6 +227,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>${spring.version}</version>
         </dependency>
@@ -234,17 +254,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
+            <version>4.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <version>4.1.2</version>
+            <version>4.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -289,12 +309,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.6.2</version>
+            <version>${assertj.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
This module a redo of all major instrumentation libraries since Brave 3.
Artifacts have the naming convention "brave-instrumentation-XXX": for
example, the directory "servlet" includes the artifact "brave-instrumentation-servlet".

Notably, this adds a more `HttpTracing` component to configure http client
and server tracing. It also adds support for async servlet and apache http
client, and tests edge cases like multiple servlet versions. Finally, it
tests and benchmarks every http component, so that people are aware of
overhead is involved in tracing.

Here's an example of configuring OkHttp. Note that all instrumentation
have the same naming policy TracingXXX, where XXX is usually the same
as the type returned.

```java
tracing = Tracing.newBuilder()
                 .localServiceName("my-service")
                 .reporter(reporter)
                 .build();
httpTracing = HttpTracing.newBuilder(tracing).serverName("github").build();
okhttp = TracingCallFactory.create(httpTracing, new OkHttpClient());
```

### Http tracing
Most instrumentation are based on http communication. For this reason,
we have specialized handlers for http clients and servers. All of these
are configured with `HttpTracing`.

The `HttpTracing` class holds a reference to a tracing component and also
includes instructions on what to put into http spans.

By default, the following is added for both http clients and servers:
* Span.name as the http method in lowercase: ex "get"
* Tags/binary annotations:
  * "http.path", which does not include query parameters.
  * "http.status_code" when the status us not success.
* Remote IP and port information

Naming and tags are configurable in a library-agnostic way. For example,
the same `HttpTracing` component configures OkHttp or Apache HttpClient
identically.

For example, to change the span and tag naming policy for clients, you
can do something like this:

```java
httpTracing = httpTracing.toBuilder()
    .clientParser(new HttpClientParser() {
      @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
        return adapter.method(req).toLowerCase() + " " + adapter.path(req);
      }

      @Override
      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
        span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // the whole url, not just the path
      }
    })
    .serverName("remote-service") // assume both libraries are calling the same service
    .build();

apache = TracingHttpClientBuilder.create(httpTracing).build();
okhttp = TracingCallFactory.create(httpTracing, new OkHttpClient());
```

---
Work accomplished in support of this
 - [x] Rough in a tentative client and server tracer api
 - [x] Integrate each library such that it sets spans in scope so `Tracer.currentSpan()` works
 - [x] Integrate each staticly initialized library such that it uses `Tracer.current()`
 - [x] Backport client and server integration tests
 - [x] add Async HttpClient and Servlet (which we never had before)
 - [x] add Tests for servlet 2.5 and grpc compat (which we never had before)
 - [x] ensure we can swap out propagation format when needed. Ex https://github.com/TraceContext/tracecontext-spec
 - [x] revise tagging approach so that it solves #276 #264
 - [x] Add tests for http client redirects
 - [x] Revisit exception parsing
 - [x] Revisit remote address parsing

Fixes #276
Fixes #264