### PR TITLE
Allows extraction of just a trace ID (not span ID) from an incoming request

### DIFF
--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -134,14 +134,12 @@ public final class B3Propagation<K> implements Propagation<K> {
           traceIdString.length() == 32 ? lowerHexToUnsignedLong(traceIdString, 0) : 0
       );
       result.traceId(lowerHexToUnsignedLong(traceIdString));
-      if (spanIdString != null) {
-        result.spanId(lowerHexToUnsignedLong(spanIdString));
-      }
+      result.spanId(lowerHexToUnsignedLong(spanIdString));
       String parentSpanIdString = getter.get(carrier, propagation.parentSpanIdKey);
       if (parentSpanIdString != null) {
         result.parentId(lowerHexToUnsignedLong(parentSpanIdString));
       }
-      return TraceContextOrSamplingFlags.create(result);
+      return TraceContextOrSamplingFlags.create(result.build());
     }
   }
 }

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -5,7 +5,13 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Union type that contains either a trace context or sampling flags, but not both.
+ * Union type that contains only one of trace context, trace ID context or sampling flags.
+ *
+ * <pre><ul>
+ *   <li>If you have the trace and span ID, use {@link #create(TraceContext)}</li>
+ *   <li>If you have only a trace ID, use {@link #create(TraceIdContext)}</li>
+ *   <li>Otherwise, use {@link #create(SamplingFlags)}</li>
+ * </ul></pre>
  *
  * <p>This is a port of {@code com.github.kristofa.brave.TraceData}, which served the same purpose.
  *
@@ -14,30 +20,38 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class TraceContextOrSamplingFlags {
-
   /** When present, create the span via {@link brave.Tracer#joinSpan(TraceContext)} */
   @Nullable public abstract TraceContext context();
+
+  /** When present, create the span via {@link brave.Tracer#newTrace(TraceIdContext)} */
+  @Nullable public abstract TraceIdContext traceIdContext();
 
   /** When present, create the span via {@link brave.Tracer#newTrace(SamplingFlags)} */
   @Nullable public abstract SamplingFlags samplingFlags();
 
-  public static TraceContextOrSamplingFlags create(SamplingFlags flags) {
-    return new AutoValue_TraceContextOrSamplingFlags(null, flags);
-  }
-
   public static TraceContextOrSamplingFlags create(TraceContext context) {
-    return new AutoValue_TraceContextOrSamplingFlags(context, null);
+    return new AutoValue_TraceContextOrSamplingFlags(context, null, null);
   }
 
+  public static TraceContextOrSamplingFlags create(TraceIdContext traceIdContext) {
+    return new AutoValue_TraceContextOrSamplingFlags(null, traceIdContext, null);
+  }
+
+  public static TraceContextOrSamplingFlags create(SamplingFlags flags) {
+    return new AutoValue_TraceContextOrSamplingFlags(null, null, flags);
+  }
+
+  /** @deprecated call one of the other factory methods vs allocating an exception */
+  @Deprecated
   public static TraceContextOrSamplingFlags create(TraceContext.Builder builder) {
     if (builder == null) throw new NullPointerException("builder == null");
     try {
-      return new AutoValue_TraceContextOrSamplingFlags(builder.build(), null);
+      return new AutoValue_TraceContextOrSamplingFlags(builder.build(), null, null);
     } catch (IllegalStateException e) { // no trace IDs, but it might have sampling flags
       SamplingFlags flags = new SamplingFlags.Builder()
           .sampled(builder.sampled())
           .debug(builder.debug()).build();
-      return new AutoValue_TraceContextOrSamplingFlags(null, flags);
+      return new AutoValue_TraceContextOrSamplingFlags(null, null, flags);
     }
   }
 

--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -1,0 +1,68 @@
+package brave.propagation;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import static brave.internal.HexCodec.writeHexLong;
+
+/**
+ * Contains inbound trace ID and sampling flags, used when users control the root trace ID, but not
+ * the span ID (ex Amazon X-Ray or other correlation).
+ */
+@Immutable
+@AutoValue
+public abstract class TraceIdContext extends SamplingFlags {
+
+  public static Builder newBuilder() {
+    return new AutoValue_TraceIdContext.Builder().traceIdHigh(0L).debug(false);
+  }
+
+  /** When non-zero, the trace containing this span uses 128-bit trace identifiers. */
+  public abstract long traceIdHigh();
+
+  /** Unique 8-byte identifier for a trace, set on all spans within it. */
+  public abstract long traceId();
+
+  // override as auto-value can't currently read the super-class's nullable annotation.
+  @Override @Nullable public abstract Boolean sampled();
+
+  public abstract Builder toBuilder();
+
+  /** Returns {@code $traceId} */
+  @Override
+  public String toString() {
+    boolean traceHi = traceIdHigh() != 0;
+    char[] result = new char[traceHi ? 32 : 16];
+    int pos = 0;
+    if (traceHi) {
+      writeHexLong(result, pos, traceIdHigh());
+      pos += 16;
+    }
+    writeHexLong(result, pos, traceId());
+    return new String(result);
+  }
+
+  @AutoValue.Builder
+  public static abstract class Builder {
+    /** @see TraceIdContext#traceIdHigh() */
+    public abstract Builder traceIdHigh(long traceIdHigh);
+
+    /** @see TraceIdContext#traceId() */
+    public abstract Builder traceId(long traceId);
+
+    /** @see TraceIdContext#sampled */
+    public abstract Builder sampled(@Nullable Boolean nullableSampled);
+
+    /** @see TraceIdContext#debug() */
+    public abstract Builder debug(boolean debug);
+
+    public abstract TraceIdContext build();
+
+    Builder() { // no external implementations
+    }
+  }
+
+  TraceIdContext() { // no external implementations
+  }
+}

--- a/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
@@ -8,51 +8,73 @@ public class TraceContextOrSamplingFlagsTest {
 
   @Test public void contextWhenIdsAreSet() {
     TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).spanId(1L);
-    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder.build());
 
-    assertThat(contextOrFlags.context())
+    assertThat(extracted.context())
         .isEqualTo(builder.build());
-    assertThat(contextOrFlags.samplingFlags())
+    assertThat(extracted.traceIdContext())
+        .isNull();
+    assertThat(extracted.samplingFlags())
         .isNull();
   }
 
   @Test public void contextWhenIdsAndSamplingAreSet() {
     TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).spanId(1L).sampled(true);
-    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder.build());
 
-    assertThat(contextOrFlags.context())
+    assertThat(extracted.context())
         .isEqualTo(builder.build());
-    assertThat(contextOrFlags.samplingFlags())
+    assertThat(extracted.traceIdContext())
+        .isNull();
+    assertThat(extracted.samplingFlags())
         .isNull();
   }
 
-  @Test public void flagsWhenMissingTraceId() {
-    TraceContext.Builder builder = TraceContext.newBuilder().spanId(1L);
-    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+  @Test  @Deprecated public void contextWhenTraceIdAndSampledAreSet() {
+    TraceIdContext.Builder builder = TraceIdContext.newBuilder().traceId(333L).sampled(true);
+    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder.build());
 
-    assertThat(contextOrFlags.context())
+    assertThat(extracted.context())
         .isNull();
-    assertThat(contextOrFlags.samplingFlags())
+    assertThat(extracted.traceIdContext())
+        .isEqualTo(builder.build());
+    assertThat(extracted.samplingFlags())
+        .isNull();
+  }
+
+  @Test @Deprecated public void deprecatedFlagsWhenMissingTraceId() {
+    TraceContext.Builder builder = TraceContext.newBuilder().spanId(1L);
+    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder);
+
+    assertThat(extracted.context())
+        .isNull();
+    assertThat(extracted.traceIdContext())
+        .isNull();
+    assertThat(extracted.samplingFlags())
         .isSameAs(SamplingFlags.EMPTY);
   }
 
