### PR TITLE
Adds Tracing.Builder.supportsJoin to disable span ID sharing

### DIFF
--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -186,6 +186,15 @@ public class Brave {
             return this;
         }
 
+        /**
+         * True means the tracing system supports sharing a span ID on {@link
+         * ServerTracer#setStateCurrentTrace}. Defaults to true.
+         */
+        public Builder supportsJoin(boolean supportsJoin) {
+            this.spanFactoryBuilder.supportsJoin(supportsJoin);
+            return this;
+        }
+
         public Brave build() {
             if (spanFactory == null) {
                 spanFactory = spanFactoryBuilder.build();

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
@@ -24,6 +24,7 @@ abstract class SpanFactory {
     static Builder builder() {
       return new AutoValue_SpanFactory_Default.Builder()
           .traceId128Bit(false)
+          .supportsJoin(true)
           .randomGenerator(new Random())
           .sampler(Sampler.ALWAYS_SAMPLE);
     }
@@ -35,6 +36,8 @@ abstract class SpanFactory {
 
       Builder traceId128Bit(boolean traceId128Bit);
 
+      Builder supportsJoin(boolean supportsJoin);
+
       Builder sampler(Sampler sampler);
 
       Default build();
@@ -43,6 +46,8 @@ abstract class SpanFactory {
     abstract Random randomGenerator();
 
     abstract boolean traceId128Bit();
+
+    abstract boolean supportsJoin();
 
     abstract Sampler sampler();
 
@@ -64,6 +69,7 @@ abstract class SpanFactory {
     }
 
     @Override Span joinSpan(SpanId context) {
+      if (!supportsJoin()) return nextSpan(context);
       // If the sampled flag was left unset, we need to make the decision here
       if (context.sampled() == null) {
         return Brave.toSpan(context.toBuilder()

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
@@ -2,15 +2,15 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
-import zipkin.Span;
-import zipkin.reporter.Reporter;
 
 public class Brave4ServerTracerTest extends ServerTracerTest {
-  @Override Brave newBrave() {
+  @Override Brave newBrave(boolean supportsJoin) {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter((Reporter<Span>) spans::add).build().tracer());
+        .reporter(spans::add)
+        .supportsJoin(supportsJoin)
+        .build().tracer());
   }
 
   @After public void close(){

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -111,6 +111,12 @@ public final class Tracer {
       return this;
     }
 
+    /** @see Tracing.Builder#supportsJoin(boolean) */
+    public Builder supportsJoin(boolean supportsJoin) {
+      delegate.supportsJoin(supportsJoin);
+      return this;
+    }
+
     public Tracer build() {
       return delegate.build().tracer();
     }
@@ -126,7 +132,7 @@ public final class Tracer {
 
   Tracer(Tracing.Builder builder, AtomicBoolean noop) {
     this.noop = noop;
-    this.supportsJoin = builder.propagationFactory.supportsJoin();
+    this.supportsJoin = builder.supportsJoin && builder.propagationFactory.supportsJoin();
     this.clock = builder.clock;
     this.recorder = new Recorder(builder.localEndpoint, clock, builder.reporter, this.noop);
     this.sampler = builder.sampler;

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -111,6 +111,7 @@ public abstract class Tracing implements Closeable {
     Sampler sampler = Sampler.ALWAYS_SAMPLE;
     CurrentTraceContext currentTraceContext = CurrentTraceContext.Default.inheritable();
     boolean traceId128Bit = false;
+    boolean supportsJoin = true;
     Propagation.Factory propagationFactory = Propagation.Factory.B3;
 
     /**
@@ -225,6 +226,24 @@ public abstract class Tracing implements Closeable {
     /** When true, new root spans will have 128-bit trace IDs. Defaults to false (64-bit) */
     public Builder traceId128Bit(boolean traceId128Bit) {
       this.traceId128Bit = traceId128Bit;
+      return this;
+    }
+
+    /**
+     * True means the tracing system supports sharing a span ID between a {@link Span.Kind#CLIENT}
+     * and {@link Span.Kind#SERVER} span. Defaults to true.
+     *
+     * <p>Set this to false when the tracing system requires the opposite. For example, if
+     * ultimately spans are sent to Amazon X-Ray or Google Stackdriver Trace, you should set this to
+     * false.
+     *
+     * <p>This is implicitly set to false when {@link Propagation.Factory#supportsJoin()} is false,
+     * as in that case, sharing IDs isn't possible anyway.
+     *
+     * @see Propagation.Factory#supportsJoin()
+     */
+    public Builder supportsJoin(boolean supportsJoin) {
+      this.supportsJoin = supportsJoin;
       return this;
     }
 

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -127,6 +127,19 @@ public class TracerTest {
 
   @Test public void join_createsChildWhenUnsupported() {
     List<zipkin2.Span> spans = new ArrayList<>();
+    tracer = Tracing.newBuilder().supportsJoin(false).spanReporter(spans::add).build().tracer();
+
+    TraceContext fromIncomingRequest = tracer.newTrace().context();
+
+    TraceContext shouldBeChild = tracer.joinSpan(fromIncomingRequest).context();
+    assertThat(shouldBeChild.shared())
+        .isFalse();
+    assertThat(shouldBeChild.parentId())
+        .isEqualTo(fromIncomingRequest.spanId());
+  }
+
+  @Test public void join_createsChildWhenUnsupportedByPropagation() {
+    List<zipkin2.Span> spans = new ArrayList<>();
     tracer = Tracing.newBuilder()
         .propagationFactory(new Propagation.Factory(){
           @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {


### PR DESCRIPTION
Similar to ClientServerSameSpan in zipkin-go, this adds the ability to
opt out of span sharing between the client and server side of an RPC.
This is important when reporting to systems that do not share span IDs,
such as Google Stackdriver and Amazon X-Ray.

Note: this still defaults to true, in favor of existing Zipkin
implementations. See https://github.com/openzipkin/zipkin/issues/1480