### PR TITLE
Avoiding NPEs in `p6spy` edge-cases

### DIFF
--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -13,6 +13,10 @@ import zipkin.Endpoint;
 import zipkin.TraceKeys;
 
 final class TracingJdbcEventListener extends SimpleJdbcEventListener {
+  /**
+   * Use this instead of the actual sql if p6spy wasn't able to intercept it.
+   */
+  static final String QUERY_PLACEHOLDER = "query ";
 
   final String remoteServiceName;
   final boolean includeParameterValues;
@@ -30,6 +34,7 @@ final class TracingJdbcEventListener extends SimpleJdbcEventListener {
     // regardless of noop or not, set it in scope so that custom contexts can see it (like slf4j)
     if (!span.isNoop()) {
       String sql = includeParameterValues ? info.getSqlWithValues() : info.getSql();
+      if (sql == null) sql = QUERY_PLACEHOLDER;
       span.kind(Span.Kind.CLIENT).name(sql.substring(0, sql.indexOf(' ')));
       span.tag(TraceKeys.SQL_QUERY, sql);
       parseServerAddress(info.getConnectionInformation().getConnection(), span);

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -32,7 +32,7 @@ public class ITTracingP6Factory {
 
   ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
 
-  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE, spans).build();
   Connection connection;
 
   @Before
@@ -110,7 +110,8 @@ public class ITTracingP6Factory {
     }
   }
 
-  Tracing.Builder tracingBuilder(Sampler sampler) {
+  public static Tracing.Builder tracingBuilder(Sampler sampler,
+                                               ConcurrentLinkedDeque<Span> spans) {
     return Tracing.newBuilder()
         .reporter(spans::add)
         .currentTraceContext(new StrictCurrentTraceContext())

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/TracingJdbcEventListenerTest.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/TracingJdbcEventListenerTest.java
@@ -1,5 +1,6 @@
 package brave.p6spy;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -8,7 +9,14 @@ import brave.Span;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import brave.Tracing;
+import brave.sampler.Sampler;
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.common.StatementInformation;
 import org.junit.Test;
+
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -18,6 +26,8 @@ import zipkin.Endpoint;
 public class TracingJdbcEventListenerTest {
   @Mock Connection connection;
   @Mock DatabaseMetaData metaData;
+  @Mock StatementInformation statementInformation;
+  @Mock ConnectionInformation ci;
 
   @Mock Span span;
   String url = "jdbc:mysql://127.0.0.1:5555/mydatabase";
@@ -65,5 +75,25 @@ public class TracingJdbcEventListenerTest {
     when(connection.getMetaData()).thenThrow(new SQLException());
 
     verifyNoMoreInteractions(span);
+  }
+
+
+  @Test public void nullSqlWontNPE() throws SQLException {
+    ConcurrentLinkedDeque<zipkin.Span> spans = new ConcurrentLinkedDeque<>();
+    Tracing tracing = ITTracingP6Factory.tracingBuilder(Sampler.ALWAYS_SAMPLE, spans).build();
+
+    when(statementInformation.getSql()).thenReturn(null);
+    when(statementInformation.getConnectionInformation()).thenReturn(ci);
+    when(ci.getConnection()).thenReturn(connection);
+    when(connection.getMetaData()).thenReturn(metaData);
+    when(metaData.getURL()).thenReturn(url);
+
+    TracingJdbcEventListener listener = new TracingJdbcEventListener("", false);
+    listener.onBeforeAnyExecute(statementInformation);
+    listener.onAfterAnyExecute(statementInformation,1,null);
+
+    assertThat(spans)
+      .extracting(s -> s.name)
+      .containsExactly("query");
   }
 }


### PR DESCRIPTION
In rare cases, `p6spy` is unable to intercept the executed SQL properly.
This will then lead to an NPE in the
`TracingJdbcEventListener#onBeforeAnyExecute` method.
This change is adding a `null` check and will use `query` as the SQL
instead.

note: this is related to https://github.com/p6spy/p6spy/pull/385

cc @kristofa @adriancole 