### PR TITLE
Parses client address from X-Forwarded-For in JAX-RS and CXF

### DIFF
--- a/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/MaybeAddClientAddressFromRequest.java
+++ b/brave-cxf3/src/main/java/com/github/kristofa/brave/cxf3/MaybeAddClientAddressFromRequest.java
@@ -1,0 +1,28 @@
+package com.github.kristofa.brave.cxf3;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerResponseInterceptor;
+import com.github.kristofa.brave.cxf3.HttpMessage.ServerRequest;
+import com.github.kristofa.brave.internal.MaybeAddClientAddress;
+import zipkin.Constants;
+
+/**
+ * Parses the {@link Constants#CLIENT_ADDR client address}, by looking at "X-Forwarded-For". This
+ * performs no DNS lookups.
+ *
+ * <p>This is a hack as {@link ServerResponseInterceptor} doesn't yet support client addresses.
+ */
+final class MaybeAddClientAddressFromRequest extends MaybeAddClientAddress<ServerRequest> {
+
+  MaybeAddClientAddressFromRequest(Brave brave) { // intentionally hidden
+    super(brave);
+  }
+
+  @Override protected byte[] parseAddressBytes(ServerRequest input) {
+    return ipStringToBytes(input.getHttpHeaderValue("X-Forwarded-For"));
+  }
+
+  @Override protected int parsePort(ServerRequest input) {
+    return -1;
+  }
+}

--- a/brave-cxf3/src/test/java/com/github/kristofa/brave/cxf3/ITBraveServerInOutInterceptors.java
+++ b/brave-cxf3/src/test/java/com/github/kristofa/brave/cxf3/ITBraveServerInOutInterceptors.java
@@ -22,8 +22,10 @@ public class ITBraveServerInOutInterceptors extends ITHttpServer {
     throw new AssumptionViolatedException("TODO: add query params to http.url");
   }
 
+  // AbstractHTTPDestination.HTTP_REQUEST can get access to the servlet request, but requires
+  // a dep on cxf-rt-transports-http
   @Override @Test public void reportsClientAddress() {
-    throw new AssumptionViolatedException("TODO: fix client address");
+    throw new AssumptionViolatedException("cannot read client address w/o cxf-rt-transports-http");
   }
 
   @Override @Test public void addsStatusCodeWhenNotOk() {

--- a/brave-http-tests/src/main/java/com/github/kristofa/brave/http/ITHttpServer.java
+++ b/brave-http-tests/src/main/java/com/github/kristofa/brave/http/ITHttpServer.java
@@ -23,8 +23,10 @@ import zipkin.storage.InMemoryStorage;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 
 public abstract class ITHttpServer {
+
   @Rule public ExpectedException thrown = ExpectedException.none();
   public OkHttpClient client = new OkHttpClient();
 
@@ -101,6 +103,23 @@ public abstract class ITHttpServer {
         .flatExtracting(s -> s.binaryAnnotations)
         .extracting(b -> b.key)
         .contains(Constants.CLIENT_ADDR);
+  }
+
+  @Test
+  public void reportsClientAddress_XForwardedFor() throws Exception {
+    String path = "/foo";
+
+    Request request = new Request.Builder().url(url(path))
+        .header("X-Forwarded-For", "1.2.3.4")
+        .build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(collectedSpans())
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key, b -> b.endpoint.ipv4)
+        .contains(tuple(Constants.CLIENT_ADDR, 1 << 24 | 2 << 16 | 3 << 8 | 4));
   }
 
   @Test

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/JaxRs2HttpResponse.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/JaxRs2HttpResponse.java
@@ -1,6 +1,5 @@
 package com.github.kristofa.brave.jaxrs2;
 
-
 import com.github.kristofa.brave.http.HttpResponse;
 
 import javax.ws.rs.client.ClientResponseContext;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/MaybeAddClientAddressFromRequest.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/MaybeAddClientAddressFromRequest.java
@@ -1,0 +1,29 @@
+package com.github.kristofa.brave.jaxrs2;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ServerResponseInterceptor;
+import com.github.kristofa.brave.internal.MaybeAddClientAddress;
+import javax.ws.rs.container.ContainerRequestContext;
+import zipkin.Constants;
+
+/**
+ * Parses the {@link Constants#CLIENT_ADDR client address}, by looking at "X-Forwarded-For". This
+ * performs no DNS lookups.
+ *
+ * <p>This is a hack as {@link ServerResponseInterceptor} doesn't yet support client addresses.
+ */
+final class MaybeAddClientAddressFromRequest
+    extends MaybeAddClientAddress<ContainerRequestContext> {
+
+  MaybeAddClientAddressFromRequest(Brave brave) { // intentionally hidden
+    super(brave);
+  }
+
+  @Override protected byte[] parseAddressBytes(ContainerRequestContext input) {
+    return ipStringToBytes(input.getHeaderString("X-Forwarded-For"));
+  }
+
+  @Override protected int parsePort(ContainerRequestContext input) {
+    return -1;
+  }
+}

--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveTracingFeature_Server.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveTracingFeature_Server.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 public class ITBraveTracingFeature_Server extends ITServletContainer {
 
   @Override @Test public void reportsClientAddress() {
-    throw new AssumptionViolatedException("TODO: fix client address");
+    throw new AssumptionViolatedException("ContainerRequestContext doesn't include remote address");
   }
 
   @Path("")

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveTracingFeature_Server.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveTracingFeature_Server.java
@@ -24,7 +24,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 public class ITBraveTracingFeature_Server extends ITServletContainer {
 
   @Override @Test public void reportsClientAddress() {
-    throw new AssumptionViolatedException("TODO: fix client address");
+    throw new AssumptionViolatedException("ContainerRequestContext doesn't include remote address");
   }
 
   /**


### PR DESCRIPTION
This adds missing client address parsing from JAX-RS and CXF. Note that
this only handles X-Forwarded-For, not the remote side of the socket as
in both cases, getting access to the client side of the socket doesn't
appear to be in the base api.