### PR TITLE
Adds brave.Tracing an object graph that holds things you need

### DIFF
--- a/brave-benchmarks/src/main/java/brave/SpanCreationBenchmarks.java
+++ b/brave-benchmarks/src/main/java/brave/SpanCreationBenchmarks.java
@@ -40,9 +40,9 @@ public class SpanCreationBenchmarks {
   @Setup
   public void setup() {
     // real everything except reporting
-    tracer = Tracer.newBuilder()
+    tracer = Tracing.newBuilder()
         .reporter(Reporter.NOOP)
-        .build();
+        .build().tracer();
     recorder = tracer.recorder;
     clock = tracer.clock;
     brave = new Brave.Builder()

--- a/brave-core/src/test/java/brave/interop/MixedBraveVersionsExample.java
+++ b/brave-core/src/test/java/brave/interop/MixedBraveVersionsExample.java
@@ -2,6 +2,7 @@ package brave.interop;
 
 import brave.Span;
 import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContextOrSamplingFlags;
 import com.github.kristofa.brave.Brave;
@@ -46,15 +47,15 @@ public class MixedBraveVersionsExample {
   InMemoryStorage storage = new InMemoryStorage();
 
   /** Use different tracers for client and server as usually they are on different hosts. */
-  Tracer brave4Client = Tracer.newBuilder()
+  Tracer brave4Client = Tracing.newBuilder()
       .localEndpoint(Endpoint.builder().serviceName("client").build())
       .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
-      .build();
+      .build().tracer();
   Brave brave3Client = TracerAdapter.newBrave(brave4Client);
-  Tracer brave4Server = Tracer.newBuilder()
+  Tracer brave4Server = Tracing.newBuilder()
       .localEndpoint(Endpoint.builder().serviceName("server").build())
       .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
-      .build();
+      .build().tracer();
   Brave brave3Server = TracerAdapter.newBrave(brave4Server);
 
   CountDownLatch flushedIncomingRequest = new CountDownLatch(1);

--- a/brave-core/src/test/java/brave/interop/TracerAdapterTest.java
+++ b/brave-core/src/test/java/brave/interop/TracerAdapterTest.java
@@ -1,6 +1,7 @@
 package brave.interop; // intentionally in a different package
 
 import brave.Tracer;
+import brave.Tracing;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TracerAdapter;
@@ -22,8 +23,11 @@ public class TracerAdapterTest {
 
   List<zipkin.Span> spans = new ArrayList<>();
   AtomicLong epochMicros = new AtomicLong();
-  Tracer brave4 =
-      Tracer.newBuilder().clock(epochMicros::incrementAndGet).reporter(spans::add).build();
+  Tracer brave4 = Tracing.newBuilder()
+      .clock(epochMicros::incrementAndGet)
+      .reporter(spans::add)
+      .build()
+      .tracer();
   Brave brave3 = TracerAdapter.newBrave(brave4);
 
   @Test public void startWithLocalTracerAndFinishWithTracer() {

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
@@ -1,13 +1,13 @@
 package com.github.kristofa.brave;
 
-import brave.Tracer;
+import brave.Tracing;
 
 public class Brave4ClientTracerTest extends ClientTracerTest {
   @Override Brave newBrave() {
-    return TracerAdapter.newBrave(Tracer.newBuilder()
+    return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(new AnnotationSubmitter.DefaultClock()::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
         .clock(clock::currentTimeMicroseconds)
-        .reporter(spans::add).build());
+        .reporter(spans::add).build().tracer());
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
@@ -1,19 +1,19 @@
 package com.github.kristofa.brave;
 
-import brave.Tracer;
+import brave.Tracing;
 
 public class Brave4LocalTracerTest extends LocalTracerTest {
   @Override Brave newBrave() {
-    return TracerAdapter.newBrave(Tracer.newBuilder()
+    return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build());
+        .reporter(spans::add).build().tracer());
   }
 
   @Override Brave newBrave(ServerClientAndLocalSpanState state) {
-    return TracerAdapter.newBrave(Tracer.newBuilder()
+    return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build(), state);
+        .reporter(spans::add).build().tracer(), state);
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
@@ -1,11 +1,11 @@
 package com.github.kristofa.brave;
 
-import brave.Tracer;
+import brave.Tracing;
 
 public class Brave4ServerRequestInterceptorTest extends ServerRequestInterceptorTest {
   @Override Brave newBrave() {
-    return TracerAdapter.newBrave(Tracer.newBuilder()
+    return TracerAdapter.newBrave(Tracing.newBuilder()
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build());
+        .reporter(spans::add).build().tracer());
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
@@ -1,12 +1,12 @@
 package com.github.kristofa.brave;
 
-import brave.Tracer;
+import brave.Tracing;
 
 public class Brave4ServerTracerTest extends ServerTracerTest {
   @Override Brave newBrave() {
-    return TracerAdapter.newBrave(Tracer.newBuilder()
+    return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build());
+        .reporter(spans::add).build().tracer());
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/Brave4Test.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/Brave4Test.java
@@ -1,22 +1,22 @@
 package com.github.kristofa.brave;
 
-import brave.Tracer;
+import brave.Tracing;
 
 public class Brave4Test extends BraveTest {
 
   @Override protected Brave newBrave() {
-    return TracerAdapter.newBrave(Tracer.newBuilder().build());
+    return TracerAdapter.newBrave(Tracing.newBuilder().build().tracer());
   }
 
   @Override protected Brave newBrave(Sampler sampler) {
-    return TracerAdapter.newBrave(Tracer.newBuilder().sampler(new brave.sampler.Sampler() {
+    return TracerAdapter.newBrave(Tracing.newBuilder().sampler(new brave.sampler.Sampler() {
       @Override public boolean isSampled(long traceId) {
         return sampler.isSampled(traceId);
       }
-    }).build());
+    }).build().tracer());
   }
 
   @Override protected Brave newBraveWith128BitTraceIds() {
-    return TracerAdapter.newBrave(Tracer.newBuilder().traceId128Bit(true).build());
+    return TracerAdapter.newBrave(Tracing.newBuilder().traceId128Bit(true).build().tracer());
   }
 }

--- a/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
@@ -1,10 +1,10 @@
 package com.github.kristofa.brave.internal;
 
-import brave.Tracer;
+import brave.Tracing;
 import com.github.kristofa.brave.TracerAdapter;
 
 public class Brave4MaybeAddClientAddressTest extends MaybeAddClientAddressTest {
   public Brave4MaybeAddClientAddressTest() {
-    brave = TracerAdapter.newBrave(Tracer.newBuilder().reporter(spans::add).build());
+    brave = TracerAdapter.newBrave(Tracing.newBuilder().reporter(spans::add).build().tracer());
   }
 }

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -1,6 +1,5 @@
 package brave;
 
-import brave.internal.Internal;
 import brave.internal.Nullable;
 import brave.internal.Platform;
 import brave.internal.recorder.Recorder;
@@ -12,9 +11,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.Sampler;
 import java.io.Closeable;
 import zipkin.Endpoint;
-import zipkin.reporter.AsyncReporter;
 import zipkin.reporter.Reporter;
-import zipkin.reporter.Sender;
 
 /**
  * Using a tracer, you can create a root span capturing the critical path of a request. Child
@@ -44,144 +41,62 @@ import zipkin.reporter.Sender;
  * @see Span
  * @see Propagation
  */
-public final class Tracer implements Closeable {
-  // volatile for visibility on get. writes guarded by Tracer.class
-  static volatile Tracer current = null;
+public final class Tracer {
 
-  /**
-   * Returns the most recently created tracer iff it hasn't been closed. null otherwise.
-   *
-   * <p>This object should not be cached.
-   */
-  @Nullable public static Tracer current() {
-    return current;
-  }
-
-  private void maybeSetCurrent() {
-    if (current != null) return;
-    synchronized (Tracer.class) {
-      if (current == null) current = this;
-    }
-  }
-
-  /** Ensures this tracer can be garbage collected, by making it not {@link #current()} */
-  @Override public void close() {
-    if (current != this) return;
-    // don't blindly set most recent to null as there could be a race
-    synchronized (Tracer.class) {
-      if (current == this) current = null;
-    }
-  }
-
-  public static Builder newBuilder() {
+  /** @deprecated Please use {@link Tracing#newBuilder()} */
+  @Deprecated public static Builder newBuilder() {
     return new Builder();
   }
 
-  public static final class Builder {
-    String localServiceName;
-    Endpoint localEndpoint;
-    Reporter<zipkin.Span> reporter;
-    Clock clock;
-    Sampler sampler = Sampler.ALWAYS_SAMPLE;
-    CurrentTraceContext currentTraceContext = new CurrentTraceContext.Default();
-    boolean traceId128Bit = false;
+  /** @deprecated Please use {@link Tracing.Builder} */
+  @Deprecated public static final class Builder {
+    final Tracing.Builder delegate = new Tracing.Builder();
 
-    /**
-     * Controls the name of the service being traced, while still using a default site-local IP.
-     * This is an alternative to {@link #localEndpoint(Endpoint)}.
-     *
-     * @param localServiceName name of the service being traced. Defaults to "unknown".
-     */
+    /** @see Tracing.Builder#localServiceName(String) */
     public Builder localServiceName(String localServiceName) {
-      if (localServiceName == null) throw new NullPointerException("localServiceName == null");
-      this.localServiceName = localServiceName;
+      delegate.localServiceName(localServiceName);
       return this;
     }
 
-    /**
-     * @param localEndpoint Endpoint of the local service being traced. Defaults to site local.
-     */
+    /**  @see Tracing.Builder#localEndpoint(Endpoint) */
     public Builder localEndpoint(Endpoint localEndpoint) {
-      if (localEndpoint == null) throw new NullPointerException("localEndpoint == null");
-      this.localEndpoint = localEndpoint;
+      delegate.localEndpoint(localEndpoint);
       return this;
     }
 
-    /**
-     * Controls how spans are reported. Defaults to logging, but often an {@link AsyncReporter}
-     * which batches spans before sending to Zipkin.
-     *
-     * The {@link AsyncReporter} includes a {@link Sender}, which is a driver for transports like
-     * http, kafka and scribe.
-     *
-     * <p>For example, here's how to batch send spans via http:
-     *
-     * <pre>{@code
-     * reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
-     *                         .build();
-     *
-     * tracerBuilder.reporter(reporter);
-     * }</pre>
-     *
-     * <p>See https://github.com/openzipkin/zipkin-reporter-java
-     */
+    /**  @see Tracing.Builder#reporter(Reporter) */
     public Builder reporter(Reporter<zipkin.Span> reporter) {
-      if (reporter == null) throw new NullPointerException("reporter == null");
-      this.reporter = reporter;
+      delegate.reporter(reporter);
       return this;
     }
 
-    /** See {@link Tracer#clock()} */
+    /** @see Tracing.Builder#clock(Clock) */
     public Builder clock(Clock clock) {
-      if (clock == null) throw new NullPointerException("clock == null");
-      this.clock = clock;
+      delegate.clock(clock);
       return this;
     }
 
-    /**
-     * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether
-     * the overhead of tracing will occur and/or if a trace will be reported to Zipkin.
-     */
+    /** @see Tracing.Builder#sampler(Sampler) */
     public Builder sampler(Sampler sampler) {
-      this.sampler = sampler;
+      delegate.sampler(sampler);
       return this;
     }
 
-    /**
-     * Responsible for implementing {@link Tracer#currentSpan()} and {@link
-     * Tracer#withSpanInScope(Span)}. By default a simple thread-local is used. Override to support
-     * other mechanisms or to synchronize with other mechanisms such as SLF4J's MDC.
-     */
+    /** @see Tracing.Builder#currentTraceContext(CurrentTraceContext) */
     public Builder currentTraceContext(CurrentTraceContext currentTraceContext) {
-      this.currentTraceContext = currentTraceContext;
+      delegate.currentTraceContext(currentTraceContext);
       return this;
     }
 
-    /** When true, new root spans will have 128-bit trace IDs. Defaults to false (64-bit) */
+    /** @see Tracing.Builder#traceId128Bit(boolean) */
     public Builder traceId128Bit(boolean traceId128Bit) {
-      this.traceId128Bit = traceId128Bit;
+      delegate.traceId128Bit(traceId128Bit);
       return this;
     }
 
     public Tracer build() {
-      if (clock == null) clock = Platform.get();
-      if (localEndpoint == null) {
-        localEndpoint = Platform.get().localEndpoint();
-        if (localServiceName != null) {
-          localEndpoint = localEndpoint.toBuilder().serviceName(localServiceName).build();
-        }
-      }
-      if (reporter == null) reporter = Platform.get();
-      return new Tracer(this);
+      return delegate.build().tracer();
     }
-  }
-
-  static {
-    Internal.instance = new Internal() {
-      @Override public Long timestamp(Tracer tracer, TraceContext context) {
-        return tracer.recorder.timestamp(context);
-      }
-    };
   }
 
   final Clock clock;
@@ -191,18 +106,17 @@ public final class Tracer implements Closeable {
   final CurrentTraceContext currentTraceContext;
   final boolean traceId128Bit;
 
-  Tracer(Builder builder) {
+  Tracer(Tracing.Builder builder) {
     this.clock = builder.clock;
     this.localEndpoint = builder.localEndpoint;
     this.recorder = new Recorder(localEndpoint, clock, builder.reporter);
     this.sampler = builder.sampler;
     this.currentTraceContext = builder.currentTraceContext;
     this.traceId128Bit = builder.traceId128Bit;
-    maybeSetCurrent();
   }
 
-  /** Used internally by operations such as {@link Span#finish()}, exposed for convenience. */
-  public Clock clock() {
+  /** @deprecated use {@link Tracing#clock()} */
+  @Deprecated public Clock clock() {
     return clock;
   }
 

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -1,0 +1,246 @@
+package brave;
+
+import brave.internal.Internal;
+import brave.internal.Nullable;
+import brave.internal.Platform;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.sampler.Sampler;
+import java.io.Closeable;
+import zipkin.Endpoint;
+import zipkin.reporter.AsyncReporter;
+import zipkin.reporter.Reporter;
+import zipkin.reporter.Sender;
+
+/**
+ * This provides utilities needed for trace instrumentation. For example, a {@link Tracer}.
+ *
+ * <p>Instances built via {@link #newBuilder()} are registered automatically such that statically
+ * configured instrumentation like JDBC drivers can use {@link #current()}.
+ *
+ * <p>This type can be extended so that the object graph can be built differently or overridden, for
+ * example via spring or when mocking.
+ */
+public abstract class Tracing implements Closeable {
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /** All tracing commands start with a {@link Span}. Use a tracer to create spans. */
+  abstract public Tracer tracer();
+
+  /**
+   * When a trace leaves the process, it needs to be propagated, usually via headers. This utility
+   * is used to inject or extract a trace context from remote requests.
+   */
+  // Implementations should override and cache this as a field.
+  public Propagation<String> propagation() {
+    return propagationFactory().create(Propagation.KeyFactory.STRING);
+  }
+
+  /** This supports edge cases like GRPC Metadata propagation which doesn't use String keys. */
+  abstract public Propagation.Factory propagationFactory();
+
+  /**
+   * This supports in-process propagation, typically across thread boundaries. This includes
+   * utilities for concurrent types like {@linkplain java.util.concurrent.ExecutorService}.
+   */
+  abstract public CurrentTraceContext currentTraceContext();
+
+  /**
+   * This exposes the microsecond clock used by operations such as {@link Span#finish()}. This is
+   * helpful when you want to time things manually.
+   */
+  abstract public Clock clock();
+
+  // volatile for visibility on get. writes guarded by Tracing.class
+  static volatile Tracing current = null;
+
+  /**
+   * Returns the most recently created tracer iff its component hasn't been closed. null otherwise.
+   *
+   * <p>This object should not be cached.
+   */
+  @Nullable public static Tracer currentTracer() {
+    Tracing tracing = current;
+    return tracing != null ? tracing.tracer() : null;
+  }
+
+  /**
+   * Returns the most recently created tracing component iff it hasn't been closed. null otherwise.
+   *
+   * <p>This object should not be cached.
+   */
+  @Nullable public static Tracing current() {
+    return current;
+  }
+
+  /** Ensures this component can be garbage collected, by making it not {@link #current()} */
+  @Override abstract public void close();
+
+  public static final class Builder {
+    String localServiceName;
+    Endpoint localEndpoint;
+    Reporter<zipkin.Span> reporter;
+    Clock clock;
+    Sampler sampler = Sampler.ALWAYS_SAMPLE;
+    CurrentTraceContext currentTraceContext = new CurrentTraceContext.Default();
+    boolean traceId128Bit = false;
+    Propagation.Factory propagationFactory = Propagation.Factory.B3;
+
+    /**
+     * Controls the name of the service being traced, while still using a default site-local IP.
+     * This is an alternative to {@link #localEndpoint(Endpoint)}.
+     *
+     * @param localServiceName name of the service being traced. Defaults to "unknown".
+     */
+    public Builder localServiceName(String localServiceName) {
+      if (localServiceName == null) throw new NullPointerException("localServiceName == null");
+      this.localServiceName = localServiceName;
+      return this;
+    }
+
+    /**
+     * @param localEndpoint Endpoint of the local service being traced. Defaults to site local.
+     */
+    public Builder localEndpoint(Endpoint localEndpoint) {
+      if (localEndpoint == null) throw new NullPointerException("localEndpoint == null");
+      this.localEndpoint = localEndpoint;
+      return this;
+    }
+
+    /**
+     * Controls how spans are reported. Defaults to logging, but often an {@link AsyncReporter}
+     * which batches spans before sending to Zipkin.
+     *
+     * The {@link AsyncReporter} includes a {@link Sender}, which is a driver for transports like
+     * http, kafka and scribe.
+     *
+     * <p>For example, here's how to batch send spans via http:
+     *
+     * <pre>{@code
+     * reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
+     *                         .build();
+     *
+     * tracerBuilder.reporter(reporter);
+     * }</pre>
+     *
+     * <p>See https://github.com/openzipkin/zipkin-reporter-java
+     */
+    public Builder reporter(Reporter<zipkin.Span> reporter) {
+      if (reporter == null) throw new NullPointerException("reporter == null");
+      this.reporter = reporter;
+      return this;
+    }
+
+    /** See {@link Tracing#clock()} */
+    public Builder clock(Clock clock) {
+      if (clock == null) throw new NullPointerException("clock == null");
+      this.clock = clock;
+      return this;
+    }
+
+    /**
+     * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether
+     * the overhead of tracing will occur and/or if a trace will be reported to Zipkin.
+     */
+    public Builder sampler(Sampler sampler) {
+      this.sampler = sampler;
+      return this;
+    }
+
+    /**
+     * Responsible for implementing {@link Tracer#currentSpan()} and {@link
+     * Tracer#withSpanInScope(Span)}. By default a simple thread-local is used. Override to support
+     * other mechanisms or to synchronize with other mechanisms such as SLF4J's MDC.
+     */
+    public Builder currentTraceContext(CurrentTraceContext currentTraceContext) {
+      this.currentTraceContext = currentTraceContext;
+      return this;
+    }
+
+    /** When true, new root spans will have 128-bit trace IDs. Defaults to false (64-bit) */
+    public Builder traceId128Bit(boolean traceId128Bit) {
+      this.traceId128Bit = traceId128Bit;
+      return this;
+    }
+
+    public Tracing build() {
+      if (clock == null) clock = Platform.get();
+      if (localEndpoint == null) {
+        localEndpoint = Platform.get().localEndpoint();
+        if (localServiceName != null) {
+          localEndpoint = localEndpoint.toBuilder().serviceName(localServiceName).build();
+        }
+      }
+      if (reporter == null) reporter = Platform.get();
+
+      return new Default(this);
+    }
+
+    Builder() {
+    }
+  }
+
+  static {
+    Internal.instance = new Internal() {
+      @Override public Long timestamp(Tracer tracer, TraceContext context) {
+        return tracer.recorder.timestamp(context);
+      }
+    };
+  }
+
+  static final class Default extends Tracing {
+    final Tracer tracer;
+    final Propagation.Factory propagationFactory;
+    final Propagation<String> stringPropagation;
+    final CurrentTraceContext currentTraceContext;
+    final Clock clock;
+
+    Default(Builder builder) {
+      this.tracer = new Tracer(builder);
+      this.propagationFactory = builder.propagationFactory;
+      this.stringPropagation = builder.propagationFactory.create(Propagation.KeyFactory.STRING);
+      this.currentTraceContext = builder.currentTraceContext;
+      this.clock = builder.clock;
+      maybeSetCurrent();
+    }
+
+    @Override public Tracer tracer() {
+      return tracer;
+    }
+
+    @Override public Propagation<String> propagation() {
+      return stringPropagation;
+    }
+
+    @Override public Propagation.Factory propagationFactory() {
+      return propagationFactory;
+    }
+
+    @Override public CurrentTraceContext currentTraceContext() {
+      return currentTraceContext;
+    }
+
+    @Override public Clock clock() {
+      return clock;
+    }
+
+    private void maybeSetCurrent() {
+      if (current != null) return;
+      synchronized (Tracing.class) {
+        if (current == null) current = this;
+      }
+    }
+
+    @Override public void close() {
+      if (current != this) return;
+      // don't blindly set most recent to null as there could be a race
+      synchronized (Tracing.class) {
+        if (current == this) current = null;
+      }
+    }
+  }
+}

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
@@ -27,7 +27,7 @@ public class CurrentTraceContextExecutorServiceTest {
   CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
   ExecutorService executor = currentTraceContext.executorService(wrappedExecutor);
 
-  Tracer tracer = Tracer.newBuilder().build();
+  Tracer tracer = Tracing.newBuilder().build().tracer();
   TraceContext context = tracer.newTrace().context();
   TraceContext context2 = tracer.newTrace().context();
 

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
@@ -21,7 +21,7 @@ public class CurrentTraceContextExecutorTest {
   CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
 
   Executor executor = currentTraceContext.executor(wrappedExecutor);
-  Tracer tracer = Tracer.newBuilder().build();
+  Tracer tracer = Tracing.newBuilder().build().tracer();
   TraceContext context = tracer.newTrace().context();
   TraceContext context2 = tracer.newTrace().context();
 

--- a/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultCurrentTraceContextTest {
   CurrentTraceContext.Default currentTraceContext = new CurrentTraceContext.Default();
-  Tracer tracer = Tracer.newBuilder().build();
+  Tracer tracer = Tracing.newBuilder().build().tracer();
   TraceContext context = tracer.newTrace().context();
   TraceContext context2 = tracer.newTrace().context();
 
@@ -50,11 +50,11 @@ public class DefaultCurrentTraceContextTest {
 
   /**
    * Ensures default scope is per thread, not per thread,instance. This is needed when using {@link
-   * Tracer#current()} such as instrumenting JDBC.
+   * Tracing#current()} such as instrumenting JDBC.
    */
   @Test public void perThreadScope() {
     try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
-      assertThat(Tracer.current().currentSpan().context())
+      assertThat(Tracing.current().tracer().currentSpan().context())
           .isEqualTo(context);
     }
   }

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -7,14 +7,14 @@ import zipkin.Endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class NoopSpanTest {
-  Tracer tracer = Tracer.newBuilder().sampler(Sampler.NEVER_SAMPLE)
+  Tracer tracer = Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE)
       .clock(() -> {
         throw new AssertionError();
       })
       .reporter(s -> {
         throw new AssertionError();
       })
-      .build();
+      .build().tracer();
   Span span = tracer.newTrace();
 
   @Test public void isNoop() {

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.tuple;
 public class RealSpanTest {
   List<zipkin.Span> spans = new ArrayList();
   Endpoint localEndpoint = Platform.get().localEndpoint();
-  Tracer tracer = Tracer.newBuilder().reporter(spans::add).build();
+  Tracer tracer = Tracing.newBuilder().reporter(spans::add).build().tracer();
   Span span = tracer.newTrace();
 
   @Test public void isNotNoop() {

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -11,7 +11,7 @@ import zipkin.Endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TracerTest {
-  Tracer tracer = Tracer.newBuilder().build();
+  Tracer tracer = Tracing.newBuilder().build().tracer();
 
   @Test public void sampler() {
     Sampler sampler = new Sampler() {
@@ -20,14 +20,14 @@ public class TracerTest {
       }
     };
 
-    tracer = Tracer.newBuilder().sampler(sampler).build();
+    tracer = Tracing.newBuilder().sampler(sampler).build().tracer();
 
     assertThat(tracer.sampler)
         .isSameAs(sampler);
   }
 
   @Test public void localServiceName() {
-    tracer = Tracer.newBuilder().localServiceName("my-foo").build();
+    tracer = Tracing.newBuilder().localServiceName("my-foo").build().tracer();
 
     assertThat(tracer.localEndpoint.serviceName)
         .isEqualTo("my-foo");
@@ -40,8 +40,8 @@ public class TracerTest {
 
   @Test public void localServiceName_ignoredWhenGivenLocalEndpoint() {
     Endpoint localEndpoint = Endpoint.create("my-bar", 127 << 24 | 1);
-    tracer = Tracer.newBuilder().localServiceName("my-foo")
-        .localEndpoint(localEndpoint).build();
+    tracer = Tracing.newBuilder().localServiceName("my-foo")
+        .localEndpoint(localEndpoint).build().tracer();
 
     assertThat(tracer.localEndpoint)
         .isSameAs(localEndpoint);
@@ -49,7 +49,7 @@ public class TracerTest {
 
   @Test public void clock() {
     Clock clock = () -> 0L;
-    tracer = Tracer.newBuilder().clock(clock).build();
+    tracer = Tracing.newBuilder().clock(clock).build().tracer();
 
     assertThat(tracer.clock())
         .isSameAs(clock);
@@ -62,14 +62,14 @@ public class TracerTest {
   }
 
   @Test public void newTrace_traceId128Bit() {
-    tracer = Tracer.newBuilder().traceId128Bit(true).build();
+    tracer = Tracing.newBuilder().traceId128Bit(true).build().tracer();
 
     assertThat(tracer.newTrace().context().traceIdHigh())
         .isNotZero();
   }
 
   @Test public void newTrace_unsampled_tracer() {
-    tracer = Tracer.newBuilder().sampler(Sampler.NEVER_SAMPLE).build();
+    tracer = Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).build().tracer();
 
     assertThat(tracer.newTrace())
         .isInstanceOf(NoopSpan.class);
@@ -82,7 +82,7 @@ public class TracerTest {
 
   @Test public void newTrace_debug_flag() {
     List<zipkin.Span> spans = new ArrayList<>();
-    tracer = Tracer.newBuilder().reporter(spans::add).build();
+    tracer = Tracing.newBuilder().reporter(spans::add).build().tracer();
 
     Span root = tracer.newTrace(SamplingFlags.DEBUG).start();
     root.finish();

--- a/brave/src/test/java/brave/features/async/OneWaySpanTest.java
+++ b/brave/src/test/java/brave/features/async/OneWaySpanTest.java
@@ -1,8 +1,7 @@
 package brave.features.async;
 
 import brave.Span;
-import brave.Tracer;
-import brave.propagation.Propagation;
+import brave.Tracing;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.Collections;
 import java.util.List;
@@ -36,11 +35,11 @@ public class OneWaySpanTest {
   InMemoryStorage storage = new InMemoryStorage();
 
   /** Use different tracers for client and server as usually they are on different hosts. */
-  Tracer clientTracer = Tracer.newBuilder()
+  Tracing clientTracing = Tracing.newBuilder()
       .localEndpoint(Endpoint.builder().serviceName("client").build())
       .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
       .build();
-  Tracer serverTracer = Tracer.newBuilder()
+  Tracing serverTracing = Tracing.newBuilder()
       .localEndpoint(Endpoint.builder().serviceName("server").build())
       .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
       .build();
@@ -51,11 +50,11 @@ public class OneWaySpanTest {
     server.setDispatcher(new Dispatcher() {
       @Override public MockResponse dispatch(RecordedRequest recordedRequest) {
         // pull the context out of the incoming request
-        TraceContextOrSamplingFlags result =
-            Propagation.B3_STRING.extractor(RecordedRequest::getHeader).extract(recordedRequest);
+        TraceContextOrSamplingFlags result = serverTracing.propagation()
+            .extractor(RecordedRequest::getHeader).extract(recordedRequest);
 
         // in real life, we'd guard result.context was set and start a new trace if not
-        serverTracer.joinSpan(result.context())
+        serverTracing.tracer().joinSpan(result.context())
             .name(recordedRequest.getMethod())
             .kind(Span.Kind.SERVER)
             .start().flush(); // start the server side and flush instead of processing a response
@@ -70,11 +69,12 @@ public class OneWaySpanTest {
   @Test
   public void startWithOneTracerAndStopWithAnother() throws Exception {
     // start a new span representing a request
-    Span span = clientTracer.newTrace();
+    Span span = clientTracing.tracer().newTrace();
 
     // inject the trace context into the request
     Request.Builder request = new Request.Builder().url(server.url("/"));
-    Propagation.B3_STRING.injector(Request.Builder::addHeader).inject(span.context(), request);
+    clientTracing.propagation()
+        .injector(Request.Builder::addHeader).inject(span.context(), request);
 
     // fire off the request asynchronously, totally dropping any response
     new OkHttpClient().newCall(request.build()).enqueue(mock(Callback.class));

--- a/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
+++ b/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
@@ -2,6 +2,7 @@ package brave.features.finagle_context;
 
 import brave.Span;
 import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import com.twitter.finagle.context.MarshalledContext;
@@ -25,7 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FinagleContextInteropTest {
 
   @Test public void finagleBraveInterop() throws Exception {
-    Tracer tracer = Tracer.newBuilder().currentTraceContext(new FinagleCurrentTraceContext()).build();
+    Tracer tracer = Tracing.newBuilder()
+        .currentTraceContext(new FinagleCurrentTraceContext()).build().tracer();
 
     Span parent = tracer.newTrace(); // start a trace in Brave
     try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {

--- a/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
+++ b/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
@@ -2,6 +2,7 @@ package brave.features.log4j2_context;
 
 import brave.Span;
 import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import org.apache.logging.log4j.ThreadContext;
@@ -19,7 +20,8 @@ public class Log4JThreadContextTest {
     assertThat(ThreadContext.get("traceID"))
         .isNull();
 
-    Tracer tracer = Tracer.newBuilder().currentTraceContext(new Log4J2CurrentTraceContext()).build();
+    Tracer tracer = Tracing.newBuilder()
+        .currentTraceContext(new Log4J2CurrentTraceContext()).build().tracer();
 
     Span parent = tracer.newTrace();
     try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -1,6 +1,6 @@
 package brave.features.opentracing;
 
-import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.TraceContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMapExtractAdapter;
@@ -23,7 +23,7 @@ import static zipkin.internal.Util.UTF_8;
  */
 public class OpenTracingAdapterTest {
   List<zipkin.Span> spans = new ArrayList<>();
-  Tracer brave = Tracer.newBuilder().reporter(spans::add).build();
+  Tracing brave = Tracing.newBuilder().reporter(spans::add).build();
   BraveTracer opentracing = BraveTracer.wrap(brave);
 
   @Test public void startWithOpenTracingAndFinishWithBrave() {
@@ -40,7 +40,7 @@ public class OpenTracingAdapterTest {
   }
 
   @Test public void startWithBraveAndFinishWithOpenTracing() {
-    brave.Span braveSpan = brave.newTrace().name("encode")
+    brave.Span braveSpan = brave.tracer().newTrace().name("encode")
         .tag(Constants.LOCAL_COMPONENT, "codec")
         .start(1L);
 

--- a/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
+++ b/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
@@ -1,6 +1,6 @@
 package brave.features.propagation;
 
-import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import io.grpc.Metadata;
@@ -10,7 +10,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** This shows propagation keys don't need to be Strings. For example, we can propagate over gRPC */
 public class NonStringPropagationKeysTest {
-  Propagation<Metadata.Key<String>> grpcPropagation = Propagation.Factory.B3.create(
+  Tracing tracing = Tracing.newBuilder().build();
+  Propagation<Metadata.Key<String>> grpcPropagation = tracing.propagationFactory().create(
       name -> Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER)
   );
   TraceContext.Extractor<Metadata> extractor = grpcPropagation.extractor(Metadata::get);
@@ -18,7 +19,7 @@ public class NonStringPropagationKeysTest {
 
   @Test
   public void injectExtractTraceContext() throws Exception {
-    TraceContext context = Tracer.newBuilder().build().newTrace().context();
+    TraceContext context = tracing.tracer().newTrace().context();
 
     Metadata metadata = new Metadata();
     injector.inject(context, metadata);

--- a/brave/src/test/java/brave/internal/InternalTest.java
+++ b/brave/src/test/java/brave/internal/InternalTest.java
@@ -1,24 +1,24 @@
 package brave.internal;
 
 import brave.Span;
-import brave.Tracer;
+import brave.Tracing;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class InternalTest {
-  Tracer tracer = Tracer.newBuilder().build();
+  Tracing tracing = Tracing.newBuilder().build();
 
   /**
    * Brave 3's LocalTracer.finish(duration) requires a read-back of the initial timestamp. While
    * that api is in use, this hook is needed.
    */
   @Test public void readBackTimestamp() {
-    long timestamp = tracer.clock().currentTimeMicroseconds();
+    long timestamp = tracing.clock().currentTimeMicroseconds();
 
-    Span span = tracer.newTrace().name("foo").start(timestamp);
+    Span span = tracing.tracer().newTrace().name("foo").start(timestamp);
 
-    assertThat(Internal.instance.timestamp(tracer, span.context()))
+    assertThat(Internal.instance.timestamp(tracing.tracer(), span.context()))
         .isEqualTo(timestamp);
   }
 }

--- a/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
@@ -1,6 +1,7 @@
 package brave.internal;
 
 import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.ExecutorService;
@@ -16,7 +17,7 @@ public class StrictCurrentTraceContextTest {
   // override default so that it isn't inheritable
   CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
 
-  Tracer tracer = Tracer.newBuilder().build();
+  Tracer tracer = Tracing.newBuilder().build().tracer();
   TraceContext context = tracer.newTrace().context();
   TraceContext context2 = tracer.newTrace().context();
 

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
@@ -1,7 +1,7 @@
 package brave.internal.recorder;
 
+import brave.Tracing;
 import brave.propagation.TraceContext;
-import brave.Tracer;
 import brave.internal.Platform;
 import java.lang.ref.Reference;
 import java.util.ArrayList;
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MutableSpanMapTest {
   Endpoint localEndpoint = Platform.get().localEndpoint();
   List<zipkin.Span> spans = new ArrayList();
-  TraceContext context = Tracer.newBuilder().build().newTrace().context();
+  TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
   MutableSpanMap map = new MutableSpanMap(localEndpoint, () -> 0L, spans::add);
 
   @Test

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -1,7 +1,7 @@
 package brave.internal.recorder;
 
 import brave.Span;
-import brave.Tracer;
+import brave.Tracing;
 import brave.internal.Platform;
 import brave.propagation.TraceContext;
 import org.junit.Test;
@@ -23,7 +23,7 @@ import static zipkin.Constants.SERVER_SEND;
 
 public class MutableSpanTest {
   Endpoint localEndpoint = Platform.get().localEndpoint();
-  TraceContext context = Tracer.newBuilder().build().newTrace().context();
+  TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
 
   // zipkin needs one annotation or binary annotation so that the local endpoint can be read
   @Test public void addsDefaultBinaryAnnotation() {


### PR DESCRIPTION
Before, we added some helpers like `Tracer.clock()` because when
instrumenting, you sometimes need more than just the Tracer. Recently,
we needed to decide how to expose the propagation format.. should we add
another convenience method?

Taking experience from Zipkin (which took its experience from Dagger and
Spring), another way is to expose an object graph.. a component that
provides types often used together.

This adds `brave.Tracing` which can be passed around or implemented
differently as needed. Instrumentation would consume this to get common
types they need. For example, `JaxRs2Tracing` would accept an instance
of tracing, so that it has what it needs, a tracer and a propagation
handler.

Instances of this can be wired up in Spring (Dagger, Guice or CDI),
making instrumentation wiring far simpler than chaining builders.

Thanks to @bogdandrutu and @llinder for discussions leading to this.