### PR TITLE
Adds brave-spring-beans for configuring Tracing without custom code

### DIFF
--- a/brave-spring-beans/README.md
+++ b/brave-spring-beans/README.md
@@ -1,0 +1,31 @@
+# brave-spring-beans
+This module contains Spring Factory Beans that allow you to configure
+tracing with only XML
+
+## Configuration
+Bean Factories exist for the following types:
+* AsyncReporterFactoryBean - for configuring how often spans are sent to Zipkin
+* EndpointFactoryBean - for configuring the service name, IP etc representing this host
+* TracingFactoryBean - wires most together, like reporter and log integration
+* HttpTracingFactoryBean - for http tagging and sampling policy
+
+Here are some example beans using the factories in this module:
+```xml
+  <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
+    <property name="localServiceName" value="brave-webmvc-example"/>
+    <property name="reporter">
+      <bean class="brave.spring.beans.AsyncReporterFactoryBean">
+        <property name="sender" ref="sender"/>
+        <!-- wait up to half a second for any in-flight spans on close -->
+        <property name="closeTimeout" value="500"/>
+      </bean>
+    </property>
+    <property name="currentTraceContext">
+      <bean class="brave.context.slf4j.MDCCurrentTraceContext" factory-method="create"/>
+    </property>
+  </bean>
+
+  <bean id="httpTracing" class="brave.spring.beans.HttpTracingFactoryBean">
+    <property name="tracing" ref="tracing"/>
+  </bean>
+```

