### PR TITLE
Adds Tracing.setNoop to disable tracing at runtime

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -178,6 +178,7 @@ next = tracer.newSpan(oneWayReceive.context()).name("step2").start();
 There's a working example of a one-way span [here](src/test/java/brave/features/async/OneWaySpanTest.java).
 
 ## Sampling
+
 Sampling may be employed to reduce the data collected and reported out
 of process. When a span isn't sampled, it adds no overhead (noop).
 
@@ -421,6 +422,12 @@ class MyFilter extends Filter {
   }
 }
 ```
+
+## Disabling Tracing
+
+If you are in a situation where you need to turn off tracing at runtime,
+invoke `Tracing.setNoop(true)`. This will turn any new spans into "noop"
+spans, and drop any data until `Tracing.setNoop(false)` is invoked.
 
 ## Performance
 Brave has been built with performance in mind. Using the core Span api,

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -80,6 +80,13 @@ public class TracerTest {
         .isInstanceOf(RealSpan.class);
   }
 
+  @Test public void newTrace_noop_on_sampled_flag() {
+    tracer.noop.set(true);
+
+    assertThat(tracer.newTrace(SamplingFlags.SAMPLED))
+        .isInstanceOf(NoopSpan.class);
+  }
+
   @Test public void newTrace_debug_flag() {
     List<zipkin.Span> spans = new ArrayList<>();
     tracer = Tracing.newBuilder().reporter(spans::add).build().tracer();
@@ -89,6 +96,13 @@ public class TracerTest {
 
     assertThat(spans).extracting(s -> s.debug)
         .containsExactly(true);
+  }
+
+  @Test public void newTrace_noop_on_debug_flag() {
+    tracer.noop.set(true);
+
+    assertThat(tracer.newTrace(SamplingFlags.DEBUG))
+        .isInstanceOf(NoopSpan.class);
   }
 
   @Test public void newTrace_notsampled_flag() {
@@ -102,6 +116,15 @@ public class TracerTest {
 
     assertThat(tracer.joinSpan(fromIncomingRequest).context())
         .isEqualTo(fromIncomingRequest.toBuilder().shared(true).build());
+  }
+
+  @Test public void join_noop() {
+    TraceContext fromIncomingRequest = tracer.newTrace().context();
+
+    tracer.noop.set(true);
+
+    assertThat(tracer.joinSpan(fromIncomingRequest))
+        .isInstanceOf(NoopSpan.class);
   }
 
   @Test public void join_ensuresSampling() {
@@ -121,6 +144,15 @@ public class TracerTest {
         .containsExactly(context);
   }
 
+  @Test public void toSpan_noop() {
+    TraceContext context = tracer.newTrace().context();
+
+    tracer.noop.set(true);
+
+    assertThat(tracer.toSpan(context))
+        .isInstanceOf(NoopSpan.class);
+  }
+
   @Test public void toSpan_unsampledIsNoop() {
     TraceContext unsampled =
         tracer.newTrace().context().toBuilder().sampled(false).build();
@@ -138,6 +170,15 @@ public class TracerTest {
           assertThat(c.context().parentId()).isEqualTo(parent.spanId());
         })
         .isInstanceOf(RealSpan.class);
+  }
+
+  @Test public void newChild_noop() {
+    TraceContext parent = tracer.newTrace().context();
+
+    tracer.noop.set(true);
+
+    assertThat(tracer.newChild(parent))
+        .isInstanceOf(NoopSpan.class);
   }
 
   @Test public void newChild_unsampledIsNoop() {

--- a/brave/src/test/java/brave/internal/recorder/RecorderTest.java
+++ b/brave/src/test/java/brave/internal/recorder/RecorderTest.java
@@ -1,0 +1,57 @@
+package brave.internal.recorder;
+
+import brave.Span;
+import brave.Tracing;
+import brave.internal.Platform;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import zipkin.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecorderTest {
+  Endpoint localEndpoint = Platform.get().localEndpoint();
+  List<zipkin.Span> spans = new ArrayList();
+  TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
+  Recorder recorder =
+      new Recorder(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));
+
+  @Test public void finish_calculatesDuration() {
+    recorder.start(context, 1L);
+    recorder.finish(context, 6L);
+
+    assertThat(spans).extracting(s -> s.duration)
+        .containsExactly(5L);
+  }
+
+  @Test public void finish_noop_drops() {
+    recorder.noop.set(true);
+
+    recorder.start(context, 1L);
+    recorder.finish(context, 6L);
+
+    assertThat(spans).isEmpty();
+  }
+
+  @Test public void flush_skipsDuration() {
+    recorder.kind(context, Span.Kind.CLIENT);
+    recorder.start(context, 1L);
+    recorder.flush(context);
+
+    assertThat(spans).extracting(s -> s.duration)
+        .containsNull();
+  }
+
+  @Test public void flush_noop_drops() {
+    recorder.noop.set(true);
+
+    recorder.kind(context, Span.Kind.CLIENT);
+    recorder.start(context, 1L);
+    recorder.flush(context);
+
+    assertThat(spans).isEmpty();
+  }
+}


### PR DESCRIPTION
If you are in a situation where you need to turn off tracing at runtime,
invoke `Tracing.setNoop(true)`. This will turn any new spans into "noop"
spans, and drop any data until `Tracing.setNoop(false)` is invoked.

Fixes #435