### PR TITLE
Special-cases noop for zipkin 2 reporting

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -171,6 +171,11 @@ public abstract class Tracing implements Closeable {
     @Deprecated
     public Builder reporter(final Reporter<zipkin.Span> reporter) {
       if (reporter == null) throw new NullPointerException("reporter == null");
+      if (reporter == Reporter.NOOP) {
+        this.reporter = s -> {
+        };
+        return this;
+      }
       this.reporter = new Reporter<zipkin2.Span>() {
         @Override public void report(zipkin2.Span span) {
           reporter.report(V2SpanConverter.toSpan(span));

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpClientBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpClientBenchmarks.java
@@ -18,7 +18,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
-import zipkin.reporter.Reporter;
 
 import static io.undertow.util.Headers.CONTENT_TYPE;
 
@@ -61,10 +60,10 @@ public abstract class HttpClientBenchmarks<C> {
 
     client = newClient();
     tracedClient = newClient(HttpTracing.create(
-        Tracing.newBuilder().reporter(Reporter.NOOP).build()
+        Tracing.newBuilder().spanReporter(s -> {}).build()
     ));
     unsampledClient = newClient(HttpTracing.create(
-        Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+        Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(s -> {}).build()
     ));
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/jaxrs2/JaxRs2ServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jaxrs2/JaxRs2ServerBenchmarks.java
@@ -23,7 +23,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import zipkin.reporter.Reporter;
 
 public class JaxRs2ServerBenchmarks extends HttpServerBenchmarks {
 
@@ -45,7 +44,7 @@ public class JaxRs2ServerBenchmarks extends HttpServerBenchmarks {
   public static class Unsampled extends Application {
     @Override public Set<Object> getSingletons() {
       return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
-          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(s -> {}).build()
       )));
     }
   }
@@ -54,7 +53,7 @@ public class JaxRs2ServerBenchmarks extends HttpServerBenchmarks {
   public static class TracedApp extends Application {
     @Override public Set<Object> getSingletons() {
       return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
-          Tracing.newBuilder().reporter(Reporter.NOOP).build()
+          Tracing.newBuilder().spanReporter(s -> {}).build()
       )));
     }
   }

--- a/instrumentation/benchmarks/src/main/java/brave/servlet/ServletBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/servlet/ServletBenchmarks.java
@@ -20,7 +20,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import zipkin.reporter.Reporter;
 
 import static javax.servlet.DispatcherType.REQUEST;
 
@@ -37,14 +36,14 @@ public class ServletBenchmarks extends HttpServerBenchmarks {
   public static class Unsampled extends ForwardingTracingFilter {
     public Unsampled() {
       super(TracingFilter.create(
-          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(s -> {}).build()
       ));
     }
   }
 
   public static class Traced extends ForwardingTracingFilter {
     public Traced() {
-      super(TracingFilter.create(Tracing.newBuilder().reporter(Reporter.NOOP).build()));
+      super(TracingFilter.create(Tracing.newBuilder().spanReporter(s -> {}).build()));
     }
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/sparkjava/SparkBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/sparkjava/SparkBenchmarks.java
@@ -14,7 +14,6 @@ import spark.Response;
 import spark.Spark;
 import spark.servlet.SparkApplication;
 import spark.servlet.SparkFilter;
-import zipkin.reporter.Reporter;
 
 import static javax.servlet.DispatcherType.REQUEST;
 
@@ -29,7 +28,7 @@ public class SparkBenchmarks extends HttpServerBenchmarks {
 
   public static class Unsampled implements SparkApplication {
     SparkTracing sparkTracing = SparkTracing.create(
-        Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+        Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(s -> {}).build()
     );
 
     @Override
@@ -42,7 +41,7 @@ public class SparkBenchmarks extends HttpServerBenchmarks {
 
   public static class Traced implements SparkApplication {
     SparkTracing sparkTracing = SparkTracing.create(
-        Tracing.newBuilder().reporter(Reporter.NOOP).build()
+        Tracing.newBuilder().spanReporter(s -> {}).build()
     );
 
     @Override

--- a/instrumentation/benchmarks/src/main/java/brave/spring/webmvc/WebMvcBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/spring/webmvc/WebMvcBenchmarks.java
@@ -20,7 +20,6 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-import zipkin.reporter.Reporter;
 
 public class WebMvcBenchmarks extends HttpServerBenchmarks {
 
@@ -47,10 +46,10 @@ public class WebMvcBenchmarks extends HttpServerBenchmarks {
   static class SpringConfig extends WebMvcConfigurerAdapter {
     @Override public void addInterceptors(InterceptorRegistry registry) {
       registry.addInterceptor(TracingHandlerInterceptor.create(
-          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).reporter(Reporter.NOOP).build()
+          Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(s -> {}).build()
       )).addPathPatterns("/unsampled");
       registry.addInterceptor(TracingHandlerInterceptor.create(
-          Tracing.newBuilder().reporter(Reporter.NOOP).build()
+          Tracing.newBuilder().spanReporter(s -> {}).build()
       )).addPathPatterns("/traced");
     }
   }


### PR DESCRIPTION
Before, we were converting spans when passed a noop reporter. This skewed benchmarks.