### PR TITLE
Deprecates KafkaTracing.joinSpan for nextSpan

### DIFF
--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -1,9 +1,10 @@
 # Brave Kafka instrumentation
 
 Add decorators for Kafka producer and consumer to enable tracing.
-The producer add the propagation headers to the records and create an async "ms" span child of the current trace.
-The consumer is responsible to create a new span "mr" span child of the header trace.
+* `TracingProducer` completes a producer span per record and propagates it via headers.
+* `TracingConsumer` completes a consumer span on `poll`, resuming a trace in headers if present.
 
+## Setup
 To use the producer simply wrap it like this : 
 ```java
 Producer<K, V> stringProducer = new KafkaProducer<>(settings);
@@ -18,13 +19,59 @@ TracingConsumer<K, V> tracingConsumer = kafkaTracing.consumer(consumer);
 tracingConsumer.poll(10);
 ```
 
-Because Kafka batches messages while consuming, we create the new span from the headers during poll.
-The new span then replace the previous record headers with the new propagation headers.
-When processing a message later, you can continue the trace like this:
+## What's happening?
+Typically, there are three spans involved in message tracing:
+* If a message producer is traced, it completes a PRODUCER span per record
+* If a consumer is traced, poll completes a CONSUMER span based on the incoming record or topic
+* Message processors use `KafkaTracing.nextSpan` to create a span representing work
+
+Similar to http, the trace context is propagated using headers. Unlike http, processing a message is
+decoupled from consuming it. For example, `Consumer.poll` receives messages in bulk, from
+potentially multiple topics at the same time. Instead of receiving one message like an http request,
+`Consumer.poll` can receive up to 500 by default. For this reason, a single CONSUMER span is shared
+for each invocation of poll when there is no incoming trace context. This span is the parent when
+`KafkaTracing.nextSpan` is later called.
+
+## Processing messages
+
+When ready for processing use `KafkaTracing.nextSpan` to continue the trace.
+
 ```java
-Span forProcessor = kafkaTracing.joinSpan(record);
+// Typically, poll is in a loop. the consumer is wrapped
+while (running) {
+  ConsumerRecords<K, V> records = tracingConsumer.poll(1000);
+  // either automatically or manually wrap your real process() method to use kafkaTracing.nextSpan()
+  records.forEach(record -> process(record));
+  consumer.commitSync();
+}
 ```
-and use the retrieved span as usual.
+
+Since kafka-clients doesn't ship with a processing abstraction, we can't bake-in means to
+automatically trace message processors. Guessing how one might make a message processor library
+isn't great, as we'd not know what the signature is, if there are checked exceptions, if it is async
+or not. If you are using a common library, you may want to raise an issue so that you don't need to
+make custom instrumentation.
+
+If you are in a position where you have a custom processing loop, you can do something like this
+to trace manually or you can do similar via automatic instrumentation like AspectJ.
+```java
+<K, V> void process(ConsumerRecords<K, V> record) {
+  // Grab any span from the record. The topic and key are automatically tagged
+  Span span = kafkaTracing.nextSpan(record).name("process").start();
+
+  // Below is the same setup as any synchronous tracing
+  try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) { // so logging can see trace ID
+    return doProcess(record); // do the actual work
+  } catch (RuntimeException | Error e) {
+    String message = e.getMessage();
+    if (message == null) message = e.getClass().getSimpleName();
+    span.tag("error", message); // make sure any error gets into the span before it is finished
+    throw e;
+  } finally {
+    span.finish(); // ensure the span representing this processing completes.
+  }
+}
+```
 
 ## Notes
 * This tracer is only compatible with Kafka versions including headers support ( > 0.11.0).

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTags.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTags.java
@@ -1,6 +1,20 @@
 package brave.kafka.clients;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Producer;
