### PR TITLE
Instructions on how to close span on error with JAX-RS

### DIFF
--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveTracingFeature_Server.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveTracingFeature_Server.java
@@ -7,7 +7,11 @@ import com.github.kristofa.brave.jaxrs2.BraveTracingFeature;
 import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -16,13 +20,6 @@ import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 
 public class ITBraveTracingFeature_Server extends ITServletContainer {
-
-  @Override @Test public void reportsSpanOnTransportException() throws Exception {
-    // TODO: it seems the only way to process exceptions in a standard way is ExceptionMapper.
-    // However, we probably shouldn't do that as it can interfere with user defined ones. We
-    // should decide whether to use non-standard means (ex jersey classes), or some other way.
-    throw new AssumptionViolatedException("jaxrs-2 filters cannot process exceptions");
-  }
 
   @Override @Test public void reportsClientAddress() {
     throw new AssumptionViolatedException("TODO: fix client address");
@@ -44,15 +41,38 @@ public class ITBraveTracingFeature_Server extends ITServletContainer {
     }
   }
 
+  /**
+   * {@link ContainerResponseFilter} has no means to handle uncaught exceptions. Unless you provide
+   * a catch-all exception mapper, requests that result in unhandled exceptions will leak until they
+   * are eventually flushed.
+   */
+  @Provider
+  public static class CatchAllExceptions implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception e) {
+      if (e instanceof WebApplicationException) {
+        return ((WebApplicationException) e).getResponse();
+      }
+
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("Internal error")
+          .type("text/plain")
+          .build();
+    }
+  }
+
   @Override
   public void init(ServletContextHandler handler, Brave brave, SpanNameProvider spanNameProvider) {
 
     ResourceConfig config = new ResourceConfig()
         .register(TestResource.class)
+        .register(CatchAllExceptions.class)
         .register(BraveTracingFeature.builder(brave)
             .spanNameProvider(spanNameProvider)
             .build()
         );
+
     handler.addServlet(new ServletHolder(new ServletContainer(config)), "/*");
   }
 }


### PR DESCRIPTION
@lijunyong noticed jax-rs spans don't close on error. This is
problematic as it can leak spans. It is also problematic as spans aren't
highlighted red in the UI.

Unfortunately, there's no hook in JAX-RS for unhandled exceptions. The
only way I can find is to ensure there's always an exception mapper.

Alternatively, we could use framework-specific classes. However, this
would require adding framework-specific modules, which don't yet exist.
If we did that, we'd likely want to do so as a part of #300