### PR TITLE
P6spy log with jdbc parameter values

### DIFF
--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -2,6 +2,7 @@
 This includes a tracing event listener for [P6Spy](https://github.com/p6spy/p6spy) (a proxy for calls to your JDBC driver).
 It reports to Zipkin how long each statement takes, along with relevant tags like the query.
 
+
 P6Spy requires a `spy.properties` in your application classpath
 (ex `src/main/resources`). `brave.p6spy.TracingP6Factory` must be in the
 `modulelist` to enable tracing.
@@ -11,9 +12,25 @@ modulelist=brave.p6spy.TracingP6Factory
 url=jdbc:p6spy:derby:memory:p6spy;create=true
 ```
 
-By default the service name corresponding to your database is the name
-of the database, but you can add another property to `spy.properties`
-named `remoteServiceName` to customise it.
+In addition, you can specify the following options in spy.properties
 
-The current tracing component is used at runtime. Until you have
-instantiated `brave.Tracing`, no traces will appear.
+`remoteServiceName`
+
+By default the zipkin service name for your database is the name of the database. Set this property to override it
+
+```
+remoteServiceName=myProductionDatabase
+```
+
+`logJdbcParameterValues`
+
+By default JDBC parameter values are not logged and will appear as '?' in the logged statement. Set this property to 'true' to also log JDBC parameter values.
+ 
+**Note**: if you enable this please also consider enabling 'excludebinary' to avoid logging large blob values as hex (see http://p6spy.readthedocs.io/en/latest/configandusage.html#excludebinary).
+
+```  
+logJdbcParameterValues=true
+excludebinary=true
+```
+
+The current tracing component is used at runtime. Until you have instantiated `brave.Tracing`, no traces will appear.

--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -22,14 +22,14 @@ By default the zipkin service name for your database is the name of the database
 remoteServiceName=myProductionDatabase
 ```
 
-`logJdbcParameterValues`
+`includeParameterValues`
 
-By default JDBC parameter values are not logged and will appear as '?' in the logged statement. Set this property to 'true' to also log JDBC parameter values.
+When set to to true, the tag `sql.query` will also include the JDBC parameter values.
  
 **Note**: if you enable this please also consider enabling 'excludebinary' to avoid logging large blob values as hex (see http://p6spy.readthedocs.io/en/latest/configandusage.html#excludebinary).
 
 ```  
-logJdbcParameterValues=true
+includeParameterValues=true
 excludebinary=true
 ```
 

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -15,11 +15,11 @@ import zipkin.TraceKeys;
 final class TracingJdbcEventListener extends SimpleJdbcEventListener {
 
   final String remoteServiceName;
-  final boolean logJdbcParameterValues;
+  final boolean includeParameterValues;
 
-  TracingJdbcEventListener(String remoteServiceName, boolean logJdbcParameterValues) {
+  TracingJdbcEventListener(String remoteServiceName, boolean includeParameterValues) {
     this.remoteServiceName = remoteServiceName;
-    this.logJdbcParameterValues = logJdbcParameterValues;
+    this.includeParameterValues = includeParameterValues;
   }
 
   @Override public void onBeforeAnyExecute(StatementInformation info) {
@@ -29,7 +29,7 @@ final class TracingJdbcEventListener extends SimpleJdbcEventListener {
     Span span = tracer.nextSpan();
     // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
     if (!span.isNoop()) {
-      String sql = logJdbcParameterValues ? info.getSqlWithValues() : info.getSql();
+      String sql = includeParameterValues ? info.getSqlWithValues() : info.getSql();
       span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
       span.tag(TraceKeys.SQL_QUERY, sql);
       parseServerAddress(info.getConnectionInformation().getConnection(), span);

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -15,9 +15,11 @@ import zipkin.TraceKeys;
 final class TracingJdbcEventListener extends SimpleJdbcEventListener {
 
   final String remoteServiceName;
+  final boolean logJdbcParameterValues;
 
-  TracingJdbcEventListener(String remoteServiceName) {
+  TracingJdbcEventListener(String remoteServiceName, boolean logJdbcParameterValues) {
     this.remoteServiceName = remoteServiceName;
+    this.logJdbcParameterValues = logJdbcParameterValues;
   }
 
   @Override public void onBeforeAnyExecute(StatementInformation info) {
@@ -27,7 +29,7 @@ final class TracingJdbcEventListener extends SimpleJdbcEventListener {
     Span span = tracer.nextSpan();
     // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
     if (!span.isNoop()) {
-      String sql = info.getSql();
+      String sql = logJdbcParameterValues ? info.getSqlWithValues() : info.getSql();
       span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
       span.tag(TraceKeys.SQL_QUERY, sql);
       parseServerAddress(info.getConnectionInformation().getConnection(), span);

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -15,6 +15,6 @@ public final class TracingP6Factory implements P6Factory {
   }
 
   @Override public JdbcEventListener getJdbcEventListener() {
-    return new TracingJdbcEventListener(options.remoteServiceName(), options.logJdbcParameterValues());
+    return new TracingJdbcEventListener(options.remoteServiceName(), options.includeParameterValues());
   }
 }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -15,6 +15,6 @@ public final class TracingP6Factory implements P6Factory {
   }
 
   @Override public JdbcEventListener getJdbcEventListener() {
-    return new TracingJdbcEventListener(options.remoteServiceName());
+    return new TracingJdbcEventListener(options.remoteServiceName(), options.logSqlWithParameterValues());
   }
 }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -15,6 +15,6 @@ public final class TracingP6Factory implements P6Factory {
   }
 
   @Override public JdbcEventListener getJdbcEventListener() {
-    return new TracingJdbcEventListener(options.remoteServiceName(), options.logSqlWithParameterValues());
+    return new TracingJdbcEventListener(options.remoteServiceName(), options.logJdbcParameterValues());
   }
 }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
@@ -25,7 +25,7 @@ final class TracingP6SpyOptions extends P6SpyOptions {
     return optionsRepository.get(String.class, REMOTE_SERVICE_NAME);
   }
 
-  Boolean logSqlWithParameterValues() {
+  Boolean logJdbcParameterValues() {
     Boolean logParameterValues = optionsRepository.get(Boolean.class, LOG_JDBC_PARAMETER_VALUES);
     return logParameterValues == null ? false : logParameterValues;
   }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 final class TracingP6SpyOptions extends P6SpyOptions {
   static final String REMOTE_SERVICE_NAME = "remoteServiceName";
+  static final String LOG_JDBC_PARAMETER_VALUES = "logJdbcParameterValues";
 
   final P6OptionsRepository optionsRepository;
 
@@ -17,9 +18,15 @@ final class TracingP6SpyOptions extends P6SpyOptions {
   @Override public void load(Map<String, String> options) {
     super.load(options);
     optionsRepository.set(String.class, REMOTE_SERVICE_NAME, options.get(REMOTE_SERVICE_NAME));
+    optionsRepository.set(Boolean.class, LOG_JDBC_PARAMETER_VALUES, options.get(LOG_JDBC_PARAMETER_VALUES));
   }
 
   String remoteServiceName() {
     return optionsRepository.get(String.class, REMOTE_SERVICE_NAME);
+  }
+
+  Boolean logSqlWithParameterValues() {
+    Boolean logParameterValues = optionsRepository.get(Boolean.class, LOG_JDBC_PARAMETER_VALUES);
+    return logParameterValues == null ? false : logParameterValues;
   }
 }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 final class TracingP6SpyOptions extends P6SpyOptions {
   static final String REMOTE_SERVICE_NAME = "remoteServiceName";
-  static final String LOG_JDBC_PARAMETER_VALUES = "logJdbcParameterValues";
+  static final String INCLUDE_PARAMETER_VALUES = "includeParameterValues";
 
   final P6OptionsRepository optionsRepository;
 
@@ -18,15 +18,15 @@ final class TracingP6SpyOptions extends P6SpyOptions {
   @Override public void load(Map<String, String> options) {
     super.load(options);
     optionsRepository.set(String.class, REMOTE_SERVICE_NAME, options.get(REMOTE_SERVICE_NAME));
-    optionsRepository.set(Boolean.class, LOG_JDBC_PARAMETER_VALUES, options.get(LOG_JDBC_PARAMETER_VALUES));
+    optionsRepository.set(Boolean.class, INCLUDE_PARAMETER_VALUES, options.get(INCLUDE_PARAMETER_VALUES));
   }
 
   String remoteServiceName() {
     return optionsRepository.get(String.class, REMOTE_SERVICE_NAME);
   }
 
-  Boolean logJdbcParameterValues() {
-    Boolean logParameterValues = optionsRepository.get(Boolean.class, LOG_JDBC_PARAMETER_VALUES);
+  Boolean includeParameterValues() {
+    Boolean logParameterValues = optionsRepository.get(Boolean.class, INCLUDE_PARAMETER_VALUES);
     return logParameterValues == null ? false : logParameterValues;
   }
 }

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/TracingJdbcEventListenerTest.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/TracingJdbcEventListenerTest.java
@@ -1,5 +1,9 @@
 package brave.p6spy;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import brave.Span;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -9,10 +13,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import zipkin.Endpoint;
-
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TracingJdbcEventListenerTest {
@@ -26,7 +26,7 @@ public class TracingJdbcEventListenerTest {
     when(connection.getMetaData()).thenReturn(metaData);
     when(metaData.getURL()).thenReturn(url);
 
-    new TracingJdbcEventListener("").parseServerAddress(connection, span);
+    new TracingJdbcEventListener("", false).parseServerAddress(connection, span);
 
     verify(span).remoteEndpoint(Endpoint.builder().serviceName("")
         .ipv4(127 << 24 | 1).port(5555).build());
@@ -37,7 +37,7 @@ public class TracingJdbcEventListenerTest {
     when(metaData.getURL()).thenReturn(url);
     when(connection.getCatalog()).thenReturn("mydatabase");
 
-    new TracingJdbcEventListener("").parseServerAddress(connection, span);
+    new TracingJdbcEventListener("", false).parseServerAddress(connection, span);
 
     verify(span).remoteEndpoint(Endpoint.builder().serviceName("mydatabase")
         .ipv4(127 << 24 | 1).port(5555).build());
@@ -47,7 +47,7 @@ public class TracingJdbcEventListenerTest {
     when(connection.getMetaData()).thenReturn(metaData);
     when(metaData.getURL()).thenReturn(url);
 
-    new TracingJdbcEventListener("foo").parseServerAddress(connection, span);
+    new TracingJdbcEventListener("foo", false).parseServerAddress(connection, span);
 
     verify(span).remoteEndpoint(Endpoint.builder().serviceName("foo")
         .ipv4(127 << 24 | 1).port(5555).build());
@@ -57,7 +57,7 @@ public class TracingJdbcEventListenerTest {
     when(connection.getMetaData()).thenReturn(metaData);
     when(metaData.getURL()).thenReturn("jdbc:mysql://localhost:5555/mydatabase");
 
-    new TracingJdbcEventListener("").parseServerAddress(connection, span);
+    new TracingJdbcEventListener("", false).parseServerAddress(connection, span);
     verifyNoMoreInteractions(span);
   }
 

--- a/instrumentation/p6spy/src/test/resources/spy.properties
+++ b/instrumentation/p6spy/src/test/resources/spy.properties
@@ -1,2 +1,3 @@
 modulelist=brave.p6spy.TracingP6Factory
 remoteServiceName=myservice
+#logJdbcParameterValues=false

--- a/instrumentation/p6spy/src/test/resources/spy.properties
+++ b/instrumentation/p6spy/src/test/resources/spy.properties
@@ -1,3 +1,3 @@
 modulelist=brave.p6spy.TracingP6Factory
 remoteServiceName=myservice
-#logJdbcParameterValues=false
+#includeParameterValues=true


### PR DESCRIPTION
allow to collect jdbc statements including parameter values during p6spy tracing. 