### PR TITLE
Adds DeclarativeSampler and JAX-RS ContainerAdapter

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -77,5 +77,21 @@
       <version>${finagle.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>1.8.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/brave/src/main/java/brave/sampler/DeclarativeSampler.java
+++ b/brave/src/main/java/brave/sampler/DeclarativeSampler.java
@@ -1,0 +1,80 @@
+package brave.sampler;
+
+import brave.propagation.SamplingFlags;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+
+/**
+ * This is an implementation of how to decide whether to trace a request using annotations on a java
+ * method. It is not an implementation of aspect-oriented or otherwise declarative tracing. See the
+ * test cases for this class for example implementations.
+ *
+ * <p>Example: A user defines an annotation, for example {@code com.myco.Traced}, and a lookup
+ * function for its rate (could be simple as reading a field, or even a constant). An interceptor
+ * uses this sampler on each invocation of a potentially annotated target. The result decides
+ * whether a new trace should be started or not.
+ *
+ * <p>No runtime parameters are considered here, but that doesn't mean you can't achieve
+ * parameterized sampling using this. If your method is annotated such that it only accepts a
+ * fraction of requests, adding a custom {@code @Traced} annotation would apply to that subset. For
+ * example, if you have a JAX-RS method, it is already qualified by method and likely path. A user
+ * can add and inspect their own grouping annotation to override whatever the default rate is.
+ *
+ * <p>Under the scenes, a map of samplers by method is maintained. The size of this map should not
+ * be a problem when it directly relates to declared methods. For example, this would be invalid if
+ * annotations were created at runtime and didn't match.
+ *
+ * @param <M> The type that uniquely identifies this method, specifically for tracing. Most often a
+ * trace annotation, but could also be a {@link java.lang.reflect.Method} or another declarative
+ * reference such as {@code javax.ws.rs.container.ResourceInfo}.
+ */
+public final class DeclarativeSampler<M> {
+  public static <M> DeclarativeSampler<M> create(RateForMethod<M> rateForMethod) {
+    return new DeclarativeSampler<>(rateForMethod);
+  }
+
+  public interface RateForMethod<M> {
+    /** Returns null if there's no configured rate for this method */
+    @Nullable Float get(M method);
+  }
+
+  // this assumes input are compared by identity as typically annotations do not override hashCode
+  final ConcurrentMap<M, Sampler> methodsToSamplers = new ConcurrentHashMap<>();
+  final RateForMethod<M> rateForMethod;
+
+  DeclarativeSampler(RateForMethod<M> rateForMethod) {
+    this.rateForMethod = rateForMethod;
+  }
+
+  public SamplingFlags sample(@Nullable M method) {
+    if (method == null) return SamplingFlags.EMPTY;
+    Sampler sampler = methodsToSamplers.get(method);
+    if (sampler == NULL_SENTINEL) return SamplingFlags.EMPTY;
+    if (sampler != null) return sample(sampler);
+
+    Float rate = rateForMethod.get(method);
+    if (rate == null) {
+      methodsToSamplers.put(method, NULL_SENTINEL);
+      return SamplingFlags.EMPTY;
+    }
+
+    sampler = CountingSampler.create(rate);
+    Sampler previousSampler = methodsToSamplers.putIfAbsent(method, sampler);
+    if (previousSampler != null) sampler = previousSampler; // lost race, use the existing counter
+    return sample(sampler);
+  }
+
+  private SamplingFlags sample(Sampler sampler) {
+    return sampler.isSampled(0L) // counting sampler ignores the input
+        ? SamplingFlags.SAMPLED
+        : SamplingFlags.NOT_SAMPLED;
+  }
+
+  /** Prevents us from recomputing a method that had no configured factory */
+  static final Sampler NULL_SENTINEL = new Sampler() {
+    @Override public boolean isSampled(long traceId) {
+      throw new AssertionError();
+    }
+  };
+}

--- a/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
+++ b/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
@@ -1,0 +1,94 @@
+package brave.features.sampler;
+
+import brave.Tracing;
+import brave.sampler.DeclarativeSampler;
+import brave.sampler.Sampler;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import zipkin.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = AspectJSamplerTest.Config.class)
+public class AspectJSamplerTest {
+
+  static List<Span> spans = new ArrayList<>();
+  static Tracing tracing = Tracing.newBuilder()
+      .reporter(spans::add)
+      .sampler(new Sampler() {
+        @Override public boolean isSampled(long traceId) {
+          throw new AssertionError(); // in this case, we aren't expecting a fallback
+        }
+      }).build();
+
+  @Autowired Service service;
+
+  @Before public void clear() {
+    spans.clear();
+  }
+
+  @Test public void traced() {
+    service.traced();
+
+    assertThat(spans).isNotEmpty();
+  }
+
+  @Test public void notTraced() {
+    service.notTraced();
+
+    assertThat(spans).isEmpty();
+  }
+
+  @Configuration
+  @EnableAspectJAutoProxy
+  @Import({Service.class, TracingAspect.class})
+  static class Config {
+  }
+
+  @Component
+  @Aspect
+  static class TracingAspect {
+    DeclarativeSampler<Traced> sampler = DeclarativeSampler.create(Traced::sampleRate);
+
+    @Around("@annotation(traced)")
+    public Object traceThing(ProceedingJoinPoint pjp, Traced traced) throws Throwable {
+      // simplification as starts a new trace always
+      brave.Span span = tracing.tracer().newTrace(sampler.sample(traced)).name("").start();
+      try {
+        return pjp.proceed();
+      } finally {
+        span.finish();
+      }
+    }
+  }
+
+  @Component // aop only works for public methods.. the type can be package private though
+  static class Service {
+    // these two methods set different rates. This shows that instances are independent
+    @Traced public void traced() {
+    }
+
+    @Traced(sampleRate = 0.0f) public void notTraced() {
+    }
+  }
+
+  @Retention(RetentionPolicy.RUNTIME) public @interface Traced {
+    float sampleRate() default 1.0f;
+  }
+}

