### PR TITLE
Adds Propagation.Factory.supportsJoin

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -214,6 +214,16 @@ public abstract class Tracing implements Closeable {
       return this;
     }
 
+    /**
+     * Controls how trace contexts are injected or extracted from remote requests, such as from http
+     * headers. Defaults to {@link Propagation.Factory#B3}
+     */
+    public Builder propagationFactory(Propagation.Factory propagationFactory) {
+      if (propagationFactory == null) throw new NullPointerException("propagationFactory == null");
+      this.propagationFactory = propagationFactory;
+      return this;
+    }
+
     /** When true, new root spans will have 128-bit trace IDs. Defaults to false (64-bit) */
     public Builder traceId128Bit(boolean traceId128Bit) {
       this.traceId128Bit = traceId128Bit;

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -11,6 +11,15 @@ import static brave.internal.HexCodec.lowerHexToUnsignedLong;
  * Implements <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
  */
 public final class B3Propagation<K> implements Propagation<K> {
+  public static final class Factory extends Propagation.Factory {
+    @Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+      return B3Propagation.create(keyFactory);
+    }
+
+    @Override public boolean supportsJoin() {
+      return true;
+    }
+  }
 
   public static <K> B3Propagation<K> create(KeyFactory<K> keyFactory) {
     return new B3Propagation<>(keyFactory);

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -20,10 +20,26 @@ import javax.annotation.Nullable;
 public interface Propagation<K> {
   Propagation<String> B3_STRING = Propagation.Factory.B3.create(Propagation.KeyFactory.STRING);
 
-  interface Factory {
-    Factory B3 = B3Propagation::create;
+  abstract class Factory {
+    public static final Factory B3 = new B3Propagation.Factory();
 
-    <K> Propagation<K> create(KeyFactory<K> keyFactory);
+    /**
+     * Does the propagation implementation support sharing client and server span IDs. For example,
+     * should an RPC server span share the same identifiers extracted from an incoming request?
+     *
+     * In usual <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>, the
+     * parent span ID is sent across the wire so that the client and server can share the same
+     * identifiers. Other propagation formats, like <a href="https://github.com/TraceContext/tracecontext-spec">trace-context</a>
+     * only propagate the calling trace and span ID, with an assumption that the receiver always
+     * starts a new child span. When join is supported, you can assume that when {@link
+     * TraceContext#parentId() the parent span ID} is null, you've been propagated a root span. When
+     * join is not supported, you must always fork a new child.
+     */
+    public boolean supportsJoin() {
+      return false;
+    }
+
+    public abstract <K> Propagation<K> create(KeyFactory<K> keyFactory);
   }
 
   /** Creates keys for use in propagated contexts */


### PR DESCRIPTION
This adds the ability to inspect if a propagation implementation can
support tracing where client and server share the same span ID. This is
important for alternative mechanisms such as X-Ray or Trace-Context
which do not propagate parent information.

Later pull requests will attempt to integrate another trace propagation
implementation using this.

Fixes #483