### PR TITLE
update p6spy version, important because https://github.com/p6spy/p6sp…

### DIFF
--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <p6spy.version>3.0.0</p6spy.version>
+    <p6spy.version>3.2.0</p6spy.version>
     <derby.version>10.13.1.1</derby.version>
   </properties>
 


### PR DESCRIPTION
…y/pull/386 made that there was no way to exclude logging of binary content