### PR TITLE
Adds an end user friendly span customiser

### DIFF
--- a/brave/src/main/java/brave/CurrentSpanCustomizer.java
+++ b/brave/src/main/java/brave/CurrentSpanCustomizer.java
@@ -3,7 +3,7 @@ package brave;
 /**
  * Provides a mechanism for end users to be able to customise the current span.
  *
- * Handles the case of there being no current span in scope.
+ * <p>Handles the case of there being no current span in scope.
  */
 public final class CurrentSpanCustomizer implements SpanCustomizer {
 

--- a/brave/src/main/java/brave/CurrentSpanCustomizer.java
+++ b/brave/src/main/java/brave/CurrentSpanCustomizer.java
@@ -1,0 +1,56 @@
+package brave;
+
+/**
+ * Provides a mechanism for end users to be able to customise the current span.
+ *
+ * Handles the case of there being no current span in scope.
+ */
+public class CurrentSpanCustomizer implements SpanCustomizer {
+
+  private Tracing tracing;
+
+  /** Creates a span customizer that will affect the current span in scope if present */
+  public static CurrentSpanCustomizer create(Tracing tracing) {
+    return new CurrentSpanCustomizer(tracing);
+  }
+
+  CurrentSpanCustomizer(Tracing tracing) {
+    this.tracing = tracing;
+  }
+
+  /** {@inheritDoc} */
+  @Override public SpanCustomizer name(String name) {
+    Span currentSpan = tracing.tracer().currentSpan();
+    if (currentSpan != null) {
+      currentSpan.name(name);
+    }
+    return this;
+  }
+
+  /** {@inheritDoc} */
+  @Override public SpanCustomizer tag(String key, String value) {
+    Span currentSpan = tracing.tracer().currentSpan();
+    if (currentSpan != null) {
+      currentSpan.tag(key, value);
+    }
+    return this;
+  }
+
+  /** {@inheritDoc} */
+  @Override public SpanCustomizer annotate(String value) {
+    Span currentSpan = tracing.tracer().currentSpan();
+    if (currentSpan != null) {
+      currentSpan.annotate(value);
+    }
+    return this;
+  }
+
+  /** {@inheritDoc} */
+  @Override public SpanCustomizer annotate(long timestamp, String value) {
+    Span currentSpan = tracing.tracer().currentSpan();
+    if (currentSpan != null) {
+      currentSpan.annotate(timestamp, value);
+    }
+    return this;
+  }
+}

--- a/brave/src/main/java/brave/CurrentSpanCustomizer.java
+++ b/brave/src/main/java/brave/CurrentSpanCustomizer.java
@@ -5,9 +5,9 @@ package brave;
  *
  * Handles the case of there being no current span in scope.
  */
-public class CurrentSpanCustomizer implements SpanCustomizer {
+public final class CurrentSpanCustomizer implements SpanCustomizer {
 
-  private Tracing tracing;
+  private final Tracer tracer;
 
   /** Creates a span customizer that will affect the current span in scope if present */
   public static CurrentSpanCustomizer create(Tracing tracing) {
@@ -15,12 +15,12 @@ public class CurrentSpanCustomizer implements SpanCustomizer {
   }
 
   CurrentSpanCustomizer(Tracing tracing) {
-    this.tracing = tracing;
+    this.tracer = tracing.tracer();
   }
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer name(String name) {
-    Span currentSpan = tracing.tracer().currentSpan();
+    Span currentSpan = tracer.currentSpan();
     if (currentSpan != null) {
       currentSpan.name(name);
     }
@@ -29,7 +29,7 @@ public class CurrentSpanCustomizer implements SpanCustomizer {
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer tag(String key, String value) {
-    Span currentSpan = tracing.tracer().currentSpan();
+    Span currentSpan = tracer.currentSpan();
     if (currentSpan != null) {
       currentSpan.tag(key, value);
     }
@@ -38,7 +38,7 @@ public class CurrentSpanCustomizer implements SpanCustomizer {
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer annotate(String value) {
-    Span currentSpan = tracing.tracer().currentSpan();
+    Span currentSpan = tracer.currentSpan();
     if (currentSpan != null) {
       currentSpan.annotate(value);
     }
@@ -47,7 +47,7 @@ public class CurrentSpanCustomizer implements SpanCustomizer {
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer annotate(long timestamp, String value) {
-    Span currentSpan = tracing.tracer().currentSpan();
+    Span currentSpan = tracer.currentSpan();
     if (currentSpan != null) {
       currentSpan.annotate(timestamp, value);
     }

--- a/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
@@ -1,0 +1,82 @@
+package brave;
+
+import brave.internal.Platform;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class CurrentSpanCustomizerTest {
+
+  Endpoint localEndpoint = Platform.get().localEndpoint();
+  List<zipkin.Span> spans = new ArrayList();
+  Tracing tracing = Tracing.newBuilder().reporter(spans::add).build();
+  CurrentSpanCustomizer spanCustomizer = CurrentSpanCustomizer.create(tracing);
+  Span span = tracing.tracer().newTrace();
+
+  @Test public void name() {
+    span.start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(span)) {
+      spanCustomizer.name("newname");
+    }
+    span.flush();
+
+    assertThat(spans).extracting(s -> s.name)
+        .containsExactly("newname");
+  }
+
+  @Test public void name_when_no_current_span() {
+    spanCustomizer.name("newname");
+  }
+
+  @Test public void tag() {
+    span.start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(span)) {
+      spanCustomizer.tag("foo", "bar");
+    }
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.binaryAnnotations)
+        .containsExactly(BinaryAnnotation.create("foo", "bar", localEndpoint));
+  }
+
+  @Test public void tag_when_no_current_span() {
+    spanCustomizer.tag("foo", "bar");
+  }
+
+  @Test public void annotate() {
+    span.start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(span)) {
+      spanCustomizer.annotate("foo");
+    }
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value, a -> a.endpoint)
+        .containsExactly(tuple("foo", localEndpoint));
+  }
+
+  @Test public void annotate_when_no_current_span() {
+    spanCustomizer.annotate("foo");
+  }
+
+  @Test public void annotate_timestamp() {
+    span.start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(span)) {
+      spanCustomizer.annotate(2, "foo");
+    }
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.annotations)
+        .containsExactly(Annotation.create(2L, "foo", localEndpoint));
+  }
+
+  @Test public void annotate_timestamp_when_no_current_span() {
+    spanCustomizer.annotate(2, "foo");
+  }
+}


### PR DESCRIPTION
As per discussions with @adriancole, we don't want to expose the need to deal with tracer.currentSpan and its possibility of being null to end users. This adds a class that nicely wraps that up, which can be made into a spring bean that end users can wire in.

@adriancole, a few things:
- not sure about whether we should just have a reference to Tracer or whether we should always do Tracing.tracer().etc ?
- You mentioned returning a Noop span if there isn't one current, however you cannot create one without a TraceContext so it seemed simpler to just not do the operation if there isn't one and then return customiser rather than the real span.
