### PR TITLE
Adds MDCCurrentTraceContext for log correlation

### DIFF
--- a/context/pom.xml
+++ b/context/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-parent</artifactId>
+    <version>4.2.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>brave-context-parent</artifactId>
+  <name>Brave: Trace Contexts</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <modules>
+    <module>slf4j</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/context/slf4j/README.md
+++ b/context/slf4j/README.md
@@ -1,0 +1,29 @@
+# brave-context-slf4j
+This adds trace and span IDs to the SLF4J Mapped Diagnostic Context (MDC)
+so that you can search or aggregate logs accordingly.
+
+To enable this, configure `brave.Tracing` with `MDCCurrentTraceContext`
+like so:
+
+```java
+tracing = Tracing.newBuilder()
+    .currentTraceContext(MDCCurrentTraceContext.create())
+    ...
+    .build();
+```
+
+Then, in your log configuration, you can use `traceId` and or `spanId`.
+
+Here's an example logback configuration:
+
+```xml
+<pattern>%d [%X{traceId}/%X{spanId}] [%thread] %-5level %logger{36} - %msg%n</pattern>
+```
+
+When a trace is in progress, it would log statements like this:
+```
+2017-05-02 23:36:04,789 [fcd015bf6f8b05ba/fcd015bf6f8b05ba] [main] INFO  c.a.FooController - I got here!
+```
+
+Users could then copy/paste the trace ID into the zipkin UI, or use log
+correlation to further debug a problem.

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-context-parent</artifactId>
+    <version>4.2.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-context-slf4j</artifactId>
+  <name>Brave Context: SLF4J</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -1,0 +1,46 @@
+package brave.context.slf4j;
+
+import brave.internal.HexCodec;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import org.slf4j.MDC;
+
+/**
+ * Adds {@linkplain MDC} properties "traceId" and "spanId" when a {@link brave.Tracer#currentSpan()
+ * span is current}. These can be used in log correlation.
+ */
+public final class MDCCurrentTraceContext extends CurrentTraceContext {
+  public static MDCCurrentTraceContext create() {
+    return new MDCCurrentTraceContext(new CurrentTraceContext.Default());
+  }
+
+  public static MDCCurrentTraceContext create(CurrentTraceContext delegate) {
+    return new MDCCurrentTraceContext(delegate);
+  }
+
+  final CurrentTraceContext delegate;
+
+  MDCCurrentTraceContext(CurrentTraceContext delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  @Override public TraceContext get() {
+    return delegate.get();
+  }
+
+  @Override public Scope newScope(TraceContext currentSpan) {
+    final String previousTraceId = MDC.get("traceId");
+    final String previousSpanId = MDC.get("spanId");
+
+    MDC.put("traceId", currentSpan.traceIdString());
+    MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+
+    Scope scope = delegate.newScope(currentSpan);
+    return () -> {
+      scope.close();
+      MDC.put("traceId", previousTraceId);
+      MDC.put("spanId", previousSpanId);
+    };
+  }
+}

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -1,0 +1,63 @@
+package brave.context.slf4j;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.internal.HexCodec;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MDCCurrentTraceContextTest {
+  Logger testLogger = LoggerFactory.getLogger(getClass());
+
+  @Test public void customCurrentTraceContext() {
+    assertThat(MDC.get("traceId"))
+        .isNull();
+    assertThat(MDC.get("spanId"))
+        .isNull();
+    testLogger.info("no span");
+
+    Tracer tracer = Tracing.newBuilder()
+        .currentTraceContext(MDCCurrentTraceContext.create())
+        .build().tracer();
+
+    Span parent = tracer.newTrace();
+    try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {
+      testLogger.info("with span: " + parent);
+
+      // the trace id is now in the logging context
+      assertThat(MDC.get("traceId"))
+          .isEqualTo(parent.context().traceIdString());
+      assertThat(MDC.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+
+      Span child = tracer.newChild(parent.context());
+      try (Tracer.SpanInScope wsChild = tracer.withSpanInScope(child)) {
+        testLogger.info("with span: " + child);
+
+        // nesting worked
+        assertThat(MDC.get("traceId"))
+            .isEqualTo(child.context().traceIdString());
+        assertThat(MDC.get("spanId"))
+            .isEqualTo(HexCodec.toLowerHex(child.context().spanId()));
+      }
+      testLogger.info("with span: " + parent);
+
+      // old parent reverted
+      assertThat(MDC.get("traceId"))
+          .isEqualTo(parent.context().traceIdString());
+      assertThat(MDC.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+    }
+    testLogger.info("no span");
+
+    assertThat(MDC.get("traceId"))
+        .isNull();
+    assertThat(MDC.get("spanId"))
+        .isNull();
+  }
+}

--- a/context/slf4j/src/test/resources/logback.xml
+++ b/context/slf4j/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <layout>
+      <pattern>%d [%X{traceId}/%X{spanId}] [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </layout>
+  </appender>
+  <root level="TRACE">
+    <appender-ref ref="stdout" />
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 
   <modules>
     <module>brave</module>
+    <module>context</module>
     <module>brave-core</module>
     <module>brave-benchmarks</module>
     <module>brave-http</module>


### PR DESCRIPTION
This adds trace and span IDs to the SLF4J Mapped Diagnostic Context (MDC)
so that you can search or aggregate logs accordingly.

To enable this, configure `brave.Tracing` with `MDCCurrentTraceContext`
like so:

```java
tracing = Tracing.newBuilder()
    .currentTraceContext(MDCCurrentTraceContext.create())
    ...
    .build();
```

Then, in your log configuration, you can use `traceId` and or `spanId`.

Here's an example logback configuration:

```xml
<pattern>%d [%X{traceId}/%X{spanId}] [%thread] %-5level %logger{36} - %msg%n</pattern>
```

When a trace is in progress, it would log statements like this:
```
2017-05-02 23:36:04,789 [fcd015bf6f8b05ba/fcd015bf6f8b05ba] [main] INFO  c.a.FooController - I got here!
```

Users could then copy/paste the trace ID into the zipkin UI, or use log
correlation to further debug a problem.

Fixes #150
See #369