### PR TITLE
Makes circleci use maven wrapper and forces retrolambda to fork

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,8 @@ dependencies:
     - ./build-support/go-offline.sh
 
 test:
+  override:
+    - ./mvnw integration-test
   post:
     # parameters used during release
     # allocate commits to CI, not the owner of the deploy key

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
               </goals>
               <configuration>
                 <target>${main.java.version}</target>
-                <fork>false</fork>
+                <fork>true</fork>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
Before, circleci's test phase didn't use the maven wrapper which was
inconsistent with other phases.

Also, retrolambda wasn't forking and this caused some spurious issues
attempting to backport lambdas.