### PR TITLE
Ensures gRPC implementations can see the current span

### DIFF
--- a/instrumentation/grpc/src/main/java/brave/grpc/TracingServerInterceptor.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TracingServerInterceptor.java
@@ -6,8 +6,8 @@ import brave.Tracing;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
-import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -37,36 +37,80 @@ final class TracingServerInterceptor implements ServerInterceptor {
     Span span = contextOrFlags.context() != null
         ? tracer.joinSpan(contextOrFlags.context())
         : tracer.newTrace(contextOrFlags.samplingFlags());
+    span.kind(Span.Kind.SERVER).name(call.getMethodDescriptor().getFullMethodName());
+
+    // startCall invokes user interceptors, so we place the span in scope here
+    ServerCall.Listener<ReqT> result;
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-      return next.startCall(new TracingServerCall<>(span, call), requestHeaders);
+      result = next.startCall(new TracingServerCall<>(span, call), requestHeaders);
     }
+
+    // This ensures the server implementation can see the span in scope
+    return new ScopingServerCallListener<>(tracer, span, result);
   }
 
   final class TracingServerCall<ReqT, RespT> extends SimpleForwardingServerCall<ReqT, RespT> {
     private final Span span;
-    private final ServerCall<ReqT, RespT> call;
 
     TracingServerCall(Span span, ServerCall<ReqT, RespT> call) {
       super(call);
       this.span = span;
-      this.call = call;
     }
 
     @Override public void request(int numMessages) {
-      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-        span.kind(Span.Kind.SERVER).name(call.getMethodDescriptor().getFullMethodName()).start();
-        super.request(numMessages);
-      }
+      span.start();
+      super.request(numMessages);
     }
 
     @Override public void close(Status status, Metadata trailers) {
-      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      try {
         if (!status.getCode().equals(Status.Code.OK)) {
           span.tag(Constants.ERROR, String.valueOf(status.getCode()));
         }
         super.close(status, trailers);
       } finally {
         span.finish();
+      }
+    }
+  }
+
+  final class ScopingServerCallListener<ReqT> extends SimpleForwardingServerCallListener<ReqT> {
+    final Tracer tracer;
+    final Span span;
+
+    ScopingServerCallListener(Tracer tracer, Span span, ServerCall.Listener<ReqT> delegate) {
+      super(delegate);
+      this.tracer = tracer;
+      this.span = span;
+    }
+
+    @Override public void onMessage(ReqT message) {
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+        delegate().onMessage(message);
+      }
+    }
+
+    @Override public void onHalfClose() {
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+        delegate().onHalfClose();
+      }
+    }
+
+    @Override public void onCancel() {
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+        delegate().onCancel();
+      }
+    }
+
+    @Override public void onComplete() {
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+        delegate().onCancel();
+      }
+    }
+
+    @Override public void onReady() {
+      try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+        delegate().onReady();
       }
     }
   }

--- a/instrumentation/grpc/src/test/java/brave/grpc/GreeterImpl.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GreeterImpl.java
@@ -1,21 +1,32 @@
 package brave.grpc;
 
+import brave.Tracing;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.stub.StreamObserver;
+import javax.annotation.Nullable;
 
 class GreeterImpl extends GreeterGrpc.GreeterImplBase {
   static final HelloRequest HELLO_REQUEST = HelloRequest.newBuilder()
       .setName("tracer")
       .build();
 
+  @Nullable final Tracing tracing;
+
+  GreeterImpl(@Nullable Tracing tracing) {
+    this.tracing = tracing;
+  }
+
   @Override public void sayHello(HelloRequest req, StreamObserver<HelloReply> responseObserver) {
     if (req.getName().equals("bad")) {
       responseObserver.onError(new IllegalArgumentException());
       return;
     }
-    HelloReply reply = HelloReply.newBuilder().setMessage("Hello " + req.getName()).build();
+    String message = tracing != null && tracing.currentTraceContext().get() != null
+        ? tracing.currentTraceContext().get().traceIdString()
+        : "";
+    HelloReply reply = HelloReply.newBuilder().setMessage(message).build();
     responseObserver.onNext(reply);
     responseObserver.onCompleted();
   }

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
@@ -77,7 +77,7 @@ public class ITTracingServerInterceptor {
         : new ServerInterceptor[] {tracingInterceptor};
 
     server = ServerBuilder.forPort(PickUnusedPort.get())
-        .addService(ServerInterceptors.intercept(new GreeterImpl(), interceptors))
+        .addService(ServerInterceptors.intercept(new GreeterImpl(tracing), interceptors))
         .build().start();
 
     client = ManagedChannelBuilder.forAddress("localhost", server.getPort())
@@ -160,6 +160,11 @@ public class ITTracingServerInterceptor {
 
     assertThat(fromUserInterceptor.get())
         .isNotNull();
+  }
+
+  @Test public void currentSpanVisibleToImpl() throws Exception {
+    assertThat(GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST).getMessage())
+        .isNotEmpty();
   }
 
   @Test

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
@@ -21,7 +21,7 @@ class TestServer {
       Propagation.Factory.B3.create(AsciiMetadataKeyFactory.INSTANCE).extractor(Metadata::get);
 
   Server server = ServerBuilder.forPort(PickUnusedPort.get())
-      .addService(ServerInterceptors.intercept(new GreeterImpl(), new ServerInterceptor() {
+      .addService(ServerInterceptors.intercept(new GreeterImpl(null), new ServerInterceptor() {
 
         @Override
         public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,


### PR DESCRIPTION
Before, we handled user interceptors, but not the server implementation.

Fixes #425