### PR TITLE
Implements letClear semantics via setting null in scope

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -293,6 +293,16 @@ try (SpanInScope ws = tracer.withSpanInScope(span)) {
 }
 ```
 
+In edge cases, you may need to clear the current span temporarily. For
+example, launching a task that should not be associated with the current
+request. To do this, simply pass null to `withSpanInScope`.
+
+```java
+try (SpanInScope cleared = tracer.withSpanInScope(null)) {
+  startBackgroundThread();
+}
+```
+
 ### Working with callbacks
 
 Many libraries expose a callback model as opposed to an interceptor one.

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -148,7 +148,6 @@ public final class Tracer {
    * @see Propagation
    * @see Extractor#extract(Object)
    * @see TraceContextOrSamplingFlags#context()
-   * @see #nextSpan(Extractor, Object)
    */
   public final Span joinSpan(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
@@ -252,9 +251,11 @@ public final class Tracer {
    * the result have no effect on the input. For example, calling close on the result does not
    * finish the span. Not only is it safe to call close, you must call close to end the scope, or
    * risk leaking resources associated with the scope.
+   *
+   * @param span span to place into scope or null to clear the scope
    */
-  public SpanInScope withSpanInScope(Span span) {
-    return new SpanInScope(currentTraceContext.newScope(span.context()));
+  public SpanInScope withSpanInScope(@Nullable Span span) {
+    return new SpanInScope(currentTraceContext.newScope(span != null ? span.context() : null));
   }
 
   /** Returns the current span in scope or null if there isn't one. */

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -25,8 +25,10 @@ public abstract class CurrentTraceContext {
   /**
    * Sets the current span in scope until the returned object is closed. It is a programming
    * error to drop or never close the result. Using try-with-resources is preferred for this reason.
+   *
+   * @param currentSpan span to place into scope or null to clear the scope
    */
-  public abstract Scope newScope(TraceContext currentSpan);
+  public abstract Scope newScope(@Nullable TraceContext currentSpan);
 
   /** A span remains in the scope it was bound to until close is called. */
   public interface Scope extends Closeable {

--- a/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
@@ -24,6 +24,19 @@ public class DefaultCurrentTraceContextTest {
     }
   }
 
+  @Test public void scope_canClearScope() {
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      try (CurrentTraceContext.Scope noScope = currentTraceContext.newScope(null)) {
+        assertThat(currentTraceContext.get())
+            .isNull();
+      }
+
+      // old context reverted
+      assertThat(currentTraceContext.get())
+          .isEqualTo(context);
+    }
+  }
+
   @Test public void scope_isDefinedPerThread() throws InterruptedException {
     final TraceContext[] threadValue = new TraceContext[1];
 

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -193,4 +193,19 @@ public class TracerTest {
           .isEqualTo(parent);
     }
   }
+
+  @Test public void withSpanInScope_clear() {
+    Span parent = tracer.newTrace();
+
+    try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {
+      try (Tracer.SpanInScope clearScope = tracer.withSpanInScope(null)) {
+        assertThat(tracer.currentSpan())
+            .isNull();
+      }
+
+      // old parent reverted
+      assertThat(tracer.currentSpan())
+          .isEqualTo(parent);
+    }
+  }
 }

--- a/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
@@ -57,6 +57,19 @@ public class StrictCurrentTraceContextTest {
     }
   }
 
+  @Test public void scope_canClearScope() {
+    try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context)) {
+      try (CurrentTraceContext.Scope noScope = currentTraceContext.newScope(null)) {
+        assertThat(currentTraceContext.get())
+            .isNull();
+      }
+
+      // old context reverted
+      assertThat(currentTraceContext.get())
+          .isEqualTo(context);
+    }
+  }
+
   @Test public void scope_enforcesCloseOnSameThread() throws InterruptedException {
     final Exception[] spawnedThreadException = new Exception[1];
     Thread scopingThread = new Thread(() -> {

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -33,8 +33,13 @@ public final class ThreadContextCurrentTraceContext extends CurrentTraceContext 
     final String previousTraceId = ThreadContext.get("traceId");
     final String previousSpanId = ThreadContext.get("spanId");
 
-    ThreadContext.put("traceId", currentSpan.traceIdString());
-    ThreadContext.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+    if (currentSpan != null) {
+      ThreadContext.put("traceId", currentSpan.traceIdString());
+      ThreadContext.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+    } else {
+      ThreadContext.remove("traceId");
+      ThreadContext.remove("spanId");
+    }
 
     Scope scope = delegate.newScope(currentSpan);
     return () -> {

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ThreadContextCurrentTraceContextTest {
   Logger testLogger = LogManager.getLogger();
 
-  @Test public void customCurrentTraceContext() {
+  @Test public void testSpan() {
     assertThat(ThreadContext.get("traceId"))
         .isNull();
     assertThat(ThreadContext.get("spanId"))
@@ -34,6 +34,16 @@ public class ThreadContextCurrentTraceContextTest {
           .isEqualTo(parent.context().traceIdString());
       assertThat(ThreadContext.get("spanId"))
           .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+
+      try (Tracer.SpanInScope noSpan = tracer.withSpanInScope(null)) {
+        noSpan.toString(); // make sure it doesn't crash
+        testLogger.info("with no span");
+
+        assertThat(ThreadContext.get("traceId"))
+            .isNull();
+        assertThat(ThreadContext.get("spanId"))
+            .isNull();
+      }
 
       Span child = tracer.newChild(parent.context());
       try (Tracer.SpanInScope wsChild = tracer.withSpanInScope(child)) {

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -33,8 +33,13 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
     final String previousTraceId = MDC.get("traceId");
     final String previousSpanId = MDC.get("spanId");
 
-    MDC.put("traceId", currentSpan.traceIdString());
-    MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+    if (currentSpan != null) {
+      MDC.put("traceId", currentSpan.traceIdString());
+      MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+    } else {
+      MDC.remove("traceId");
+      MDC.remove("spanId");
+    }
 
     Scope scope = delegate.newScope(currentSpan);
     return () -> {

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -4,6 +4,7 @@ import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
 import brave.internal.HexCodec;
+import org.apache.logging.log4j.ThreadContext;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MDCCurrentTraceContextTest {
   Logger testLogger = LoggerFactory.getLogger(getClass());
 
-  @Test public void customCurrentTraceContext() {
+  @Test public void test() {
     assertThat(MDC.get("traceId"))
         .isNull();
     assertThat(MDC.get("spanId"))
@@ -28,6 +29,16 @@ public class MDCCurrentTraceContextTest {
     Span parent = tracer.newTrace();
     try (Tracer.SpanInScope wsParent = tracer.withSpanInScope(parent)) {
       testLogger.info("with span: " + parent);
+
+      try (Tracer.SpanInScope noSpan = tracer.withSpanInScope(null)) {
+        noSpan.toString(); // make sure it doesn't crash
+        testLogger.info("with no span");
+
+        assertThat(ThreadContext.get("traceId"))
+            .isNull();
+        assertThat(ThreadContext.get("spanId"))
+            .isNull();
+      }
 
       // the trace id is now in the logging context
       assertThat(MDC.get("traceId"))


### PR DESCRIPTION
In edge cases, you may need to clear the current span temporarily. For
example, launching a task that should not be associated with the current
request. To do this, simply pass null to `withSpanInScope`.

```java
try (SpanInScope cleared = tracer.withSpanInScope(null)) {
  startBackgroundThread();
}
```