### PR TITLE
Makes traceIdHigh convertable to AWS X-Ray

### DIFF
--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
@@ -50,7 +50,7 @@ abstract class SpanFactory {
       long newSpanId = randomGenerator().nextLong();
       if (maybeParent == null) { // new trace
         return Brave.toSpan(SpanId.builder()
-            .traceIdHigh(traceId128Bit() ? randomGenerator().nextLong() : 0L)
+            .traceIdHigh(traceId128Bit() ? nextTraceIdHigh(randomGenerator()) : 0L)
             .traceId(newSpanId)
             .spanId(newSpanId)
             .sampled(sampler().isSampled(newSpanId))
@@ -77,6 +77,13 @@ abstract class SpanFactory {
         return Brave.toSpan(context);
       }
     }
+  }
+
+  static long nextTraceIdHigh(Random prng) {
+    long epochSeconds = System.currentTimeMillis() / 1000;
+    int random = prng.nextInt();
+    return (epochSeconds & 0xffffffffL) << 32
+        |  (random & 0xffffffffL);
   }
 }
 

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -240,7 +240,7 @@ public final class Tracer {
     return TraceContext.newBuilder()
         .sampled(sampled)
         .debug(samplingFlags.debug())
-        .traceIdHigh(traceId128Bit ? Platform.get().randomLong() : 0L).traceId(nextId)
+        .traceIdHigh(traceId128Bit ? Platform.get().nextTraceIdHigh() : 0L).traceId(nextId)
         .spanId(nextId).build();
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
@@ -72,6 +72,12 @@ public class EndToEndBenchmarks extends HttpServerBenchmarks {
     }
   }
 
+  public static class Traced128 extends ForwardingTracingFilter {
+    public Traced128() {
+      super(Tracing.newBuilder().traceId128Bit(true).spanReporter(Reporter.NOOP).build());
+    }
+  }
+
   @Override protected void init(DeploymentInfo servletBuilder) {
     servletBuilder.addFilter(new FilterInfo("Unsampled", Unsampled.class))
         .addFilterUrlMapping("Unsampled", "/unsampled", REQUEST)
@@ -79,6 +85,9 @@ public class EndToEndBenchmarks extends HttpServerBenchmarks {
         .addFilter(new FilterInfo("Traced", Traced.class))
         .addFilterUrlMapping("Traced", "/traced", REQUEST)
         .addFilterUrlMapping("Traced", "/traced/api", REQUEST)
+        .addFilter(new FilterInfo("Traced128", Traced128.class))
+        .addFilterUrlMapping("Traced128", "/traced128", REQUEST)
+        .addFilterUrlMapping("Traced128", "/traced128/api", REQUEST)
         .addServlets(Servlets.servlet("HelloServlet", HelloServlet.class).addMapping("/*"));
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
@@ -86,7 +86,20 @@ public abstract class HttpServerBenchmarks {
 
   @Benchmark public void tracedServer_get_resumeTrace() throws Exception {
     client.newCall(new Request.Builder().url(baseUrl() + "/traced")
-        .header("X-B3-TraceId", "7180c278b62e8f6a216a2aea45d08fc9")
+        .header("X-B3-TraceId", "216a2aea45d08fc9")
+        .header("X-B3-SpanId", "5b4185666d50f68b")
+        .header("X-B3-Sampled", "1")
+        .build())
+        .execute().body().close();
+  }
+
+  @Benchmark public void traced128Server_get() throws Exception {
+    get("/traced128");
+  }
+
+  @Benchmark public void traced128Server_get_resumeTrace() throws Exception {
+    client.newCall(new Request.Builder().url(baseUrl() + "/traced128")
+        .header("X-B3-TraceId", "5759e988b62e8f6a216a2aea45d08fc9")
         .header("X-B3-SpanId", "5b4185666d50f68b")
         .header("X-B3-Sampled", "1")
         .build())

--- a/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class PlatformBenchmarks {
+  static final Platform jre6 = Platform.Jre6.build(false);
+  static final Platform jre7 = Platform.Jre7.buildIfSupported(false);
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public long no_contention_nextTraceIdHigh_jre6() {
+    return jre6.nextTraceIdHigh();
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public long mild_contention_nextTraceIdHigh_jre6() {
+    return jre6.nextTraceIdHigh();
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public long high_contention_nextTraceIdHigh_jre6() {
+    return jre6.nextTraceIdHigh();
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public long no_contention_randomLong_jre6() {
+    return jre6.randomLong();
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public long mild_contention_randomLong_jre6() {
+    return jre6.randomLong();
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public long high_contention_randomLong_jre6() {
+    return jre6.randomLong();
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public long no_contention_nextTraceIdHigh_jre7() {
+    return jre7.nextTraceIdHigh();
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public long mild_contention_nextTraceIdHigh_jre7() {
+    return jre7.nextTraceIdHigh();
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public long high_contention_nextTraceIdHigh_jre7() {
+    return jre7.nextTraceIdHigh();
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public long no_contention_randomLong_jre7() {
+    return jre7.randomLong();
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public long mild_contention_randomLong_jre7() {
+    return jre7.randomLong();
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public long high_contention_randomLong_jre7() {
+    return jre7.randomLong();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + PlatformBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
This customizes the trace ID generator to make the high bits convertable
to Amazon X-Ray trace ID format v1.

See https://github.com/openzipkin/zipkin/issues/1754