### PR TITLE
Adds Tracer.current(): last resort when you can't otherwise get a tracer

### DIFF
--- a/brave/src/main/java/brave/internal/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/internal/StrictCurrentTraceContext.java
@@ -6,6 +6,7 @@ import brave.propagation.TraceContext;
 /** Useful when developing instrumentation as state is enforced more strictly */
 public final class StrictCurrentTraceContext extends CurrentTraceContext {
   // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
+  // intentionally not static to make explicit when instrumentation need per thread semantics
   final ThreadLocal<TraceContext> local = new ThreadLocal<>();
 
   @Override public TraceContext get() {

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -34,9 +34,12 @@ public abstract class CurrentTraceContext {
     @Override void close();
   }
 
-  /** Default implementation which is backed by an inheritable thread local */
+  /** Default implementation which is backed by a static inheritable thread local */
   public static final class Default extends CurrentTraceContext {
-    final InheritableThreadLocal<TraceContext> local = new InheritableThreadLocal<>();
+    // static as we want one context per thread, not one context per thread-instance.
+    // if this is not static, patterns that coordinate via statics (like Tracer.current()) will break.
+    // static ThreadLocal was also used in Brave 3's ThreadLocalServerClientAndLocalSpanState
+    static final InheritableThreadLocal<TraceContext> local = new InheritableThreadLocal<>();
 
     @Override public TraceContext get() {
       return local.get();

--- a/brave/src/test/java/brave/CurrentTracerTest.java
+++ b/brave/src/test/java/brave/CurrentTracerTest.java
@@ -1,0 +1,73 @@
+package brave;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CurrentTracerTest {
+  @Before
+  public void reset() {
+    Tracer.current = null;
+  }
+
+  @Test public void defaultsToNull() {
+    assertThat(Tracer.current()).isNull();
+  }
+
+  @Test public void autoRegisters() {
+    Tracer tracer = Tracer.newBuilder().build();
+
+    assertThat(Tracer.current())
+        .isSameAs(tracer);
+  }
+
+  @Test public void setsNotCurrentOnClose() {
+    autoRegisters();
+
+    Tracer.current().close();
+
+    assertThat(Tracer.current()).isNull();
+  }
+
+  @Test public void canSetCurrentAgain() {
+    setsNotCurrentOnClose();
+
+    autoRegisters();
+  }
+
+  @Test public void onlyRegistersOnce() throws InterruptedException {
+    final Tracer[] threadValues = new Tracer[10]; // array ref for thread-safe setting
+
+    List<Thread> getOrSet = new ArrayList<>(20);
+
+    for (int i = 0; i < 10; i++) {
+      final int index = i;
+      getOrSet.add(new Thread(() -> threadValues[index] = Tracer.current()));
+    }
+    for (int i = 10; i < 20; i++) {
+      getOrSet.add(new Thread(() -> Tracer.newBuilder().build()));
+    }
+
+    // make it less predictable
+    Collections.shuffle(getOrSet);
+
+    // start the races
+    getOrSet.forEach(Thread::start);
+    for (Thread thread : getOrSet) {
+      thread.join();
+    }
+
+    Set<Tracer> tracers = new LinkedHashSet<>(Arrays.asList(threadValues));
+    tracers.remove(null);
+    // depending on race, we should have either one tracer or no tracer
+    assertThat(tracers.isEmpty() || tracers.size() == 1)
+        .isTrue();
+  }
+}

--- a/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
@@ -48,16 +48,14 @@ public class DefaultCurrentTraceContextTest {
     }
   }
 
-  @Test public void instancesAreIndependent() {
-    CurrentTraceContext.Default currentTraceContext2 = new CurrentTraceContext.Default();
-
-    try (CurrentTraceContext.Scope scope1 = currentTraceContext.newScope(context)) {
-      assertThat(currentTraceContext2.get()).isNull();
-
-      try (CurrentTraceContext.Scope scope2 = currentTraceContext2.newScope(context2)) {
-        assertThat(currentTraceContext.get()).isEqualTo(context);
-        assertThat(currentTraceContext2.get()).isEqualTo(context2);
-      }
+  /**
+   * Ensures default scope is per thread, not per thread,instance. This is needed when using {@link
+   * Tracer#current()} such as instrumenting JDBC.
+   */
+  @Test public void perThreadScope() {
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      assertThat(Tracer.current().currentSpan().context())
+          .isEqualTo(context);
     }
   }
 


### PR DESCRIPTION
This adds `Tracer.current()` which particularly paves the way for trace
instrumentation on resources that initialize prior to the tracer, like
JDBC drivers.

static method `Tracer.current()` represents the last initialized Tracer
instance method `Tracer.close()` deregisters a tracer if it is current

This was based on an implementation in #210 by @ewhauser
The close hook hopefully satisfies @schlosna deregistration request

This isn't a separate type or pluggable in attempts to keep the behavior
easy to understand.

Closes #210
Fixes #206