### PR TITLE
Makes maven fail on error during integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
 
 test:
   override:
-    - ./mvnw integration-test
+    - ./mvnw verify
   post:
     # parameters used during release
     # allocate commits to CI, not the owner of the deploy key

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -30,6 +30,10 @@ import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.apache.http.protocol.HttpContext;
 import zipkin.Endpoint;
 
+/**
+ * Note: The current span is only visible to interceptors {@link #addInterceptorLast(HttpRequestInterceptor)
+ * added last}.
+ */
 public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
 
   public static HttpAsyncClientBuilder create(Tracing tracing) {

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -50,7 +50,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpClient<CloseableHttpA
     closeClient(client);
 
     client = TracingHttpAsyncClientBuilder.create(httpTracing)
-        .addInterceptorFirst((HttpRequestInterceptor) (request, context) ->
+        .addInterceptorLast((HttpRequestInterceptor) (request, context) ->
             request.setHeader("my-id", currentTraceContext.get().traceIdString())
         ).build();
     client.start();


### PR DESCRIPTION
Exceptions are not assertions, so materialize as errors. Errors don't
cause the integration-test phase to fail, while it will for verify.