--- a/brave-spring-beans/pom.xml
+++ b/brave-spring-beans/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-parent</artifactId>
+    <version>4.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-spring-beans</artifactId>
+  <name>Brave Spring Factory Beans</name>
+  <description>Allows you to configure Brave using XML</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>${spring.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/brave-spring-beans/src/main/java/brave/spring/beans/AsyncReporterFactoryBean.java
+++ b/brave-spring-beans/src/main/java/brave/spring/beans/AsyncReporterFactoryBean.java
@@ -1,0 +1,69 @@
+package brave.spring.beans;
+
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin.reporter.AsyncReporter;
+import zipkin.reporter.ReporterMetrics;
+import zipkin.reporter.Sender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class AsyncReporterFactoryBean extends AbstractFactoryBean<AsyncReporter> {
+  Sender sender;
+  ReporterMetrics metrics;
+  Integer messageMaxBytes;
+  Integer messageTimeout;
+  Integer closeTimeout;
+  Integer queuedMaxSpans;
+  Integer queuedMaxBytes;
+
+  @Override public Class<? extends AsyncReporter> getObjectType() {
+    return AsyncReporter.class;
+  }
+
+  @Override protected AsyncReporter createInstance() throws Exception {
+    AsyncReporter.Builder builder = AsyncReporter.builder(sender);
+    if (metrics != null) builder.metrics(metrics);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    if (messageTimeout != null) builder.messageTimeout(messageTimeout, TimeUnit.MILLISECONDS);
+    if (closeTimeout != null) builder.closeTimeout(closeTimeout, TimeUnit.MILLISECONDS);
+    if (queuedMaxSpans != null) builder.queuedMaxSpans(queuedMaxSpans);
+    if (queuedMaxBytes != null) builder.queuedMaxBytes(queuedMaxBytes);
+    return builder.build();
+  }
+
+  @Override protected void destroyInstance(AsyncReporter instance) throws Exception {
+    instance.close();
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setSender(Sender sender) {
+    this.sender = sender;
+  }
+
+  public void setMetrics(ReporterMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+
+  public void setMessageTimeout(Integer messageTimeout) {
+    this.messageTimeout = messageTimeout;
+  }
+
+  public void setCloseTimeout(Integer closeTimeout) {
+    this.closeTimeout = closeTimeout;
+  }
+
+  public void setQueuedMaxSpans(Integer queuedMaxSpans) {
+    this.queuedMaxSpans = queuedMaxSpans;
+  }
+
+  public void setQueuedMaxBytes(Integer queuedMaxBytes) {
+    this.queuedMaxBytes = queuedMaxBytes;
+  }
+}

--- a/brave-spring-beans/src/main/java/brave/spring/beans/EndpointFactoryBean.java
+++ b/brave-spring-beans/src/main/java/brave/spring/beans/EndpointFactoryBean.java
@@ -1,0 +1,42 @@
+package brave.spring.beans;
+
+import org.springframework.beans.factory.FactoryBean;
+import zipkin.Endpoint;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class EndpointFactoryBean implements FactoryBean<Endpoint> {
+
+  String serviceName;
+  String ip;
+  Integer port;
+
+  @Override public Endpoint getObject() throws Exception {
+    Endpoint.Builder builder = Endpoint.builder();
+    if (serviceName != null) builder.serviceName(serviceName);
+    if (ip != null && !builder.parseIp(ip)) {
+      throw new IllegalArgumentException("endpoint.ip: " + ip + " is not an IP literal");
+    }
+    if (port != null) builder.port(port);
+    return builder.build();
+  }
+
+  @Override public Class<? extends Endpoint> getObjectType() {
+    return Endpoint.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+}

--- a/brave-spring-beans/src/main/java/brave/spring/beans/HttpTracingFactoryBean.java
+++ b/brave-spring-beans/src/main/java/brave/spring/beans/HttpTracingFactoryBean.java
@@ -1,0 +1,55 @@
+package brave.spring.beans;
+
+import brave.Tracing;
+import brave.http.HttpClientParser;
+import brave.http.HttpSampler;
+import brave.http.HttpServerParser;
+import brave.http.HttpTracing;
+import org.springframework.beans.factory.FactoryBean;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class HttpTracingFactoryBean implements FactoryBean<HttpTracing> {
+
+  Tracing tracing;
+  HttpClientParser clientParser;
+  HttpServerParser serverParser;
+  HttpSampler clientSampler;
+  HttpSampler serverSampler;
+
+  @Override public HttpTracing getObject() throws Exception {
+    HttpTracing.Builder builder = HttpTracing.newBuilder(tracing);
+    if (clientParser != null) builder.clientParser(clientParser);
+    if (serverParser != null) builder.serverParser(serverParser);
+    if (clientSampler != null) builder.clientSampler(clientSampler);
+    if (serverSampler != null) builder.serverSampler(serverSampler);
+    return builder.build();
+  }
+
+  @Override public Class<? extends HttpTracing> getObjectType() {
+    return HttpTracing.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setTracing(Tracing tracing) {
+    this.tracing = tracing;
+  }
+
+  public void setClientParser(HttpClientParser clientParser) {
+    this.clientParser = clientParser;
+  }
+
+  public void setServerParser(HttpServerParser serverParser) {
+    this.serverParser = serverParser;
+  }
+
+  public void setClientSampler(HttpSampler clientSampler) {
+    this.clientSampler = clientSampler;
+  }
+
+  public void setServerSampler(HttpSampler serverSampler) {
+    this.serverSampler = serverSampler;
+  }
+}

--- a/brave-spring-beans/src/main/java/brave/spring/beans/TracingFactoryBean.java
+++ b/brave-spring-beans/src/main/java/brave/spring/beans/TracingFactoryBean.java
@@ -1,0 +1,73 @@
+package brave.spring.beans;
+
+import brave.Clock;
+import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.sampler.Sampler;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin.Endpoint;
+import zipkin.reporter.Reporter;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class TracingFactoryBean extends AbstractFactoryBean<Tracing> {
+
+  String localServiceName;
+  Endpoint localEndpoint;
+  Reporter<zipkin.Span> reporter;
+  Clock clock;
+  Sampler sampler;
+  CurrentTraceContext currentTraceContext;
+  Boolean traceId128Bit;
+
+  @Override protected Tracing createInstance() throws Exception {
+    Tracing.Builder builder = Tracing.newBuilder();
+    if (localServiceName != null) builder.localServiceName(localServiceName);
+    if (localEndpoint != null) builder.localEndpoint(localEndpoint);
+    if (reporter != null) builder.reporter(reporter);
+    if (clock != null) builder.clock(clock);
+    if (sampler != null) builder.sampler(sampler);
+    if (currentTraceContext != null) builder.currentTraceContext(currentTraceContext);
+    if (traceId128Bit != null) builder.traceId128Bit(traceId128Bit);
+    return builder.build();
+  }
+
+  @Override protected void destroyInstance(Tracing instance) throws Exception {
+    instance.close();
+  }
+
+  @Override public Class<? extends Tracing> getObjectType() {
+    return Tracing.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setLocalServiceName(String localServiceName) {
+    this.localServiceName = localServiceName;
+  }
+
+  public void setLocalEndpoint(Endpoint localEndpoint) {
+    this.localEndpoint = localEndpoint;
+  }
+
+  public void setReporter(Reporter<zipkin.Span> reporter) {
+    this.reporter = reporter;
+  }
+
+  public void setClock(Clock clock) {
+    this.clock = clock;
+  }
+
+  public void setSampler(Sampler sampler) {
+    this.sampler = sampler;
+  }
+
+  public void setCurrentTraceContext(CurrentTraceContext currentTraceContext) {
+    this.currentTraceContext = currentTraceContext;
+  }
+
+  public void setTraceId128Bit(boolean traceId128Bit) {
+    this.traceId128Bit = traceId128Bit;
+  }
+}

--- a/brave-spring-beans/src/test/java/brave/spring/beans/AsyncReporterFactoryBeanTest.java
+++ b/brave-spring-beans/src/test/java/brave/spring/beans/AsyncReporterFactoryBeanTest.java
@@ -1,0 +1,143 @@
+package brave.spring.beans;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+import zipkin.reporter.AsyncReporter;
+import zipkin.reporter.Encoding;
+import zipkin.reporter.ReporterMetrics;
+import zipkin.reporter.Sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AsyncReporterFactoryBeanTest {
+
+  public static Sender SENDER = mock(Sender.class);
+  public static ReporterMetrics METRICS = mock(ReporterMetrics.class);
+
+  static {
+    when(SENDER.encoding()).thenReturn(Encoding.JSON);
+    when(SENDER.messageMaxBytes()).thenReturn(1024);
+  }
+
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void sender() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("sender")
+        .containsExactly(SENDER);
+  }
+
+  @Test public void metrics() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"metrics\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".METRICS\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("metrics")
+        .containsExactly(METRICS);
+  }
+
+  @Test public void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"512\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(512);
+  }
+
+  @Test public void messageTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"messageTimeout\" value=\"500\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("messageTimeoutNanos")
+        .containsExactly(TimeUnit.MILLISECONDS.toNanos(500));
+  }
+
+  @Test public void closeTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"closeTimeout\" value=\"500\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("closeTimeoutNanos")
+        .containsExactly(TimeUnit.MILLISECONDS.toNanos(500));
+  }
+
+  @Test public void queuedMaxSpans() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"queuedMaxSpans\" value=\"10\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("pending.maxSize")
+        .containsExactly(10);
+  }
+
+  @Test public void queuedMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"brave.spring.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"queuedMaxBytes\" value=\"512\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(AsyncReporter.class))
+        .extracting("pending.maxBytes")
+        .containsExactly(512);
+  }
+}

