### PR TITLE
Adds HttpSampler for parameterized sampling of http requests

### DIFF
--- a/brave/src/main/java/brave/http/HttpSampler.java
+++ b/brave/src/main/java/brave/http/HttpSampler.java
@@ -1,0 +1,49 @@
+package brave.http;
+
+import brave.internal.Nullable;
+
+/**
+ * Decides whether to start a new trace based on http request properties such as path.
+ *
+ * <p>Ex. Here's a sampler that only traces api requests
+ * <pre>{@code
+ * httpTracingBuilder.serverSampler(new HttpSampler() {
+ *   @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+ *     return adapter.path(request).startsWith("/api");
+ *   }
+ * });
+ * }</pre>
+ */
+// abstract class as you can't lambda generic methods anyway. This lets us make helpers in the future
+public abstract class HttpSampler {
+  /** Ignores the request and uses the {@link brave.sampler.Sampler trace ID instead}. */
+  public static final HttpSampler TRACE_ID = new HttpSampler() {
+    @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+      return null;
+    }
+
+    @Override public String toString() {
+      return "DeferDecision";
+    }
+  };
+  /**
+   * Returns false to never start new traces for http requests. This could make sense for http
+   * clients. For example, you may wish to never capture http traces unless they originated for a
+   * server request. For example, this would filter out client requests made during bootstrap.
+   */
+  public static final HttpSampler NEVER_SAMPLE = new HttpSampler() {
+    @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+      return false;
+    }
+
+    @Override public String toString() {
+      return "NeverSample";
+    }
+  };
+
+  /**
+   * Returns an overriding sampling decision for a new trace. Return null ignore the request and use
+   * the {@link brave.sampler.Sampler trace ID sampler}.
+   */
+  @Nullable public abstract <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request);
+}

--- a/brave/src/main/java/brave/http/HttpTracing.java
+++ b/brave/src/main/java/brave/http/HttpTracing.java
@@ -15,7 +15,9 @@ public abstract class HttpTracing {
         .tracing(tracing)
         .serverName("")
         .clientParser(new HttpClientParser())
-        .serverParser(new HttpServerParser());
+        .serverParser(new HttpServerParser())
+        .clientSampler(HttpSampler.TRACE_ID)
+        .serverSampler(HttpSampler.TRACE_ID);
   }
 
   public abstract Tracing tracing();
