### PR TITLE
Adds ExtraFieldPropagation

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -324,6 +324,31 @@ extracted = tracing.propagation().extractor(Request::getHeader);
 span = tracer.nextSpan(extracted, request);
 ```
 
+### Propagating extra fields
+
+Sometimes you need to propagate extra fields, such as a request ID or an alternate trace context.
+For example, if you are in a Cloud Foundry environment, you might want to pass the request ID:
+
+```java
+// when you initialize the builder, define the extra field you want to propagate
+tracingBuilder.propagationFactory(
+  ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-vcap-request-id")
+);
+
+// later, you can tag that request ID or use it in log correlation
+requestId = ExtraFieldPropagation.current("x-vcap-request-id");
+```
+
+You may also need to propagate a trace context you aren't using. For example, you may be in an
+Amazon Web Services environment, but not reporting data to X-Ray. To ensure X-Ray can co-exist
+correctly, pass-through its tracing header like so.
+
+```java
+tracingBuilder.propagationFactory(
+  ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-amzn-trace-id")
+);
+```
+
 ### Extracting a propagated context
 The `TraceContext.Extractor<C>` reads trace identifiers and sampling status
 from an incoming request or message. The carrier is usually a request object

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -1,0 +1,230 @@
+package brave.propagation;
+
+import brave.Tracing;
+import brave.propagation.TraceContext.Extractor;
+import brave.propagation.TraceContext.Injector;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Allows you to propagate predefined request-scoped fields, usually but not always HTTP headers.
+ *
+ * <p>For example, if you are in a Cloud Foundry environment, you might want to pass the request
+ * ID:
+ * <pre>{@code
+ * // when you initialize the builder, define the extra field you want to propagate
+ * tracingBuilder.propagationFactory(
+ *   ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-vcap-request-id")
+ * );
+ *
+ * // later, you can tag that request ID or use it in log correlation
+ * requestId = ExtraFieldPropagation.current("x-vcap-request-id");
+ * }</pre>
+ *
+ * <p>You may also need to propagate a trace context you aren't using. For example, you may be in an
+ * Amazon Web Services environment, but not reporting data to X-Ray. To ensure X-Ray can co-exist
+ * correctly, pass-through its tracing header like so.
+ *
+ * <pre>{@code
+ * tracingBuilder.propagationFactory(
+ *   ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-amzn-trace-id")
+ * );
+ * }</pre>
+ */
+public final class ExtraFieldPropagation<K> implements Propagation<K> {
+
+  /** Wraps an underlying propagation implementation, pushing one or more fields */
+  public static Propagation.Factory newFactory(Propagation.Factory delegate, String... names) {
+    return new Factory(delegate, Arrays.asList(names));
+  }
+
+  /** Wraps an underlying propagation implementation, pushing one or more fields */
+  public static Propagation.Factory newFactory(Propagation.Factory delegate, Collection<String> names) {
+    return new Factory(delegate, names);
+  }
+
+  /** Returns the value of the field with the specified key or null if not available */
+  @Nullable public static String current(String name) {
+    Tracing tracing = Tracing.current();
+    if (tracing == null) return null;
+    TraceContext context = tracing.currentTraceContext().get();
+    if (context == null) return null;
+    return get(context, name);
+  }
+
+  /** Returns the value of the field with the specified key or null if not available */
+  @Nullable public static String get(TraceContext context, String name) {
+    if (context == null) throw new NullPointerException("context == null");
+    if (name == null) throw new NullPointerException("name == null");
+    name = name.toLowerCase(Locale.ROOT); // since not all propagation handle mixed case
+    for (Object extra : context.extra()) {
+      if (extra instanceof Extra) return ((Extra) extra).get(name);
+    }
+    return null;
+  }
+
+  static final class Factory extends Propagation.Factory {
+    final Propagation.Factory delegate;
+    final List<String> names;
+
+    Factory(Propagation.Factory delegate, Collection<String> names) {
+      if (delegate == null) throw new NullPointerException("field == null");
+      if (names == null) throw new NullPointerException("names == null");
+      if (names.isEmpty()) throw new NullPointerException("names.length == 0");
+      this.delegate = delegate;
+      this.names = new ArrayList<>();
+      for (String name : names) {
+        this.names.add(name.toLowerCase(Locale.ROOT));
+      }
+    }
+
+    @Override public boolean supportsJoin() {
+      return delegate.supportsJoin();
+    }
+
+    @Override public boolean requires128BitTraceId() {
+      return delegate.requires128BitTraceId();
+    }
+
+    @Override public final <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+      Map<String, K> names = new LinkedHashMap<>();
+      for (String name : this.names) {
+        names.put(name, keyFactory.create(name));
+      }
+      return new ExtraFieldPropagation<>(delegate.create(keyFactory), names);
+    }
+  }
+
+  final Propagation<K> delegate;
+  final List<K> keys;
+  final Map<String, K> nameToKey;
+
+  ExtraFieldPropagation(Propagation<K> delegate, Map<String, K> nameToKey) {
+    this.delegate = delegate;
+    this.nameToKey = nameToKey;
+    List<K> keys = new ArrayList<>(delegate.keys());
+    keys.addAll(nameToKey.values());
+    this.keys = Collections.unmodifiableList(keys);
+  }
+
+  @Override public List<K> keys() {
+    return keys;
+  }
+
+  @Override public <C> Injector<C> injector(Setter<C, K> setter) {
+    return new ExtraFieldInjector<>(delegate.injector(setter), setter, nameToKey);
+  }
+
+  @Override public <C> Extractor<C> extractor(Getter<C, K> getter) {
+    Extractor<C> extractorDelegate = delegate.extractor(getter);
+    return new ExtraFieldExtractor<>(extractorDelegate, getter, nameToKey);
+  }
+
+  static abstract class Extra { // internal marker type
+    abstract void put(String field, String value);
+
+    abstract String get(String field);
+
+    abstract <C, K> void setAll(C carrier, Setter<C, K> setter, Map<String, K> nameToKey);
+  }
+
+  static final class One extends Extra {
+    String name, value;
+
+    @Override void put(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    @Override String get(String name) {
+      return name.equals(this.name) ? value : null;
+    }
+
+    @Override <C, K> void setAll(C carrier, Setter<C, K> setter, Map<String, K> nameToKey) {
+      K key = nameToKey.get(name);
+      if (key == null) return;
+      setter.put(carrier, key, value);
+    }
+  }
+
+  static final class Many extends Extra {
+    final LinkedHashMap<String, String> fields = new LinkedHashMap<>();
+
+    @Override void put(String name, String value) {
+      fields.put(name, value);
+    }
+
+    @Override String get(String name) {
+      return fields.get(name);
+    }
+
+    @Override <C, K> void setAll(C carrier, Setter<C, K> setter, Map<String, K> nameToKey) {
+      for (Map.Entry<String, String> field : fields.entrySet()) {
+        K key = nameToKey.get(field.getKey());
+        if (key == null) continue;
+        setter.put(carrier, nameToKey.get(field.getKey()), field.getValue());
+      }
+    }
+  }
+
+  static final class ExtraFieldInjector<C, K> implements Injector<C> {
+    final Injector<C> delegate;
+    final Propagation.Setter<C, K> setter;
+    final Map<String, K> nameToKey;
+
+    ExtraFieldInjector(Injector<C> delegate, Setter<C, K> setter, Map<String, K> nameToKey) {
+      this.delegate = delegate;
+      this.setter = setter;
+      this.nameToKey = nameToKey;
+    }
+
+    @Override public void inject(TraceContext traceContext, C carrier) {
+      for (Object extra : traceContext.extra()) {
+        if (extra instanceof Extra) {
+          ((Extra) extra).setAll(carrier, setter, nameToKey);
+          break;
+        }
+      }
+      delegate.inject(traceContext, carrier);
+    }
+  }
+
+  static final class ExtraFieldExtractor<C, K> implements Extractor<C> {
+    final Extractor<C> delegate;
+    final Propagation.Getter<C, K> getter;
+    final Map<String, K> names;
+
+    ExtraFieldExtractor(Extractor<C> delegate, Getter<C, K> getter, Map<String, K> names) {
+      this.delegate = delegate;
+      this.getter = getter;
+      this.names = names;
+    }
+
+    @Override public TraceContextOrSamplingFlags extract(C carrier) {
+      TraceContextOrSamplingFlags result = delegate.extract(carrier);
+
+      Extra extra = null;
+      for (Map.Entry<String, K> field : names.entrySet()) {
+        String maybeValue = getter.get(carrier, field.getValue());
+        if (maybeValue == null) continue;
+        if (extra == null) {
+          extra = new One();
+        } else if (extra instanceof One) {
+          One one = (One) extra;
+          extra = new Many();
+          extra.put(one.name, one.value);
+        }
+        extra.put(field.getKey(), maybeValue);
+      }
+      if (extra == null) return result;
+      return result.toBuilder().addExtra(extra).build();
+    }
+  }
+}

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -1,0 +1,128 @@
+package brave.propagation;
+
+import brave.Tracing;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static brave.propagation.Propagation.Factory.B3;
+import static brave.propagation.Propagation.KeyFactory.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExtraFieldPropagationTest {
+  Propagation.Factory factory =
+      ExtraFieldPropagation.newFactory(B3, "x-vcap-request-id", "x-amzn-trace-id");
+  Map<String, String> carrier = new LinkedHashMap<>();
+  TraceContext.Injector<Map<String, String>> injector = factory.create(STRING).injector(Map::put);
+  TraceContext.Extractor<Map<String, String>> extractor =
+      factory.create(STRING).extractor(Map::get);
+
+  String awsTraceId =
+      "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1";
+  String uuid = "f4308d05-2228-4468-80f6-92a8377ba193";
+
+  TraceContext context = TraceContext.newBuilder()
+      .traceId(1L)
+      .spanId(2L)
+      .sampled(true)
+      .build();
+
+  @Test public void get() throws Exception {
+    context = contextWithAmazonTraceId();
+
+    assertThat(ExtraFieldPropagation.get(context, "x-amzn-trace-id"))
+        .isEqualTo(awsTraceId);
+  }
+
+  @Test public void get_null_if_not_extraField() throws Exception {
+    assertThat(ExtraFieldPropagation.get(context, "x-amzn-trace-id"))
+        .isNull();
+  }
+
+  @Test public void current() throws Exception {
+    context = contextWithAmazonTraceId();
+
+    try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build();
+         CurrentTraceContext.Scope scope = t.currentTraceContext().newScope(context)) {
+      assertThat(ExtraFieldPropagation.current("x-amzn-trace-id"))
+          .isEqualTo(awsTraceId);
+    }
+  }
+
+  @Test public void current_null_if_no_current_context() throws Exception {
+    try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build()) {
+      assertThat(ExtraFieldPropagation.current("x-amzn-trace-id"))
+          .isNull();
+    }
+  }
+
+  @Test public void current_null_if_nothing_current() throws Exception {
+    assertThat(ExtraFieldPropagation.current("x-amzn-trace-id"))
+        .isNull();
+  }
+
+  @Test public void inject_one() throws Exception {
+    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.One();
+    extra.put("x-vcap-request-id", uuid);
+    context = context.toBuilder().extra(Collections.singletonList(extra)).build();
+
+    injector.inject(context, carrier);
+
+    assertThat(carrier).containsEntry("x-vcap-request-id", uuid);
+  }
+
+  @Test public void inject_two() throws Exception {
+    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.Many();
+    extra.put("x-amzn-trace-id", awsTraceId);
+    extra.put("x-vcap-request-id", uuid);
+    context = context.toBuilder().extra(Collections.singletonList(extra)).build();
+
+    injector.inject(context, carrier);
+
+    assertThat(carrier)
+        .containsEntry("x-amzn-trace-id", awsTraceId)
+        .containsEntry("x-vcap-request-id", uuid);
+  }
+
+  @Test public void extract_one() throws Exception {
+    Propagation.B3_STRING.<Map<String, String>>injector(Map::put).inject(context, carrier);
+    carrier.put("x-amzn-trace-id", awsTraceId);
+
+    TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
+    assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
+        .isEqualTo(context);
+    assertThat(extracted.context().extra())
+        .hasSize(1);
+
+    ExtraFieldPropagation.One one = (ExtraFieldPropagation.One) extracted.context().extra().get(0);
+    assertThat(one.name)
+        .isEqualTo("x-amzn-trace-id");
+    assertThat(one.value)
+        .isEqualTo(awsTraceId);
+  }
+
+  @Test public void extract_two() throws Exception {
+    Propagation.B3_STRING.<Map<String, String>>injector(Map::put).inject(context, carrier);
+    carrier.put("x-amzn-trace-id", awsTraceId);
+    carrier.put("x-vcap-request-id", uuid);
+
+    TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
+    assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
+        .isEqualTo(context);
+    assertThat(extracted.context().extra())
+        .hasSize(1);
+
+    ExtraFieldPropagation.Many many =
+        (ExtraFieldPropagation.Many) extracted.context().extra().get(0);
+    assertThat(many.fields)
+        .containsEntry("x-amzn-trace-id", awsTraceId)
+        .containsEntry("x-vcap-request-id", uuid);
+  }
+
+  TraceContext contextWithAmazonTraceId() {
+    Propagation.B3_STRING.<Map<String, String>>injector(Map::put).inject(context, carrier);
+    carrier.put("x-amzn-trace-id", awsTraceId);
+    return extractor.extract(carrier).context();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/internal/PropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/PropagationBenchmarks.java
@@ -13,6 +13,8 @@
  */
 package brave.internal;
 
+import brave.propagation.B3Propagation;
+import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Extractor;
@@ -37,6 +39,8 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import static brave.propagation.Propagation.KeyFactory.STRING;
+
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
 @Fork(3)
@@ -44,15 +48,23 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
 public class PropagationBenchmarks {
+  static final Propagation<String> b3 = Propagation.B3_STRING;
+  static final Propagation<String> aws = AWSPropagation.FACTORY.create(STRING);
+  static final Propagation<String> b3ExtraAws = ExtraFieldPropagation.newFactory(
+      B3Propagation.FACTORY, aws.keys()
+  ).create(STRING);
+  static final Propagation<String> awsExtraB3 = ExtraFieldPropagation.newFactory(
+      AWSPropagation.FACTORY, b3.keys()
+  ).create(STRING);
 
-  static final Injector<Map<String, String>> b3Injector =
-      Propagation.B3_STRING.injector(Map::put);
-  static final Injector<Map<String, String>> awsInjector =
-      AWSPropagation.FACTORY.create(Propagation.KeyFactory.STRING).injector(Map::put);
-  static final Extractor<Map<String, String>> b3Extractor =
-      Propagation.B3_STRING.extractor(Map::get);
-  static final Extractor<Map<String, String>> awsExtractor =
-      AWSPropagation.FACTORY.create(Propagation.KeyFactory.STRING).extractor(Map::get);
+  static final Injector<Map<String, String>> b3Injector = b3.injector(Map::put);
+  static final Injector<Map<String, String>> awsInjector = aws.injector(Map::put);
+  static final Injector<Map<String, String>> b3ExtraAwsInjector = b3ExtraAws.injector(Map::put);
+  static final Injector<Map<String, String>> awsExtraB3Injector = awsExtraB3.injector(Map::put);
+  static final Extractor<Map<String, String>> b3Extractor = b3.extractor(Map::get);
+  static final Extractor<Map<String, String>> awsExtractor = aws.extractor(Map::get);
+  static final Extractor<Map<String, String>> b3ExtraAwsExtractor = b3ExtraAws.extractor(Map::get);
+  static final Extractor<Map<String, String>> awsExtraB3Extractor = awsExtraB3.extractor(Map::get);
 
   static final TraceContext context = TraceContext.newBuilder()
       .traceIdHigh(HexCodec.lowerHexToUnsignedLong("67891233abcdef01"))
@@ -80,6 +92,14 @@ public class PropagationBenchmarks {
     awsInjector.inject(context, carrier);
   }
 
+  @Benchmark public void inject_awsExtraB3() {
+    awsExtraB3Injector.inject(context, carrier);
+  }
+
+  @Benchmark public void inject_b3ExtraAws() {
+    b3ExtraAwsInjector.inject(context, carrier);
+  }
+
   @Benchmark public TraceContextOrSamplingFlags extract_b3() {
     return b3Extractor.extract(incoming);
   }
@@ -88,12 +108,28 @@ public class PropagationBenchmarks {
     return awsExtractor.extract(incoming);
   }
 
+  @Benchmark public TraceContextOrSamplingFlags extract_awsExtraB3() {
+    return awsExtraB3Extractor.extract(incoming);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_b3ExtraAws() {
+    return b3ExtraAwsExtractor.extract(incoming);
+  }
+
   @Benchmark public TraceContextOrSamplingFlags extract_b3_nothing() {
     return b3Extractor.extract(nothingIncoming);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract_aws_nothing() {
     return awsExtractor.extract(nothingIncoming);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_awsExtraB3_nothing() {
+    return awsExtraB3Extractor.extract(nothingIncoming);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_b3ExtraAws_nothing() {
+    return b3ExtraAwsExtractor.extract(nothingIncoming);
   }
 
   // Convenience main entry-point

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
@@ -2,6 +2,8 @@ package brave.http;
 
 import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.Propagation;
 import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
@@ -41,6 +43,7 @@ public abstract class ITHttp {
           }
           spans.add(s);
         })
+        .propagationFactory(ExtraFieldPropagation.newFactory(Propagation.Factory.B3, "user-id"))
         .currentTraceContext(currentTraceContext)
         .sampler(sampler);
   }

--- a/propagation/aws/README.md
+++ b/propagation/aws/README.md
@@ -23,7 +23,7 @@ tracing = Tracing.newBuilder()
 ## Utilities
 There are a couple added utilities for parsing and generating an AWS trace ID string:
 
-* `AWSPropagation.rootField` - used to generate a formatted root field ID for correlation purposes.
+* `AWSPropagation.traceId` - used for correlation purposes and lookup in the X-Ray UI
 * `AWSPropagation.extract` - extracts a trace context from a string such as an environment variable.
 
 Ex. to extract a trace context from the built-in AWS Lambda variable


### PR DESCRIPTION
Sometimes you need to propagate extra fields, such as a request ID or an alternate trace context.
For example, if you are in a Cloud Foundry environment, you might want to pass the request ID:

```java
// when you initialize the builder, define the extra field you want to propagate
tracingBuilder.propagationFactory(
  ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-vcap-request-id")
);

// later, you can tag that request ID or use it in log correlation
requestId = ExtraFieldPropagation.current("x-vcap-request-id");
```

You may also need to propagate a trace context you aren't using. For example, you may be in an
Amazon Web Services environment, but not reporting data to X-Ray. To ensure X-Ray can co-exist
correctly, pass-through its tracing header like so.

```java
tracingBuilder.propagationFactory(
  ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-amzn-trace-id")
);
```

See #390