### PR TITLE
Adds EndToEndBenchmarks

### DIFF
--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -113,7 +113,8 @@ public final class B3Propagation<K> implements Propagation<K> {
       boolean debug = "1".equals(getter.get(carrier, propagation.debugKey));
 
       String traceIdString = getter.get(carrier, propagation.traceIdKey);
-      if (traceIdString == null) { // return early if there's no trace ID
+      String spanIdString = getter.get(carrier, propagation.spanIdKey);
+      if (traceIdString == null || spanIdString == null) { // return early if there's no trace ID
         return TraceContextOrSamplingFlags.create(
             new SamplingFlags.Builder().sampled(sampled).debug(debug).build()
         );
@@ -124,7 +125,6 @@ public final class B3Propagation<K> implements Propagation<K> {
           traceIdString.length() == 32 ? lowerHexToUnsignedLong(traceIdString, 0) : 0
       );
       result.traceId(lowerHexToUnsignedLong(traceIdString));
-      String spanIdString = getter.get(carrier, propagation.spanIdKey);
       if (spanIdString != null) {
         result.spanId(lowerHexToUnsignedLong(spanIdString));
       }

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -128,7 +128,7 @@ public abstract class TraceContext extends SamplingFlags {
     public abstract Builder spanId(long spanId);
 
     /** @see TraceContext#sampled */
-    public abstract Builder sampled(Boolean nullableSampled);
+    public abstract Builder sampled(@Nullable Boolean nullableSampled);
 
     /** @see TraceContext#debug() */
     public abstract Builder debug(boolean debug);

--- a/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
@@ -1,0 +1,120 @@
+package brave;
+
+import brave.http.HttpServerBenchmarks;
+import brave.okhttp3.TracingCallFactory;
+import brave.sampler.Sampler;
+import brave.servlet.TracingFilter;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.FilterInfo;
+import java.io.IOException;
+import java.util.Date;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import okhttp3.Call;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static javax.servlet.DispatcherType.REQUEST;
+
+/** Uses the canonical zipkin frontend-backend app, with the fastest components */
+public class EndToEndBenchmarks extends HttpServerBenchmarks {
+  static volatile int PORT;
+
+  static class HelloServlet extends HttpServlet {
+    final Call.Factory callFactory = new OkHttpClient();
+
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+        throws IOException {
+      resp.addHeader("Content-Type", "text/plain; charset=UTF-8");
+      // regardless of how we got here, if we are "api" we just return a string
+      if (req.getRequestURI().endsWith("/api")) {
+        resp.getWriter().println(new Date().toString());
+      } else {
+        Request request = new Request.Builder().url(new HttpUrl.Builder()
+            .scheme("http")
+            .host("127.0.0.1")
+            .port(PORT)
+            .encodedPath(req.getRequestURI() + "/api").build()).build();
+
+        // If we are tracing, we'll have a scoped call factory available
+        Call.Factory localCallFactory =
+            (Call.Factory) req.getAttribute(Call.Factory.class.getName());
+        if (localCallFactory == null) localCallFactory = callFactory;
+
+        resp.getWriter().println(localCallFactory.newCall(request).execute().body().string());
+      }
+    }
+  }
+
+  public static class Unsampled extends ForwardingTracingFilter {
+    public Unsampled() {
+      super(Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(s -> {
+      }).build());
+    }
+  }
+
+  public static class Traced extends ForwardingTracingFilter {
+    public Traced() {
+      super(Tracing.newBuilder().spanReporter(s -> {
+      }).build());
+    }
+  }
+
+  @Override protected void init(DeploymentInfo servletBuilder) {
+    servletBuilder.addFilter(new FilterInfo("Unsampled", Unsampled.class))
+        .addFilterUrlMapping("Unsampled", "/unsampled", REQUEST)
+        .addFilterUrlMapping("Unsampled", "/unsampled/api", REQUEST)
+        .addFilter(new FilterInfo("Traced", Traced.class))
+        .addFilterUrlMapping("Traced", "/traced", REQUEST)
+        .addFilterUrlMapping("Traced", "/traced/api", REQUEST)
+        .addServlets(Servlets.servlet("HelloServlet", HelloServlet.class).addMapping("/*"));
+  }
+
+  @Override protected int initServer() throws ServletException {
+    return PORT = super.initServer();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + EndToEndBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  static class ForwardingTracingFilter implements Filter {
+    final Filter delegate;
+    final Call.Factory callFactory;
+
+    public ForwardingTracingFilter(Tracing tracing) {
+      this.delegate = TracingFilter.create(tracing);
+      this.callFactory = TracingCallFactory.create(tracing, new OkHttpClient());
+    }
+
+    @Override public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+        FilterChain filterChain) throws IOException, ServletException {
+      servletRequest.setAttribute(Call.Factory.class.getName(), callFactory);
+      delegate.doFilter(servletRequest, servletResponse, filterChain);
+    }
+
+    @Override public void destroy() {
+    }
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
@@ -50,7 +50,7 @@ public abstract class HttpServerBenchmarks {
   @TearDown(Level.Trial) public void close() throws Exception {
     if (server != null) server.stop();
     client.dispatcher().executorService().shutdown();
-    Tracing.current().close();
+    if (Tracing.current() != null) Tracing.current().close();
   }
 
   protected int initServer() throws ServletException {
@@ -84,9 +84,16 @@ public abstract class HttpServerBenchmarks {
     get("/traced");
   }
 
+  @Benchmark public void tracedServer_get_resumeTrace() throws Exception {
+    client.newCall(new Request.Builder().url(baseUrl() + "/traced")
+        .header("X-B3-TraceId", "7180c278b62e8f6a216a2aea45d08fc9")
+        .header("X-B3-SpanId", "5b4185666d50f68b")
+        .header("X-B3-Sampled", "1")
+        .build())
+        .execute().body().close();
+  }
+
   void get(String path) throws IOException {
-    client.newCall(new Request.Builder().url(baseUrl() + path).build())
-        .execute()
-        .body().close();
+    client.newCall(new Request.Builder().url(baseUrl() + path).build()).execute().body().close();
   }
 }


### PR DESCRIPTION
This adds a benchmark of our canonical zipkin example. The goal is to 
show relative overhead, conceding some of this will be skewed a bit.

EndToEndBenchmarks takes the same approach as example projects like
https://github.com/openzipkin/sleuth-webmvc-example, using the fastest
components we have: currently servlet and okhttp instrumentation.

the benchmark runner calls http://localhost:PORT/BASEPATH which calls http://localhost:PORT/BASEPATH/api
This simulates a simple ingress -> egress scenario

EndToEndBenchmarks include the following:

* server_get - uninstrumented baseline
* tracedServer_get - server starts and propagates a new trace
* tracedServer_get_resumeTrace - server resumes an existing trace
* unsampledServer_get - server doesn't sample, but propagates

Here's a sample run:
```
Benchmark                                        Mode  Cnt    Score   Error  Units
EndToEndBenchmarks.server_get                    avgt   15  141.483 ± 9.793  us/op
EndToEndBenchmarks.tracedServer_get              avgt   15  160.231 ± 3.479  us/op
EndToEndBenchmarks.tracedServer_get_resumeTrace  avgt   15  165.453 ± 7.216  us/op
EndToEndBenchmarks.unsampledServer_get           avgt   15  153.022 ± 4.111  us/op
```

In this case, it appears resuming a trace takes longer than starting a 
new one. While this can be explained, having benchmarks allow us to 
drive numbers down relatively objectively.
