### PR TITLE
Allows non-inheriting trace context

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -109,7 +109,7 @@ public abstract class Tracing implements Closeable {
     Reporter<zipkin.Span> reporter;
     Clock clock;
     Sampler sampler = Sampler.ALWAYS_SAMPLE;
-    CurrentTraceContext currentTraceContext = new CurrentTraceContext.Default();
+    CurrentTraceContext currentTraceContext = CurrentTraceContext.Default.inheritable();
     boolean traceId128Bit = false;
     Propagation.Factory propagationFactory = Propagation.Factory.B3;
 

--- a/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
+++ b/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
@@ -53,7 +53,7 @@ public class Log4JThreadContextTest {
   }
 
   static class Log4J2CurrentTraceContext extends CurrentTraceContext {
-    CurrentTraceContext delegate = new CurrentTraceContext.Default();
+    CurrentTraceContext delegate = CurrentTraceContext.Default.create();
 
     @Override public TraceContext get() {
       return delegate.get();

--- a/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
@@ -35,7 +35,7 @@ public class StrictCurrentTraceContextTest {
    * need to share a static instance explicitly.
    */
   @Test public void instancesAreIndependent() {
-    CurrentTraceContext.Default currentTraceContext2 = new CurrentTraceContext.Default();
+    CurrentTraceContext currentTraceContext2 = new StrictCurrentTraceContext();
 
     try (CurrentTraceContext.Scope scope1 = currentTraceContext.newScope(context)) {
       assertThat(currentTraceContext2.get()).isNull();

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
@@ -11,7 +11,7 @@ import org.apache.log4j.MDC;
  */
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
   public static MDCCurrentTraceContext create() {
-    return new MDCCurrentTraceContext(new Default());
+    return create(CurrentTraceContext.Default.inheritable());
   }
 
   public static MDCCurrentTraceContext create(CurrentTraceContext delegate) {

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.ThreadContext;
  */
 public final class ThreadContextCurrentTraceContext extends CurrentTraceContext {
   public static ThreadContextCurrentTraceContext create() {
-    return new ThreadContextCurrentTraceContext(new CurrentTraceContext.Default());
+    return create(CurrentTraceContext.Default.inheritable());
   }
 
   public static ThreadContextCurrentTraceContext create(CurrentTraceContext delegate) {

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -11,7 +11,7 @@ import org.slf4j.MDC;
  */
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
   public static MDCCurrentTraceContext create() {
-    return new MDCCurrentTraceContext(new CurrentTraceContext.Default());
+    return create(CurrentTraceContext.Default.inheritable());
   }
 
   public static MDCCurrentTraceContext create(CurrentTraceContext delegate) {


### PR DESCRIPTION
Eventhough convenience may mean an inheriting thread local is a good
choice, there are problems with this approach, such as the inability to
cleanup data. This encourages use of non-inheriting thread local w/o
changing the default.

fixes https://github.com/openzipkin/brave-opentracing/issues/48