### PR TITLE
Adds first http server integration tests for "current span"

### DIFF
--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ITJerseyServletTraceFilter.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ITJerseyServletTraceFilter.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.jersey;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.LocalTracer;
 import com.github.kristofa.brave.http.ITServletContainer;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import com.github.kristofa.brave.servlet.BraveServletFilter;
@@ -9,8 +10,10 @@ import com.sun.jersey.spi.container.servlet.ServletContainer;
 import java.io.IOException;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
+import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -20,10 +23,23 @@ public class ITJerseyServletTraceFilter extends ITServletContainer {
 
   @Path("")
   public static class TestResource {
+    final LocalTracer localTracer;
+
+    public TestResource(@Context ServletContext context) {
+      this.localTracer = ((Brave) context.getAttribute("brave")).localTracer();
+    }
 
     @GET
     @Path("foo")
     public Response get() {
+      return Response.status(200).build();
+    }
+
+    @GET
+    @Path("child")
+    public Response child() {
+      localTracer.startNewSpan("child", "child");
+      localTracer.finishSpan();
       return Response.status(200).build();
     }
 
@@ -38,6 +54,7 @@ public class ITJerseyServletTraceFilter extends ITServletContainer {
   public void init(ServletContextHandler handler, Brave brave, SpanNameProvider spanNameProvider) {
 
     // add a servlet for the test resource
+    handler.setAttribute("brave", brave); // TestResource needs a Brave
     DefaultResourceConfig config = new DefaultResourceConfig(TestResource.class);
     handler.addServlet(new ServletHolder(new ServletContainer(config)), "/*");
 

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveTracingFeature_Server.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveTracingFeature_Server.java
@@ -1,13 +1,16 @@
 package com.github.kristofa.brave.resteasy3;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.LocalTracer;
 import com.github.kristofa.brave.http.ITServletContainer;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import java.io.IOException;
+import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -18,6 +21,7 @@ import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.jboss.resteasy.plugins.spring.SpringContextLoaderListener;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
@@ -50,10 +54,24 @@ public class ITBraveTracingFeature_Server extends ITServletContainer {
 
   @Path("")
   public static class TestResource {
+    final LocalTracer localTracer;
+
+    @Autowired
+    public TestResource(Brave brave) {
+      this.localTracer = brave.localTracer();
+    }
 
     @GET
     @Path("foo")
     public Response get() {
+      return Response.status(200).build();
+    }
+
+    @GET
+    @Path("child")
+    public Response child() {
+      localTracer.startNewSpan("child", "child");
+      localTracer.finishSpan();
       return Response.status(200).build();
     }
 

--- a/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ITServletHandlerInterceptor.java
+++ b/brave-spring-web-servlet-interceptor/src/test/java/com/github/kristofa/brave/spring/ITServletHandlerInterceptor.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.spring;
 
 import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.LocalTracer;
 import com.github.kristofa.brave.http.ITServletContainer;
 import com.github.kristofa.brave.http.SpanNameProvider;
 import java.io.IOException;
@@ -33,9 +34,22 @@ public class ITServletHandlerInterceptor extends ITServletContainer {
 
   @Controller
   static class TestController {
+    final LocalTracer localTracer;
+
+    @Autowired
+    TestController(Brave brave) {
+      this.localTracer = brave.localTracer();
+    }
 
     @RequestMapping(value = "/foo")
     public ResponseEntity<Void> foo() throws IOException {
+      return ResponseEntity.ok().build();
+    }
+
+    @RequestMapping(value = "/child")
+    public ResponseEntity<Void> child() {
+      localTracer.startNewSpan("child", "child");
+      localTracer.finishSpan();
       return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
This adds a test that ensures thread-state is propagated from the trace
interceptors and user code. The endpoint /child will create a local
span. When this happens, it should be a child of the "current span", in
this case the span representing an incoming server request. When thread
state isn't managed properly, the child span will appear as a new trace.