### PR TITLE
Unimplements java.io interfaces on brave.Span

### DIFF
--- a/brave-benchmarks/src/main/java/brave/SpanCreationBenchmarks.java
+++ b/brave-benchmarks/src/main/java/brave/SpanCreationBenchmarks.java
@@ -82,10 +82,9 @@ public class SpanCreationBenchmarks {
 
   @Benchmark
   public Span simpleRootSpan_brave4() {
-    try (Span span = tracer.newTrace().name("encode").start()) {
-      // pretend we are doing codec work
-      return span; // to satisfy the signature
-    }
+    Span span = tracer.newTrace().name("encode").start();
+    span.finish();
+    return span; // to satisfy the signature
   }
 
   @Benchmark

--- a/brave/README.md
+++ b/brave/README.md
@@ -47,8 +47,11 @@ the correct spot in the tree representing the distributed operation.
 
 When tracing local code, just run it inside a span.
 ```java
-try (Span span = tracer.newTrace().name("encode").start()) {
+Span span = tracer.newTrace().name("encode").start();
+try {
   doSomethingExpensive();
+} finally {
+  span.finish();
 }
 ```
 
@@ -57,13 +60,11 @@ you will be a part of an existing trace. When this is the case, call
 `newChild` instead of `newTrace`
 
 ```java
-try (Span root = tracer.newTrace().name("2pc").start()) {
-  try (Span child = tracer.newChild(root.context()).name("prepare").start()) {
-    prepare();
-  }
-  try (Span child = tracer.newChild(root.context()).name("commit").start()) {
-    commit();
-  }
+Span span = tracer.newChild(root.context()).name("encode").start();
+try {
+  doSomethingExpensive();
+} finally {
+  span.finish();
 }
 ```
 

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -20,13 +20,22 @@ import zipkin.reporter.Sender;
  *
  * Here's a contrived example:
  * <pre>{@code
- * try (Span root = tracer.newTrace().name("2pc").start()) {
- *   try (Span child = tracer.newChild(root.context()).name("prepare").start()) {
+ * Span twoPhase = tracer.newTrace().name("twoPhase").start();
+ * try {
+ *   Span prepare = tracer.newChild(twoPhase.context()).name("prepare").start();
+ *   try {
  *     prepare();
+ *   } finally {
+ *     prepare.finish();
  *   }
- *   try (Span child = tracer.newChild(root.context()).name("commit").start()) {
+ *   Span commit = tracer.newChild(twoPhase.context()).name("commit").start();
+ *   try {
  *     commit();
+ *   } finally {
+ *     commit.finish();
  *   }
+ * } finally {
+ *   twoPhase.finish();
  * }
  * }</pre>
  *

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -8,7 +8,6 @@ import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
 import zipkin.Endpoint;
 
-import static brave.Span.Kind.SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -87,18 +86,11 @@ public class RealSpanTest {
         .containsExactly(BinaryAnnotation.create("foo", "bar", localEndpoint));
   }
 
-  @Test public void autoCloseOnTryFinally() {
-    try (Span span = tracer.newTrace().name("foo").start()) {
-      span.tag("holy", "toledo");
-    }
+  @Test public void doubleFinishDoesntDoubleReport() {
+    Span span = tracer.newTrace().name("foo").start();
 
-    assertThat(spans).hasSize(1);
-  }
-
-  @Test public void autoCloseOnTryFinally_doesntDoubleClose() {
-    try (Span span = tracer.newTrace().kind(SERVER).name("getOrCreate").start()) {
-      span.finish(); // user closes and also auto-close closes
-    }
+    span.finish();
+    span.finish();
 
     assertThat(spans).hasSize(1);
   }


### PR DESCRIPTION
This is a api altering change that's better done now, before more use
`brave.Span`. Notable, this removes Closeable from the implements list.

`Closeable` was added as a convenience on `brave.Span`. It allowed a
try-with-resources pattern with a span, which closes on finish. In
reality this type of usage is contrived. For example, there's no
instrumentation in Brave that can use a try-with-resources pattern. The
only usage was a demo.

When we add an interface, it needs to come with high value, and more
importantly not interfere. For example, questions arise like how are
exceptions handled in the implicit finally block? What might this throw?

Also, static analysis tools like error-prone notice unclosed resources.
Since spans will be created often, if they were always closeable, and
seldom closed (instead using finish), then these static analysis tools
become useless.

More importantly, we will have a need to auto-close something: attaching
a span to the current thread. If we make span closeable, the pattern for
attaching a span, also closeable, becomes more confusing than necessary.

The end result is that the cure is worse than the disease. No code in
Brave instrumentation, or even GitHub searches, take advantage of the
implicit close functionality provided by retro-fitting span with
Closeable. This pull request removes this, in order to reserve try-with-
resources for attaching a span to the current thread.

---

Note this also removes Flushable from brave.Span, as that discourages
typical usage of the `flush` operator (like routinely syncing to disk),
which wasn't what the function was designed for here.