### PR TITLE
Adds Log4J 2 ThreadContext integration

### DIFF
--- a/context/log4j2/README.md
+++ b/context/log4j2/README.md
@@ -1,0 +1,29 @@
+# brave-context-log4j2
+This adds trace and span IDs to the Log4J 2 Thread Context so that you
+can search or aggregate logs accordingly.
+
+To enable this, configure `brave.Tracing` with `ThreadContextCurrentTraceContext`
+like so:
+
+```java
+tracing = Tracing.newBuilder()
+    .currentTraceContext(ThreadContextCurrentTraceContext.create())
+    ...
+    .build();
+```
+
+Then, in your log configuration, you can use `traceId` and or `spanId`.
+
+Here's an example log4j2.properties pattern:
+
+```xml
+appender.console.layout.pattern = %d{ABSOLUTE} [%X{traceId}/%X{spanId}] %-5p [%t] %C{2} (%F:%L) - %m%n
+```
+
+When a trace is in progress, it would log statements like this:
+```
+11:01:29,799 [e2ffceb485bdfb1d/e2ffceb485bdfb1d] INFO  [main] c.a.FooController (FooController.java:30) - I got here!
+```
+
+Users could then copy/paste the trace ID into the zipkin UI, or use log
+correlation to further debug a problem.

--- a/context/log4j2/pom.xml
+++ b/context/log4j2/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-context-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-context-log4j2</artifactId>
+  <name>Brave Context: Log4J 2</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -1,0 +1,46 @@
+package brave.context.log4j2;
+
+import brave.internal.HexCodec;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * Adds {@linkplain ThreadContext} properties "traceId" and "spanId" when a {@link
+ * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ */
+public final class ThreadContextCurrentTraceContext extends CurrentTraceContext {
+  public static ThreadContextCurrentTraceContext create() {
+    return new ThreadContextCurrentTraceContext(new CurrentTraceContext.Default());
+  }
+
+  public static ThreadContextCurrentTraceContext create(CurrentTraceContext delegate) {
+    return new ThreadContextCurrentTraceContext(delegate);
+  }
+
+  final CurrentTraceContext delegate;
+
+  ThreadContextCurrentTraceContext(CurrentTraceContext delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  @Override public TraceContext get() {
+    return delegate.get();
+  }
+
+  @Override public Scope newScope(TraceContext currentSpan) {
+    final String previousTraceId = ThreadContext.get("traceId");
+    final String previousSpanId = ThreadContext.get("spanId");
+
+    ThreadContext.put("traceId", currentSpan.traceIdString());
+    ThreadContext.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+
+    Scope scope = delegate.newScope(currentSpan);
+    return () -> {
+      scope.close();
+      ThreadContext.put("traceId", previousTraceId);
+      ThreadContext.put("spanId", previousSpanId);
+    };
+  }
+}

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -1,0 +1,63 @@
+package brave.context.log4j2;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.internal.HexCodec;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadContextCurrentTraceContextTest {
+  Logger testLogger = LogManager.getLogger();
+
+  @Test public void customCurrentTraceContext() {
+    assertThat(ThreadContext.get("traceId"))
+        .isNull();
+    assertThat(ThreadContext.get("spanId"))
+        .isNull();
+    testLogger.info("no span");
+
+    Tracer tracer = Tracing.newBuilder()
+        .currentTraceContext(ThreadContextCurrentTraceContext.create())
+        .build().tracer();
+
+    Span parent = tracer.newTrace();
+    try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {
+      testLogger.info("with span: " + parent);
+
+      // the trace id is now in the logging context
+      assertThat(ThreadContext.get("traceId"))
+          .isEqualTo(parent.context().traceIdString());
+      assertThat(ThreadContext.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+
+      Span child = tracer.newChild(parent.context());
+      try (Tracer.SpanInScope wsChild = tracer.withSpanInScope(child)) {
+        testLogger.info("with span: " + child);
+
+        // nesting worked
+        assertThat(ThreadContext.get("traceId"))
+            .isEqualTo(child.context().traceIdString());
+        assertThat(ThreadContext.get("spanId"))
+            .isEqualTo(HexCodec.toLowerHex(child.context().spanId()));
+      }
+      testLogger.info("with span: " + parent);
+
+      // old parent reverted
+      assertThat(ThreadContext.get("traceId"))
+          .isEqualTo(parent.context().traceIdString());
+      assertThat(ThreadContext.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+    }
+    testLogger.info("no span");
+
+    assertThat(ThreadContext.get("traceId"))
+        .isNull();
+    assertThat(ThreadContext.get("spanId"))
+        .isNull();
+  }
+}

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -20,6 +20,7 @@
 
   <modules>
     <module>slf4j</module>
+    <module>log4j2</module>
   </modules>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <zipkin.version>1.24.0</zipkin.version>
     <zipkin-reporter.version>0.7.1</zipkin-reporter.version>
     <finagle.version>6.44.0</finagle.version>
-    <log4j.version>2.8.1</log4j.version>
+    <log4j.version>2.8.2</log4j.version>
     <okhttp.version>3.6.0</okhttp.version>
     <grpc.version>1.2.0</grpc.version>
     <powermock.version>1.6.6</powermock.version>


### PR DESCRIPTION
This adds trace and span IDs to the Log4J 2 Thread Context so that you
can search or aggregate logs accordingly.

To enable this, configure `brave.Tracing` with `ThreadContextCurrentTraceContext`
like so:

```java
tracing = Tracing.newBuilder()
    .currentTraceContext(ThreadContextCurrentTraceContext.create())
    ...
    .build();
```

See #389