### PR TITLE
Adds HttpRuleSampler for assigning sample rates to http endpoints

### DIFF
--- a/brave/src/main/java/brave/sampler/ParameterizedSampler.java
+++ b/brave/src/main/java/brave/sampler/ParameterizedSampler.java
@@ -1,0 +1,58 @@
+package brave.sampler;
+
+import brave.propagation.SamplingFlags;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * This is an implementation of how to decide whether to trace a request using ordered rules. For
+ * example, you could write rules to look at an HTTP method and path, or a RabbitMQ routing key and
+ * queue name.
+ *
+ * <p>This looks at runtime parameters to see if they {@link Rule#matches(Object) match} a rule. If
+ * all calls to a java method should have the same sample rate, consider {@link DeclarativeSampler}
+ * instead.
+ *
+ * @param <P> The type that encloses parameters associated with a sample rate. For example, this
+ * could be a pair of http and method..
+ */
+public final class ParameterizedSampler<P> {
+  public static final <P> ParameterizedSampler<P> create(List<? extends Rule<P>> rules) {
+    if (rules == null) throw new NullPointerException("rules == null");
+    return new ParameterizedSampler<>(rules);
+  }
+
+  public static abstract class Rule<P> {
+    final Sampler sampler;
+
+    /**
+     * @param rate percentage of requests to start traces for. 1.0 is 100%
+     */
+    protected Rule(float rate) {
+      sampler = CountingSampler.create(rate);
+    }
+
+    /** Returns true if this rule matches the input parameters */
+    public abstract boolean matches(P parameters);
+
+    SamplingFlags isSampled() {
+      return sampler.isSampled(0L) // counting sampler ignores the input
+          ? SamplingFlags.SAMPLED
+          : SamplingFlags.NOT_SAMPLED;
+    }
+  }
+
+  final List<? extends Rule<P>> rules;
+
+  ParameterizedSampler(List<? extends Rule<P>> rules) {
+    this.rules = rules;
+  }
+
+  public SamplingFlags sample(@Nullable P parameters) {
+    if (parameters == null) return SamplingFlags.EMPTY;
+    for (Rule<P> rule : rules) {
+      if (rule.matches(parameters)) return rule.isSampled();
+    }
+    return SamplingFlags.EMPTY;
+  }
+}

--- a/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
@@ -1,0 +1,53 @@
+package brave.sampler;
+
+import brave.propagation.SamplingFlags;
+import java.util.function.Function;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParameterizedSamplerTest {
+
+  @Test public void matchesParameters() {
+    ParameterizedSampler<Boolean> sampler = ParameterizedSampler.create(asList(rule(1.0f,
+        Boolean::booleanValue)));
+
+    assertThat(sampler.sample(true))
+        .isEqualTo(SamplingFlags.SAMPLED);
+  }
+
+  @Test public void emptyOnNoMatch() {
+    ParameterizedSampler<Boolean> sampler = ParameterizedSampler.create(asList(rule(1.0f,
+        Boolean::booleanValue)));
+
+    assertThat(sampler.sample(false))
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void emptyOnNull() {
+    ParameterizedSampler<Void> sampler = ParameterizedSampler.create(asList(rule(1.0f, v -> true)));
+
+    assertThat(sampler.sample(null))
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void multipleRules() {
+    ParameterizedSampler<Boolean> sampler = ParameterizedSampler.create(asList(
+        rule(1.0f, v -> false), // doesn't match
+        rule(0.0f, v -> true) // match
+    ));
+
+    assertThat(sampler.sample(true))
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  // we can do this in tests because tests compile against java 8
+  static <P> ParameterizedSampler.Rule<P> rule(float rate, Function<P, Boolean> rule) {
+    return new ParameterizedSampler.Rule<P>(rate) {
+      @Override public boolean matches(P parameters) {
+        return rule.apply(parameters);
+      }
+    };
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -120,7 +120,9 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
   @Test public void customSampler() throws Exception {
     close();
-    httpTracing = httpTracing.toBuilder().clientSampler(HttpSampler.NEVER_SAMPLE).build();
+    httpTracing = httpTracing.toBuilder().clientSampler(HttpRuleSampler.newBuilder()
+        .addRule(null, "/foo", 0.0f)
+        .build()).build();
     client = newClient(server.getPort());
 
     server.enqueue(new MockResponse());

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
@@ -64,6 +64,24 @@ public abstract class ITHttpServer extends ITHttp {
         .isEmpty();
   }
 
+
+  @Test public void customSampler() throws Exception {
+    String path = "/foo";
+
+    httpTracing = httpTracing.toBuilder().serverSampler(HttpRuleSampler.newBuilder()
+        .addRule(null, path, 0.0f)
+        .build()).build();
+    init();
+
+    Request request = new Request.Builder().url(url(path)).build();
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+
+    assertThat(spans)
+        .isEmpty();
+  }
+
   /**
    * Tests that the span propagates between under asynchronous callbacks (even if explicitly)
    */

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -1,0 +1,81 @@
+package brave.http;
+
+import brave.Tracing;
+import brave.sampler.ParameterizedSampler;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import zipkin.internal.Pair;
+
+/**
+ * Assigns sample rates to http routes.
+ *
+ * <p>Ex. Here's a sampler that traces 80% requests to /foo and 10% of POST requests to /bar. Other
+ * requests will use a global rate provided by the {@link Tracing tracing component}.
+ * <pre>{@code
+ * httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
+ *   .addRule(null, "/foo", 0.8f)
+ *   .addRule("POST", "/bar", 0.1f)
+ *   .build());
+ * }</pre>
+ *
+ * <p>Note that the path is a prefix, so "/foo" will match "/foo/abcd".
+ */
+public final class HttpRuleSampler extends HttpSampler {
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    final List<MethodAndPathRule> rules = new ArrayList<>();
+
+    /**
+     * Assigns a sample rate to all requests that match the input.
+     *
+     * @param method if null, any method is accepted
+     * @param path all paths starting with this string are accepted
+     * @param rate percentage of requests to start traces for. 1.0 is 100%
+     */
+    public Builder addRule(@Nullable String method, String path, float rate) {
+      rules.add(new MethodAndPathRule(method, path, rate));
+      return this;
+    }
+
+    public HttpSampler build() {
+      return new HttpRuleSampler(rules);
+    }
+
+    Builder() {
+    }
+  }
+
+  final ParameterizedSampler<Pair<String>> sampler;
+
+  HttpRuleSampler(List<MethodAndPathRule> rules) {
+    this.sampler = ParameterizedSampler.create(rules);
+  }
+
+  @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+    String method = adapter.method(request);
+    String path = adapter.path(request);
+    if (method == null || path == null) return null; // use default if we couldn't parse
+    return sampler.sample(Pair.create(method, path)).sampled();
+  }
+
+  static final class MethodAndPathRule extends ParameterizedSampler.Rule<Pair<String>> {
+    @Nullable final String method;
+    final String path;
+
+    MethodAndPathRule(@Nullable String method, String path, float rate) {
+      super(rate);
+      this.method = method;
+      this.path = path;
+    }
+
+    @Override public boolean matches(Pair<String> parameters) {
+      if (method != null && !method.equals(parameters._1)) return false;
+      return parameters._2.startsWith(path);
+    }
+  }
+}

--- a/instrumentation/http/src/main/java/brave/http/HttpSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpSampler.java
@@ -13,6 +13,8 @@ import javax.annotation.Nullable;
  *   }
  * });
  * }</pre>
+ *
+ * @see HttpRuleSampler
  */
 // abstract class as you can't lambda generic methods anyway. This lets us make helpers in the future
 public abstract class HttpSampler {

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -1,0 +1,133 @@
+package brave.http;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpRuleSamplerTest {
+  @Mock HttpClientAdapter<Object, Object> adapter;
+  Object request = new Object();
+
+  @Test public void onPath() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule(null, "/foo", 1.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isTrue();
+  }
+
+  @Test public void onPath_sampled() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule(null, "/foo", 0.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isFalse();
+  }
+
+  @Test public void onPath_sampled_prefix() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule(null, "/foo", 0.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo/abcd");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isFalse();
+  }
+
+  @Test public void onPath_doesntMatch() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule(null, "/foo", 0.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/bar");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isNull();
+  }
+
+  @Test public void onMethodAndPath_sampled() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule("GET", "/foo", 1.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isTrue();
+  }
+
+  @Test public void onMethodAndPath_sampled_prefix() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule("GET", "/foo", 1.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo/abcd");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isTrue();
+  }
+
+  @Test public void onMethodAndPath_unsampled() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule("GET", "/foo", 0.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isFalse();
+  }
+
+  @Test public void onMethodAndPath_doesntMatch_method() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule("GET", "/foo", 0.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("POST");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isNull();
+  }
+
+  @Test public void onMethodAndPath_doesntMatch_path() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule("GET", "/foo", 0.0f)
+        .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/bar");
+
+    assertThat(sampler.trySample(adapter, request))
+        .isNull();
+  }
+
+  @Test public void nullOnParseFailure() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+        .addRule("GET", "/foo", 0.0f)
+        .build();
+
+    // not setting up mocks means they return null which is like a parse fail
+    assertThat(sampler.trySample(adapter, request))
+        .isNull();
+  }
+}

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingHttpClientBuilder.java
@@ -16,9 +16,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.execchain.ClientExecChain;
-import org.apache.http.impl.execchain.MainClientExec;
-import org.apache.http.protocol.HttpProcessor;
-import org.apache.http.protocol.HttpRequestExecutor;
 import zipkin.Endpoint;
 
 public final class TracingHttpClientBuilder extends HttpClientBuilder {
@@ -92,7 +89,7 @@ public final class TracingHttpClientBuilder extends HttpClientBuilder {
     }
 
     @Override public String path(HttpRequestWrapper request) {
-      String result = request.getRequestLine().getUri();
+      String result = request.getURI().getPath();
       int queryIndex = result.indexOf('?');
       return queryIndex == -1 ? result : result.substring(0, queryIndex);
     }


### PR DESCRIPTION
This allows you to declare rules based on http patterns. These decide
which sample rate to apply.

Ex. Here's a sampler that traces 80% requests to /foo and 10% of POST
requests to /bar. Other requests will use a global rate provided by the
tracing component.

```java
httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
  .addRule(null, "/foo", 0.8f)
  .addRule("POST", "/bar", 0.1f)
  .build());
```

Fixes #432