### PR TITLE
Encourages scoping when setting the server name of a client

### DIFF
--- a/brave/src/main/java/brave/http/HttpTracing.java
+++ b/brave/src/main/java/brave/http/HttpTracing.java
@@ -35,9 +35,7 @@ public abstract class HttpTracing {
    *
    * For example:
    * <pre>{@code
-   * github = TracingHttpClientBuilder.create(
-   *   httpTracing.toBuilder().serverName("github").build()
-   * ).build();
+   * github = TracingHttpClientBuilder.create(httpTracing.serverName("github"));
    * }</pre>
    *
    * @see zipkin.Constants#SERVER_ADDR
@@ -45,6 +43,15 @@ public abstract class HttpTracing {
    * @see brave.Span#remoteEndpoint(Endpoint)
    */
   public abstract String serverName();
+
+  /**
+   * Scopes this component for a client of the indicated server.
+   *
+   * @see #serverName()
+   */
+  public HttpTracing clientOf(String serverName) {
+    return toBuilder().serverName(serverName).build();
+  }
 
   public abstract HttpServerParser serverParser();
 
@@ -56,11 +63,11 @@ public abstract class HttpTracing {
 
     public abstract Builder clientParser(HttpClientParser clientParser);
 
-    public abstract Builder serverName(String serverName);
-
     public abstract Builder serverParser(HttpServerParser serverParser);
 
     public abstract HttpTracing build();
+
+    abstract Builder serverName(String serverName);
 
     Builder() {
     }

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -57,11 +57,10 @@ httpTracing = httpTracing.toBuilder()
         span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // the whole url, not just the path
       }
     })
-    .serverName("remote-service") // assume both libraries are calling the same service
     .build();
 
-apache = TracingHttpClientBuilder.create(httpTracing).build();
-okhttp = TracingCallFactory.create(httpTracing, new OkHttpClient());
+apache = TracingHttpClientBuilder.create(httpTracing.clientOf("s3")).build();
+okhttp = TracingCallFactory.create(httpTracing.clientOf("sqs"), new OkHttpClient());
 ```
 
 # Developing new instrumentation

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -169,8 +169,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
             span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
           }
         })
-        .serverName("remote-service")
-        .build();
+        .build().clientOf("remote-service");
 
     client = newClient(server.getPort());
     server.enqueue(new MockResponse());


### PR DESCRIPTION
Before, the serverName (SA.serviceName) field was a public builder
method on HttpTracing. This had a couple issues.

* It encourages the wrong usage pattern
* It doesn't work with Spring XML configuration

By encouraging the wrong usage, I mean that the server name is only
valid for a given client. Usually, the `HttpTracing` component is
shared across all implementation. It is a better idea to encourage
scoping where components are put together.

Here's two examples:

```java
sqsClient = TracingCallFactory.create(httpTracing.clientOf("sqs"), new OkHttpClient());
```

```xml
<bean class="brave.spring.web.TracingClientHttpRequestInterceptor" factory-method="create">
  <constructor-arg>
    <bean factory-bean="httpTracing" factory-method="clientOf">
      <constructor-arg type="String" value="s3"/>
    </bean>
  </constructor-arg>
</bean>
```