### PR TITLE
Instrumentation support for mysql-connector-java 6

### DIFF
--- a/instrumentation/mysql6/README.md
+++ b/instrumentation/mysql6/README.md
@@ -1,0 +1,15 @@
+# brave-instrumentation-mysql
+
+This includes a MySQL-6 statement interceptor that will report to Zipkin
+how long each statement takes, along with relevant tags like the query.
+
+To use it, append `?statementInterceptors=brave.mysql6.TracingStatementInterceptor`
+to the end of the connection url.
+
+By default the service name corresponding to your database uses the format
+`mysql-${database}`, but you can append another property `zipkinServiceName` to customise it.
+
+`?statementInterceptors=brave.mysql6.TracingStatementInterceptor&zipkinServiceName=myDatabaseService`
+
+The current tracing component is used at runtime. Until you have
+instantiated `brave.Tracing`, no traces will appear.

--- a/instrumentation/mysql6/README.md
+++ b/instrumentation/mysql6/README.md
@@ -1,6 +1,6 @@
-# brave-instrumentation-mysql
+# brave-instrumentation-mysql-6
 
-This includes a MySQL-6 statement interceptor that will report to Zipkin
+This includes a mysql-connector-java 6+ statement interceptor that will report to Zipkin
 how long each statement takes, along with relevant tags like the query.
 
 To use it, append `?statementInterceptors=brave.mysql6.TracingStatementInterceptor`

--- a/instrumentation/mysql6/README.md
+++ b/instrumentation/mysql6/README.md
@@ -1,4 +1,4 @@
-# brave-instrumentation-mysql-6
+# brave-instrumentation-mysql6
 
 This includes a mysql-connector-java 6+ statement interceptor that will report to Zipkin
 how long each statement takes, along with relevant tags like the query.

--- a/instrumentation/mysql6/pom.xml
+++ b/instrumentation/mysql6/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.5.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-mysql6</artifactId>
+  <name>Brave Instrumentation: MySQL6</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>6.0.6</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
@@ -1,0 +1,117 @@
+package brave.mysql6;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import com.mysql.cj.api.MysqlConnection;
+import com.mysql.cj.api.jdbc.Statement;
+import com.mysql.cj.api.jdbc.interceptors.StatementInterceptor;
+import com.mysql.cj.api.log.Log;
+import com.mysql.cj.api.mysqla.result.Resultset;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import com.mysql.cj.jdbc.PreparedStatement;
+import zipkin.Constants;
+import zipkin.Endpoint;
+import zipkin.TraceKeys;
+
+/**
+ * A MySQL statement interceptor that will report to Zipkin how long each statement takes.
+ *
+ * <p>To use it, append <code>?statementInterceptors=brave.mysql6.TracingStatementInterceptor</code>
+ * to the end of the connection url.
+ */
+public class TracingStatementInterceptor implements StatementInterceptor {
+
+
+  @Override
+  public <T extends Resultset> T preProcess(String sql, Statement interceptedStatement) throws SQLException {
+    Tracer tracer = Tracing.currentTracer();
+    if (tracer == null) return null;
+
+    Span span = tracer.nextSpan();
+    // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
+    if (!span.isNoop()) {
+      // When running a prepared statement, sql will be null and we must fetch the sql from the statement itself
+      if (interceptedStatement instanceof PreparedStatement) {
+        sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
+      }
+      int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
+      span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+      span.tag(TraceKeys.SQL_QUERY, sql);
+      parseServerAddress(interceptedStatement.getConnection(), span);
+      span.start();
+    }
+
+    currentSpanInScope.set(tracer.withSpanInScope(span));
+
+    return null;
+  }
+
+  /**
+   * There's no attribute namespace shared across request and response. Hence, we need to save off
+   * a reference to the span in scope, so that we can close it in the response.
+   */
+  final ThreadLocal<Tracer.SpanInScope> currentSpanInScope = new ThreadLocal<>();
+
+  @Override
+  public <T extends Resultset> T postProcess(String sql, Statement interceptedStatement, T originalResultSet, int warningCount, boolean noIndexUsed, boolean noGoodIndexUsed, Exception statementException) throws SQLException {
+    Tracer tracer = Tracing.currentTracer();
+    if (tracer == null) return null;
+
+    Span span = tracer.currentSpan();
+    if (span == null) return null;
+    currentSpanInScope.get().close();
+    currentSpanInScope.remove();
+
+    if (statementException != null && statementException instanceof SQLException) {
+      span.tag(Constants.ERROR, Integer.toString(((SQLException)statementException).getErrorCode()));
+    }
+    span.finish();
+
+    return null;
+  }
+
+  /**
+   * MySQL exposes the host connecting to, but not the port. This attempts to get the port from the
+   * JDBC URL. Ex. 5555 from {@code jdbc:mysql://localhost:5555/database}, or 3306 if absent.
+   */
+  static void parseServerAddress(Connection connection, Span span) {
+    try {
+      URI url = URI.create(connection.getMetaData().getURL().substring(5)); // strip "jdbc:"
+      int port = url.getPort() == -1 ? 3306 : url.getPort();
+      String remoteServiceName = connection.getClientInfo().getProperty("zipkinServiceName");
+      if (remoteServiceName == null || "".equals(remoteServiceName)) {
+        String databaseName = connection.getCatalog();
+        if (databaseName != null && !databaseName.isEmpty()) {
+          remoteServiceName = "mysql-" + databaseName;
+        } else {
+          remoteServiceName = "mysql";
+        }
+      }
+      Endpoint.Builder builder = Endpoint.builder().serviceName(remoteServiceName).port(port);
+      if (!builder.parseIp(connection.getClientInfo("ClientHostname"))) return;
+      span.remoteEndpoint(builder.build());
+    } catch (Exception e) {
+      // remote address is optional
+    }
+  }
+
+  @Override
+  public boolean executeTopLevelOnly() {
+    return true;  // True means that we don't get notified about queries that other interceptors issue
+  }
+
+  @Override
+  public StatementInterceptor init(MysqlConnection mysqlConnection, Properties properties, Log log) {
+    return null; //Don't care
+  }
+
+  @Override
+  public void destroy() {
+    // Don't care
+  }
+}

