### PR TITLE
Adds support for "current span" formerly supported with thread binders

### DIFF
--- a/brave-benchmarks/pom.xml
+++ b/brave-benchmarks/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-core_2.12</artifactId>
-      <version>6.43.0</version>
+      <version>${finagle.version}</version>
     </dependency>
   </dependencies>
 

--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ITJerseyClientTraceFilter.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ITJerseyClientTraceFilter.java
@@ -35,18 +35,11 @@ public class ITJerseyClientTraceFilter extends ITHttpClient<Client> {
 
   @Override protected void get(Client client, String pathIncludingQuery)
       throws IOException {
-    client.resource(server.url("/foo").uri()).get(String.class);
+    client.resource(server.url(pathIncludingQuery).uri()).get(String.class);
   }
 
   @Override protected void getAsync(Client client, String pathIncludingQuery) throws Exception {
-    client.asyncResource(server.url("/foo").uri()).get(String.class);
-  }
-
-
-  @Override
-  @Test(expected = AssertionError.class) // query params are not logged in jersey
-  public void httpUrlTagIncludesQueryParams() throws Exception {
-    super.httpUrlTagIncludesQueryParams();
+    client.asyncResource(server.url(pathIncludingQuery).uri()).get(String.class);
   }
 
   @Override

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -71,5 +71,11 @@
       <version>${grpc.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>finagle-core_2.12</artifactId>
+      <version>${finagle.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -1,21 +1,18 @@
 package brave;
 
 import brave.propagation.TraceContext;
+import com.google.auto.value.AutoValue;
 import zipkin.Endpoint;
 
-final class NoopSpan extends Span {
-  final TraceContext context;
+@AutoValue
+abstract class NoopSpan extends Span {
 
-  NoopSpan(TraceContext context) {
-    this.context = context;
+  static NoopSpan create(TraceContext context) {
+    return new AutoValue_NoopSpan(context);
   }
 
   @Override public boolean isNoop() {
     return true;
-  }
-
-  @Override public TraceContext context() {
-    return context;
   }
 
   @Override public Span start() {
@@ -57,10 +54,5 @@ final class NoopSpan extends Span {
   }
 
   @Override public void flush() {
-  }
-
-  @Override
-  public String toString() {
-    return "NoopSpan(" + context + ")";
   }
 }

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -2,81 +2,77 @@ package brave;
 
 import brave.internal.recorder.Recorder;
 import brave.propagation.TraceContext;
+import com.google.auto.value.AutoValue;
 import zipkin.Endpoint;
 
 /** This wraps the public api and guards access to a mutable span. */
-final class RealSpan extends Span {
+@AutoValue
+abstract class RealSpan extends Span {
 
-  final TraceContext context;
-  final Clock clock;
-  final Recorder recorder;
+  abstract Clock clock();
 
-  RealSpan(TraceContext context, Clock clock, Recorder recorder) {
-    this.context = context;
-    this.clock = clock;
-    this.recorder = recorder;
+  abstract Recorder recorder();
+
+  static RealSpan create(TraceContext context, Clock clock, Recorder recorder) {
+    return new AutoValue_RealSpan(context, clock, recorder);
   }
 
   @Override public boolean isNoop() {
     return false;
   }
 
-  @Override public TraceContext context() {
-    return context;
-  }
-
   @Override public Span start() {
-    return start(clock.currentTimeMicroseconds());
+    return start(clock().currentTimeMicroseconds());
   }
 
   @Override public Span start(long timestamp) {
-    recorder.start(context, timestamp);
+    recorder().start(context(), timestamp);
     return this;
   }
 
   @Override public Span name(String name) {
-    recorder.name(context, name);
+    recorder().name(context(), name);
     return this;
   }
 
   @Override public Span kind(Kind kind) {
-    recorder.kind(context, kind);
+    recorder().kind(context(), kind);
     return this;
   }
 
   @Override public Span annotate(String value) {
-    return annotate(clock.currentTimeMicroseconds(), value);
+    return annotate(clock().currentTimeMicroseconds(), value);
   }
 
   @Override public Span annotate(long timestamp, String value) {
-    recorder.annotate(context, timestamp, value);
+    recorder().annotate(context(), timestamp, value);
     return this;
   }
 
   @Override public Span tag(String key, String value) {
-    recorder.tag(context, key, value);
+    recorder().tag(context(), key, value);
     return this;
   }
 
   @Override public Span remoteEndpoint(Endpoint remoteEndpoint) {
-    recorder.remoteEndpoint(context, remoteEndpoint);
+    recorder().remoteEndpoint(context(), remoteEndpoint);
     return this;
   }
 
   @Override public void finish() {
-    finish(clock.currentTimeMicroseconds());
+    finish(clock().currentTimeMicroseconds());
   }
 
   @Override public void finish(long timestamp) {
-    recorder.finish(context, timestamp);
+    recorder().finish(context(), timestamp);
   }
 
   @Override public void flush() {
-    recorder.flush(context);
+    recorder().flush(context());
   }
 
   @Override
   public String toString() {
-    return "RealSpan(" + context + ")";
+    return "RealSpan(" + context() + ")";
   }
 }

--- a/brave/src/main/java/brave/internal/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/internal/StrictCurrentTraceContext.java
@@ -1,0 +1,44 @@
+package brave.internal;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+
+/** Useful when developing instrumentation as state is enforced more strictly */
+public final class StrictCurrentTraceContext extends CurrentTraceContext {
+  // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
+  final ThreadLocal<TraceContext> local = new ThreadLocal<>();
+
+  @Override public TraceContext get() {
+    return local.get();
+  }
+
+  /** Identifies problems by throwing assertion errors when a scope is closed on a different thread. */
+  @Override public Scope newScope(TraceContext currentSpan) {
+    local.set(currentSpan);
+    return new StrictScope(new Throwable(String.format("Thread %s opened scope for %s here:",
+        Thread.currentThread().getName(), currentSpan)));
+  }
+
+  class StrictScope implements Scope {
+    final Throwable caller;
+    final TraceContext previous = local.get();
+    final long threadId = Thread.currentThread().getId();
+
+    StrictScope(Throwable caller) {
+      this.caller = caller;
+    }
+
+    @Override public void close() {
+      if (Thread.currentThread().getId() != threadId) {
+        throw new IllegalStateException(
+            "scope closed in a different thread: " + Thread.currentThread().getName(),
+            caller);
+      }
+      local.set(previous);
+    }
+
+    @Override public String toString() {
+      return caller.toString();
+    }
+  }
+}

--- a/brave/src/main/java/brave/internal/WrappingExecutorService.java
+++ b/brave/src/main/java/brave/internal/WrappingExecutorService.java
@@ -1,0 +1,100 @@
+package brave.internal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/** Used to implement a context propagating executor service which wraps tasks */
+public abstract class WrappingExecutorService implements ExecutorService {
+  protected WrappingExecutorService() {
+  }
+
+  protected abstract ExecutorService delegate();
+
+  protected abstract <C> Callable<C> wrap(Callable<C> task);
+
+  protected abstract Runnable wrap(Runnable task);
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate().awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return delegate().invokeAll(wrap(tasks));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+      TimeUnit unit) throws InterruptedException {
+    return delegate().invokeAll(wrap(tasks), timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    return delegate().invokeAny(wrap(tasks));
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate().invokeAny(wrap(tasks), timeout, unit);
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate().isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate().isTerminated();
+  }
+
+  @Override
+  public void shutdown() {
+    delegate().shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return delegate().shutdownNow();
+  }
+
+  @Override
+  public void execute(Runnable task) {
+    delegate().execute(wrap(task));
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return delegate().submit(wrap(task));
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return delegate().submit(wrap(task));
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return delegate().submit(wrap(task), result);
+  }
+
+  <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks) {
+    ArrayList<Callable<T>> result = new ArrayList<>(tasks.size());
+    for (Callable<T> task : tasks) {
+      result.add(wrap(task));
+    }
+    return result;
+  }
+}

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -1,0 +1,106 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import java.io.Closeable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This makes a given span the current span by placing it in scope (usually but not always a thread
+ * local scope).
+ *
+ * <p>This type is an SPI, and intended to be used by implementors looking to change thread-local
+ * storage, or integrate with other contexts such as logging (MDC).
+ *
+ * <h3>Design</h3>
+ *
+ * This design was inspired by com.google.instrumentation.trace.ContextUtils,
+ * com.google.inject.servlet.RequestScoper and com.github.kristofa.brave.CurrentSpan
+ */
+public abstract class CurrentTraceContext {
+  /** Returns the current span in scope or null if there isn't one. */
+  public abstract @Nullable TraceContext get();
+
+  /**
+   * Sets the current span in scope until the returned object is closed. It is a programming
+   * error to drop or never close the result. Using try-with-resources is preferred for this reason.
+   */
+  public abstract Scope newScope(TraceContext currentSpan);
+
+  /** A span remains in the scope it was bound to until close is called. */
+  public interface Scope extends Closeable {
+    /** No exceptions are thrown when unbinding a span scope. */
+    @Override void close();
+  }
+
+  /** Default implementation which is backed by an inheritable thread local */
+  public static final class Default extends CurrentTraceContext {
+    final InheritableThreadLocal<TraceContext> local = new InheritableThreadLocal<>();
+
+    @Override public TraceContext get() {
+      return local.get();
+    }
+
+    @Override public Scope newScope(TraceContext currentSpan) {
+      final TraceContext previous = local.get();
+      local.set(currentSpan);
+      return () -> local.set(previous);
+    }
+  }
+
+  /** Wraps the input so that it executes with the same context as now. */
+  public <C> Callable<C> wrap(Callable<C> task) {
+    final TraceContext invocationContext = get();
+    return () -> {
+      try (Scope scope = newScope(invocationContext)) {
+        return task.call();
+      }
+    };
+  }
+
+  /** Wraps the input so that it executes with the same context as now. */
+  public Runnable wrap(Runnable task) {
+    final TraceContext invocationContext = get();
+    return () -> {
+      try (Scope scope = newScope(invocationContext)) {
+        task.run();
+      }
+    };
+  }
+
+  /**
+   * Decorates the input such that the {@link #get() current trace context} at the time a task is
+   * scheduled is made current when the task is executed.
+   */
+  public Executor executor(Executor delegate) {
+    class CurrentTraceContextExecutor implements Executor {
+      @Override public void execute(Runnable task) {
+        delegate.execute(CurrentTraceContext.this.wrap(task));
+      }
+    }
+    return new CurrentTraceContextExecutor();
+  }
+
+  /**
+   * Decorates the input such that the {@link #get() current trace context} at the time a task is
+   * scheduled is made current when the task is executed.
+   */
+  public ExecutorService executorService(ExecutorService delegate) {
+    class CurrentTraceContextExecutorService extends brave.internal.WrappingExecutorService {
+
+      @Override protected ExecutorService delegate() {
+        return delegate;
+      }
+
+      @Override protected <C> Callable<C> wrap(Callable<C> task) {
+        return CurrentTraceContext.this.wrap(task);
+      }
+
+      @Override protected Runnable wrap(Runnable task) {
+        return CurrentTraceContext.this.wrap(task);
+      }
+    }
+    return new CurrentTraceContextExecutorService();
+  }
+}

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
@@ -1,0 +1,122 @@
+package brave;
+
+import brave.internal.StrictCurrentTraceContext;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This class is in a separate test as ExecutorService has more features than everything else
+ *
+ * <p>Tests were ported from com.github.kristofa.brave.BraveExecutorServiceTest
+ */
+public class CurrentTraceContextExecutorServiceTest {
+  // Ensures one at-a-time, but also on a different thread
+  ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
+
+  // override default so that it isn't inheritable
+  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  ExecutorService executor = currentTraceContext.executorService(wrappedExecutor);
+
+  Tracer tracer = Tracer.newBuilder().build();
+  TraceContext context = tracer.newTrace().context();
+  TraceContext context2 = tracer.newTrace().context();
+
+  @After public void shutdownExecutor() throws InterruptedException {
+    wrappedExecutor.shutdown();
+    wrappedExecutor.awaitTermination(1, TimeUnit.SECONDS);
+  }
+
+  final TraceContext[] threadValues = new TraceContext[2];
+  CountDownLatch latch = new CountDownLatch(1);
+
+  @Test
+  public void execute() throws Exception {
+    eachTaskHasCorrectSpanAttached(() -> {
+      executor.execute(() -> {
+        threadValues[0] = currentTraceContext.get();
+        try {
+          latch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          e.printStackTrace();
+        }
+      });
+      // this won't run immediately because the other is blocked
+      executor.execute(() -> threadValues[1] = currentTraceContext.get());
+      return null;
+    });
+  }
+
+  @Test
+  public void submit_Runnable() throws Exception {
+    eachTaskHasCorrectSpanAttached(() -> {
+      executor.submit(() -> {
+        threadValues[0] = currentTraceContext.get();
+        try {
+          latch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          e.printStackTrace();
+        }
+      });
+      // this won't run immediately because the other is blocked
+      return executor.submit(() -> threadValues[1] = currentTraceContext.get());
+    });
+  }
+
+  @Test
+  public void submit_Callable() throws Exception {
+    eachTaskHasCorrectSpanAttached(() -> {
+      executor.submit(() -> {
+        threadValues[0] = currentTraceContext.get();
+        latch.await();
+        return true;
+      });
+      // this won't run immediately because the other is blocked
+      return executor.submit(() -> threadValues[1] = currentTraceContext.get());
+    });
+  }
+
+  @Test
+  public void invokeAll() throws Exception {
+    eachTaskHasCorrectSpanAttached(() -> executor.invokeAll(asList(
+        () -> {
+          threadValues[0] = currentTraceContext.get();
+          // Can't use externally supplied latch as invokeAll calls get before returning!
+          Thread.sleep(100); // block the queue in a dodgy compromise
+          return true;
+        },
+        // this won't run immediately because the other is blocked
+        () -> threadValues[1] = currentTraceContext.get())
+    ));
+  }
+
+  void eachTaskHasCorrectSpanAttached(Callable<?> scheduleTwoTasks) throws Exception {
+    // First task should block the queue, forcing the latter to not be scheduled immediately
+    // Both should have the same parent, as the parent applies to the task creation time, not
+    // execution time.
+    try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(context)) {
+      scheduleTwoTasks.call();
+    }
+
+    // switch the current span to something else. If there's a bug, when the
+    // second runnable starts, it will have this span as opposed to the one it was
+    // invoked with
+    try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(context2)) {
+      latch.countDown();
+      shutdownExecutor();
+      assertThat(threadValues)
+          .containsExactly(context, context);
+    }
+  }
+}

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
@@ -1,0 +1,65 @@
+package brave;
+
+import brave.internal.StrictCurrentTraceContext;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** This class is in a separate test to ensure the trace context is not inheritable. */
+public class CurrentTraceContextExecutorTest {
+  // Ensures one at-a-time, but also on a different thread
+  ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
+  // override default so that it isn't inheritable
+  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+
+  Executor executor = currentTraceContext.executor(wrappedExecutor);
+  Tracer tracer = Tracer.newBuilder().build();
+  TraceContext context = tracer.newTrace().context();
+  TraceContext context2 = tracer.newTrace().context();
+
+  @After public void shutdownExecutor() throws InterruptedException {
+    wrappedExecutor.shutdown();
+    wrappedExecutor.awaitTermination(1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void execute() throws Exception {
+    final TraceContext[] threadValues = new TraceContext[2];
+
+    CountDownLatch latch = new CountDownLatch(1);
+    // First task should block the queue, forcing the latter to not be scheduled immediately
+    // Both should have the same parent, as the parent applies to the task creation time, not
+    // execution time.
+    try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(context)) {
+      executor.execute(() -> {
+        threadValues[0] = currentTraceContext.get();
+        try {
+          latch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          e.printStackTrace();
+        }
+      });
+      // this won't run immediately because the other is blocked
+      executor.execute(() -> threadValues[1] = currentTraceContext.get());
+    }
+
+    // switch the current span to something else. If there's a bug, when the
+    // second runnable starts, it will have this span as opposed to the one it was
+    // invoked with
+    try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(context2)) {
+      latch.countDown();
+      shutdownExecutor();
+      assertThat(threadValues)
+          .containsExactly(context, context);
+    }
+  }
+}

--- a/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
@@ -1,0 +1,116 @@
+package brave;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import java.util.concurrent.Callable;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultCurrentTraceContextTest {
+  CurrentTraceContext.Default currentTraceContext = new CurrentTraceContext.Default();
+  Tracer tracer = Tracer.newBuilder().build();
+  TraceContext context = tracer.newTrace().context();
+  TraceContext context2 = tracer.newTrace().context();
+
+  @Test public void currentSpan_defaultsToNull() {
+    assertThat(currentTraceContext.get()).isNull();
+  }
+
+  @Test public void scope_retainsContext() {
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      assertThat(currentTraceContext.get())
+          .isEqualTo(context);
+    }
+  }
+
+  @Test public void scope_isDefinedPerThread() throws InterruptedException {
+    final TraceContext[] threadValue = new TraceContext[1];
+
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      Thread t = new Thread(() -> { // inheritable thread local
+        assertThat(currentTraceContext.get())
+            .isEqualTo(context);
+
+        try (CurrentTraceContext.Scope scope2 = currentTraceContext.newScope(context2)) {
+          assertThat(currentTraceContext.get())
+              .isEqualTo(context2);
+          threadValue[0] = context2;
+        }
+      });
+
+      t.start();
+      t.join();
+      assertThat(currentTraceContext.get())
+          .isEqualTo(context);
+      assertThat(threadValue[0])
+          .isEqualTo(context2);
+    }
+  }
+
+  @Test public void instancesAreIndependent() {
+    CurrentTraceContext.Default currentTraceContext2 = new CurrentTraceContext.Default();
+
+    try (CurrentTraceContext.Scope scope1 = currentTraceContext.newScope(context)) {
+      assertThat(currentTraceContext2.get()).isNull();
+
+      try (CurrentTraceContext.Scope scope2 = currentTraceContext2.newScope(context2)) {
+        assertThat(currentTraceContext.get()).isEqualTo(context);
+        assertThat(currentTraceContext2.get()).isEqualTo(context2);
+      }
+    }
+  }
+
+  @Test
+  public void attachesSpanInCallable() throws Exception {
+    Callable<?> callable;
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      callable = currentTraceContext.wrap(() -> {
+        assertThat(currentTraceContext.get())
+            .isEqualTo(context);
+        return true;
+      });
+    }
+
+    // Set another span between the time the task was made and executed.
+    try (CurrentTraceContext.Scope scope2 = currentTraceContext.newScope(context2)) {
+      callable.call(); // runs assertion
+    }
+  }
+
+  @Test
+  public void restoresSpanAfterCallable() throws Exception {
+    TraceContext context0 = tracer.newTrace().context();
+    try (CurrentTraceContext.Scope scope0 = currentTraceContext.newScope(context0)) {
+      attachesSpanInCallable();
+      assertThat(currentTraceContext.get())
+          .isEqualTo(context0);
+    }
+  }
+
+  @Test
+  public void attachesSpanInRunnable() throws Exception {
+    Runnable runnable;
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      runnable = currentTraceContext.wrap(() -> {
+        assertThat(currentTraceContext.get())
+            .isEqualTo(context);
+      });
+    }
+
+    // Set another span between the time the task was made and executed.
+    try (CurrentTraceContext.Scope scope2 = currentTraceContext.newScope(context2)) {
+      runnable.run(); // runs assertion
+    }
+  }
+
+  @Test
+  public void restoresSpanAfterRunnable() throws Exception {
+    TraceContext context0 = tracer.newTrace().context();
+    try (CurrentTraceContext.Scope scope0 = currentTraceContext.newScope(context0)) {
+      attachesSpanInRunnable();
+      assertThat(currentTraceContext.get())
+          .isEqualTo(context0);
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
+++ b/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
@@ -1,0 +1,120 @@
+package brave.features.finagle_context;
+
+import brave.Span;
+import brave.Tracer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import com.twitter.finagle.context.MarshalledContext;
+import com.twitter.finagle.tracing.Flags$;
+import com.twitter.finagle.tracing.SpanId;
+import com.twitter.finagle.tracing.Trace;
+import com.twitter.finagle.tracing.Trace$;
+import com.twitter.finagle.tracing.TraceId;
+import com.twitter.io.Buf;
+import com.twitter.util.Local;
+import java.lang.reflect.Field;
+import org.junit.Test;
+import scala.Option;
+import scala.Some;
+import scala.collection.immutable.Map;
+import scala.runtime.AbstractFunction0;
+
+import static com.twitter.finagle.context.Contexts.broadcast;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FinagleContextInteropTest {
+
+  @Test public void finagleBraveInterop() throws Exception {
+    Tracer tracer = Tracer.newBuilder().currentTraceContext(new FinagleCurrentTraceContext()).build();
+
+    Span parent = tracer.newTrace(); // start a trace in Brave
+    try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {
+      // Inside the parent scope, trace context is consistent between finagle and brave
+      assertThat(tracer.currentSpan().context().spanId())
+          .isEqualTo(Trace.id().spanId().self());
+
+      // create a child in finagle
+      Trace.letId(Trace.nextId(), false, new AbstractFunction0<Void>() {
+        @Override public Void apply() {
+          // Inside the child scope, trace context is consistent between finagle and brave
+          assertThat(tracer.currentSpan().context().spanId())
+              .isEqualTo(Trace.id().spanId().self());
+
+          // The child span has the correct parent (consistent between finagle and brave)
+          assertThat(tracer.currentSpan().context().parentId())
+              .isEqualTo(parent.context().spanId())
+              .isEqualTo(Trace.id().parentId().self());
+
+          return null;
+        }
+      });
+
+      // After leaving the child scope, trace context is consistent between finagle and brave
+      assertThat(tracer.currentSpan().context().spanId())
+          .isEqualTo(Trace.id().spanId().self());
+
+      // The parent span was reverted
+      assertThat(tracer.currentSpan().context().spanId())
+          .isEqualTo(parent.context().spanId())
+          .isEqualTo(Trace.id().spanId().self());
+    }
+
+    // Outside a scope, trace context is consistent between finagle and brave
+    assertThat(tracer.currentSpan()).isNull();
+    assertThat(Trace.idOption().isDefined()).isFalse();
+  }
+
+  /**
+   * In Finagle, let forms are used to apply an trace context to a function. This is implemented
+   * under the scenes by a try-finally block using {@link Local#set(Option)}. The below code uses
+   * this detail to allow interop between finagle and {@link CurrentTraceContext}.
+   */
+  static class FinagleCurrentTraceContext extends CurrentTraceContext {
+    static final MarshalledContext.Key<TraceId> TRACE_ID_KEY = Trace$.MODULE$.idCtx();
+
+    final Local broadcastLocal;
+
+    FinagleCurrentTraceContext() throws NoSuchFieldException, IllegalAccessException {
+      Field field = MarshalledContext.class.getDeclaredField("local");
+      field.setAccessible(true);
+      this.broadcastLocal = (Local) field.get(broadcast());
+    }
+
+    @Override public TraceContext get() {
+      Option<TraceId> option = broadcast().get(Trace$.MODULE$.idCtx());
+      if (option.isEmpty()) return null;
+      return toTraceContext(option.get());
+    }
+
+    @Override public Scope newScope(TraceContext currentSpan) {
+      Map<Buf, MarshalledContext.Cell> saved = broadcast().env();
+      Map<Buf, MarshalledContext.Cell> update = broadcast().env().updated(
+          TRACE_ID_KEY.marshalId(),
+          broadcast().Real().apply(TRACE_ID_KEY, new Some(toTraceId(currentSpan)))
+      );
+      broadcastLocal.set(new Some(update));
+      return () -> broadcastLocal.set(new Some(saved));
+    }
+  }
+
+  static TraceContext toTraceContext(TraceId id) {
+    return TraceContext.newBuilder()
+        .traceId(id.traceId().self())
+        .parentId(id._parentId().isEmpty() ? null : id.parentId().self())
+        .spanId(id.spanId().self())
+        .sampled(id.getSampled().isEmpty() ? null : id.getSampled().get())
+        .debug(id.flags().isDebug())
+        // .shared(isn't known in finagle)
+        .build();
+  }
+
+  static TraceId toTraceId(TraceContext context) {
+    return new TraceId(
+        Option.apply(SpanId.apply(context.traceId())),
+        Option.apply(context.parentId() == null ? null : SpanId.apply(context.parentId())),
+        SpanId.apply(context.spanId()),
+        Option.apply(context.sampled()),
+        Flags$.MODULE$.apply(context.debug() ? 1 : 0)
+    );
+  }
+}

--- a/brave/src/test/java/brave/features/finagle_context/package-info.java
+++ b/brave/src/test/java/brave/features/finagle_context/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This shows how you can reuse finagle's trace context in Brave
+ */
+package brave.features.finagle_context;

--- a/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
+++ b/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
@@ -1,0 +1,62 @@
+package brave.features.log4j2_context;
+
+import brave.Span;
+import brave.Tracer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Log4JThreadContextTest {
+
+  /**
+   * One common request is to support SLF4J or Log4J2 log correlation. This shows you can make a
+   * custom implementation
+   */
+  @Test public void customCurrentTraceContext() {
+    assertThat(ThreadContext.get("traceID"))
+        .isNull();
+
+    Tracer tracer = Tracer.newBuilder().currentTraceContext(new Log4J2CurrentTraceContext()).build();
+
+    Span parent = tracer.newTrace();
+    try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {
+      // the trace id is now in the logging context
+      assertThat(ThreadContext.get("traceId"))
+          .isEqualTo(parent.context().traceIdString());
+
+      Span child = tracer.newChild(parent.context());
+      try (Tracer.SpanInScope wsChild = tracer.withSpanInScope(child)) {
+        // nesting worked
+        assertThat(ThreadContext.get("traceId"))
+            .isEqualTo(child.context().traceIdString());
+      }
+
+      // old parent reverted
+      assertThat(ThreadContext.get("traceId"))
+          .isEqualTo(parent.context().traceIdString());
+    }
+    assertThat(ThreadContext.get("traceId"))
+        .isNull();
+  }
+
+  static class Log4J2CurrentTraceContext extends CurrentTraceContext {
+    CurrentTraceContext delegate = new CurrentTraceContext.Default();
+
+    @Override public TraceContext get() {
+      return delegate.get();
+    }
+
+    @Override public Scope newScope(TraceContext currentSpan) {
+      final String previousTraceId = ThreadContext.get("traceId");
+      ThreadContext.put("traceId", currentSpan.traceIdString());
+      Scope scope = delegate.newScope(currentSpan);
+      return () -> {
+        scope.close();
+        ThreadContext.put("traceId", previousTraceId);
+      };
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/log4j2_context/package-info.java
+++ b/brave/src/test/java/brave/features/log4j2_context/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This shows how you can add brave trace context into log4j2's ThreadContext (MDC)
+ */
+package brave.features.log4j2_context;

--- a/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
@@ -1,0 +1,68 @@
+package brave.internal;
+
+import brave.Tracer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StrictCurrentTraceContextTest {
+  ExecutorService executor = Executors.newSingleThreadExecutor();
+  // override default so that it isn't inheritable
+  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+
+  Tracer tracer = Tracer.newBuilder().build();
+  TraceContext context = tracer.newTrace().context();
+
+  @After public void after() throws InterruptedException {
+    executor.shutdownNow();
+    executor.awaitTermination(1, TimeUnit.SECONDS);
+  }
+
+  @Test public void scope_isNotInheritable() throws InterruptedException {
+    final TraceContext[] threadValue = new TraceContext[1];
+
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      Thread t = new Thread(() -> { // should not inherit scope!
+        threadValue[0] = currentTraceContext.get();
+      });
+
+      t.start();
+      t.join();
+      assertThat(threadValue[0]).isNull();
+    }
+  }
+
+  @Test public void scope_enforcesCloseOnSameThread() throws InterruptedException {
+    final Exception[] spawnedThreadException = new Exception[1];
+    Thread scopingThread = new Thread(() -> {
+      try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+        Thread spawnedThread = new Thread(() -> { // should not inherit scope!
+          try {
+            scope.close();
+          } catch (IllegalStateException e) {
+            spawnedThreadException[0] = e;
+          }
+        }, "spawned thread");
+        spawnedThread.start();
+        spawnedThread.join();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+        Thread.currentThread().interrupt();
+      }
+    }, "scoping thread");
+
+    scopingThread.start();
+    scopingThread.join();
+
+    assertThat(spawnedThreadException[0])
+        .hasMessage("scope closed in a different thread: spawned thread");
+    assertThat(spawnedThreadException[0].getCause())
+        .hasMessage("Thread scoping thread opened scope for " + context + " here:");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <jetty.version>8.1.22.v20160922</jetty.version>
     <zipkin.version>1.19.2</zipkin.version>
     <zipkin-reporter.version>0.6.13</zipkin-reporter.version>
+    <finagle.version>6.43.0</finagle.version>
     <log4j.version>2.8.1</log4j.version>
     <okhttp.version>3.6.0</okhttp.version>
     <grpc.version>1.2.0</grpc.version>


### PR DESCRIPTION
This implements a "current span" concept which represents the in-flight
operation. `Tracer.currentSpan()` can be used to add custom tags to a
span and `Tracer.nextSpan()` can be used to create a child of whatever
is in-flight.

The backend of this is `CurrentTraceContext` which can be extended to
support SLF4J or Finagle synchronization. It also exposes concurrent
wrappers for types like `ExecutorService`.

Particularly, this includes the ability to get the "current span" and assign is to a scope. In most cases the implementation will be backed by thread locals, whether that's directly (as brave's former thread state was) or indirectly via a GRPC or Finagle Context.

The (power) user apis are located in the Tracer api:
* `Span currentSpan` - retrieves any span in scope or null
* `Span nextSpan` - creates a new child or trace if there's no current span
* `SpanInScope withSpanInScope(span)` - makes a span current and available to calls within the scope

The SPI for this is called `CurrentTraceContext`, and it can be implemented to support MDC integration or alternate span storage
* `TraceContext get()` - returns the current trace context or null
*  `Scope newScope(context)` - creates a scope where calls to get will return the input

By default, `CurrentTraceContext` is implemented by a thread local, though there are tests to show it can be implemented by Finagle (or gRPC or otherwise).

Fixes #166