### PR TITLE
Prefers zipkin reporter2

### DIFF
--- a/archive/brave-core/pom.xml
+++ b/archive/brave-core/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>zipkin-reporter</artifactId>
       <version>${zipkin-reporter.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${zipkin-reporter2.version}</version>
+    </dependency>
     <!-- for value types... don't worry. this dependency is compile only! -->
     <dependency>
         <groupId>com.google.auto.value</groupId>

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/AbstractSpanCollector.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Implemented {@link #sendSpans} to transport a encoded list of spans to Zipkin.
  *
- * @deprecated replaced by {@link zipkin.reporter.AsyncReporter}
+ * @deprecated replaced by {@link zipkin2.reporter.AsyncReporter}
  */
 @Deprecated
 public abstract class AbstractSpanCollector extends FlushingSpanCollector {

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollector.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollector.java
@@ -7,7 +7,7 @@ import com.twitter.zipkin.gen.Span;
  * 
  * @author adriaens
  *
- * @deprecated replaced by {@link zipkin.reporter.Reporter#NOOP}.
+ * @deprecated replaced by {@link zipkin2.reporter.Reporter#NOOP}.
  */
 @Deprecated
 public class EmptySpanCollector implements SpanCollector {

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollectorMetricsHandler.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/EmptySpanCollectorMetricsHandler.java
@@ -3,7 +3,7 @@ package com.github.kristofa.brave;
 
 /**
  * Empty implementation ignoring all events.
- * @deprecated Replaced by {@code zipkin.reporter.ReporterMetrics#NOOP_METRICS}
+ * @deprecated Replaced by {@code zipkin2.reporter.ReporterMetrics#NOOP_METRICS}
  */
 @Deprecated
 public class EmptySpanCollectorMetricsHandler implements SpanCollectorMetricsHandler {

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/FlushingSpanCollector.java
@@ -20,7 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * Extend this class to offload the task of reporting spans to separate thread. By doing so, callers
  * are protected from latency or exceptions possible when exporting spans out of process.
  *
- * @deprecated replaced by {@link zipkin.reporter.AsyncReporter}
+ * @deprecated replaced by {@link zipkin2.reporter.AsyncReporter}
  */
 @Deprecated
 public abstract class FlushingSpanCollector implements SpanCollector, Flushable, Closeable {

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanCollector.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanCollector.java
@@ -8,7 +8,7 @@ import com.twitter.zipkin.gen.Span;
  * 
  * @author kristof
  *
- * @deprecated replaced by {@link zipkin.reporter.Reporter}
+ * @deprecated replaced by {@link zipkin2.reporter.Reporter}
  */
 @Deprecated
 public interface SpanCollector {

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorMetricsHandler.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorMetricsHandler.java
@@ -4,7 +4,7 @@ package com.github.kristofa.brave;
  * Monitor {@linkplain SpanCollector} by implementing reactions to these events, e.g. updating suitable metrics.
  *
  * See DropwizardMetricsScribeCollectorMetricsHandlerExample in isSampled sources for an example.
- * @deprecated Replaced by {@code zipkin.reporter.ReporterMetrics}
+ * @deprecated Replaced by {@code zipkin2.reporter.ReporterMetrics}
  */
 @Deprecated
 public interface SpanCollectorMetricsHandler {

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
@@ -2,6 +2,8 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
+import zipkin.Span;
+import zipkin.reporter.Reporter;
 
 public class Brave4ClientTracerTest extends ClientTracerTest {
   @Override Brave newBrave() {
@@ -9,7 +11,7 @@ public class Brave4ClientTracerTest extends ClientTracerTest {
         .clock(new AnnotationSubmitter.DefaultClock()::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
         .clock(clock::currentTimeMicroseconds)
-        .reporter(spans::add).build().tracer());
+        .reporter((Reporter<Span>) spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
@@ -2,20 +2,22 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
+import zipkin.Span;
+import zipkin.reporter.Reporter;
 
 public class Brave4LocalTracerTest extends LocalTracerTest {
   @Override Brave newBrave() {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build().tracer());
+        .reporter((Reporter<Span>) spans::add).build().tracer());
   }
 
   @Override Brave newBrave(ServerClientAndLocalSpanState state) {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build().tracer(), state);
+        .reporter((Reporter<Span>) spans::add).build().tracer(), state);
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
@@ -2,12 +2,14 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
+import zipkin.Span;
+import zipkin.reporter.Reporter;
 
 public class Brave4ServerRequestInterceptorTest extends ServerRequestInterceptorTest {
   @Override Brave newBrave() {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build().tracer());
+        .reporter((Reporter<Span>) spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
@@ -2,13 +2,15 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
+import zipkin.Span;
+import zipkin.reporter.Reporter;
 
 public class Brave4ServerTracerTest extends ServerTracerTest {
   @Override Brave newBrave() {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add).build().tracer());
+        .reporter((Reporter<Span>) spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
@@ -3,10 +3,13 @@ package com.github.kristofa.brave.internal;
 import brave.Tracing;
 import com.github.kristofa.brave.TracerAdapter;
 import org.junit.After;
+import zipkin.Span;
+import zipkin.reporter.Reporter;
 
 public class Brave4MaybeAddClientAddressTest extends MaybeAddClientAddressTest {
   public Brave4MaybeAddClientAddressTest() {
-    brave = TracerAdapter.newBrave(Tracing.newBuilder().reporter(spans::add).build().tracer());
+    brave = TracerAdapter.newBrave(
+        Tracing.newBuilder().reporter((Reporter<Span>) spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-spancollector-http/src/main/java/com/github/kristofa/brave/http/HttpSpanCollector.java
+++ b/archive/brave-spancollector-http/src/main/java/com/github/kristofa/brave/http/HttpSpanCollector.java
@@ -15,8 +15,8 @@ import java.util.zip.GZIPOutputStream;
 /**
  * SpanCollector which submits spans to Zipkin, using its {@code POST /spans} endpoint.
  *
- * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code URLConnectionSender}
- *             located in the "io.zipkin.reporter:zipkin-sender-urlconnection" dependency.
+ * @deprecated replaced by {@link zipkin2.reporter.AsyncReporter} and {@code URLConnectionSender}
+ *             located in the "io.zipkin.reporter2:zipkin-sender-urlconnection" dependency.
  */
 @Deprecated
 public final class HttpSpanCollector extends AbstractSpanCollector {

--- a/archive/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
+++ b/archive/brave-spancollector-kafka/src/main/java/com/github/kristofa/brave/kafka/KafkaSpanCollector.java
@@ -18,8 +18,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
  *
  * <p><b>Important</b> If using zipkin-collector-service (or zipkin-receiver-kafka), you must run v1.35+
  *
- * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code KafkaSender}
- *             located in the "io.zipkin.reporter:zipkin-sender-kafka08" dependency.
+ * @deprecated replaced by {@link zipkin2.reporter.AsyncReporter} and {@code KafkaSender}
+ *             located in the "io.zipkin.reporter2:zipkin-sender-kafka11" dependency.
  */
 @Deprecated
 public final class KafkaSpanCollector extends AbstractSpanCollector {

--- a/archive/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
+++ b/archive/brave-spancollector-local/src/main/java/com/github/kristofa/brave/local/LocalSpanCollector.java
@@ -17,8 +17,7 @@ import static com.github.kristofa.brave.internal.DefaultSpanCodec.toZipkin;
 /**
  * SpanCollector which submits spans directly to a Zipkin {@link StorageComponent}.
  *
- * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code LocalSender}
- *             located in the "io.zipkin.reporter:zipkin-sender-local" dependency.
+ * @deprecated this is a niche component, please use something else
  */
 @Deprecated
 public final class LocalSpanCollector extends FlushingSpanCollector {

--- a/archive/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
+++ b/archive/brave-spancollector-scribe/src/main/java/com/github/kristofa/brave/scribe/ScribeSpanCollector.java
@@ -34,13 +34,11 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  *
  * @author kristof
  *
- * @deprecated replaced by {@link zipkin.reporter.AsyncReporter} and {@code LibthriftSender}
- *             located in the "io.zipkin.reporter:zipkin-sender-libthrift" dependency.
+ * @deprecated scribe is an archived transport. Please change to something else
  */
 @Deprecated
 public class ScribeSpanCollector implements SpanCollector, Closeable {
 
-    private static final String UTF_8 = "UTF-8";
     private static final Logger LOGGER = Logger.getLogger(ScribeSpanCollector.class.getName());
 
     private final BlockingQueue<Span> spanQueue;

--- a/brave/README.md
+++ b/brave/README.md
@@ -19,13 +19,13 @@ http (as opposed to Kafka).
 
 ```java
 // Configure a reporter, which controls how often spans are sent
-//   (the dependency is io.zipkin.reporter:zipkin-sender-okhttp3)
-sender = OkHttpSender.json("http://127.0.0.1:9411/api/v2/spans");
-spanReporter = AsyncReporter.v2(sender);
+//   (the dependency is io.zipkin.reporter2:zipkin-sender-okhttp3)
+sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
+spanReporter = AsyncReporter.create(sender);
 // Create a tracing component with the service name you want to see in Zipkin.
 tracing = Tracing.newBuilder()
                  .localServiceName("my-service")
-                 .spanReporter(spanReporter)
+                 .reporter(reporter)
                  .build();
 
 // Tracing exposes objects you might need, most importantly the tracer
@@ -477,7 +477,7 @@ ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
 
 Tracing tracing = Tracing.newBuilder()
                  .currentTraceContext(new StrictCurrentTraceContext())
-                 .reporter(spans::add)
+                 .reporter((Reporter<Span>) spans::add)
                  .build();
 
   @After public void close() {

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -29,6 +29,11 @@
       <version>${zipkin-reporter.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${zipkin-reporter2.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
       <version>1.0</version>

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -12,8 +12,8 @@ import brave.sampler.Sampler;
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 /**
  * Using a tracer, you can create a root span capturing the critical path of a request. Child spans
@@ -76,14 +76,21 @@ public final class Tracer {
 
     /** @deprecated use {@link #spanReporter(Reporter)} */
     @Deprecated
-    public Builder reporter(Reporter<zipkin.Span> reporter) {
+    public Builder reporter(zipkin.reporter.Reporter<zipkin.Span> reporter) {
       delegate.reporter(reporter);
       return this;
     }
 
-    /** @see Tracing.Builder#spanReporter(Reporter) */
-    public Builder spanReporter(Reporter<zipkin2.Span> reporter) {
+    /** @deprecated use {@link #spanReporter(Reporter)} */
+    @Deprecated
+    public Builder spanReporter(zipkin.reporter.Reporter<zipkin2.Span> reporter) {
       delegate.spanReporter(reporter);
+      return this;
+    }
+
+    /** @see Tracing.Builder#reporter(Reporter) */
+    public Builder spanReporter(Reporter<zipkin2.Span> reporter) {
+      delegate.reporter(reporter);
       return this;
     }
 

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -11,8 +11,8 @@ import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jvnet.animal_sniffer.IgnoreJRERequirement;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 /**
  * Access to platform-specific features and implements a default logging reporter.

--- a/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
@@ -11,8 +11,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 /**
  * Similar to Finagle's deadline span map, except this is GC pressure as opposed to timeout driven.

--- a/brave/src/main/java/brave/internal/recorder/Recorder.java
+++ b/brave/src/main/java/brave/internal/recorder/Recorder.java
@@ -5,8 +5,8 @@ import brave.Span;
 import brave.propagation.TraceContext;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 /** Dispatches mutations on a span to a shared object per trace/span id. */
 public final class Recorder {

--- a/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
@@ -1,21 +1,19 @@
 package brave;
 
-import brave.internal.Platform;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.Annotation;
-import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 public class CurrentSpanCustomizerTest {
 
-  Endpoint localEndpoint = Platform.get().localEndpoint();
   List<zipkin2.Span> spans = new ArrayList();
-  Tracing tracing = Tracing.newBuilder().spanReporter(spans::add).build();
+  Tracing tracing = Tracing.newBuilder().reporter((Reporter<zipkin2.Span>) spans::add).build();
   CurrentSpanCustomizer spanCustomizer = CurrentSpanCustomizer.create(tracing);
   Span span = tracing.tracer().newTrace();
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.1.3.Final</resteasy.version>
     <zipkin.version>2.0.1</zipkin.version>
+    <zipkin-reporter2.version>2.0.0</zipkin-reporter2.version>
     <zipkin-reporter.version>1.1.1</zipkin-reporter.version>
     <finagle.version>6.45.0</finagle.version>
     <log4j.version>2.8.2</log4j.version>

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -11,7 +11,7 @@ Bean Factories exist for the following types:
 
 Here are some example beans using the factories in this module:
 ```xml
-  <bean id="sender" class="zipkin.reporter.okhttp3.OkHttpSender" factory-method="json"
+  <bean id="sender" class="zipkin.reporter2.okhttp3.OkHttpSender" factory-method="create"
       destroy-method="close">
     <constructor-arg type="String" value="http://localhost:9411/api/v2/spans"/>
   </bean>

--- a/spring-beans/src/main/java/brave/spring/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/AsyncReporterFactoryBean.java
@@ -2,15 +2,15 @@ package brave.spring.beans;
 
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
-import zipkin.reporter.AsyncReporter;
-import zipkin.reporter.ReporterMetrics;
-import zipkin.reporter.Sender;
-import zipkin.reporter.SpanEncoder;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ReporterMetrics;
+import zipkin2.reporter.Sender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class AsyncReporterFactoryBean extends AbstractFactoryBean<AsyncReporter> {
   Sender sender;
-  SpanEncoder encoder = SpanEncoder.JSON_V1;
+  SpanBytesEncoder encoder = SpanBytesEncoder.JSON_V1;
   ReporterMetrics metrics;
   Integer messageMaxBytes;
   Integer messageTimeout;
@@ -45,7 +45,7 @@ public class AsyncReporterFactoryBean extends AbstractFactoryBean<AsyncReporter>
     this.sender = sender;
   }
 
-  public void setEncoder(SpanEncoder encoder) {
+  public void setEncoder(SpanBytesEncoder encoder) {
     this.encoder = encoder;
   }
 

--- a/spring-beans/src/main/java/brave/spring/beans/TracingFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/TracingFactoryBean.java
@@ -5,15 +5,16 @@ import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import brave.sampler.Sampler;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class TracingFactoryBean extends AbstractFactoryBean<Tracing> {
 
   String localServiceName;
   Endpoint localEndpoint;
-  Reporter<zipkin2.Span> reporter, spanReporter;
+  Reporter<Span> reporter;
   Clock clock;
   Sampler sampler;
   CurrentTraceContext currentTraceContext;
@@ -23,8 +24,7 @@ public class TracingFactoryBean extends AbstractFactoryBean<Tracing> {
     Tracing.Builder builder = Tracing.newBuilder();
     if (localServiceName != null) builder.localServiceName(localServiceName);
     if (localEndpoint != null) builder.localEndpoint(localEndpoint);
-    if (spanReporter != null) builder.spanReporter(spanReporter);
-    if (reporter != null) builder.spanReporter(reporter);
+    if (reporter != null) builder.reporter(reporter);
     if (clock != null) builder.clock(clock);
     if (sampler != null) builder.sampler(sampler);
     if (currentTraceContext != null) builder.currentTraceContext(currentTraceContext);
@@ -52,12 +52,8 @@ public class TracingFactoryBean extends AbstractFactoryBean<Tracing> {
     this.localEndpoint = localEndpoint;
   }
 
-  public void setReporter(Reporter<zipkin2.Span> reporter) {
+  public void setReporter(Reporter<Span> reporter) {
     this.reporter = reporter;
-  }
-
-  public void setSpanReporter(Reporter<zipkin2.Span> spanReporter) {
-    this.spanReporter = spanReporter;
   }
 
   public void setClock(Clock clock) {

--- a/spring-beans/src/test/java/brave/spring/beans/AsyncReporterFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/AsyncReporterFactoryBeanTest.java
@@ -3,11 +3,11 @@ package brave.spring.beans;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Test;
-import zipkin.reporter.AsyncReporter;
-import zipkin.reporter.Encoding;
-import zipkin.reporter.ReporterMetrics;
-import zipkin.reporter.Sender;
-import zipkin.reporter.SpanEncoder;
+import zipkin2.codec.Encoding;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ReporterMetrics;
+import zipkin2.reporter.Sender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -155,6 +155,6 @@ public class AsyncReporterFactoryBeanTest {
 
     assertThat(context.getBean(AsyncReporter.class))
         .extracting("encoder")
-        .containsExactly(SpanEncoder.JSON_V2);
+        .containsExactly(SpanBytesEncoder.JSON_V2);
   }
 }

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -7,7 +7,7 @@ import brave.sampler.Sampler;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.Endpoint;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -61,7 +61,7 @@ public class TracingFactoryBeanTest {
     context = new XmlBeans(""
         + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
         + "  <property name=\"reporter\">\n"
-        + "    <util:constant static-field=\"zipkin.reporter.Reporter.CONSOLE\"/>\n"
+        + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
         + "  </property>\n"
         + "</bean>"
     );


### PR DESCRIPTION
This prefers `zipkin.reporter2` artifacts, as they can lead us to a
place where zipkin v1 deps are optional. That isn't the case now, but
can be started on.