--- a/brave/src/test/java/brave/sampler/DeclarativeSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/DeclarativeSamplerTest.java
@@ -1,0 +1,70 @@
+package brave.sampler;
+
+import brave.propagation.SamplingFlags;
+import com.google.auto.value.AutoAnnotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeclarativeSamplerTest {
+
+  DeclarativeSampler<Traced> sampler =
+      DeclarativeSampler.create(t -> t.enabled() ? t.sampleRate() : null);
+
+  @Before public void clear() {
+    sampler.methodsToSamplers.clear();
+  }
+
+  @Test public void honorsSampleRate() {
+    assertThat(sampler.sample(traced(1.0f, true)))
+        .isEqualTo(SamplingFlags.SAMPLED);
+
+    assertThat(sampler.sample(traced(0.0f, true)))
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test public void acceptsFallback() {
+    assertThat(sampler.sample(traced(1.0f, false)))
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void samplerLoadsLazy() {
+    assertThat(sampler.methodsToSamplers)
+        .isEmpty();
+
+    sampler.sample(traced(1.0f, true));
+
+    assertThat(sampler.methodsToSamplers)
+        .hasSize(1);
+
+    sampler.sample(traced(0.0f, true));
+
+    assertThat(sampler.methodsToSamplers)
+        .hasSize(2);
+  }
+
+  @Test public void cardinalityIsPerAnnotationNotInvocation() {
+    Traced traced = traced(1.0f, true);
+
+    sampler.sample(traced);
+    sampler.sample(traced);
+    sampler.sample(traced);
+
+    assertThat(sampler.methodsToSamplers)
+        .hasSize(1);
+  }
+
+  @Retention(RetentionPolicy.RUNTIME) public @interface Traced {
+    float sampleRate() default 1.0f;
+
+    boolean enabled() default true;
+  }
+
+  // note: Unlike normal java annotations, auto-annotation do value-based equals and hashCode
+  @AutoAnnotation static Traced traced(float sampleRate, boolean enabled) {
+    return new AutoAnnotation_DeclarativeSamplerTest_traced(sampleRate, enabled);
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ServletContainer.java
@@ -1,0 +1,53 @@
+package brave.http;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.bio.SocketConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+/** Starts a jetty server which runs a servlet container */
+public abstract class ServletContainer {
+  int port = 0; // initially get a port, later reuse one
+  Server server;
+
+  /** recreates the server so that it uses the supplied trace configuration */
+  public final void init() {
+    stop();
+    SocketConnector connector = new SocketConnector();
+    connector.setMaxIdleTime(1000 * 60 * 60);
+    connector.setPort(port);
+    server = new Server();
+    server.setConnectors(new Connector[] {connector});
+
+    ServletContextHandler context = new ServletContextHandler();
+    context.setContextPath("/");
+    server.setHandler(context);
+
+    init(context);
+
+    try {
+      server.start();
+      port = server.getConnectors()[0].getLocalPort();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to start server.", e);
+    }
+  }
+
+  public final String url(String path) {
+    return "http://localhost:" + port + path;
+  }
+
+  /** Implement by registering a servlet for the test resource and anything needed for tracing */
+  public abstract void init(ServletContextHandler handler);
+
+  public void stop() {
+    if (server == null) return;
+    try {
+      server.stop();
+      server.join();
+      server = null;
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/instrumentation/jaxrs2/README.md
+++ b/instrumentation/jaxrs2/README.md
@@ -51,6 +51,20 @@ WebTarget target = target("/mytarget");
 target.register(TracingFeature.create(tracing));
 ```
 
+## Customizing Span data based on Java Annotations
+JAX-RS resources are declared via annotations. You may want to consider
+the resource method when choosing name or tags.
+
+For example, the below adds the java method name as the span name:
+```java
+TracingFeature.create(httpTracing.toBuilder().serverParser(new HttpServerParser() {
+  @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+    Method method = ((ContainerAdapter) adapter).resourceMethod(req);
+    return method.getName().toLowerCase();
+  }
+}).build());
+```
+
 ## Exception handling
 `ContainerResponseFilter` has no means to handle uncaught exceptions.
 Unless you provide a catch-all exception mapper, requests that result in

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerAdapter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerAdapter.java
@@ -1,0 +1,60 @@
+package brave.jaxrs2;
+
+import brave.http.HttpServerAdapter;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
+
+/**
+ * This can also parse the resource info of the method.
+ *
+ * <p>For example, the below adds the java method name as the span name:
+ * <pre>{@code
+ * TracingFeature.create(httpTracing.toBuilder().serverParser(new HttpServerParser() {
+ *   @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+ *     Method method = ((ContainerAdapter) adapter).resourceMethod(req);
+ *     return method.getName().toLowerCase();
+ *   }
+ * }).build());
+ * }</pre>
+ */
+public final class ContainerAdapter
+    extends HttpServerAdapter<ContainerRequestContext, ContainerResponseContext> {
+  @Override public String method(ContainerRequestContext request) {
+    return request.getMethod();
+  }
+
+  @Override public String path(ContainerRequestContext request) {
+    return request.getUriInfo().getRequestUri().getPath();
+  }
+
+  @Override public String url(ContainerRequestContext request) {
+    return request.getUriInfo().getRequestUri().toString();
+  }
+
+  @Override public String requestHeader(ContainerRequestContext request, String name) {
+    return request.getHeaderString(name);
+  }
+
+  @Override public Integer statusCode(ContainerResponseContext response) {
+    return response.getStatus();
+  }
+
+  @Nullable public final <Req> Method resourceMethod(Req request) {
+    ResourceInfo resourceInfo = resourceInfo(request);
+    return resourceInfo != null ? resourceInfo.getResourceMethod() : null;
+  }
+
+  @Nullable public final <Req> Class<?> resourceClass(Req request) {
+    ResourceInfo resourceInfo = resourceInfo(request);
+    return resourceInfo != null ? resourceInfo.getResourceClass() : null;
+  }
+
+  @Nullable public final <Req> ResourceInfo resourceInfo(Req request) {
+    if (!(request instanceof ContainerRequestContext)) return null;
+    return (ResourceInfo) ((ContainerRequestContext) request).getProperty(
+        ResourceInfo.class.getName());
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ContainerAdapterTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ContainerAdapterTest.java
@@ -1,0 +1,58 @@
+package brave.jaxrs2;
+
+import java.lang.reflect.Method;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerAdapterTest {
+  ContainerAdapter adapter = new ContainerAdapter();
+  @Mock ContainerRequestContext request;
+  @Mock ResourceInfo info;
+
+  @Test public void resourceInfo_requiresContainerRequest() {
+    assertThat(adapter.resourceInfo(new Object()))
+        .isNull();
+  }
+
+  @Test public void resourceInfo_returnsResourceInfo() {
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+
+    assertThat(adapter.resourceInfo(request))
+        .isEqualTo(info);
+  }
+
+  @Test public void resourceClass_requiresContainerRequest() {
+    assertThat(adapter.resourceClass(new Object()))
+        .isNull();
+  }
+
+  @Test public void resourceClass_returnsClassFromResourceInfo() {
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+    when(info.getResourceClass()).thenReturn((Class) String.class);
+
+    assertThat(adapter.resourceClass(request))
+        .isEqualTo(String.class);
+  }
+
+  @Test public void resourceMethod_requiresContainerRequest() {
+    assertThat(adapter.resourceMethod(new Object()))
+        .isNull();
+  }
+
+  @Test public void resourceMethod_returnsMethodFromResourceInfo() throws Exception {
+    Method method = String.class.getMethod("toString");
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+    when(info.getResourceMethod()).thenReturn(method);
+
+    assertThat(adapter.resourceMethod(request))
+        .isEqualTo(method);
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
@@ -1,33 +1,24 @@
 package brave.jaxrs2;
 
 import brave.Tracer;
+import brave.http.HttpAdapter;
+import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
 import brave.http.ITServletContainer;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
+import java.lang.reflect.Method;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.Suspended;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
-import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
-import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
-import org.jboss.resteasy.spi.ResteasyConfiguration;
-import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITTracingFeature_Container extends ITServletContainer {
 
@@ -45,7 +36,7 @@ public class ITTracingFeature_Container extends ITServletContainer {
 
     @GET
     @Path("foo")
-    public Response get() {
+    public Response foo() {
       return Response.status(200).build();
     }
 
@@ -81,51 +72,27 @@ public class ITTracingFeature_Container extends ITServletContainer {
     }
   }
 
-  /**
-   * {@link ContainerResponseFilter} has no means to handle uncaught exceptions. Unless you provide
-   * a catch-all exception mapper, requests that result in unhandled exceptions will leak until they
-   * are eventually flushed.
-   */
-  @Provider
-  public static class CatchAllExceptions implements ExceptionMapper<Exception> {
-
-    @Override
-    public Response toResponse(Exception e) {
-      if (e instanceof WebApplicationException) {
-        return ((WebApplicationException) e).getResponse();
+  @Test
+  public void declarative_namingPolicy() throws Exception {
+    httpTracing = httpTracing.toBuilder().serverParser(new HttpServerParser() {
+      @Override
+      public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+        Method method = ((ContainerAdapter) adapter).resourceMethod(req);
+        return method.getName().toLowerCase();
       }
+    }).build();
+    init();
 
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-          .entity("Internal error")
-          .type("text/plain")
-          .build();
-    }
+    get("/foo");
+
+    assertThat(spans)
+        .extracting(s -> s.name)
+        .containsExactly("foo");
   }
 
   @Override public void init(ServletContextHandler handler) {
-
-
     // Adds application programmatically as opposed to using web.xml
     handler.addServlet(new ServletHolder(new HttpServletDispatcher()), "/*");
-    handler.addEventListener(new ResteasyBootstrap() {
-      @Override public void contextInitialized(ServletContextEvent event) {
-        deployment = new ResteasyDeployment();
-        deployment.setApplication(new Application(){
-          @Override public Set<Object> getSingletons() {
-            return new LinkedHashSet<>(Arrays.asList(
-                new TestResource(httpTracing),
-                new CatchAllExceptions(),
-                new TracingFeature(httpTracing)
-            ));
-          }
-        });
-        ServletContext servletContext = event.getServletContext();
-        ListenerBootstrap config = new ListenerBootstrap(servletContext);
-        servletContext.setAttribute(ResteasyDeployment.class.getName(), deployment);
-        deployment.getDefaultContextObjects().put(ResteasyConfiguration.class, config);
-        config.createDeployment();
-        deployment.start();
-      }
-    });
+    handler.addEventListener(new TracingBootstrap(httpTracing, new TestResource(httpTracing)));
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TracingBootstrap.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TracingBootstrap.java
@@ -1,0 +1,64 @@
+package brave.jaxrs2;
+
+import brave.http.HttpTracing;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+public class TracingBootstrap extends ResteasyBootstrap {
+
+  /**
+   * {@link ContainerResponseFilter} has no means to handle uncaught exceptions. Unless you provide
+   * a catch-all exception mapper, requests that result in unhandled exceptions will leak until they
+   * are eventually flushed.
+   */
+  @Provider
+  public static class CatchAllExceptions implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception e) {
+      if (e instanceof WebApplicationException) {
+        return ((WebApplicationException) e).getResponse();
+      }
+
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("Internal error")
+          .type("text/plain")
+          .build();
+    }
+  }
+
+  public TracingBootstrap(HttpTracing httpTracing, Object resource) {
+    deployment = new ResteasyDeployment();
+    deployment.setApplication(new Application() {
+      @Override public Set<Object> getSingletons() {
+        return new LinkedHashSet<>(Arrays.asList(
+            resource,
+            new CatchAllExceptions(),
+            new TracingFeature(httpTracing)
+        ));
+      }
+    });
+  }
+
+  @Override public void contextInitialized(ServletContextEvent event) {
+    ServletContext servletContext = event.getServletContext();
+    ListenerBootstrap config = new ListenerBootstrap(servletContext);
+    servletContext.setAttribute(ResteasyDeployment.class.getName(), deployment);
+    deployment.getDefaultContextObjects().put(ResteasyConfiguration.class, config);
+    config.createDeployment();
+    deployment.start();
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/DeclarativeSamplingTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/DeclarativeSamplingTest.java
@@ -1,0 +1,100 @@
+package brave.jaxrs2.features.sampling;
+
+import brave.Tracing;
+import brave.http.HttpAdapter;
+import brave.http.HttpSampler;
+import brave.http.HttpTracing;
+import brave.http.ServletContainer;
+import brave.jaxrs2.TracingBootstrap;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import javax.annotation.Nullable;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeclarativeSamplingTest extends ServletContainer {
+  ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+  OkHttpClient client = new OkHttpClient();
+  HttpTracing httpTracing = HttpTracing.newBuilder(Tracing.newBuilder()
+      .reporter(spans::add)
+      .build())
+      .serverSampler(new Traced.Sampler(new HttpSampler() {
+        @Nullable @Override
+        public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+          return !"/foo".equals(adapter.path(request));
+        }
+      })).build();
+
+  @Path("")
+  public static class Resource { // public for resteasy to inject
+
+    @GET
+    @Path("foo")
+    @Traced // overrides path-based decision to not trace /foo
+    public String foo() {
+      return "";
+    }
+
+    @GET
+    @Path("bar")
+    @Traced(enabled = false) // overrides path-based decision to trace /bar
+    public String bar() {
+      return "";
+    }
+
+    @GET
+    @Path("baz")
+    public String baz() {
+      return "";
+    }
+  }
+
+  @Test
+  public void annotationOverridesHttpSampler() throws Exception {
+    get("/bar");
+    assertThat(spans).isEmpty();
+
+    get("/foo");
+    assertThat(spans).isNotEmpty();
+  }
+
+  @Test
+  public void lackOfAnnotationFallsback() throws Exception {
+    get("/baz");
+    assertThat(spans).isNotEmpty();
+  }
+
+  @Override public void init(ServletContextHandler handler) {
+    // Adds application programmatically as opposed to using web.xml
+    handler.addServlet(new ServletHolder(new HttpServletDispatcher()), "/*");
+    handler.addEventListener(new TracingBootstrap(httpTracing, new Resource()));
+  }
+
+  @Before public void setUp() {
+    super.init();
+  }
+
+  @After public void tearDown() {
+    super.stop();
+  }
+
+  Response get(String path) throws IOException {
+    try (Response response = client.newCall(new Request.Builder().url(url(path)).build())
+        .execute()) {
+
+      return response;
+    }
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/Traced.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/Traced.java
@@ -1,0 +1,37 @@
+package brave.jaxrs2.features.sampling;
+
+import brave.http.HttpAdapter;
+import brave.http.HttpSampler;
+import brave.jaxrs2.ContainerAdapter;
+import brave.sampler.DeclarativeSampler;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Traced {
+  float sampleRate() default 1.0f;
+
+  boolean enabled() default true;
+
+  final class Sampler extends HttpSampler {
+    final DeclarativeSampler<Traced> sampler;
+    final HttpSampler fallback;
+
+    Sampler(HttpSampler fallback) {
+      this.sampler = DeclarativeSampler.create(t -> t.enabled() ? t.sampleRate() : 0.0f);
+      this.fallback = fallback;
+    }
+
+    @Nullable @Override
+    public final <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+      if (adapter instanceof ContainerAdapter) {
+        Method method = ((ContainerAdapter) adapter).resourceMethod(request);
+        Traced traced = method != null ? method.getAnnotation(Traced.class) : null;
+        if (traced != null) return sampler.sample(traced).sampled();
+      }
+      return fallback.trySample(adapter, request);
+    }
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/TracedSamplerTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/TracedSamplerTest.java
@@ -1,0 +1,96 @@
+package brave.jaxrs2.features.sampling;
+
+import brave.http.HttpAdapter;
+import brave.http.HttpSampler;
+import brave.jaxrs2.ContainerAdapter;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracedSamplerTest {
+  @Mock ContainerRequestContext request;
+  @Mock ResourceInfo info;
+
+  @Test public void requiresContainerAdapter() {
+    Traced.Sampler sampler = new Traced.Sampler(HttpSampler.NEVER_SAMPLE);
+
+    assertThat(sampler.trySample(mock(HttpAdapter.class), new Object()))
+        .isFalse();
+  }
+
+  @Test public void requiresContainerRequest() {
+    Traced.Sampler sampler = new Traced.Sampler(HttpSampler.NEVER_SAMPLE);
+
+    assertThat(sampler.trySample((HttpAdapter) new ContainerAdapter(), new Object()))
+        .isFalse();
+  }
+
+  @Test public void requiresResourceInfo() {
+    Traced.Sampler sampler = new Traced.Sampler(HttpSampler.NEVER_SAMPLE);
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+
+    assertThat(sampler.trySample(new ContainerAdapter(), request))
+        .isFalse();
+  }
+
+  @Path("")
+  public static class Resource { // public for resteasy to inject
+
+    @GET
+    @Path("foo")
+    @Traced
+    public String traced() {
+      return "";
+    }
+
+    @GET
+    @Path("bar")
+    @Traced(enabled = false) // overrides path-based decision to trace /bar
+    public String disabled() {
+      return "";
+    }
+
+    @GET
+    @Path("baz")
+    public String noAnnotation() {
+      return "";
+    }
+  }
+
+  @Test public void parsesAnnotation_traced() throws NoSuchMethodException {
+    Traced.Sampler sampler = new Traced.Sampler(HttpSampler.NEVER_SAMPLE);
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+    when(info.getResourceMethod()).thenReturn(Resource.class.getMethod("traced"));
+
+    assertThat(sampler.trySample(new ContainerAdapter(), request))
+        .isTrue();
+  }
+
+  @Test public void parsesAnnotation_disabled() throws NoSuchMethodException {
+    Traced.Sampler sampler = new Traced.Sampler(HttpSampler.NEVER_SAMPLE);
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+    when(info.getResourceMethod()).thenReturn(Resource.class.getMethod("disabled"));
+
+    assertThat(sampler.trySample(new ContainerAdapter(), request))
+        .isFalse();
+  }
+
+  @Test public void fallsBackOnNull() throws NoSuchMethodException {
+    Traced.Sampler sampler = new Traced.Sampler(HttpSampler.NEVER_SAMPLE);
+    when(request.getProperty("javax.ws.rs.container.ResourceInfo")).thenReturn(info);
+    when(info.getResourceMethod()).thenReturn(Resource.class.getMethod("noAnnotation"));
+
+    assertThat(sampler.trySample(new ContainerAdapter(), request))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
This adds functionality needed to make sampling decisions based on 
annotations present on a Java method (as opposed to runtime parameters).

Specifically, this adds `DeclarativeSampler` which parses a description
of a method into a sample rate (or null to defer the decision).

It also adds `ContainerSampler`, which uses `DeclarativeSampler` to 
allow decisions based on the JAX-RS `ResourceInfo` type.

Finally, this adds a feature test showing how arbitrary tracing might 
look like using the `DeclarativeSampler` with AspectJ.

Fixes #433