--- a/brave-spring-beans/src/test/java/brave/spring/beans/EndpointFactoryBeanTest.java
+++ b/brave-spring-beans/src/test/java/brave/spring/beans/EndpointFactoryBeanTest.java
@@ -1,0 +1,80 @@
+package brave.spring.beans;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import zipkin.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class EndpointFactoryBeanTest {
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void serviceName() {
+    context = new XmlBeans(""
+        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Endpoint.class))
+        .isEqualTo(Endpoint.builder().serviceName("brave-webmvc-example").build());
+  }
+
+  @Test public void ip() {
+    context = new XmlBeans(""
+        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
+        + "  <property name=\"ip\" value=\"1.2.3.4\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Endpoint.class))
+        .isEqualTo(Endpoint.builder()
+            .serviceName("brave-webmvc-example")
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4)
+            .build());
+  }
+
+  @Test public void ip_malformed() {
+    context = new XmlBeans(""
+        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
+        + "  <property name=\"ip\" value=\"localhost\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    try {
+      context.getBean(Endpoint.class);
+      failBecauseExceptionWasNotThrown(BeanCreationException.class);
+    } catch (BeanCreationException e) {
+      assertThat(e)
+          .hasMessageContaining("endpoint.ip: localhost is not an IP literal");
+    }
+  }
+
+  @Test public void port() {
+    context = new XmlBeans(""
+        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
+        + "  <property name=\"ip\" value=\"1.2.3.4\"/>\n"
+        + "  <property name=\"port\" value=\"8080\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Endpoint.class))
+        .isEqualTo(Endpoint.builder()
+            .serviceName("brave-webmvc-example")
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4)
+            .port(8080).build());
+  }
+}