@@ -55,15 +57,44 @@ public abstract class HttpTracing {
 
   public abstract HttpServerParser serverParser();
 
+  /**
+   * Returns an overriding sampling decision for a new trace. Defaults to ignore the request and use
+   * the {@link HttpSampler#TRACE_ID trace ID instead}.
+   *
+   * <p>This decision happens when a trace was not yet started in process. For example, you may be
+   * making an http request as a part of booting your application. You may want to opt-out of
+   * tracing client requests that did not originate from a server request.
+   */
+  public abstract HttpSampler clientSampler();
+
+  /**
+   * Returns an overriding sampling decision for a new trace. Defaults to ignore the request and use
+   * the {@link HttpSampler#TRACE_ID trace ID instead}.
+   *
+   * <p>This decision happens when trace IDs were not in headers, or a sampling decision has not yet
+   * been made. For example, if a trace is already in progress, this function is not called. You can
+   * implement this to skip paths that you never want to trace.
+   */
+  public abstract HttpSampler serverSampler();
+
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
   public static abstract class Builder {
+    /** @see HttpTracing#tracing() */
     public abstract Builder tracing(Tracing tracing);
 
+    /** @see HttpTracing#clientParser() */
     public abstract Builder clientParser(HttpClientParser clientParser);
 
+    /** @see HttpTracing#serverParser() */
     public abstract Builder serverParser(HttpServerParser serverParser);
+
+    /** @see HttpTracing#clientSampler() */
+    public abstract Builder clientSampler(HttpSampler clientSampler);
+
+    /** @see HttpTracing#serverSampler() */
+    public abstract Builder serverSampler(HttpSampler serverSampler);
 
     public abstract HttpTracing build();
 

--- a/brave/src/test/java/brave/features/http/RequestSamplingTest.java
+++ b/brave/src/test/java/brave/features/http/RequestSamplingTest.java
@@ -1,0 +1,85 @@
+package brave.features.http;
+
+import brave.Tracing;
+import brave.http.HttpAdapter;
+import brave.http.HttpSampler;
+import brave.http.HttpTracing;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.Endpoint;
+import zipkin.internal.Util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** This is an example of http request sampling */
+public class RequestSamplingTest {
+  @Rule public MockWebServer server = new MockWebServer();
+
+  ConcurrentLinkedDeque<zipkin.Span> spans = new ConcurrentLinkedDeque<>();
+  Tracing tracing = Tracing.newBuilder()
+      .localEndpoint(Endpoint.builder().serviceName("server").build())
+      .reporter(spans::push)
+      .build();
+  HttpTracing httpTracing = HttpTracing.newBuilder(tracing)
+      // server starts traces under the path /api
+      .serverSampler(new HttpSampler() {
+        @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+          return adapter.path(request).startsWith("/api");
+        }
+      })
+      // client doesn't start new traces
+      .clientSampler(HttpSampler.NEVER_SAMPLE)
+      .build();
+
+  OkHttpClient client = new OkHttpClient();
+
+  @Before public void setup() {
+    server.setDispatcher(new TracingDispatcher(httpTracing, new Dispatcher() {
+      OkHttpClient tracedClient = client.newBuilder()
+          .addNetworkInterceptor(new TracingInterceptor(httpTracing)).build();
+
+      @Override public MockResponse dispatch(RecordedRequest request) {
+        if (request.getPath().equals("/next")) return new MockResponse().setBody("next");
+        Call next = tracedClient.newCall(new Request.Builder().url(server.url("/next")).build());
+        try (ResponseBody responseBody = next.execute().body()) {
+          return new MockResponse().setBody(responseBody.string());
+        } catch (IOException e) {
+          return new MockResponse().setBody(e.getMessage()).setResponseCode(500);
+        }
+      }
+    }));
+  }
+
+  @Test public void serverDoesntTraceFoo() throws Exception {
+    callServer("/foo");
+    assertThat(spans).isEmpty();
+  }
+
+  @Test public void clientTracedWhenServerIs() throws Exception {
+    callServer("/api");
+
+    assertThat(spans)
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(b -> b.key.equals("http.path"))
+        .extracting(b -> new String(b.value, Util.UTF_8))
+        .containsOnly("/api", "/next");
+  }
+
+  void callServer(String path) throws IOException {
+    Call next = client.newCall(new Request.Builder().url(server.url(path)).build());
+    try (ResponseBody responseBody = next.execute().body()) {
+      assertThat(responseBody.string()).isEqualTo("next");
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/http/TracingDispatcher.java
+++ b/brave/src/test/java/brave/features/http/TracingDispatcher.java
@@ -1,0 +1,62 @@
+package brave.features.http;
+
+import brave.Span;
+import brave.Tracer;
+import brave.http.HttpServerAdapter;
+import brave.http.HttpServerHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+final class TracingDispatcher extends Dispatcher {
+  final Dispatcher delegate;
+  final Tracer tracer;
+  final HttpServerHandler<RecordedRequest, MockResponse> handler;
+  final TraceContext.Extractor<RecordedRequest> extractor;
+
+  TracingDispatcher(HttpTracing httpTracing, Dispatcher delegate) {
+    tracer = httpTracing.tracing().tracer();
+    handler = HttpServerHandler.create(httpTracing, new MockWebServerAdapter());
+    extractor = httpTracing.tracing().propagation().extractor(RecordedRequest::getHeader);
+    this.delegate = delegate;
+  }
+
+  @Override public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+    Span span = handler.handleReceive(extractor, request);
+    MockResponse response = null;
+    Throwable error = null;
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      return response = delegate.dispatch(request);
+    } catch (InterruptedException | RuntimeException | Error e) {
+      error = e;
+      throw e;
+    } finally {
+      handler.handleSend(response, error, span);
+    }
+  }
+
+  static final class MockWebServerAdapter extends HttpServerAdapter<RecordedRequest, MockResponse> {
+
+    @Override public String method(RecordedRequest request) {
+      return request.getMethod();
+    }
+
+    @Override public String path(RecordedRequest request) {
+      return request.getPath();
+    }
+
+    @Override public String url(RecordedRequest request) {
+      return request.getRequestUrl().toString();
+    }
+
+    @Override public String requestHeader(RecordedRequest request, String name) {
+      return request.getHeader(name);
+    }
+
+    @Override public Integer statusCode(MockResponse response) {
+      return Integer.parseInt(response.getStatus().split(" ")[1]);
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/http/TracingInterceptor.java
+++ b/brave/src/test/java/brave/features/http/TracingInterceptor.java
@@ -1,0 +1,61 @@
+package brave.features.http;
+
+import brave.Span;
+import brave.Tracer;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/** Example interceptor. Use the real deal brave-instrumentation-okhttp3 in real life */
+final class TracingInterceptor implements Interceptor {
+  final Tracer tracer;
+  final HttpClientHandler<Request, Response> clientHandler;
+  final TraceContext.Injector<Request.Builder> injector;
+
+  TracingInterceptor(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    clientHandler = HttpClientHandler.create(httpTracing, new OkHttpAdapter());
+    injector = httpTracing.tracing().propagation().injector(Request.Builder::header);
+  }
+
+  @Override public Response intercept(Interceptor.Chain chain) throws IOException {
+    Request.Builder builder = chain.request().newBuilder();
+    Span span = clientHandler.handleSend(injector, builder, chain.request());
+    Response response = null;
+    Throwable error = null;
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      return response = chain.proceed(builder.build());
+    } catch (IOException | RuntimeException | Error e) {
+      error = e;
+      throw e;
+    } finally {
+      clientHandler.handleReceive(response, error, span);
+    }
+  }
+
+  static final class OkHttpAdapter extends brave.http.HttpClientAdapter<Request, Response> {
+    @Override public String method(Request request) {
+      return request.method();
+    }
+
+    @Override public String path(Request request) {
+      return request.url().encodedPath();
+    }
+
+    @Override public String url(Request request) {
+      return request.url().toString();
+    }
+
+    @Override public String requestHeader(Request request, String name) {
+      return request.header(name);
+    }
+
+    @Override public Integer statusCode(Response response) {
+      return response.code();
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/http/package-info.java
+++ b/brave/src/test/java/brave/features/http/package-info.java
@@ -1,0 +1,2 @@
+/** This shows how to use the brave.http package */
+package brave.features.http;

--- a/brave/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/brave/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -1,5 +1,6 @@
 package brave.http;
 
+import brave.Tracer;
 import brave.Tracing;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.when;
 public class HttpClientHandlerTest {
   List<Span> spans = new ArrayList<>();
   HttpTracing httpTracing;
+  @Mock HttpSampler sampler;
   @Mock HttpClientAdapter<Object, Object> adapter;
   @Mock TraceContext.Injector<Object> injector;
   @Mock brave.Span span;
@@ -30,16 +32,37 @@ public class HttpClientHandlerTest {
   HttpClientHandler<Object, Object> handler;
 
   @Before public void init() {
-    httpTracing = HttpTracing.create(Tracing.newBuilder().reporter(spans::add).build());
+    httpTracing = HttpTracing.newBuilder(Tracing.newBuilder().reporter(spans::add).build())
+        .clientSampler(sampler).build();
     handler = HttpClientHandler.create(httpTracing, adapter);
 
     when(adapter.method(request)).thenReturn("GET");
   }
 
   @Test public void handleSend_defaultsToMakeNewTrace() {
+    // request sampler abstains (trace ID sampler will say true)
+    when(sampler.trySample(adapter, request)).thenReturn(null);
+
     assertThat(handler.handleSend(injector, request))
         .extracting(s -> s.isNoop(), s -> s.context().parentId())
         .containsExactly(false, null);
+  }
+
+  @Test public void handleSend_makesAChild() {
+    brave.Span parent = httpTracing.tracing().tracer().newTrace();
+    try (Tracer.SpanInScope ws = httpTracing.tracing().tracer().withSpanInScope(parent)) {
+      assertThat(handler.handleSend(injector, request))
+          .extracting(s -> s.isNoop(), s -> s.context().parentId())
+          .containsExactly(false, parent.context().spanId());
+    }
+  }
+
+  @Test public void handleSend_makesRequestBasedSamplingDecision() {
+    // request sampler says false eventhough trace ID sampler would have said true
+    when(sampler.trySample(adapter, request)).thenReturn(false);
+
+    assertThat(handler.handleSend(injector, request).isNoop())
+        .isTrue();
   }
 
   @Test public void handleSend_injectsTheTraceContext() {
@@ -56,7 +79,10 @@ public class HttpClientHandlerTest {
   }
 
   @Test public void handleSend_addsClientAddressWhenOnlyServiceName() {
-    httpTracing = httpTracing.toBuilder().serverName("remote-service").build();
+    httpTracing = httpTracing.clientOf("remote-service");
+
+    // request sampler abstains (trace ID sampler will say true)
+    when(sampler.trySample(adapter, request)).thenReturn(null);
     HttpClientHandler.create(httpTracing, adapter).handleSend(injector, request).finish();
 
     assertThat(spans)

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -22,14 +22,15 @@ httpTracing = HttpTracing.newBuilder(tracing).serverName("github").build();
 okhttp = TracingCallFactory.create(httpTracing, new OkHttpClient());
 ```
 
-### Http tracing
+# Http tracing
 Most instrumentation are based on http communication. For this reason,
 we have specialized handlers for http clients and servers. All of these
 are configured with `HttpTracing`.
 
-The `HttpTracing` class holds a reference to a tracing component and also
-includes instructions on what to put into http spans.
+The `HttpTracing` class holds a reference to a tracing component,
+instructions on what to put into http spans, and sampling policy.
 
+## Tagging policy
 By default, the following is added for both http clients and servers:
 * Span.name as the http method in lowercase: ex "get"
 * Tags/binary annotations:
@@ -61,6 +62,36 @@ httpTracing = httpTracing.toBuilder()
 
 apache = TracingHttpClientBuilder.create(httpTracing.clientOf("s3")).build();
 okhttp = TracingCallFactory.create(httpTracing.clientOf("sqs"), new OkHttpClient());
+```
+
+## Sampling Policy
+The default sampling policy is to use the default (trace ID) sampler for
+server and client requests.
+
+For example, if there's a incoming request that has no trace IDs in its
+headers, the sampler indicated by `Tracing.Builder.sampler` decides whether
+or not to start a new trace. Once a trace is in progress, it is used for
+any outgoing http client requests.
+
+On the other hand, you may have http client requests that didn't originate
+from a server. For example, you may be bootstrapping your application,
+and that makes an http call to a system service. The default policy will
+start a trace for any http call, even ones that didn't come from a server
+request.
+
+You can change the sampling policy by specifying it in the `HttpTracing`
+component. Here's an example which only starts traces for requests
+originating from the  `/api` endpoint. It chooses 100% of such requests.
+
+```java
+httpTracing = httpTracing.toBuilder()
+    .serverSampler(new HttpSampler() {
+       @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+         return adapter.path(request).startsWith("/api");
+       }
+     })
+    .clientSampler(HttpSampler.NEVER_SAMPLE)
+    .build();
 ```
 
 # Developing new instrumentation

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -80,17 +80,17 @@ start a trace for any http call, even ones that didn't come from a server
 request.
 
 You can change the sampling policy by specifying it in the `HttpTracing`
-component. Here's an example which only starts traces for requests
-originating from the  `/api` endpoint. It chooses 100% of such requests.
+component. Here's an example which doesn't start new traces for requests
+to favicon (which many browsers automatically fetch).
 
 ```java
 httpTracing = httpTracing.toBuilder()
     .serverSampler(new HttpSampler() {
        @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
-         return adapter.path(request).startsWith("/api");
+         if (adapter.path(request).startsWith("/favicon")) return false;
+         return null; // defer decision to probabilistic on trace ID
        }
      })
-    .clientSampler(HttpSampler.NEVER_SAMPLE)
     .build();
 ```
 


### PR DESCRIPTION
The prior sampling policy was to use the default (trace ID) sampler for
server and client requests.  For example, if there's a incoming request
that has no trace IDs in its headers, the sampler indicated by
`Tracing.Builder.sampler` decides whether or not to start a new trace.
Once a trace is in progress, it is used for any outgoing http client
requests.

On the other hand, you may have http client requests that didn't originate
from a server. For example, you may be bootstrapping your application,
and that makes an http call to a system service. The default policy will
start a trace for any http call, even ones that didn't come from a server
request.

This change makes it possible to make sampling decisions based on the
http request, in a way that applies to all http instrumentation uniformly.

Here's an example which only starts traces for requests
originating from the  `/api` endpoint. It chooses 100% of such requests.

```java
httpTracing = httpTracing.toBuilder()
    .serverSampler(new HttpSampler() {
       @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
         return adapter.path(request).startsWith("/api");
       }
     })
    .clientSampler(HttpSampler.NEVER_SAMPLE)
    .build();
```

Fixes #395