### PR TITLE
Teaches TracingStatementInterceptor about single-word statements

### DIFF
--- a/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
@@ -36,7 +36,8 @@ public class TracingStatementInterceptor implements StatementInterceptorV2 {
       if (interceptedStatement instanceof PreparedStatement) {
         sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
       }
-      span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
+      int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
+      span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
       span.tag(TraceKeys.SQL_QUERY, sql);
       parseServerAddress(connection, span);
       span.start();

--- a/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
@@ -89,6 +89,17 @@ public class ITTracingStatementInterceptor {
         .containsExactly("select");
   }
 
+  /** This intercepts all SQL, not just queries. This ensures single-word statements work */
+  @Test
+  public void defaultSpanNameIsOperationName_oneWord() throws Exception {
+    connection.setAutoCommit(false);
+    connection.commit();
+
+    assertThat(spans)
+        .extracting(s -> s.name)
+        .contains("commit");
+  }
+
   @Test
   public void addsQueryTag() throws Exception {
     prepareExecuteSelect(QUERY);


### PR DESCRIPTION
Before, we assumed SQL always had a space in it. This isn't true, as
COMMIT is single-word.

Fixes #430