### PR TITLE
Adds brave.Tagger, a safer type to expose for simple customization

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -75,14 +75,39 @@ try {
 }
 ```
 
+### Customizing spans
 Once you have a span, you can add tags to it, which can be used as lookup
-keys or details. For example, you might add a tag with your runtime version:
+keys or details. For example, you might add a tag with your runtime
+version.
 
 ```java
 span.tag("clnt/finagle.version", "6.36.0");
 ```
 
+When exposing the ability to customize spans to third parties, prefer
+`brave.Tagger` as opposed to `brave.Span`. The former is simpler to
+understand and test, and doesn't tempt users with span lifecycle hooks.
+
+```java
+interface MyTraceCallback {
+  void requestTags(Request request, Tagger tagger);
+}
+```
+
+Since `brave.Span` implements `brave.Tagger`, it is just as easy for you
+to pass to users.
+
+Ex.
+```java
+for (MyTraceCallback callback : userCallbacks) {
+  callback.requestTags(request, span);
+}
+```
+
 ### RPC tracing
+Check for [instrumentation written here](../instrumentation/) and [Zipkin's list](http://zipkin.io/pages/existing_instrumentations.html)
+before rolling your own RPC instrumentation!
+
 RPC tracing is often done automatically by interceptors. Under the scenes,
 they add tags and events that relate to their role in an RPC operation.
 

--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -3,7 +3,6 @@ package brave;
 import brave.propagation.TraceContext;
 import zipkin.Constants;
 import zipkin.Endpoint;
-import zipkin.TraceKeys;
 
 /**
  * Used to model the latency of an operation.
@@ -22,7 +21,7 @@ import zipkin.TraceKeys;
 // Design note: this does not require a builder as the span is mutable anyway. Having a single
 // mutation interface is less code to maintain. Those looking to prepare a span before starting it
 // can simply call start when they are ready.
-public abstract class Span {
+public abstract class Span implements Tagger {
   public enum Kind {
     CLIENT,
     SERVER
@@ -75,16 +74,8 @@ public abstract class Span {
   /** Like {@link #annotate(String)}, except with a given timestamp in microseconds. */
   public abstract Span annotate(long timestamp, String value);
 
-  /**
-   * Tags give your span context for search, viewing and analysis. For example, a key
-   * "your_app.version" would let you lookup spans by version. A tag {@link TraceKeys#SQL_QUERY}
-   * isn't searchable, but it can help in debugging when viewing a trace.
-   *
-   * @param key Name used to lookup spans, such as "your_app.version". See {@link TraceKeys} for
-   * standard ones.
-   * @param value String value, cannot be <code>null</code>.
-   */
-  public abstract Span tag(String key, String value);
+  /** {@inheritDoc} */
+  @Override public abstract Span tag(String key, String value);
 
   /**
    * For a client span, this would be the server's address.

--- a/brave/src/main/java/brave/Tagger.java
+++ b/brave/src/main/java/brave/Tagger.java
@@ -1,0 +1,24 @@
+package brave;
+
+import zipkin.TraceKeys;
+
+/**
+ * Simple interface users can customize a span with. For example, this can add custom tags useful
+ * in looking up spans.
+ *
+ * <p>This interface is safer to expose directly to users than {@link Span}, as it has no hooks that
+ * can affect the span lifecycle.
+ */
+public interface Tagger {
+
+  /**
+   * Tags give your span context for search, viewing and analysis. For example, a key
+   * "your_app.version" would let you lookup spans by version. A tag {@link TraceKeys#SQL_QUERY}
+   * isn't searchable, but it can help in debugging when viewing a trace.
+   *
+   * @param key Name used to lookup spans, such as "your_app.version". See {@link TraceKeys} for
+   * standard ones.
+   * @param value String value, cannot be <code>null</code>.
+   */
+  Tagger tag(String key, String value);
+}

--- a/brave/src/main/java/brave/http/HttpClientParser.java
+++ b/brave/src/main/java/brave/http/HttpClientParser.java
@@ -1,6 +1,6 @@
 package brave.http;
 
-import brave.Span;
+import brave.Tagger;
 import brave.internal.Nullable;
 
 /**
@@ -14,8 +14,8 @@ public class HttpClientParser extends HttpParser {
    *
    * <p>{@inheritDoc}
    */
-  @Override public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Span span) {
-    super.requestTags(adapter, req, span);
+  @Override public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Tagger tagger) {
+    super.requestTags(adapter, req, tagger);
   }
 
   /**
@@ -24,7 +24,7 @@ public class HttpClientParser extends HttpParser {
    * <p>{@inheritDoc}
    */
   @Override public <Resp> void responseTags(HttpAdapter<?, Resp> adapter, @Nullable Resp res,
-      @Nullable Throwable error, Span span) {
-    super.responseTags(adapter, res, error, span);
+      @Nullable Throwable error, Tagger tagger) {
+    super.responseTags(adapter, res, error, tagger);
   }
 }

--- a/brave/src/main/java/brave/http/HttpServerParser.java
+++ b/brave/src/main/java/brave/http/HttpServerParser.java
@@ -1,6 +1,6 @@
 package brave.http;
 
-import brave.Span;
+import brave.Tagger;
 import brave.internal.Nullable;
 
 /**
@@ -14,8 +14,8 @@ public class HttpServerParser extends HttpParser {
    *
    * <p>{@inheritDoc}
    */
-  @Override public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Span span) {
-    super.requestTags(adapter, req, span);
+  @Override public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Tagger tagger) {
+    super.requestTags(adapter, req, tagger);
   }
 
   /**
@@ -24,7 +24,7 @@ public class HttpServerParser extends HttpParser {
    * <p>{@inheritDoc}
    */
   @Override public <Resp> void responseTags(HttpAdapter<?, Resp> adapter, @Nullable Resp res,
-      @Nullable Throwable error, Span span) {
-    super.responseTags(adapter, res, error, span);
+      @Nullable Throwable error, Tagger tagger) {
+    super.responseTags(adapter, res, error, tagger);
   }
 }

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -54,8 +54,8 @@ httpTracing = httpTracing.toBuilder()
       }
 
       @Override
-      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
-        span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // the whole url, not just the path
+      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Tagger tagger) {
+        tagger.tag(TraceKeys.HTTP_URL, adapter.url(req)); // the whole url, not just the path
       }
     })
     .build();

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -1,5 +1,6 @@
 package brave.http;
 
+import brave.Tagger;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
 import brave.internal.HexCodec;
@@ -176,8 +177,8 @@ public abstract class ITHttpClient<C> extends ITHttp {
           }
 
           @Override
-          public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
-            span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
+          public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Tagger tagger) {
+            tagger.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
           }
         })
         .build().clientOf("remote-service");

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
@@ -1,5 +1,6 @@
 package brave.http;
 
+import brave.Tagger;
 import brave.internal.HexCodec;
 import brave.sampler.Sampler;
 import okhttp3.OkHttpClient;
@@ -189,9 +190,8 @@ public abstract class ITHttpServer extends ITHttp {
         return adapter.method(req).toLowerCase() + " " + adapter.path(req);
       }
 
-      @Override
-      public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, brave.Span span) {
-        span.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
+      @Override public <Req> void requestTags(HttpAdapter<Req, ?> adapter, Req req, Tagger tagger) {
+        tagger.tag(TraceKeys.HTTP_URL, adapter.url(req)); // just the path is logged by default
       }
     }).build();
     init();

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingContainerFilter.java
@@ -18,9 +18,7 @@ import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
-import zipkin.Constants;
 
 import static javax.ws.rs.RuntimeType.SERVER;
 
@@ -68,11 +66,6 @@ import static javax.ws.rs.RuntimeType.SERVER;
       span = handler.handleReceive(extractor, request);
     } else {
       return; // unknown state
-    }
-
-    Response.StatusType statusInfo = response.getStatusInfo();
-    if (statusInfo.getFamily() == Response.Status.Family.SERVER_ERROR) {
-      span.tag(Constants.ERROR, statusInfo.getReasonPhrase());
     }
     handler.handleSend(response, null, span);
   }


### PR DESCRIPTION
Before, we passed `brave.Span` to callbacks that only add tags. This has
a number of problems, including that it is harder to test and tempts
users to interfere with the Span (like calling finish).

This changes our callbacks to use a simpler type `brave.Tagger`, which
existed in an early version of Brave 4, and recommends exposing this
instead of `brave.Span` for user callbacks like tag customization.