### PR TITLE
Marks contexts extracted by AWSPropagation and cuts overhead

### DIFF
--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -18,10 +18,10 @@ import java.util.List;
  * @param <K> Usually, but not always a String
  */
 public interface Propagation<K> {
-  Propagation<String> B3_STRING = Propagation.Factory.B3.create(Propagation.KeyFactory.STRING);
+  Propagation<String> B3_STRING = B3Propagation.FACTORY.create(Propagation.KeyFactory.STRING);
 
   abstract class Factory {
-    public static final Factory B3 = new B3Propagation.Factory();
+    public static final Factory B3 = B3Propagation.FACTORY;
 
     /**
      * Does the propagation implementation support sharing client and server span IDs. For example,

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -39,13 +39,15 @@ public abstract class SamplingFlags {
       return this;
     }
 
-    public SamplingFlags build() {
-      if (debug) {
-        return DEBUG;
-      } else if (sampled != null) {
-        return sampled ? SAMPLED : NOT_SAMPLED;
-      }
+    /** Allows you to create flags from a boolean value without allocating a builder instance */
+    public static SamplingFlags build(@Nullable Boolean sampled) {
+      if (sampled != null) return sampled ? SAMPLED : NOT_SAMPLED;
       return EMPTY;
+    }
+
+    public SamplingFlags build() {
+      if (debug) return DEBUG;
+      return build(sampled);
     }
   }
 

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -166,9 +166,8 @@ public abstract class TraceContext extends SamplingFlags {
     public abstract TraceContext autoBuild();
 
     public final TraceContext build() {
-      if (extra().isEmpty()) return autoBuild();
       // make sure the extra data is immutable and unmodifiable
-      return extra(Collections.unmodifiableList(new ArrayList<>(extra()))).autoBuild();
+      return extra(ensureImmutable(extra())).autoBuild();
     }
 
     @Nullable abstract Boolean sampled();
@@ -180,5 +179,12 @@ public abstract class TraceContext extends SamplingFlags {
   }
 
   TraceContext() { // no external implementations
+  }
+
+  static List<Object> ensureImmutable(List<Object> extra) {
+    if (extra == Collections.EMPTY_LIST) return extra;
+    // Faster to make a copy than check the type to see if it is already a singleton list
+    if (extra.size() == 1) return Collections.singletonList(extra.get(0));
+    return Collections.unmodifiableList(new ArrayList<>(extra));
   }
 }

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -146,7 +146,7 @@ public class TracerTest {
     tracer = Tracing.newBuilder()
         .propagationFactory(new Propagation.Factory(){
           @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-            return B3Propagation.create(keyFactory);
+            return B3Propagation.FACTORY.create(keyFactory);
           }
         })
         .spanReporter(spans::add).build().tracer();

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -1,5 +1,8 @@
 package brave.propagation;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,5 +38,24 @@ public class TraceContextTest {
 
     assertThat(context.toString())
         .isEqualTo("000000000000014d00000000000001bc/0000000000000003");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void ensureImmutable_returnsImmutableEmptyList() {
+    TraceContext.ensureImmutable(new ArrayList<>()).add("foo");
+  }
+
+  @Test public void ensureImmutable_convertsToSingletonList() {
+    List<Object> list = new ArrayList<>();
+    list.add("foo");
+    TraceContext.ensureImmutable(list);
+    assertThat(TraceContext.ensureImmutable(list).getClass().getSimpleName())
+        .isEqualTo("SingletonList");
+  }
+
+  @Test public void ensureImmutable_returnsEmptyList() {
+    List<Object> list = Collections.emptyList();
+    assertThat(TraceContext.ensureImmutable(list))
+        .isSameAs(list);
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
@@ -82,7 +82,7 @@ public class EndToEndBenchmarks extends HttpServerBenchmarks {
   public static class TracedAWS extends ForwardingTracingFilter {
     public TracedAWS() {
       super(Tracing.newBuilder()
-          .propagationFactory(new AWSPropagation.Factory())
+          .propagationFactory(AWSPropagation.FACTORY)
           .spanReporter(Reporter.NOOP)
           .build());
     }

--- a/propagation/aws/README.md
+++ b/propagation/aws/README.md
@@ -2,11 +2,11 @@
 This changes brave to use "x-amzn-trace-id" as opposed to "x-b3" prefixed headers to propagate trace
 context across processes.
 
-To enable this, configure `brave.Tracing` with `AWSPropagation.Factory` like so:
+To enable this, configure `brave.Tracing` with `AWSPropagation.FACTORY` like so:
 
 ```java
 tracing = Tracing.newBuilder()
-    .propagationFactory(new AWSPropagation.Factory())
+    .propagationFactory(AWSPropagation.FACTORY)
     ...
     .build();
 ```
@@ -23,10 +23,10 @@ tracing = Tracing.newBuilder()
 ## Utilities
 There are a couple added utilities for parsing and generating an AWS trace ID string:
 
-* `AWSPropagation.traceIdString` - used to generate a formatted trace ID for correlation purposes.
+* `AWSPropagation.rootField` - used to generate a formatted root field ID for correlation purposes.
 * `AWSPropagation.extract` - extracts a trace context from a string such as an environment variable.
 
-Ex to extract the trace ID from the built-in AWS Lambda variable
+Ex. to extract a trace context from the built-in AWS Lambda variable
 ```java
 extracted = AWSPropagation.extract(System.getenv("_X_AMZN_TRACE_ID"));
 ```


### PR DESCRIPTION
This marks contexts extracted by AWSPropagation so that calls to
`rootField` are reliable even when AWS isn't the current propagation
factory.

This also dramatically reduces extraction overhead by avoiding
allocation of constants, and early returning when required fields are
absent.

Before:
```
Benchmark                                   Mode  Cnt    Score   Error   Units
PropagationBenchmarks.extract_aws          thrpt   15    4.145 ± 0.292  ops/us
PropagationBenchmarks.extract_aws_nothing  thrpt   15  132.670 ± 1.465  ops/us
PropagationBenchmarks.extract_b3           thrpt   15   10.697 ± 0.394  ops/us
PropagationBenchmarks.extract_b3_nothing   thrpt   15  170.315 ± 5.142  ops/us
```

After: (higher numbers are better)
```
Benchmark                                   Mode  Cnt    Score    Error   Units
PropagationBenchmarks.extract_aws          thrpt   15    4.256 ± 0.245  ops/us
PropagationBenchmarks.extract_aws_nothing  thrpt   15  214.205 ±  4.829  ops/us
PropagationBenchmarks.extract_b3           thrpt   15   10.769 ±  0.316  ops/us
PropagationBenchmarks.extract_b3_nothing   thrpt   15  268.972 ± 12.388  ops/us
```