### PR TITLE
updated the JSR305 to servicemix bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,9 +332,9 @@
        This is added as a root-level dependency to prevent javadoc from failing.
        -->
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
+      <version>3.0.2_1</version>
       <!-- eventhough annotations are runtime retention, we do not look them up reflectively -->
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Updated the brave JSR305 with service mix JSR305 3.0.2_1 bundle to make the `javax.annotation;version="[1.1,2.0)"` instead of `javax.annotation;version="[3.0.0,4.0.0)"` to make it deployable in OSGi containers that already export javax.annotation.