### PR TITLE
Adds the ability to customize http errors, defaulting to status 400+

### DIFF
--- a/brave/src/main/java/brave/http/HttpAdapter.java
+++ b/brave/src/main/java/brave/http/HttpAdapter.java
@@ -45,6 +45,17 @@ public abstract class HttpAdapter<Req, Resp> {
    */
   @Nullable public abstract Integer statusCode(Resp response);
 
+  String parseError(@Nullable Resp response, @Nullable Throwable error) {
+    if (error != null) {
+      String message = error.getMessage();
+      return message != null ? message : error.getClass().getSimpleName();
+    }
+    Integer httpStatus = statusCode(response);
+    if (httpStatus != null && (httpStatus < 200 || httpStatus > 399)) {
+      return String.valueOf(httpStatus);
+    }
+    return null;
+  }
   HttpAdapter() {
   }
 }

--- a/brave/src/main/java/brave/http/HttpClientHandler.java
+++ b/brave/src/main/java/brave/http/HttpClientHandler.java
@@ -24,6 +24,7 @@ import zipkin.Endpoint;
  *   handler.handleReceive(response, error, span);
  * }
  * }</pre>
+ *
  * @param <Req> the native http request type of the client.
  * @param <Resp> the native http response type of the client.
  */
@@ -90,10 +91,9 @@ public final class HttpClientHandler<Req, Resp> {
     if (span.isNoop()) return;
 
     try {
-      if (error != null) {
-        String message = error.getMessage();
-        if (message == null) message = error.getClass().getSimpleName();
-        span.tag(zipkin.Constants.ERROR, message);
+      if (response != null || error != null) {
+        String message = adapter.parseError(response, error);
+        if (message != null) span.tag(zipkin.Constants.ERROR, message);
       }
       if (response != null) parser.responseTags(adapter, response, span);
     } finally {

--- a/brave/src/main/java/brave/http/HttpClientParser.java
+++ b/brave/src/main/java/brave/http/HttpClientParser.java
@@ -1,22 +1,52 @@
 package brave.http;
 
 import brave.Span;
+import brave.internal.Nullable;
 import zipkin.TraceKeys;
 
+/**
+ * Provides reasonable defaults for the data contained in http client spans. Subclass to customize,
+ * for example, to add tags based on response headers.
+ */
 public class HttpClientParser {
+  /** Returns the span name of the request. Defaults to the http method. */
   public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
     return adapter.method(req);
   }
 
+  /**
+   * Adds any tags based on the request that will be sent to the server.
+   *
+   * <p>By default, this adds the {@link TraceKeys#HTTP_PATH}.
+   */
   public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Span span) {
     String path = adapter.path(req);
     if (path != null) span.tag(TraceKeys.HTTP_PATH, path);
   }
 
+  /**
+   * Adds any tags based on the response received from the server.
+   *
+   * <p>By default, this adds the {@link TraceKeys#HTTP_STATUS_CODE} if the status code is >=300.
+   */
   public <Resp> void responseTags(HttpAdapter<?, Resp> adapter, Resp res, Span span) {
     Integer httpStatus = adapter.statusCode(res);
     if (httpStatus != null && (httpStatus < 200 || httpStatus > 299)) {
       span.tag(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
     }
+  }
+
+  /**
+   * Returns an {@link zipkin.Constants#ERROR error message}, if there was an error sending the
+   * request to the server, or if the response received was an error.
+   *
+   * <p>By default, this makes an error message based on the exception message, or the status code,
+   * if the status code is >=400.
+   *
+   * <p>Note: Either the response or error parameters may be null, but not both
+   */
+  @Nullable public <Resp> String error(HttpAdapter<?, Resp> adapter, @Nullable Resp res,
+      @Nullable Throwable error) {
+    return adapter.parseError(res, error);
   }
 }

--- a/brave/src/main/java/brave/http/HttpServerHandler.java
+++ b/brave/src/main/java/brave/http/HttpServerHandler.java
@@ -86,10 +86,9 @@ public final class HttpServerHandler<Req, Resp> {
     if (span.isNoop()) return;
 
     try {
-      if (error != null) {
-        String message = error.getMessage();
-        if (message == null) message = error.getClass().getSimpleName();
-        span.tag(zipkin.Constants.ERROR, message);
+      if (response != null || error != null) {
+        String message = adapter.parseError(response, error);
+        if (message != null) span.tag(zipkin.Constants.ERROR, message);
       }
       if (response != null) parser.responseTags(adapter, response, span);
     } finally {

--- a/brave/src/main/java/brave/http/HttpServerParser.java
+++ b/brave/src/main/java/brave/http/HttpServerParser.java
@@ -1,22 +1,52 @@
 package brave.http;
 
 import brave.Span;
+import brave.internal.Nullable;
 import zipkin.TraceKeys;
 
+/**
+ * Provides reasonable defaults for the data contained in http server spans. Subclass to customize,
+ * for example, to add tags based on user ID.
+ */
 public class HttpServerParser {
+  /** Returns the span name of the request. Defaults to the http method. */
   public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
     return adapter.method(req);
   }
 
+  /**
+   * Adds any tags based on the request received from the client.
+   *
+   * <p>By default, this adds the {@link TraceKeys#HTTP_PATH}.
+   */
   public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Span span) {
     String path = adapter.path(req);
     if (path != null) span.tag(TraceKeys.HTTP_PATH, path);
   }
 
+  /**
+   * Adds any tags based on the response sent to the client.
+   *
+   * <p>By default, this adds the {@link TraceKeys#HTTP_STATUS_CODE} if the status code is >=300.
+   */
   public <Resp> void responseTags(HttpAdapter<?, Resp> adapter, Resp res, Span span) {
     Integer httpStatus = adapter.statusCode(res);
     if (httpStatus != null && (httpStatus < 200 || httpStatus > 299)) {
       span.tag(TraceKeys.HTTP_STATUS_CODE, String.valueOf(httpStatus));
     }
+  }
+
+  /**
+   * Returns an {@link zipkin.Constants#ERROR error message}, if there was an error lieu of a
+   * response, or if the response sent to the client was an error.
+   *
+   * <p>By default, this makes an error message based on the exception message, or the status code,
+   * if the status code is >=400.
+   *
+   * <p>Note: Either the response or error parameters may be null, but not both
+   */
+  @Nullable public <Resp> String error(HttpAdapter<?, Resp> adapter, @Nullable Resp res,
+      @Nullable Throwable error) {
+    return adapter.parseError(res, error);
   }
 }

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -35,6 +35,7 @@ By default, the following is added for both http clients and servers:
 * Tags/binary annotations:
   * "http.path", which does not include query parameters.
   * "http.status_code" when the status us not success.
+  * "error", when there is an exception or status is >=400
 * Remote IP and port information
 
 Naming and tags are configurable in a library-agnostic way. For example,

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -191,15 +191,16 @@ public abstract class ITHttpClient<C> extends ITHttp {
   }
 
   @Test public void addsStatusCodeWhenNotOk() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse().setResponseCode(400));
 
     try {
       get(client, "/foo");
     } catch (RuntimeException e) {
-      // some clients think 404 is an error
+      // some clients think 400 is an error
     }
 
-    assertReportedTagsInclude(TraceKeys.HTTP_STATUS_CODE, "404");
+    assertReportedTagsInclude(TraceKeys.HTTP_STATUS_CODE, "400");
+    assertReportedTagsInclude(Constants.ERROR, "400");
   }
 
   @Test public void redirect() throws Exception {

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
@@ -223,6 +223,7 @@ public abstract class ITHttpServer extends ITHttp {
     }
 
     assertReportedTagsInclude(TraceKeys.HTTP_STATUS_CODE, "400");
+    assertReportedTagsInclude(Constants.ERROR, "400");
   }
 
   @Test


### PR DESCRIPTION
This adds HttpClientParser and HttpServerParser.error, which by default
adds an error tag when the status is >=400 or there's an exception.

This policy is similar to ratpack, but overridable.