--- a/brave-spring-beans/src/test/java/brave/spring/beans/HttpTracingFactoryBeanTest.java
+++ b/brave-spring-beans/src/test/java/brave/spring/beans/HttpTracingFactoryBeanTest.java
@@ -1,0 +1,112 @@
+package brave.spring.beans;
+
+import brave.Tracing;
+import brave.http.HttpClientParser;
+import brave.http.HttpSampler;
+import brave.http.HttpServerParser;
+import brave.http.HttpTracing;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class HttpTracingFactoryBeanTest {
+
+  public static Tracing TRACING = mock(Tracing.class);
+  public static HttpClientParser CLIENT_PARSER = mock(HttpClientParser.class);
+  public static HttpServerParser SERVER_PARSER = mock(HttpServerParser.class);
+
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void tracing() {
+    context = new XmlBeans(""
+        + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+        + "  <property name=\"tracing\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(HttpTracing.class))
+        .extracting("tracing")
+        .containsExactly(TRACING);
+  }
+
+  @Test public void clientParser() {
+    context = new XmlBeans(""
+        + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+        + "  <property name=\"tracing\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"clientParser\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".CLIENT_PARSER\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(HttpTracing.class))
+        .extracting("clientParser")
+        .containsExactly(CLIENT_PARSER);
+  }
+
+  @Test public void serverParser() {
+    context = new XmlBeans(""
+        + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+        + "  <property name=\"tracing\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"serverParser\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SERVER_PARSER\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(HttpTracing.class))
+        .extracting("serverParser")
+        .containsExactly(SERVER_PARSER);
+  }
+
+  @Test public void clientSampler() {
+    context = new XmlBeans(""
+        + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+        + "  <property name=\"tracing\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"clientSampler\">\n"
+        + "    <util:constant static-field=\"brave.http.HttpSampler.NEVER_SAMPLE\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(HttpTracing.class))
+        .extracting("clientSampler")
+        .containsExactly(HttpSampler.NEVER_SAMPLE);
+  }
+
+  @Test public void serverSampler() {
+    context = new XmlBeans(""
+        + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+        + "  <property name=\"tracing\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"serverSampler\">\n"
+        + "    <util:constant static-field=\"brave.http.HttpSampler.NEVER_SAMPLE\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(HttpTracing.class))
+        .extracting("serverSampler")
+        .containsExactly(HttpSampler.NEVER_SAMPLE);
+  }
+}

--- a/brave-spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/brave-spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -1,0 +1,132 @@
+package brave.spring.beans;
+
+import brave.Clock;
+import brave.Tracing;
+import brave.internal.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import org.junit.After;
+import org.junit.Test;
+import zipkin.Endpoint;
+import zipkin.reporter.Reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class TracingFactoryBeanTest {
+  public static Clock CLOCK = mock(Clock.class);
+
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void localServiceName() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"localServiceName\" value=\"brave-webmvc-example\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.localEndpoint")
+        .extracting("serviceName")
+        .containsExactly("brave-webmvc-example");
+  }
+
+  @Test public void localEndpoint() {
+    context = new XmlBeans(""
+        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
+        + "  <property name=\"ip\" value=\"1.2.3.4\"/>\n"
+        + "  <property name=\"port\" value=\"8080\"/>\n"
+        + "</bean>"
+        , ""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"localEndpoint\" ref=\"localEndpoint\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.localEndpoint")
+        .containsExactly(Endpoint.builder()
+            .serviceName("brave-webmvc-example")
+            .ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4)
+            .port(8080).build());
+  }
+
+  @Test public void reporter() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"reporter\">\n"
+        + "    <util:constant static-field=\"zipkin.reporter.Reporter.CONSOLE\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.recorder.reporter")
+        .containsExactly(Reporter.CONSOLE);
+  }
+
+  @Test public void clock() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"clock\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".CLOCK\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.clock")
+        .containsExactly(CLOCK);
+  }
+
+  @Test public void sampler() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"sampler\">\n"
+        + "    <util:constant static-field=\"brave.sampler.Sampler.NEVER_SAMPLE\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.sampler")
+        .containsExactly(Sampler.NEVER_SAMPLE);
+  }
+
+  @Test public void currentTraceContext() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"currentTraceContext\">\n"
+        + "    <bean class=\"brave.internal.StrictCurrentTraceContext\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.currentTraceContext")
+        .allMatch(o -> o instanceof StrictCurrentTraceContext);
+  }
+
+  @Test public void traceId128Bit() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"traceId128Bit\" value=\"true\"/>\n"
+        + "</bean>"
+    );
+    context.refresh();
+
+    assertThat(context.getBean(Tracing.class))
+        .extracting("tracer.traceId128Bit")
+        .containsExactly(true);
+  }
+}