-  @Test public void flagsWhenMissingSpanId() {
+  @Test  @Deprecated public void deprecatedFlagsWhenMissingSpanId() {
     TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).sampled(true);
-    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder);
 
-    assertThat(contextOrFlags.context())
+    assertThat(extracted.context())
         .isNull();
-    assertThat(contextOrFlags.samplingFlags())
+    assertThat(extracted.traceIdContext())
+        .isNull();
+    assertThat(extracted.samplingFlags())
         .isSameAs(SamplingFlags.SAMPLED);
   }
 
   @Test public void flags() {
-    TraceContext.Builder builder = TraceContext.newBuilder().sampled(true);
-    TraceContextOrSamplingFlags contextOrFlags = TraceContextOrSamplingFlags.create(builder);
+    TraceContextOrSamplingFlags extracted =
+        TraceContextOrSamplingFlags.create(SamplingFlags.SAMPLED);
 
-    assertThat(contextOrFlags.context())
+    assertThat(extracted.context())
         .isNull();
-    assertThat(contextOrFlags.samplingFlags())
+    assertThat(extracted.traceIdContext())
+        .isNull();
+    assertThat(extracted.samplingFlags())
         .isSameAs(SamplingFlags.SAMPLED);
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceIdContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceIdContextTest.java
@@ -1,0 +1,29 @@
+package brave.propagation;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceIdContextTest {
+  TraceIdContext context = TraceIdContext.newBuilder().traceId(333L).build();
+
+  @Test public void compareUnequalIds() {
+    assertThat(context)
+        .isNotEqualTo(context.toBuilder().traceIdHigh(222L).build());
+  }
+
+  @Test public void compareEqualIds() {
+    assertThat(context)
+        .isEqualTo(TraceIdContext.newBuilder().traceId(333L).build());
+  }
+
+  @Test public void testToString_lo() {
+    assertThat(context.toString())
+        .isEqualTo("000000000000014d");
+  }
+
+  @Test public void testToString() {
+    assertThat(context.toBuilder().traceIdHigh(222L).build().toString())
+        .isEqualTo("00000000000000de000000000000014d");
+  }
+}

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -45,11 +45,13 @@ public final class KafkaTracing {
    * available.
    */
   public Span joinSpan(ConsumerRecord record) {
-    TraceContextOrSamplingFlags contextOrSamplingFlags = extractor.extract(record.headers());
-    if (contextOrSamplingFlags.context() != null) {
-      return tracing.tracer().toSpan(contextOrSamplingFlags.context());
+    TraceContextOrSamplingFlags extracted = extractor.extract(record.headers());
+    if (extracted.context() != null) {
+      return tracing.tracer().toSpan(extracted.context()); // avoid creating an unnecessary child
+    } else if (extracted.traceIdContext() != null) {
+      return tracing.tracer().newTrace(extracted.traceIdContext());
     } else {
-      return tracing.tracer().newTrace(contextOrSamplingFlags.samplingFlags());
+      return tracing.tracer().newTrace(extracted.samplingFlags());
     }
   }
 

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -2,11 +2,17 @@ package brave.kafka.clients;
 
 import brave.Tracing;
 import brave.internal.HexCodec;
+import brave.propagation.Propagation;
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.propagation.TraceIdContext;
 import brave.sampler.Sampler;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.github.charithe.kafka.KafkaJunitRule;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.Future;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,12 +24,14 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import zipkin2.Span;
-import zipkin2.reporter.Reporter;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 public class ITKafkaTracing {
 
@@ -35,16 +43,18 @@ public class ITKafkaTracing {
   LinkedList<Span> producerSpans = new LinkedList<>();
 
   KafkaTracing consumerTracing = KafkaTracing.create(Tracing.newBuilder()
-      .spanReporter((Reporter<Span>) consumerSpans::add)
+      .spanReporter(consumerSpans::add)
       .sampler(Sampler.ALWAYS_SAMPLE)
       .build());
   KafkaTracing producerTracing = KafkaTracing.create(Tracing.newBuilder()
-      .spanReporter((Reporter<Span>) producerSpans::add)
+      .spanReporter(producerSpans::add)
       .sampler(Sampler.ALWAYS_SAMPLE)
       .build());
 
+  @ClassRule
+  public static KafkaJunitRule kafkaRule = new KafkaJunitRule(EphemeralKafkaBroker.create());
   @Rule
-  public KafkaJunitRule kafkaRule = new KafkaJunitRule(EphemeralKafkaBroker.create());
+  public TestName testName = new TestName();
 
   @After
   public void close() throws Exception {
@@ -53,12 +63,12 @@ public class ITKafkaTracing {
   }
 
   @Test
-  public void produce_and_consume_kafka_message_continues_a_trace() throws Exception {
+  public void continues_a_trace() throws Exception {
     Producer<String, String> tracingProducer = createTracingProducer();
     Consumer<String, String> tracingConsumer = createTracingConsumer();
 
     Future<RecordMetadata> send =
-        tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE));
+        tracingProducer.send(new ProducerRecord<>(testName.getMethodName(), TEST_KEY, TEST_VALUE));
     // Block for synchronous send
     send.get();
 
@@ -72,15 +82,90 @@ public class ITKafkaTracing {
         .isEqualTo(producerSpans.getFirst().traceId());
 
     for (ConsumerRecord<String, String> record : records) {
-      brave.Span span = consumerTracing.joinSpan(record);
-      assertThat(HexCodec.toLowerHex(span.context().parentId()))
-          .isEqualTo(producerSpans.getLast().traceId());
+      TraceContext joined = consumerTracing.joinSpan(record).context();
+
+      Span consumerSpan = consumerSpans.getLast();
+      assertThat(joined.traceIdString()).isEqualTo(consumerSpan.traceId());
+      assertThat(HexCodec.toLowerHex(joined.spanId())).isEqualTo(consumerSpan.id());
+      assertThat(HexCodec.toLowerHex(joined.parentId())).isEqualTo(consumerSpan.parentId());
+    }
+  }
+
+  static class TraceIdOnlyPropagation<K> implements Propagation<K> {
+    final K key;
+
+    TraceIdOnlyPropagation(Propagation.KeyFactory<K> keyFactory){
+      key = keyFactory.create("x-b3-traceid");
+    }
+
+    @Override public List<K> keys() {
+      return Collections.singletonList(key);
+    }
+
+    @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+      return (traceContext, carrier) -> setter.put(carrier, key, traceContext.traceIdString());
+    }
+
+    @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+      return carrier -> {
+        String result = getter.get(carrier, key);
+        if (result == null) return TraceContextOrSamplingFlags.create(SamplingFlags.EMPTY);
+        return TraceContextOrSamplingFlags.create(TraceIdContext.newBuilder()
+            .traceId(lowerHexToUnsignedLong(result))
+            .build());
+      };
+    }
+  }
+
+  @Test
+  public void continues_a_trace_when_only_trace_id_propagated() throws Exception {
+    consumerTracing = KafkaTracing.create(Tracing.newBuilder()
+        .spanReporter(consumerSpans::add)
+        .propagationFactory(new Propagation.Factory() {
+          @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+            return new TraceIdOnlyPropagation<>(keyFactory);
+          }
+        })
+        .sampler(Sampler.ALWAYS_SAMPLE)
+        .build());
+    producerTracing = KafkaTracing.create(Tracing.newBuilder()
+        .spanReporter(producerSpans::add)
+        .propagationFactory(new Propagation.Factory() {
+          @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+            return new TraceIdOnlyPropagation<>(keyFactory);
+          }
+        })
+        .sampler(Sampler.ALWAYS_SAMPLE)
+        .build());
+
+    Producer<String, String> tracingProducer = createTracingProducer();
+    Consumer<String, String> tracingConsumer = createTracingConsumer();
+
+    Future<RecordMetadata> send =
+        tracingProducer.send(new ProducerRecord<>(testName.getMethodName(), TEST_KEY, TEST_VALUE));
+    // Block for synchronous send
+    send.get();
+
+    ConsumerRecords<String, String> records = tracingConsumer.poll(10000);
+
+    assertThat(records).hasSize(1);
+    assertThat(producerSpans).hasSize(1);
+    assertThat(consumerSpans).hasSize(1);
+
+    assertThat(consumerSpans.getFirst().traceId())
+        .isEqualTo(producerSpans.getFirst().traceId());
+
+    for (ConsumerRecord<String, String> record : records) {
+      TraceContext joined = consumerTracing.joinSpan(record).context();
+
+      Span consumerSpan = consumerSpans.getLast();
+      assertThat(joined.traceIdString()).isEqualTo(consumerSpan.traceId());
     }
   }
 
   Consumer<String, String> createTracingConsumer() {
     KafkaConsumer<String, String> consumer = kafkaRule.helper().createStringConsumer();
-    consumer.assign(Collections.singleton(new TopicPartition(TEST_TOPIC, 0)));
+    consumer.assign(Collections.singleton(new TopicPartition(testName.getMethodName(), 0)));
     return consumerTracing.consumer(consumer);
   }
 


### PR DESCRIPTION
`Extractor.extract` returns a union type `TraceContextOrSamplingFlags` which
contains one of:
* `TraceContext` if trace and span IDs were present.
* `TraceIdContext` if a trace ID was present, but not span IDs.
* `SamplingFlags` if no identifiers were present

`TraceIdContext` is new to this change and allows you to work with pre-ordained trace IDs, such as are present in `x-amzn-trace-id` header when a request originates from an ELB.