--- a/instrumentation/mysql6/src/main/java/brave/mysql6/package-info.java
+++ b/instrumentation/mysql6/src/main/java/brave/mysql6/package-info.java
@@ -1,0 +1,2 @@
+@javax.annotation.ParametersAreNonnullByDefault
+package brave.mysql6;

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.Assume.assumeTrue;
 import static zipkin.internal.Util.envOr;
 
-@SuppressWarnings("Duplicates")
 public class ITTracingStatementInterceptor {
   static final String QUERY = "select 'hello world'";
 
@@ -41,6 +40,7 @@ public class ITTracingStatementInterceptor {
     if (db != null) url.append("/").append(db);
     url.append("?statementInterceptors=").append(TracingStatementInterceptor.class.getName());
     url.append("&zipkinServiceName=").append("myservice");
+    url.append("&serverTimezone=").append("UTC");
 
     MysqlDataSource dataSource = new MysqlDataSource();
     dataSource.setUrl(url.toString());

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
@@ -1,0 +1,141 @@
+package brave.mysql6;
+
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.internal.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.Constants;
+import zipkin.Span;
+import zipkin.TraceKeys;
+import zipkin.internal.Util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.Assume.assumeTrue;
+import static zipkin.internal.Util.envOr;
+
+@SuppressWarnings("Duplicates")
+public class ITTracingStatementInterceptor {
+  static final String QUERY = "select 'hello world'";
+
+  ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+  Connection connection;
+
+  @Before public void init() throws SQLException {
+    StringBuilder url = new StringBuilder("jdbc:mysql://");
+    url.append(envOr("MYSQL_HOST", "127.0.0.1"));
+    url.append(":").append(envOr("MYSQL_TCP_PORT", 3306));
+    String db = envOr("MYSQL_DB", null);
+    if (db != null) url.append("/").append(db);
+    url.append("?statementInterceptors=").append(TracingStatementInterceptor.class.getName());
+    url.append("&zipkinServiceName=").append("myservice");
+
+    MysqlDataSource dataSource = new MysqlDataSource();
+    dataSource.setUrl(url.toString());
+
+    dataSource.setUser(System.getenv("MYSQL_USER"));
+    assumeTrue("Minimally, the environment variable MYSQL_USER must be set",
+        dataSource.getUser() != null);
+    dataSource.setPassword(envOr("MYSQL_PASS", ""));
+    connection = dataSource.getConnection();
+    spans.clear();
+  }
+
+  @After public void close() throws SQLException {
+    Tracing.current().close();
+    if (connection != null) connection.close();
+  }
+
+  @Test
+  public void makesChildOfCurrentSpan() throws Exception {
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      prepareExecuteSelect(QUERY);
+    } finally {
+      parent.finish();
+    }
+
+    assertThat(spans)
+        .hasSize(2);
+  }
+
+  @Test
+  public void reportsClientAnnotationsToZipkin() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .flatExtracting(s -> s.annotations)
+        .extracting(a -> a.value)
+        .containsExactly("cs", "cr");
+  }
+
+  @Test
+  public void defaultSpanNameIsOperationName() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .extracting(s -> s.name)
+        .containsExactly("select");
+  }
+
+  /** This intercepts all SQL, not just queries. This ensures single-word statements work */
+  @Test
+  public void defaultSpanNameIsOperationName_oneWord() throws Exception {
+    connection.setAutoCommit(false);
+    connection.commit();
+
+    assertThat(spans)
+        .extracting(s -> s.name)
+        .contains("commit");
+  }
+
+  @Test
+  public void addsQueryTag() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .flatExtracting(s -> s.binaryAnnotations)
+        .filteredOn(a -> a.key.equals(TraceKeys.SQL_QUERY))
+        .extracting(a -> new String(a.value, Util.UTF_8))
+        .containsExactly(QUERY);
+  }
+
+  @Test
+  public void reportsServerAddress() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .flatExtracting(s -> s.binaryAnnotations)
+        .extracting(b -> b.key, b -> b.endpoint.serviceName)
+        .contains(tuple(Constants.SERVER_ADDR, "myservice"));
+  }
+
+  void prepareExecuteSelect(String query) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(query)) {
+      try (ResultSet resultSet = ps.executeQuery()) {
+        while (resultSet.next()) {
+          resultSet.getString(1);
+        }
+      }
+    }
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .reporter(spans::add)
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .sampler(sampler);
+  }
+}

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/TracingStatementInterceptorTest.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/TracingStatementInterceptorTest.java
@@ -1,0 +1,88 @@
+package brave.mysql6;
+
+import brave.Span;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import com.mysql.cj.jdbc.DatabaseMetaData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import zipkin.Endpoint;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracingStatementInterceptorTest {
+  @Mock
+  Connection connection;
+  @Mock
+  DatabaseMetaData metaData;
+
+  @Mock Span span;
+  String url = "jdbc:mysql://myhost:5555/mydatabase";
+
+  @Test public void parseServerAddress_ipFromHost_portFromUrl() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1");
+
+    TracingStatementInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.builder().serviceName("mysql")
+        .ipv4(127 << 24 | 1).port(5555).build());
+  }
+
+  @Test public void parseServerAddress_serviceNameFromDatabaseName() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1");
+    when(connection.getCatalog()).thenReturn("mydatabase");
+
+    TracingStatementInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.builder().serviceName("mysql-mydatabase")
+        .ipv4(127 << 24 | 1).port(5555).build());
+  }
+
+  @Test public void parseServerAddress_propertiesOverrideServiceName() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1").setProperty("zipkinServiceName", "foo");
+
+    TracingStatementInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.builder().serviceName("foo")
+        .ipv4(127 << 24 | 1).port(5555).build());
+  }
+
+  @Test public void parseServerAddress_emptyZipkinServiceNameIgnored() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1").setProperty("zipkinServiceName", "");
+
+    TracingStatementInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.builder().serviceName("mysql")
+        .ipv4(127 << 24 | 1).port(5555).build());
+  }
+
+  @Test public void parseServerAddress_doesntNsLookup() throws SQLException {
+    setupAndReturnPropertiesForHost("localhost");
+
+    TracingStatementInterceptor.parseServerAddress(connection, span);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void parseServerAddress_doesntCrash() throws SQLException {
+    when(connection.getMetaData()).thenThrow(new SQLException());
+
+    verifyNoMoreInteractions(span);
+  }
+
+  Properties setupAndReturnPropertiesForHost(String host) throws SQLException {
+    when(connection.getMetaData()).thenReturn(metaData);
+    when(metaData.getURL()).thenReturn(url);
+    Properties properties = new Properties();
+    when(connection.getClientInfo()).thenReturn(properties);
+    when(connection.getClientInfo("ClientHostname")).thenReturn(host);
+    return properties;
+  }
+}

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/TracingStatementInterceptorTest.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/TracingStatementInterceptorTest.java
@@ -2,10 +2,10 @@ package brave.mysql6;
 
 import brave.Span;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import com.mysql.cj.api.jdbc.JdbcConnection;
 import com.mysql.cj.jdbc.DatabaseMetaData;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TracingStatementInterceptorTest {
   @Mock
-  Connection connection;
+  JdbcConnection connection;
   @Mock
   DatabaseMetaData metaData;
 
@@ -79,10 +79,10 @@ public class TracingStatementInterceptorTest {
 
   Properties setupAndReturnPropertiesForHost(String host) throws SQLException {
     when(connection.getMetaData()).thenReturn(metaData);
-    when(metaData.getURL()).thenReturn(url);
+    when(connection.getURL()).thenReturn(url);
     Properties properties = new Properties();
-    when(connection.getClientInfo()).thenReturn(properties);
-    when(connection.getClientInfo("ClientHostname")).thenReturn(host);
+    when(connection.getProperties()).thenReturn(properties);
+    when(connection.getHost()).thenReturn(host);
     return properties;
   }
 }

--- a/instrumentation/mysql6/src/test/resources/log4j2.properties
+++ b/instrumentation/mysql6/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -25,6 +25,7 @@
     <module>httpclient</module>
     <module>jaxrs2</module>
     <module>mysql</module>
+    <module>mysql6</module>
     <module>okhttp3</module>
     <module>p6spy</module>
     <module>servlet</module>


### PR DESCRIPTION
The current instrumentation code under` brave/mysql` was causing `java.lang.NoClassDefFoundError: com/mysql/jdbc/StatementInterceptorV2`. The connector for `mysql-connector-java 6` seems to have removed this class and also changed the signature of methods to be overridden.