### PR TITLE
Adds TracingInterceptor because some libaries need to use OkHttpClient

### DIFF
--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -1,5 +1,7 @@
 # brave-instrumentation-okhttp3
-This module contains a tracing decorator for [OkHttp](https://github.com/square/okhttp) 3.x.
+This module contains a tracing decorators for [OkHttp](https://github.com/square/okhttp) 3.x.
+
+## TracingCallFactory
 `TracingCallFactory` adds trace headers to outgoing requests. It
 then reports to Zipkin how long each request takes, along with relevant
 tags like the http url.
@@ -9,3 +11,22 @@ To enable tracing, wrap your client using `TracingCallFactory`.
 ```java
 callFactory = TracingCallFactory.create(tracing, okhttp);
 ```
+
+## TracingInterceptor
+Sometimes code must use `OkHttpClient`, not `Call.Factory`. When this is
+the case, you can add the network interceptor `TracingInterceptor`. Make
+sure you wrap the dispatcher's executor service.
+
+```java
+new OkHttpClient.Builder()
+        .dispatcher(new Dispatcher(
+            httpTracing.tracing().currentTraceContext()
+                .executorService(new Dispatcher().executorService())
+        ))
+        .addNetworkInterceptor(TracingInterceptor.create(httpTracing))
+        .build()
+```
+
+Note that when the keep-alive pool is full (backlog situation), this
+approach can result in broken traces. This limitation is not the case
+when using the call factory approach.

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -1,20 +1,16 @@
 package brave.okhttp3;
 
-import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
+import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import okhttp3.Call;
-import okhttp3.Connection;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import zipkin.Endpoint;
 
 /**
  * This internally adds an interceptor which ensures whatever current span exists is available via
@@ -32,95 +28,38 @@ public final class TracingCallFactory implements Call.Factory {
     return new TracingCallFactory(httpTracing, ok);
   }
 
-  final Tracer tracer;
-  final String remoteServiceName;
-  final HttpClientHandler<Request, Response> handler;
-  final TraceContext.Injector<Request.Builder> injector;
+  final CurrentTraceContext currentTraceContext;
   final OkHttpClient ok;
 
   TracingCallFactory(HttpTracing httpTracing, OkHttpClient ok) {
     if (httpTracing == null) throw new NullPointerException("HttpTracing == null");
     if (ok == null) throw new NullPointerException("OkHttpClient == null");
-    tracer = httpTracing.tracing().tracer();
-    remoteServiceName = httpTracing.serverName();
-    handler = HttpClientHandler.create(httpTracing, new HttpAdapter());
-    injector = httpTracing.tracing().propagation().injector(Request.Builder::addHeader);
-    this.ok = ok;
+    this.currentTraceContext = httpTracing.tracing().currentTraceContext();
+    OkHttpClient.Builder builder = ok.newBuilder();
+    builder.networkInterceptors().add(0, TracingInterceptor.create(httpTracing));
+    this.ok = builder.build();
   }
 
   @Override public Call newCall(Request request) {
-    Span currentSpan = tracer.currentSpan();
+    TraceContext currentSpan = currentTraceContext.get();
     OkHttpClient.Builder b = ok.newBuilder();
     if (currentSpan != null) b.interceptors().add(0, new SetParentSpanInScope(currentSpan));
-    b.networkInterceptors().add(0, new TracingNetworkInterceptor());
     // TODO: This can hide errors at the beginning of call.execute, such as invalid host!
     return b.build().newCall(request);
   }
 
   /** In case a request is deferred due to a backlog, we re-apply the span that was in scope */
   class SetParentSpanInScope implements Interceptor {
-    final Span previous;
+    final TraceContext previous;
 
-    SetParentSpanInScope(Span previous) {
+    SetParentSpanInScope(TraceContext previous) {
       this.previous = previous;
     }
 
     @Override public Response intercept(Chain chain) throws IOException {
-      try (Tracer.SpanInScope ws = tracer.withSpanInScope(previous)) {
+      try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(previous)) {
         return chain.proceed(chain.request());
       }
-    }
-  }
-
-  class TracingNetworkInterceptor implements Interceptor {
-    @Override public Response intercept(Chain chain) throws IOException {
-      Request request = chain.request();
-      Request.Builder requestBuilder = request.newBuilder();
-
-      Span span = handler.handleSend(injector, requestBuilder, request);
-      parseServerAddress(chain.connection(), span);
-      Response response = null;
-      Throwable error = null;
-      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-        return response = chain.proceed(requestBuilder.build());
-      } catch (IOException | RuntimeException | Error e) {
-        error = e;
-        throw e;
-      } finally {
-        handler.handleReceive(response, error, span);
-      }
-    }
-  }
-
-  /** This is different than default because the request does not hold the address */
-  void parseServerAddress(Connection connection, Span span) {
-    if (span.isNoop()) return;
-    InetSocketAddress remoteAddress = connection.route().socketAddress();
-    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
-    builder.parseIp(remoteAddress.getAddress());
-    builder.port(remoteAddress.getPort());
-    span.remoteEndpoint(builder.build());
-  }
-
-  static final class HttpAdapter extends brave.http.HttpClientAdapter<Request, Response> {
-    @Override public String method(Request request) {
-      return request.method();
-    }
-
-    @Override public String path(Request request) {
-      return request.url().encodedPath();
-    }
-
-    @Override public String url(Request request) {
-      return request.url().toString();
-    }
-
-    @Override public String requestHeader(Request request, String name) {
-      return request.header(name);
-    }
-
-    @Override public Integer statusCode(Response response) {
-      return response.code();
     }
   }
 }

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
@@ -1,0 +1,94 @@
+package brave.okhttp3;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import zipkin.Endpoint;
+
+/**
+ * This is a network-level interceptor, which creates a new span for each attempt. Note that this
+ * does not work well for high traffic servers, as the span context can be lost when under backlog.
+ * In cases like that, use {@link TracingCallFactory}.
+ */
+public final class TracingInterceptor implements Interceptor {
+
+  public static Interceptor create(Tracing tracing) {
+    return create(HttpTracing.create(tracing));
+  }
+
+  public static Interceptor create(HttpTracing httpTracing) {
+    return new TracingInterceptor(httpTracing);
+  }
+
+  final Tracer tracer;
+  final String remoteServiceName;
+  final HttpClientHandler<Request, Response> handler;
+  final TraceContext.Injector<Request.Builder> injector;
+
+  TracingInterceptor(HttpTracing httpTracing) {
+    if (httpTracing == null) throw new NullPointerException("HttpTracing == null");
+    tracer = httpTracing.tracing().tracer();
+    remoteServiceName = httpTracing.serverName();
+    handler = HttpClientHandler.create(httpTracing, new HttpAdapter());
+    injector = httpTracing.tracing().propagation().injector(Request.Builder::addHeader);
+  }
+
+  @Override public Response intercept(Chain chain) throws IOException {
+    Request request = chain.request();
+    Request.Builder requestBuilder = request.newBuilder();
+
+    Span span = handler.handleSend(injector, requestBuilder, request);
+    parseServerAddress(chain.connection(), span);
+    Response response = null;
+    Throwable error = null;
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      return response = chain.proceed(requestBuilder.build());
+    } catch (IOException | RuntimeException | Error e) {
+      error = e;
+      throw e;
+    } finally {
+      handler.handleReceive(response, error, span);
+    }
+  }
+
+  /** This is different than default because the request does not hold the address */
+  void parseServerAddress(Connection connection, Span span) {
+    if (span.isNoop()) return;
+    InetSocketAddress remoteAddress = connection.route().socketAddress();
+    Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName);
+    builder.parseIp(remoteAddress.getAddress());
+    builder.port(remoteAddress.getPort());
+    span.remoteEndpoint(builder.build());
+  }
+
+  static final class HttpAdapter extends brave.http.HttpClientAdapter<Request, Response> {
+    @Override public String method(Request request) {
+      return request.method();
+    }
+
+    @Override public String path(Request request) {
+      return request.url().encodedPath();
+    }
+
+    @Override public String url(Request request) {
+      return request.url().toString();
+    }
+
+    @Override public String requestHeader(Request request, String name) {
+      return request.header(name);
+    }
+
+    @Override public Integer statusCode(Response response) {
+      return response.code();
+    }
+  }
+}

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -1,0 +1,59 @@
+package brave.okhttp3;
+
+import brave.http.ITHttpClient;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Dispatcher;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class ITTracingInterceptor extends ITHttpClient<Call.Factory> {
+
+  @Override protected Call.Factory newClient(int port) {
+    return new OkHttpClient.Builder()
+        .connectTimeout(1, TimeUnit.SECONDS)
+        .readTimeout(1, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(false)
+        .dispatcher(new Dispatcher(
+            httpTracing.tracing().currentTraceContext()
+                .executorService(new Dispatcher().executorService())
+        ))
+        .addNetworkInterceptor(TracingInterceptor.create(httpTracing))
+        .build();
+  }
+
+  @Override protected void closeClient(Call.Factory client) throws IOException {
+    ((OkHttpClient) client).dispatcher().executorService().shutdownNow();
+  }
+
+  @Override protected void get(Call.Factory client, String pathIncludingQuery)
+      throws IOException {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
+        .execute();
+  }
+
+  @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
+      throws Exception {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery))
+        .post(RequestBody.create(MediaType.parse("text/plain"), body)).build())
+        .execute();
+  }
+
+  @Override protected void getAsync(Call.Factory client, String pathIncludingQuery)
+      throws Exception {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
+        .enqueue(new Callback() {
+          @Override public void onFailure(Call call, IOException e) {
+            e.printStackTrace();
+          }
+
+          @Override public void onResponse(Call call, Response response) throws IOException {
+          }
+        });
+  }
+}

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/TracingInterceptorTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/TracingInterceptorTest.java
@@ -4,7 +4,6 @@ import brave.Span;
 import brave.Tracing;
 import brave.http.HttpTracing;
 import okhttp3.Connection;
-import okhttp3.OkHttpClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -15,9 +14,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TracingCallFactoryTest {
-  TracingCallFactory filter =
-      new TracingCallFactory(HttpTracing.create(Tracing.newBuilder().build()), new OkHttpClient());
+public class TracingInterceptorTest {
+  TracingInterceptor filter =
+      new TracingInterceptor(HttpTracing.create(Tracing.newBuilder().build()));
   @Mock Connection connection;
   @Mock Span span;
 


### PR DESCRIPTION
Not all applications can substitute Call.Factory for OkHttpClient. This
exposes the TracingInterceptor for scenarios like zipkin-server tracing
of Elasticsearch.