+
+/**
+ * Tagging policy is not yet dynamic. The descriptions below reflect static policy.
+ */
 final class KafkaTags {
-  static final String KAFKA_TOPIC_TAG = "kafka.topic";
+  /**
+   * Added on {@link KafkaTracing#producer(Producer) producer} and {@link
+   * KafkaTracing#nextSpan(ConsumerRecord) processor} spans when the key not null or empty.
+   *
+   * <p><em>Note:</em> this is not added on {@link KafkaTracing#consumer(Consumer) consumer} spans
+   * as they represent a bulk task (potentially multiple keys).
+   */
   static final String KAFKA_KEY_TAG = "kafka.key";
+  static final String KAFKA_TOPIC_TAG = "kafka.topic";
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
@@ -1,0 +1,49 @@
+package brave.kafka.clients;
+
+import brave.Tracing;
+import com.google.common.base.Charsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.junit.After;
+import zipkin.internal.Util;
+import zipkin2.Span;
+
+abstract class BaseTracingTest {
+  static String TRACE_ID = "463ac35c9f6413ad";
+  static String PARENT_ID = "463ac35c9f6413ab";
+  static String SPAN_ID = "48485a3953bb6124";
+  static String SAMPLED = "1";
+
+  String TEST_TOPIC = "myTopic";
+  String TEST_KEY = "foo";
+  String TEST_VALUE = "bar";
+
+  ConsumerRecord<String, String> fakeRecord =
+      new ConsumerRecord<>(TEST_TOPIC, 0, 1L, TEST_KEY, TEST_VALUE);
+
+  ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+  Tracing tracing = Tracing.newBuilder().spanReporter(spans::add).build();
+  KafkaTracing kafkaTracing = KafkaTracing.create(tracing);
+
+  @After public void tearDown() throws Exception {
+    tracing.close();
+  }
+
+  static <K, V> void addB3Headers(ConsumerRecord<K, V> record) {
+    record.headers()
+        .add("X-B3-TraceId", TRACE_ID.getBytes(Util.UTF_8))
+        .add("X-B3-ParentSpanId", PARENT_ID.getBytes(Util.UTF_8))
+        .add("X-B3-SpanId", SPAN_ID.getBytes(Util.UTF_8))
+        .add("X-B3-Sampled", SAMPLED.getBytes(Util.UTF_8));
+  }
+
+  static Set<Map.Entry<String, String>> lastHeaders(Headers headers) {
+    Map<String, String> result = new LinkedHashMap<>();
+    headers.forEach(h -> result.put(h.key(), new String(h.value(), Charsets.UTF_8)));
+    return result.entrySet();
+  }
+}

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
@@ -1,78 +1,98 @@
 package brave.kafka.clients;
 
 import brave.Span;
-import brave.Tracing;
+import brave.internal.HexCodec;
 import brave.propagation.TraceContext;
-import brave.sampler.Sampler;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import zipkin.internal.Util;
 
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-public class KafkaTracingTest {
-  String TRACE_ID = "463ac35c9f6413ad";
-  String PARENT_ID = "463ac35c9f6413ab";
-  String SPAN_ID = "48485a3953bb6124";
-  String SAMPLED = "1";
-
-  String TEST_TOPIC = "myTopic";
-  String TEST_KEY = "foo";
-  String TEST_VALUE = "bar";
-
-  KafkaTracing kafkaTracing;
-  ConsumerRecord<String, String> fakeRecord;
-
-  List<zipkin2.Span> spans = new ArrayList<>();
-
-  @Before
-  public void setUp() throws IOException {
-    Tracing tracing = Tracing.newBuilder()
-        .spanReporter(spans::add)
-        .sampler(Sampler.NEVER_SAMPLE)
-        .build();
-
-    kafkaTracing = KafkaTracing.create(tracing);
-    fakeRecord = new ConsumerRecord<>(TEST_TOPIC, 0, 1, TEST_KEY, TEST_VALUE);
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    spans.clear();
-  }
-
+public class KafkaTracingTest extends BaseTracingTest {
   @Test
-  public void should_retrieve_span_from_headers() throws Exception {
-    addB3Headers();
-
+  public void joinSpan_should_retrieve_span_from_headers() throws Exception {
+    addB3Headers(fakeRecord);
     Span span = kafkaTracing.joinSpan(fakeRecord);
 
     TraceContext context = span.context();
-    assertThat(Long.toHexString(context.traceId())).isEqualTo(TRACE_ID);
-    assertThat(Long.toHexString(context.spanId())).isEqualTo(SPAN_ID);
+    assertThat(HexCodec.toLowerHex(context.traceId())).isEqualTo(TRACE_ID);
+    assertThat(HexCodec.toLowerHex(context.spanId())).isEqualTo(SPAN_ID);
     assertThat(context.sampled()).isEqualTo(true);
   }
 
   @Test
-  public void should_create_span_if_no_headers() throws Exception {
+  public void joinSpan_should_create_span_if_no_headers() throws Exception {
     Span span = kafkaTracing.joinSpan(fakeRecord);
 
     TraceContext context = span.context();
-    assertThat(Long.toHexString(context.traceId())).isNotEmpty().isNotEqualTo(TRACE_ID);
-    assertThat(Long.toHexString(context.spanId())).isNotEmpty().isNotEqualTo(SPAN_ID);
-    assertThat(context.sampled()).isEqualTo(false);
+    assertThat(HexCodec.toLowerHex(context.traceId())).isNotEmpty().isNotEqualTo(TRACE_ID);
+    assertThat(HexCodec.toLowerHex(context.spanId())).isNotEmpty().isNotEqualTo(SPAN_ID);
   }
 
-  void addB3Headers() {
-    fakeRecord.headers()
-        .add("X-B3-TraceId", TRACE_ID.getBytes(Util.UTF_8))
-        .add("X-B3-ParentSpanId", PARENT_ID.getBytes(Util.UTF_8))
-        .add("X-B3-SpanId", SPAN_ID.getBytes(Util.UTF_8))
-        .add("X-B3-Sampled", SAMPLED.getBytes(Util.UTF_8));
+  @Test
+  public void nextSpan_should_use_span_from_headers_as_parent() throws Exception {
+    addB3Headers(fakeRecord);
+    Span span = kafkaTracing.nextSpan(fakeRecord);
+
+    TraceContext context = span.context();
+    assertThat(HexCodec.toLowerHex(context.traceId())).isEqualTo(TRACE_ID);
+    assertThat(HexCodec.toLowerHex(context.parentId())).isEqualTo(SPAN_ID);
+    assertThat(context.sampled()).isEqualTo(true);
+  }
+
+  @Test
+  public void nextSpan_should_create_span_if_no_headers() throws Exception {
+    Span span = kafkaTracing.nextSpan(fakeRecord);
+
+    TraceContext context = span.context();
+    assertThat(HexCodec.toLowerHex(context.traceId())).isNotEmpty().isNotEqualTo(TRACE_ID);
+    assertThat(HexCodec.toLowerHex(context.spanId())).isNotEmpty().isNotEqualTo(SPAN_ID);
+  }
+
+  @Test
+  public void nextSpan_should_tag_topic_and_key_when_no_incoming_context() throws Exception {
+    kafkaTracing.nextSpan(fakeRecord).start().finish();
+
+    assertThat(spans)
+        .flatExtracting(s -> s.tags().entrySet())
+        .containsOnly(entry("kafka.topic", TEST_TOPIC), entry("kafka.key", TEST_KEY));
+  }
+
+  @Test
+  public void nextSpan_shouldnt_tag_null_key() throws Exception {
+    fakeRecord = new ConsumerRecord<>(TEST_TOPIC, 0, 1, null, TEST_VALUE);
+
+    kafkaTracing.nextSpan(fakeRecord).start().finish();
+
+    assertThat(spans)
+        .flatExtracting(s -> s.tags().entrySet())
+        .containsOnly(entry("kafka.topic", TEST_TOPIC));
+  }
+
+  @Test
+  public void nextSpan_shouldnt_tag_binary_key() throws Exception {
+    ConsumerRecord<byte[], String> record =
+        new ConsumerRecord<>(TEST_TOPIC, 0, 1, new byte[1], TEST_VALUE);
+
+    kafkaTracing.nextSpan(record).start().finish();
+
+    assertThat(spans)
+        .flatExtracting(s -> s.tags().entrySet())
+        .containsOnly(entry("kafka.topic", TEST_TOPIC));
+  }
+
+  /**
+   * We assume topic and key are already tagged by the producer span. However, we can change this
+   * policy now, or later when dynamic policy is added to KafkaTracing
+   */
+  @Test
+  public void nextSpan_shouldnt_tag_topic_and_key_when_incoming_context() throws Exception {
+    addB3Headers(fakeRecord);
+    kafkaTracing.nextSpan(fakeRecord).start().finish();
+
+    assertThat(spans)
+        .flatExtracting(s -> s.tags().entrySet())
+        .isEmpty();
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingCallbackTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingCallbackTest.java
@@ -1,32 +1,13 @@
 package brave.kafka.clients;
 
 import brave.Span;
-import brave.Tracing;
-import brave.sampler.Sampler;
-import java.util.LinkedList;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TracingCallbackTest {
-
-  LinkedList<zipkin2.Span> spans = new LinkedList<>();
-
-  Tracing tracing = Tracing.newBuilder()
-      .spanReporter(spans::add)
-      .sampler(Sampler.ALWAYS_SAMPLE)
-      .build();
-
-  @After
-  public void close() throws Exception {
-    Tracing current = Tracing.current();
-    if (current != null) current.close();
-    spans.clear();
-  }
-
+public class TracingCallbackTest extends BaseTracingTest {
   @Test
   public void on_completion_should_finish_span() throws Exception {
     Span span = tracing.tracer().nextSpan();


### PR DESCRIPTION
`KafkaTracing.joinSpan` will always mutate a completed span when a trace
is in progress. `KafkaTracing.nextSpan` accomplishes this by creating a
separate span for this activity.

The problem with `KafkaTracing.joinSpan` is that it returns a span that
is finished. Any tags or annotations will be delayed until Brave flushes
them:

```
[producer span], [consumer span{end} {late data}]
```

`KafkaTracing.nextSpan` instead returns a child which can be started and
stopped without tainting its parent:

```
[producer span], [consumer span], [processor span]
```