### PR TITLE
Ensures legacy apps written in Spring 3 can use new instrumentation

### DIFF
--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <spring.version>${spring4.version}</spring.version>
   </properties>
   
   <dependencies>

--- a/brave-spring-resttemplate-interceptors/pom.xml
+++ b/brave-spring-resttemplate-interceptors/pom.xml
@@ -43,5 +43,10 @@
           <artifactId>brave-http-tests</artifactId>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/BraveClientHttpRequestInterceptorTest.java
@@ -6,24 +6,23 @@ import com.github.kristofa.brave.ClientResponseInterceptor;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.http.SpanNameProvider;
+import java.io.IOException;
+import java.net.URI;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import zipkin.TraceKeys;
-
-import java.io.IOException;
-import java.net.URI;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.junit.Assert.assertSame;
@@ -33,6 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = BraveClientHttpRequestInterceptorTest.AppConfig.class)
 public class BraveClientHttpRequestInterceptorTest {
     @Autowired ClientTracer clientTracer;
     @Autowired SpanNameProvider spanNameProvider;
@@ -130,8 +130,12 @@ public class BraveClientHttpRequestInterceptorTest {
     }
 
     @Configuration
-    @Import(BraveClientHttpRequestInterceptor.class)
     static class AppConfig {
+        @Bean
+        BraveClientHttpRequestInterceptor tracingInterceptor(SpanNameProvider spanNameProvider, Brave brave) {
+            return BraveClientHttpRequestInterceptor.builder(brave).spanNameProvider(spanNameProvider).build();
+        }
+
         @Bean ClientTracer clientTracer() {
             return mock(ClientTracer.class);
         }

--- a/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/ITBraveClientHttpRequestInterceptor.java
+++ b/brave-spring-resttemplate-interceptors/src/test/java/com/github/kristofa/brave/spring/ITBraveClientHttpRequestInterceptor.java
@@ -6,20 +6,20 @@ import java.io.IOException;
 import java.util.Collections;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
-import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-public class ITBraveClientHttpRequestInterceptor
-    extends ITHttpClient<OkHttp3ClientHttpRequestFactory> {
+public class ITBraveClientHttpRequestInterceptor extends ITHttpClient<ClientHttpRequestFactory>{
 
   BraveClientHttpRequestInterceptor interceptor;
 
-  @Override protected OkHttp3ClientHttpRequestFactory newClient(int port) {
+  @Override protected ClientHttpRequestFactory newClient(int port) {
     return configureClient(BraveClientHttpRequestInterceptor.create(brave));
   }
 
-  OkHttp3ClientHttpRequestFactory configureClient(BraveClientHttpRequestInterceptor interceptor) {
-    OkHttp3ClientHttpRequestFactory factory = new OkHttp3ClientHttpRequestFactory();
+  ClientHttpRequestFactory configureClient(BraveClientHttpRequestInterceptor interceptor) {
+    HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
     factory.setReadTimeout(1000);
     factory.setConnectTimeout(1000);
     this.interceptor = interceptor;
@@ -27,16 +27,16 @@ public class ITBraveClientHttpRequestInterceptor
   }
 
   @Override
-  protected OkHttp3ClientHttpRequestFactory newClient(int port, SpanNameProvider spanNameProvider) {
+  protected ClientHttpRequestFactory newClient(int port, SpanNameProvider spanNameProvider) {
     return configureClient(BraveClientHttpRequestInterceptor.builder(brave)
         .spanNameProvider(spanNameProvider).build());
   }
 
-  @Override protected void closeClient(OkHttp3ClientHttpRequestFactory client) throws IOException {
-    client.destroy();
+  @Override protected void closeClient(ClientHttpRequestFactory client) throws IOException {
+    ((HttpComponentsClientHttpRequestFactory) client).destroy();
   }
 
-  @Override protected void get(OkHttp3ClientHttpRequestFactory client, String pathIncludingQuery)
+  @Override protected void get(ClientHttpRequestFactory client, String pathIncludingQuery)
       throws Exception {
     RestTemplate restTemplate = new RestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));
@@ -44,7 +44,7 @@ public class ITBraveClientHttpRequestInterceptor
   }
 
   @Override
-  protected void getAsync(OkHttp3ClientHttpRequestFactory client, String pathIncludingQuery) {
+  protected void getAsync(ClientHttpRequestFactory client, String pathIncludingQuery) {
     throw new AssumptionViolatedException("TODO: async rest template has its own interceptor");
   }
 

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -14,6 +14,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <undertow.version>1.4.14.Final</undertow.version>
+    <spring.version>${spring4.version}</spring.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -50,13 +50,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-spring</artifactId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <version>${resteasy.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- to test the inject annotations -->

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -53,6 +53,7 @@ public final class TracingCallFactory implements Call.Factory {
     OkHttpClient.Builder b = ok.newBuilder();
     if (currentSpan != null) b.interceptors().add(0, new SetParentSpanInScope(currentSpan));
     b.networkInterceptors().add(0, new TracingNetworkInterceptor());
+    // TODO: This can hide errors at the beginning of call.execute, such as invalid host!
     return b.build().newCall(request);
   }
 

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -14,6 +14,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -26,6 +28,11 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/TracingClientHttpRequestInterceptorAutowireTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/TracingClientHttpRequestInterceptorAutowireTest.java
@@ -17,21 +17,7 @@ public class TracingClientHttpRequestInterceptorAutowireTest {
     }
   }
 
-  @Configuration @Import({
-      HttpTracingConfiguration.class,
-      TracingClientHttpRequestInterceptor.class
-  })
-  static class ImportConfiguration {
-  }
-
-  @Test public void autowiredWithImportConfig() {
-    AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
-    ctx.register(ImportConfiguration.class);
-    ctx.refresh();
-
-    ctx.getBean(ClientHttpRequestInterceptor.class);
-  }
-
+  // NOTE: while bean configuration via @Import works with Spring 4, it does not with Spring 3
   @Configuration @Import(HttpTracingConfiguration.class)
   static class BeanConfiguration {
     @Bean ClientHttpRequestInterceptor tracingInterceptor(HttpTracing httpTracing) {

--- a/instrumentation/spring-webmvc/README.md
+++ b/instrumentation/spring-webmvc/README.md
@@ -20,16 +20,18 @@ Then, configure `TracingHandlerInterceptor` in either XML or Java.
 
 ```java
 @Configuration
-@Import(TracingHandlerInterceptor.class)
-public class WebConfig extends WebMvcConfigurerAdapter {
+@EnableWebMvc
+class TracingConfig extends WebMvcConfigurerAdapter {
+  @Bean AsyncHandlerInterceptor tracingInterceptor(HttpTracing httpTracing) {
+    return TracingHandlerInterceptor.create(httpTracing);
+  }
 
-    @Autowired
-    private TracingHandlerInterceptor interceptor;
+  @Autowired
+  private AsyncHandlerInterceptor tracingInterceptor;
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(interceptor);
-    }
-
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(tracingInterceptor);
+  }
 }
 ```

--- a/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
@@ -11,15 +11,21 @@ import brave.servlet.HttpServletAdapter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
+/**
+ * Tracing interceptor for Spring Web MVC, which can be used as both an {@link
+ * AsyncHandlerInterceptor} or a normal {@link HandlerInterceptor}.
+ */
 public final class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
 
-  public static HandlerInterceptorAdapter create(Tracing tracing) {
+  public static AsyncHandlerInterceptor create(Tracing tracing) {
     return new TracingHandlerInterceptor(HttpTracing.create(tracing));
   }
 
-  public static HandlerInterceptorAdapter create(HttpTracing httpTracing) {
+  public static AsyncHandlerInterceptor create(HttpTracing httpTracing) {
     return new TracingHandlerInterceptor(httpTracing);
   }
 

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/TracingHandlerInterceptorAutowireTest.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/TracingHandlerInterceptorAutowireTest.java
@@ -17,21 +17,7 @@ public class TracingHandlerInterceptorAutowireTest {
     }
   }
 
-  @Configuration @Import({
-      HttpTracingConfiguration.class,
-      TracingHandlerInterceptor.class
-  })
-  static class ImportConfiguration {
-  }
-
-  @Test public void autowiredWithImportConfig() {
-    AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
-    ctx.register(ImportConfiguration.class);
-    ctx.refresh();
-
-    ctx.getBean(HandlerInterceptor.class);
-  }
-
+  // NOTE: while bean configuration via @Import works with Spring 4, it does not with Spring 3
   @Configuration @Import(HttpTracingConfiguration.class)
   static class BeanConfiguration {
     @Bean HandlerInterceptor tracingInterceptor(HttpTracing httpTracing) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,9 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <spring.version>4.3.4.RELEASE</spring.version>
+    <!-- Ensure older versions of spring still work -->
+    <spring4.version>4.3.4.RELEASE</spring4.version>
+    <spring.version>3.2.18.RELEASE</spring.version>
     <!-- don't use apis not in jetty 7.6* else testing servlet 2.5 will imply duplication -->
     <jetty.version>8.1.22.v20160922</jetty.version>
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>


### PR DESCRIPTION
This reverts the default spring version to 3 to make sure we don't
accidentally use new apis.