### PR TITLE
Fixes span mapping when using Brave 3 bridge

### DIFF
--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/MaybeAddClientAddressTest.java
@@ -69,6 +69,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void kickOutIfExceptionParsingAddress() {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -90,6 +91,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void kickOutIfNullAddress() {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -111,6 +113,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void kickOutIfInvalidAddress() {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -132,6 +135,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void ignoreExceptionParsingPort() {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -154,6 +158,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void usesBlankServiceName() {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -175,6 +180,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void addsPort() {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -217,6 +223,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void acceptsIpv6() throws UnknownHostException {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     final byte[] ipv6 = Inet6Address.getByName("2001:db8::c001").getAddress();
 
@@ -242,6 +249,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void acceptsIpv4MappedIpV6Address() throws UnknownHostException {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -265,6 +273,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void acceptsIpv4CompatIpV6Address() throws UnknownHostException {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {
@@ -289,6 +298,7 @@ public class MaybeAddClientAddressTest {
   @Test
   public void acceptsIpV6Localhost() throws UnknownHostException {
     brave.serverTracer().setStateUnknown("foo");
+    brave.serverTracer().setServerReceived();
 
     MaybeAddClientAddress function = new MaybeAddClientAddress(brave) {
       @Override protected byte[] parseAddressBytes(Object input) {

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -44,7 +44,19 @@ final class MutableSpan {
   }
 
   synchronized MutableSpan annotate(long timestamp, String value) {
-    span.addAnnotation(timestamp, value);
+    if ("cs".equals(value)) {
+      span.kind(zipkin2.Span.Kind.CLIENT).timestamp(this.timestamp = timestamp);
+    } else if ("sr".equals(value)) {
+      span.kind(zipkin2.Span.Kind.SERVER).timestamp(this.timestamp = timestamp);
+    } else if ("cr".equals(value)) {
+      span.kind(zipkin2.Span.Kind.CLIENT);
+      finish(timestamp);
+    } else if ("ss".equals(value)) {
+      span.kind(zipkin2.Span.Kind.SERVER);
+      finish(timestamp);
+    } else {
+      span.addAnnotation(timestamp, value);
+    }
     return this;
   }
 

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -81,6 +81,28 @@ public class MutableSpanTest {
     assertThat(span2.kind()).isEqualTo(span2Kind);
   }
 
+  @Test
+  public void finished_client_annotation() {
+    finish("cs", "cr", Span.Kind.CLIENT);
+  }
+
+  @Test
+  public void finished_server_annotation() {
+    finish("sr", "ss", Span.Kind.SERVER);
+  }
+
+  private void finish(String start, String end, Span.Kind span2Kind) {
+    MutableSpan span = newSpan();
+    span.annotate(1L, start);
+    span.annotate(2L, end);
+
+    Span span2 = span.toSpan();
+    assertThat(span2.annotations()).isEmpty();
+    assertThat(span2.timestamp()).isEqualTo(1L);
+    assertThat(span2.duration()).isEqualTo(1L);
+    assertThat(span2.kind()).isEqualTo(span2Kind);
+  }
+
   @Test public void flushed_client() {
     flush(Kind.CLIENT, Span.Kind.CLIENT);
   }


### PR DESCRIPTION
Brave 3 doesn't know about Span.Kind. This reverse implements the core
annotations (RPC) so that old brave code completes properly when using
the new span reporter.