### PR TITLE
Adds ThreadLocalSpan to show how to deal with callbacks w/o attributes

### DIFF
--- a/brave/src/main/java/brave/propagation/ThreadLocalSpan.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalSpan.java
@@ -1,0 +1,98 @@
+package brave.propagation;
+
+import brave.Span;
+import brave.Tracer;
+import javax.annotation.Nullable;
+
+/**
+ * This type allows you to place a span in scope in one method and access it in another without
+ * using an explicit request parameter.
+ *
+ * <p>Many libraries expose a callback model as opposed to an interceptor one. When creating new
+ * instrumentation, you may find places where you need to place a span in scope in one callback
+ * (like `onStart()`) and end the scope in another callback (like `onFinish()`).
+ *
+ * <p>Provided the library guarantees these run on the same thread, you can simply propagate the
+ * result of {@link Tracer#withSpanInScope(Span)} from the starting callback to the closing one.
+ * This is typically done with a request-scoped attribute.
+ *
+ * Here's an example:
+ * <pre>{@code
+ * class MyFilter extends Filter {
+ *   public void onStart(Request request, Attributes attributes) {
+ *     // Assume you have code to start the span and add relevant tags...
+ *
+ *     // We now set the span in scope so that any code between here and
+ *     // the end of the request can see it with Tracer.currentSpan()
+ *     SpanInScope spanInScope = tracer.withSpanInScope(span);
+ *
+ *     // We don't want to leak the scope, so we place it somewhere we can
+ *     // lookup later
+ *     attributes.put(SpanInScope.class, spanInScope);
+ *   }
+ *
+ *   public void onFinish(Response response, Attributes attributes) {
+ *     // as long as we are on the same thread, we can read the span started above
+ *     Span span = tracer.currentSpan();
+ *
+ *     // Assume you have code to complete the span
+ *
+ *     // We now remove the scope (which implicitly detaches it from the span)
+ *     attributes.remove(SpanInScope.class).close();
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>Sometimes you have to instrument a library where There's no attribute namespace shared across
+ * request and response. For this scenario, you can use {@link ThreadLocalSpan} to temporarily store
+ * the span between callbacks.
+ *
+ * Here's an example:
+ * <pre>{@code
+ * class MyFilter extends Filter {
+ *   final ThreadLocalSpan threadLocalSpan;
+ *
+ *   public void onStart(Request request) {
+ *     // Assume you have code to start the span and add relevant tags...
+ *
+ *     // We now set the span in scope so that any code between here and
+ *     // the end of the request can see it with Tracer.currentSpan()
+ *     threadLocalSpan.set(span);
+ *   }
+ *
+ *   public void onFinish(Response response, Attributes attributes) {
+ *     // as long as we are on the same thread, we can read the span started above
+ *     Span span = threadLocalSpan.remove();
+ *     if (span == null) return;
+ *
+ *     // Assume you have code to complete the span
+ *   }
+ * }
+ * }</pre>
+ */
+public final class ThreadLocalSpan {
+  public static ThreadLocalSpan create(Tracer tracer) {
+    return new ThreadLocalSpan(tracer);
+  }
+
+  final Tracer tracer;
+  final ThreadLocal<Tracer.SpanInScope> currentSpanInScope = new ThreadLocal<>();
+
+  ThreadLocalSpan(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  public void set(Span span) {
+    currentSpanInScope.set(tracer.withSpanInScope(span));
+  }
+
+  public @Nullable Span remove() {
+    Span span = tracer.currentSpan();
+    Tracer.SpanInScope scope = currentSpanInScope.get();
+    if (scope != null) {
+      scope.close();
+      currentSpanInScope.remove();
+    }
+    return span;
+  }
+}

--- a/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
@@ -1,8 +1,7 @@
 package brave.mysql6;
 
 import brave.Span;
-import brave.Tracer;
-import brave.Tracing;
+import brave.propagation.ThreadLocalSpan;
 import com.mysql.cj.api.MysqlConnection;
 import com.mysql.cj.api.jdbc.JdbcConnection;
 import com.mysql.cj.api.jdbc.Statement;
@@ -23,47 +22,36 @@ import zipkin2.Endpoint;
  */
 public class TracingStatementInterceptor implements StatementInterceptor {
 
-
+  /**
+   * Uses {@link ThreadLocalSpan} as there's no attribute namespace shared between callbacks, but
+   * all callbacks happen on the same thread.
+   *
+   * <p>Uses {@link ThreadLocalSpan#CURRENT_TRACER} and this interceptor initializes before tracing.
+   */
   @Override
   public Resultset preProcess(String sql, Statement interceptedStatement) throws SQLException {
-    Tracer tracer = Tracing.currentTracer();
-    if (tracer == null) return null;
+    // Gets the next span (and places it in scope) so code between here and postProcess can read it
+    Span span = ThreadLocalSpan.CURRENT_TRACER.next();
+    if (span == null || span.isNoop()) return null;
 
-    Span span = tracer.nextSpan();
-    // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
-    if (!span.isNoop()) {
-      // When running a prepared statement, sql will be null and we must fetch the sql from the statement itself
-      if (interceptedStatement instanceof PreparedStatement) {
-        sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
-      }
-      int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
-      span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
-      span.tag("sql.query", sql);
-      parseServerAddress(connection, span);
-      span.start();
+    // When running a prepared statement, sql will be null and we must fetch the sql from the statement itself
+    if (interceptedStatement instanceof PreparedStatement) {
+      sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
     }
-
-    currentSpanInScope.set(tracer.withSpanInScope(span));
-
+    int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
+    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+    span.tag("sql.query", sql);
+    parseServerAddress(connection, span);
+    span.start();
     return null;
   }
 
-  /**
-   * There's no attribute namespace shared across request and response. Hence, we need to save off
-   * a reference to the span in scope, so that we can close it in the response.
-   */
-  final ThreadLocal<Tracer.SpanInScope> currentSpanInScope = new ThreadLocal<>();
   private MysqlConnection connection;
 
   @Override
   public <T extends Resultset> T postProcess(String sql, Statement interceptedStatement, T originalResultSet, int warningCount, boolean noIndexUsed, boolean noGoodIndexUsed, Exception statementException) throws SQLException {
-    Tracer tracer = Tracing.currentTracer();
-    if (tracer == null) return null;
-
-    Span span = tracer.currentSpan();
-    if (span == null) return null;
-    currentSpanInScope.get().close();
-    currentSpanInScope.remove();
+    Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+    if (span == null || span.isNoop()) return null;
 
     if (statementException != null && statementException instanceof SQLException) {
       span.tag("error", Integer.toString(((SQLException)statementException).getErrorCode()));

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -1,9 +1,8 @@
 package brave.p6spy;
 
 import brave.Span;
-import brave.Tracer;
-import brave.Tracing;
 import brave.internal.Nullable;
+import brave.propagation.ThreadLocalSpan;
 import com.p6spy.engine.common.StatementInformation;
 import com.p6spy.engine.event.SimpleJdbcEventListener;
 import java.net.URI;
@@ -26,42 +25,30 @@ final class TracingJdbcEventListener extends SimpleJdbcEventListener {
     this.includeParameterValues = includeParameterValues;
   }
 
+  /**
+   * Uses {@link ThreadLocalSpan} as there's no attribute namespace shared between callbacks, but
+   * all callbacks happen on the same thread.
+   *
+   * <p>Uses {@link ThreadLocalSpan#CURRENT_TRACER} and this interceptor initializes before tracing.
+   */
   @Override public void onBeforeAnyExecute(StatementInformation info) {
-    Tracer tracer = Tracing.currentTracer();
-    if (tracer == null) return;
     String sql = includeParameterValues ? info.getSqlWithValues() : info.getSql();
     // don't start a span unless there is SQL as we cannot choose a relevant name without it
     if (sql == null || sql.isEmpty()) return;
 
-    Span span = tracer.nextSpan();
-    // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
-    if (!span.isNoop()) {
-      span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
-      span.tag("sql.query", sql);
-      parseServerAddress(info.getConnectionInformation().getConnection(), span);
-      span.start();
-    }
+    // Gets the next span (and places it in scope) so code between here and postProcess can read it
+    Span span = ThreadLocalSpan.CURRENT_TRACER.next();
+    if (span == null || span.isNoop()) return;
 
-    currentSpanInScope.set(tracer.withSpanInScope(span));
+    span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
+    span.tag("sql.query", sql);
+    parseServerAddress(info.getConnectionInformation().getConnection(), span);
+    span.start();
   }
 
-  /**
-   * There's no attribute namespace shared across request and response. Hence, we need to save off
-   * a reference to the span in scope, so that we can close it in the response.
-   */
-  final ThreadLocal<Tracer.SpanInScope> currentSpanInScope = new ThreadLocal<>();
-
   @Override public void onAfterAnyExecute(StatementInformation info, long elapsed, SQLException e) {
-    Tracer tracer = Tracing.currentTracer();
-    if (tracer == null) return;
-
-    Span span = tracer.currentSpan();
-    if (span == null) return;
-    Tracer.SpanInScope scope = currentSpanInScope.get();
-    if (scope != null) {
-      scope.close();
-      currentSpanInScope.remove();
-    }
+    Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+    if (span == null || span.isNoop()) return;
 
     if (e != null) {
       span.tag("error", Integer.toString(e.getErrorCode()));


### PR DESCRIPTION
Sometimes you have to instrument a library where there's no attribute
namespace shared across request and response. For this scenario, you can
use `ThreadLocalSpan` to temporarily store the span between callbacks.

Here's an example:
```java
class MyFilter extends Filter {
  final ThreadLocalSpan threadLocalSpan;

  public void onStart(Request request) {
    // Allocates a span and places it in scope so that code between here and onFinish can see it
    Span span = threadLocalSpan.next();
    if (span == null || span.isNoop()) return; // skip below logic on noop

    // Assume you have code to start the span and add relevant tags...
  }

  public void onFinish(Response response, Attributes attributes) {
    // as long as we are on the same thread, we can read the span started above
    Span span = threadLocalSpan.remove();
    if (span == null || span.isNoop()) return; // skip below logic on noop

    // Assume you have code to complete the span
  }
}
```