### PR TITLE
Updates release timeout to 30m in response to latent maven central syncs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -54,8 +54,10 @@ deployment:
   publish-stable:
     owner: openzipkin
     tag: /\d+\.\d+\.\d+/
+    # triples the timeout to 30 minutes as maven central sync takes a lot longer than 10m
     commands:
-      - ./build-support/publish-stable.sh
+      - ./build-support/publish-stable.sh:
+        timeout: 1800
   publish-snapshot:
     owner: openzipkin
     branch: master


### PR DESCRIPTION
Last two releases include a lot more jars, and have timed out syncing to
Maven Central. The builds actually worked, as did the maven central
sync. However, the build failure causes alarm. This raises the timeout
to 30m until we no longer have timeouts (likely when we stop publishing
archived jars)