### PR TITLE
Clarifies close instructions

### DIFF
--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -11,8 +11,7 @@ Bean Factories exist for the following types:
 
 Here are some example beans using the factories in this module:
 ```xml
-  <bean id="sender" class="zipkin.reporter2.okhttp3.OkHttpSender" factory-method="create"
-      destroy-method="close">
+  <bean id="sender" class="zipkin.reporter2.okhttp3.OkHttpSender" factory-method="create">
     <constructor-arg type="String" value="http://localhost:9411/api/v2/spans"/>
   </bean>
 

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -21,6 +21,21 @@ public class TracingFactoryBeanTest {
     if (context != null) context.close();
   }
 
+  @Test public void autoCloses() {
+    context = new XmlBeans(""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\"/>\n"
+    );
+    context.refresh();
+
+    assertThat(Tracing.current()).isNotNull();
+
+    context.close();
+
+    assertThat(Tracing.current()).isNull();
+
+    context = null;
+  }
+
   @Test public void localServiceName() {
     context = new XmlBeans(""
         + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"


### PR DESCRIPTION
The README on the core library doesn't say why close is needed. This
fixes that and other places where instructions were too loose.

Spring automatically detects closeable things, so removed explicitness
there.