### PR TITLE
Clears static references to Tracing after each test

### DIFF
--- a/archive/brave-core/src/test/java/brave/interop/MixedBraveVersionsExample.java
+++ b/archive/brave-core/src/test/java/brave/interop/MixedBraveVersionsExample.java
@@ -15,6 +15,7 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,6 +74,10 @@ public class MixedBraveVersionsExample {
         return new MockResponse();
       }
     });
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 
   @Test

--- a/archive/brave-core/src/test/java/brave/interop/TracerAdapterTest.java
+++ b/archive/brave-core/src/test/java/brave/interop/TracerAdapterTest.java
@@ -9,6 +9,7 @@ import com.twitter.zipkin.gen.Span;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Constants;
 
@@ -29,6 +30,10 @@ public class TracerAdapterTest {
       .build()
       .tracer();
   Brave brave3 = TracerAdapter.newBrave(brave4);
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @Test public void startWithLocalTracerAndFinishWithTracer() {
     SpanId spanId = brave3.localTracer().startNewSpan("codec", "encode", 1L);

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import brave.Tracing;
+import org.junit.After;
 
 public class Brave4ClientTracerTest extends ClientTracerTest {
   @Override Brave newBrave() {
@@ -9,5 +10,9 @@ public class Brave4ClientTracerTest extends ClientTracerTest {
         .localEndpoint(ZIPKIN_ENDPOINT)
         .clock(clock::currentTimeMicroseconds)
         .reporter(spans::add).build().tracer());
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import brave.Tracing;
+import org.junit.After;
 
 public class Brave4LocalTracerTest extends LocalTracerTest {
   @Override Brave newBrave() {
@@ -15,5 +16,9 @@ public class Brave4LocalTracerTest extends LocalTracerTest {
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
         .reporter(spans::add).build().tracer(), state);
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
@@ -1,11 +1,16 @@
 package com.github.kristofa.brave;
 
 import brave.Tracing;
+import org.junit.After;
 
 public class Brave4ServerRequestInterceptorTest extends ServerRequestInterceptorTest {
   @Override Brave newBrave() {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .localEndpoint(ZIPKIN_ENDPOINT)
         .reporter(spans::add).build().tracer());
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import brave.Tracing;
+import org.junit.After;
 
 public class Brave4ServerTracerTest extends ServerTracerTest {
   @Override Brave newBrave() {
@@ -8,5 +9,9 @@ public class Brave4ServerTracerTest extends ServerTracerTest {
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
         .reporter(spans::add).build().tracer());
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4Test.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4Test.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave;
 
 import brave.Tracing;
+import org.junit.After;
 
 public class Brave4Test extends BraveTest {
 
@@ -18,5 +19,9 @@ public class Brave4Test extends BraveTest {
 
   @Override protected Brave newBraveWith128BitTraceIds() {
     return TracerAdapter.newBrave(Tracing.newBuilder().traceId128Bit(true).build().tracer());
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
@@ -2,9 +2,14 @@ package com.github.kristofa.brave.internal;
 
 import brave.Tracing;
 import com.github.kristofa.brave.TracerAdapter;
+import org.junit.After;
 
 public class Brave4MaybeAddClientAddressTest extends MaybeAddClientAddressTest {
   public Brave4MaybeAddClientAddressTest() {
     brave = TracerAdapter.newBrave(Tracing.newBuilder().reporter(spans::add).build().tracer());
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
@@ -3,6 +3,7 @@ package brave;
 import brave.internal.Platform;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
@@ -18,6 +19,10 @@ public class CurrentSpanCustomizerTest {
   Tracing tracing = Tracing.newBuilder().reporter(spans::add).build();
   CurrentSpanCustomizer spanCustomizer = CurrentSpanCustomizer.create(tracing);
   Span span = tracing.tracer().newTrace();
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @Test public void name() {
     span.start();

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
@@ -34,6 +34,8 @@ public class CurrentTraceContextExecutorServiceTest {
   @After public void shutdownExecutor() throws InterruptedException {
     wrappedExecutor.shutdown();
     wrappedExecutor.awaitTermination(1, TimeUnit.SECONDS);
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
   }
 
   final TraceContext[] threadValues = new TraceContext[2];

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
@@ -28,6 +28,8 @@ public class CurrentTraceContextExecutorTest {
   @After public void shutdownExecutor() throws InterruptedException {
     wrappedExecutor.shutdown();
     wrappedExecutor.awaitTermination(1, TimeUnit.SECONDS);
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
   }
 
   @Test

--- a/brave/src/test/java/brave/CurrentTracingTest.java
+++ b/brave/src/test/java/brave/CurrentTracingTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,6 +16,11 @@ public class CurrentTracingTest {
   @Before
   public void reset() {
     Tracing.current = null;
+  }
+
+  @After public void close(){
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
   }
 
   @Test public void defaultsToNull() {

--- a/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/DefaultCurrentTraceContextTest.java
@@ -3,6 +3,7 @@ package brave;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.Callable;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,6 +13,10 @@ public class DefaultCurrentTraceContextTest {
   Tracer tracer = Tracing.newBuilder().build().tracer();
   TraceContext context = tracer.newTrace().context();
   TraceContext context2 = tracer.newTrace().context();
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @Test public void currentSpan_defaultsToNull() {
     assertThat(currentTraceContext.get()).isNull();

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -1,6 +1,7 @@
 package brave;
 
 import brave.sampler.Sampler;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Endpoint;
 
@@ -16,6 +17,10 @@ public class NoopSpanTest {
       })
       .build().tracer();
   Span span = tracer.newTrace();
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @Test public void isNoop() {
     assertThat(span.isNoop()).isTrue();

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -3,6 +3,7 @@ package brave;
 import brave.internal.Platform;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
@@ -16,6 +17,10 @@ public class RealSpanTest {
   Endpoint localEndpoint = Platform.get().localEndpoint();
   Tracer tracer = Tracing.newBuilder().reporter(spans::add).build().tracer();
   Span span = tracer.newTrace();
+
+  @After public void close() {
+    Tracing.current().close();
+  }
 
   @Test public void isNotNoop() {
     assertThat(span.isNoop()).isFalse();

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -5,6 +5,7 @@ import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Endpoint;
 
@@ -12,6 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TracerTest {
   Tracer tracer = Tracing.newBuilder().build().tracer();
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @Test public void sampler() {
     Sampler sampler = new Sampler() {

--- a/brave/src/test/java/brave/features/async/OneWaySpanTest.java
+++ b/brave/src/test/java/brave/features/async/OneWaySpanTest.java
@@ -13,6 +13,7 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,6 +65,10 @@ public class OneWaySpanTest {
         return new MockResponse();
       }
     });
+  }
+
+  @After public void close() {
+    Tracing.current().close();
   }
 
   @Test

--- a/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
+++ b/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
@@ -14,6 +14,7 @@ import com.twitter.finagle.tracing.TraceId;
 import com.twitter.io.Buf;
 import com.twitter.util.Local;
 import java.lang.reflect.Field;
+import org.junit.After;
 import org.junit.Test;
 import scala.Option;
 import scala.Some;
@@ -25,7 +26,6 @@ import static com.twitter.finagle.context.Contexts.broadcast;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FinagleContextInteropTest {
-
   @Test public void finagleBraveInterop() throws Exception {
     Tracer tracer = Tracing.newBuilder()
         .currentTraceContext(new FinagleCurrentTraceContext()).build().tracer();
@@ -80,6 +80,8 @@ public class FinagleContextInteropTest {
     // Outside a scope, trace context is consistent between finagle and brave
     assertThat(tracer.currentSpan()).isNull();
     assertThat(Trace.idOption().isDefined()).isFalse();
+
+    Tracing.current().close();
   }
 
   /**

--- a/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
+++ b/brave/src/test/java/brave/features/log4j2_context/Log4JThreadContextTest.java
@@ -48,6 +48,8 @@ public class Log4JThreadContextTest {
     }
     assertThat(ThreadContext.get("traceId"))
         .isNull();
+
+    Tracing.current().close();
   }
 
   static class Log4J2CurrentTraceContext extends CurrentTraceContext {

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Constants;
 
@@ -25,6 +26,10 @@ public class OpenTracingAdapterTest {
   List<zipkin.Span> spans = new ArrayList<>();
   Tracing brave = Tracing.newBuilder().reporter(spans::add).build();
   BraveTracer opentracing = BraveTracer.wrap(brave);
+
+  @After public void close() {
+    Tracing.current().close();
+  }
 
   @Test public void startWithOpenTracingAndFinishWithBrave() {
     io.opentracing.Span openTracingSpan = opentracing.buildSpan("encode")

--- a/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
+++ b/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
@@ -4,6 +4,7 @@ import brave.Tracing;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import io.grpc.Metadata;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +17,10 @@ public class NonStringPropagationKeysTest {
   );
   TraceContext.Extractor<Metadata> extractor = grpcPropagation.extractor(Metadata::get);
   TraceContext.Injector<Metadata> injector = grpcPropagation.injector(Metadata::put);
+
+  @After public void close() {
+    tracing.close();
+  }
 
   @Test
   public void injectExtractTraceContext() throws Exception {

--- a/brave/src/test/java/brave/internal/InternalTest.java
+++ b/brave/src/test/java/brave/internal/InternalTest.java
@@ -2,12 +2,17 @@ package brave.internal;
 
 import brave.Span;
 import brave.Tracing;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class InternalTest {
   Tracing tracing = Tracing.newBuilder().build();
+
+  @After public void close() {
+    Tracing.current().close();
+  }
 
   /**
    * Brave 3's LocalTracer.finish(duration) requires a read-back of the initial timestamp. While

--- a/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
+++ b/brave/src/test/java/brave/internal/StrictCurrentTraceContextTest.java
@@ -21,6 +21,10 @@ public class StrictCurrentTraceContextTest {
   TraceContext context = tracer.newTrace().context();
   TraceContext context2 = tracer.newTrace().context();
 
+  @After public void close() {
+    Tracing.current().close();
+  }
+
   @After public void after() throws InterruptedException {
     executor.shutdownNow();
     executor.awaitTermination(1, TimeUnit.SECONDS);

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
@@ -7,6 +7,7 @@ import java.lang.ref.Reference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Endpoint;
 
@@ -18,6 +19,10 @@ public class MutableSpanMapTest {
   TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
   MutableSpanMap map =
       new MutableSpanMap(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));
+
+  @After public void close() {
+    Tracing.current().close();
+  }
 
   @Test
   public void getOrCreate_lazyCreatesASpan() throws Exception {

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -4,6 +4,7 @@ import brave.Span;
 import brave.Tracing;
 import brave.internal.Platform;
 import brave.propagation.TraceContext;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.Endpoint;
@@ -17,6 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MutableSpanTest {
   Endpoint localEndpoint = Platform.get().localEndpoint();
   TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
+
+  @After public void close() {
+    Tracing.current().close();
+  }
 
   // zipkin needs one annotation or binary annotation so that the local endpoint can be read
   @Test public void addsLocalEndpoint() {

--- a/brave/src/test/java/brave/internal/recorder/RecorderTest.java
+++ b/brave/src/test/java/brave/internal/recorder/RecorderTest.java
@@ -7,6 +7,7 @@ import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
 import org.junit.Test;
 import zipkin.Endpoint;
 
@@ -18,6 +19,10 @@ public class RecorderTest {
   TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
   Recorder recorder =
       new Recorder(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));
+
+  @After public void close() {
+    Tracing.current().close();
+  }
 
   @Test public void finish_calculatesDuration() {
     recorder.start(context, 1L);

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
@@ -7,6 +7,7 @@ import brave.internal.HexCodec;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.MDC;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,5 +71,7 @@ public class MDCCurrentTraceContextTest {
         .isNull();
     assertThat(MDC.get("spanId"))
         .isNull();
+
+    Tracing.current().close();
   }
 }

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -69,5 +69,7 @@ public class ThreadContextCurrentTraceContextTest {
         .isNull();
     assertThat(ThreadContext.get("spanId"))
         .isNull();
+
+    Tracing.current().close();
   }
 }

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -70,5 +70,7 @@ public class MDCCurrentTraceContextTest {
         .isNull();
     assertThat(MDC.get("spanId"))
         .isNull();
+
+    Tracing.current().close();
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpClientBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpClientBenchmarks.java
@@ -73,6 +73,7 @@ public abstract class HttpClientBenchmarks<C> {
     close(unsampledClient);
     close(tracedClient);
     server.stop();
+    Tracing.current().close();
   }
 
   @Benchmark public void client_get() throws Exception {

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
@@ -1,5 +1,6 @@
 package brave.http;
 
+import brave.Tracing;
 import io.undertow.Undertow;
 import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
@@ -49,6 +50,7 @@ public abstract class HttpServerBenchmarks {
   @TearDown(Level.Trial) public void close() throws Exception {
     if (server != null) server.stop();
     client.dispatcher().executorService().shutdown();
+    Tracing.current().close();
   }
 
   protected int initServer() throws ServletException {

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
@@ -45,19 +45,20 @@ public class ITTracingClientInterceptor {
 
   ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
 
-  Tracing tracing;
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
   TestServer server = new TestServer();
   ManagedChannel client;
 
   @Before public void setup() throws IOException {
     server.start();
-    tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
     client = newClient();
   }
 
   @After public void close() throws Exception {
     closeClient(client);
     server.stop();
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
   }
 
   ManagedChannel newClient() {

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
@@ -95,6 +95,8 @@ public class ITTracingServerInterceptor {
       server.shutdown();
       server.awaitTermination();
     }
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
   }
 
   @Test

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
@@ -5,8 +5,10 @@ import brave.internal.StrictCurrentTraceContext;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
+import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import zipkin.Span;
@@ -22,6 +24,11 @@ public abstract class ITHttp {
 
   protected CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
   protected HttpTracing httpTracing;
+
+  @After public void close() throws IOException {
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
+  }
 
   Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -39,8 +39,9 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
   protected abstract void getAsync(C client, String pathIncludingQuery) throws Exception;
 
-  @After public void close() throws IOException {
+  @Override @After public void close() throws IOException {
     closeClient(client);
+    super.close();
   }
 
   @Test public void propagatesSpan() throws Exception {

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -5,6 +5,7 @@ import brave.Tracing;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +38,10 @@ public class HttpClientHandlerTest {
     handler = HttpClientHandler.create(httpTracing, adapter);
 
     when(adapter.method(request)).thenReturn("GET");
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 
   @Test public void handleSend_defaultsToMakeNewTrace() {

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -5,6 +5,7 @@ import brave.Tracing;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,10 @@ public class HttpServerHandlerTest {
 
     when(adapter.method(request)).thenReturn("GET");
     when(adapter.parseClientAddress(eq(request), anyObject())).thenCallRealMethod();
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 
   @Test public void handleReceive_defaultsToMakeNewTrace() {

--- a/instrumentation/http/src/test/java/brave/http/features/RequestSamplingTest.java
+++ b/instrumentation/http/src/test/java/brave/http/features/RequestSamplingTest.java
@@ -14,6 +14,7 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,6 +60,10 @@ public class RequestSamplingTest {
         }
       }
     }));
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 
   @Test public void serverDoesntTraceFoo() throws Exception {

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
@@ -5,6 +5,7 @@ import brave.http.HttpTracing;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,6 +18,10 @@ public class InjectionTest {
       bind(HttpTracing.class).toInstance(HttpTracing.create(Tracing.newBuilder().build()));
     }
   });
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @Test public void tracingClientFilter() throws Exception {
     assertThat(injector.getInstance(TracingClientFilter.class))

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TracingContainerFilterTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TracingContainerFilterTest.java
@@ -12,6 +12,7 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,10 @@ public class TracingContainerFilterTest {
   @Mock ContainerRequestContext context;
   @Mock UriInfo uriInfo;
   @Mock ResourceInfo resourceInfo;
+
+  @After public void close(){
+    Tracing.current().close();
+  }
 
   @GET
   @Path("foo")

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/DeclarativeSamplingTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/DeclarativeSamplingTest.java
@@ -37,6 +37,10 @@ public class DeclarativeSamplingTest extends ServletContainer {
         }
       })).build();
 
+  @After public void close(){
+    Tracing.current().close();
+  }
+
   @Path("")
   public static class Resource { // public for resteasy to inject
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/TracingInterceptorTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/TracingInterceptorTest.java
@@ -4,6 +4,7 @@ import brave.Span;
 import brave.Tracing;
 import brave.http.HttpTracing;
 import okhttp3.Connection;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,5 +27,9 @@ public class TracingInterceptorTest {
 
     verify(span).isNoop();
     verifyNoMoreInteractions(span);
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/TracingClientHttpRequestInterceptorAutowireTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/TracingClientHttpRequestInterceptorAutowireTest.java
@@ -2,6 +2,7 @@ package brave.spring.web;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -31,5 +32,9 @@ public class TracingClientHttpRequestInterceptorAutowireTest {
     ctx.refresh();
 
     ctx.getBean(ClientHttpRequestInterceptor.class);
+  }
+
+  @After public void close(){
+    Tracing.current().close();
   }
 }


### PR DESCRIPTION
A side-effect of `Tracing.newBuilder` is that it registers itself if no
other instance has been. This can create side-effects on tests that rely
on the current tracer, such as MySQL. This clears all tests that use
`Tracing.newBuilder` so they can't taint others.