--- a/brave-spring-beans/src/test/java/brave/spring/beans/XmlBeans.java
+++ b/brave-spring-beans/src/test/java/brave/spring/beans/XmlBeans.java
@@ -1,0 +1,36 @@
+package brave.spring.beans;
+
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import zipkin.internal.Util;
+
+class XmlBeans extends AbstractXmlApplicationContext {
+
+  final ByteArrayResource resource;
+
+  XmlBeans(String... beans) {
+    StringBuilder joined = new StringBuilder();
+    for (String bean : beans) {
+      joined.append(bean).append('\n');
+    }
+    this.resource = new ByteArrayResource(beans(joined.toString()).getBytes(Util.UTF_8));
+  }
+
+  @Override protected Resource[] getConfigResources() {
+    return new Resource[] {resource};
+  }
+
+  static String beans(String bean) {
+    return "<beans xmlns=\"http://www.springframework.org/schema/beans\"\n"
+        + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+        + "    xmlns:util=\"http://www.springframework.org/schema/util\"\n"
+        + "    xsi:schemaLocation=\"\n"
+        + "        http://www.springframework.org/schema/beans\n"
+        + "        http://www.springframework.org/schema/beans/spring-beans-3.2.xsd\n"
+        + "        http://www.springframework.org/schema/util\n"
+        + "        http://www.springframework.org/schema/util/spring-util-3.2.xsd\">\n"
+        + bean
+        + "</beans>";
+  }
+}

--- a/brave-spring-beans/src/test/resources/log4j2.properties
+++ b/brave-spring-beans/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.1.2.Final</resteasy.version>
     <zipkin.version>1.24.0</zipkin.version>
-    <zipkin-reporter.version>0.8.0</zipkin-reporter.version>
+    <zipkin-reporter.version>0.9.0</zipkin-reporter.version>
     <finagle.version>6.44.0</finagle.version>
     <log4j.version>2.8.2</log4j.version>
     <okhttp.version>3.7.0</okhttp.version>
@@ -94,6 +94,7 @@
 
   <modules>
     <module>brave</module>
+    <module>brave-spring-beans</module>
     <module>context</module>
     <module>instrumentation</module>
     <module>brave-core</module>


### PR DESCRIPTION
This adds Factory Beans so that legacy apps can configure Tracing
without writing custom code.

This is tested against https://github.com/openzipkin/brave-webmvc-example/pull/15