### PR TITLE
Makes BraveTracingFeature a provider (so it can be auto-registered)

### DIFF
--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveTracingFeature.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveTracingFeature.java
@@ -6,9 +6,11 @@ import com.github.kristofa.brave.http.SpanNameProvider;
 import javax.inject.Inject;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
+@Provider
 public final class BraveTracingFeature implements Feature {
 
   /** Creates a tracing feature with defaults. Use {@link #builder(Brave)} to customize. */

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveTracingFeature_Server.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveTracingFeature_Server.java
@@ -98,8 +98,7 @@ public class ITBraveTracingFeature_Server extends ITServletContainer {
 
     appContext.register(TestResource.class); // the test resource
     appContext.register(CatchAllExceptions.class);
-    // TODO: deprecated
-    appContext.register(ContainerFiltersConfiguration.class); // generic tracing setup
+    appContext.register(BraveTracingFeatureConfiguration.class); // generic tracing setup
 
     // resteasy + spring configuration, programmatically as opposed to using web.xml
     handler.addServlet(new ServletHolder(new HttpServletDispatcher()), "/*");


### PR DESCRIPTION
Before, `BraveTracingFeatureConfiguration` for RestEasy wasn't usable
as `BraveTracingFeature` would never be invoked. This was due to a
missing annotation, which is now present.