### PR TITLE
Fixes bug where context invisible to user parsers

### DIFF
--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
@@ -251,10 +251,16 @@ public class ITTracingClientInterceptor {
     tracing = tracing.toBuilder().clientParser(new GrpcClientParser() {
       @Override protected <M> void onMessageSent(M message, SpanCustomizer span) {
         span.tag("grpc.message_sent", message.toString());
+        if (tracing.tracing().currentTraceContext().get() != null) {
+          span.tag("grpc.message_sent.visible", "true");
+        }
       }
 
       @Override protected <M> void onMessageReceived(M message, SpanCustomizer span) {
         span.tag("grpc.message_received", message.toString());
+        if (tracing.tracing().currentTraceContext().get() != null) {
+          span.tag("grpc.message_received.visible", "true");
+        }
       }
 
       @Override
@@ -268,7 +274,8 @@ public class ITTracingClientInterceptor {
 
     assertThat(spans.getFirst().name()).isEqualTo("unary");
     assertThat(spans).flatExtracting(s -> s.tags().keySet()).containsExactlyInAnyOrder(
-        "grpc.message_received", "grpc.message_sent"
+        "grpc.message_received", "grpc.message_sent",
+        "grpc.message_received.visible", "grpc.message_sent.visible"
     );
   }
 

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
@@ -237,10 +237,16 @@ public class ITTracingServerInterceptor {
     grpcTracing = grpcTracing.toBuilder().serverParser(new GrpcServerParser() {
       @Override protected <M> void onMessageSent(M message, SpanCustomizer span) {
         span.tag("grpc.message_sent", message.toString());
+        if (grpcTracing.tracing().currentTraceContext().get() != null) {
+          span.tag("grpc.message_sent.visible", "true");
+        }
       }
 
       @Override protected <M> void onMessageReceived(M message, SpanCustomizer span) {
         span.tag("grpc.message_received", message.toString());
+        if (grpcTracing.tracing().currentTraceContext().get() != null) {
+          span.tag("grpc.message_received.visible", "true");
+        }
       }
 
       @Override
@@ -254,7 +260,8 @@ public class ITTracingServerInterceptor {
 
     assertThat(spans.getFirst().name()).isEqualTo("unary");
     assertThat(spans).flatExtracting(s -> s.tags().keySet()).containsExactlyInAnyOrder(
-        "grpc.message_received", "grpc.message_sent"
+        "grpc.message_received", "grpc.message_sent",
+        "grpc.message_received.visible", "grpc.message_sent.visible"
     );
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -174,6 +174,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
           public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
             customizer.name(adapter.method(req).toLowerCase() + " " + adapter.path(req));
             customizer.tag("http.url", adapter.url(req)); // just the path is logged by default
+            customizer.tag("context.visible", String.valueOf(currentTraceContext.get() != null));
           }
         })
         .build().clientOf("remote-service");
@@ -191,6 +192,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
         .containsExactly("remote-service");
 
     assertReportedTagsInclude("http.url", url(uri));
+    assertReportedTagsInclude("context.visible", "true");
   }
 
   @Test public void addsStatusCodeWhenNotOk() throws Exception {

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpServer.java
@@ -157,6 +157,7 @@ public abstract class ITHttpServer extends ITHttp {
       public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
         customizer.name(adapter.method(req).toLowerCase() + " " + adapter.path(req));
         customizer.tag("http.url", adapter.url(req)); // just the path is logged by default
+        customizer.tag("context.visible", String.valueOf(currentTraceContext.get() != null));
       }
     }).build();
     init();
@@ -169,6 +170,7 @@ public abstract class ITHttpServer extends ITHttp {
         .containsExactly("get /foo");
 
     assertReportedTagsInclude("http.url", url(uri));
+    assertReportedTagsInclude("context.visible", "true");
   }
 
   @Test

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -71,7 +71,14 @@ public final class HttpServerHandler<Req, Resp> {
 
     // all of the parsing here occur before a timestamp is recorded on the span
     span.kind(Span.Kind.SERVER);
-    parser.request(adapter, request, span);
+
+    // Ensure user-code can read the current trace context
+    Tracer.SpanInScope ws = tracer.withSpanInScope(span);
+    try {
+      parser.request(adapter, request, span);
+    } finally {
+      ws.close();
+    }
 
     boolean parsedEndpoint = false;
     if (Platform.get().zipkinV1Present()) {
@@ -109,9 +116,13 @@ public final class HttpServerHandler<Req, Resp> {
    */
   public void handleSend(@Nullable Resp response, @Nullable Throwable error, Span span) {
     if (span.isNoop()) return;
+
+    // Ensure user-code can read the current trace context
+    Tracer.SpanInScope ws = tracer.withSpanInScope(span);
     try {
       parser.response(adapter, response, error, span);
     } finally {
+      ws.close();
       span.finish();
     }
   }


### PR DESCRIPTION
SpanCustomizer does not directly expose the trace context. This allows tools that implicitly view the trace context or extra stuff in it to work.