### PR TITLE
Adds AWSPropagation.extractLambda to avoid subtle bugs

### DIFF
--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -152,6 +152,10 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       if (key == null) return;
       setter.put(carrier, key, value);
     }
+
+    @Override public String toString() {
+      return "ExtraFieldPropagation{" + name + "=" + value + "}";
+    }
   }
 
   static final class Many extends Extra {
@@ -171,6 +175,10 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
         if (key == null) continue;
         setter.put(carrier, nameToKey.get(field.getKey()), field.getValue());
       }
+    }
+
+    @Override public String toString() {
+      return "ExtraFieldPropagation" + fields;
     }
   }
 

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -62,6 +62,24 @@ public class ExtraFieldPropagationTest {
         .isNull();
   }
 
+  @Test public void toString_one() throws Exception {
+    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.One();
+    extra.put("x-vcap-request-id", uuid);
+
+    assertThat(extra)
+        .hasToString("ExtraFieldPropagation{x-vcap-request-id=" + uuid + "}");
+  }
+
+  @Test public void toString_two() throws Exception {
+    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.Many();
+    extra.put("x-amzn-trace-id", awsTraceId);
+    extra.put("x-vcap-request-id", uuid);
+
+    assertThat(extra).hasToString(
+        "ExtraFieldPropagation{x-amzn-trace-id=" + awsTraceId + ", x-vcap-request-id=" + uuid + "}"
+    );
+  }
+
   @Test public void inject_one() throws Exception {
     ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.One();
     extra.put("x-vcap-request-id", uuid);

--- a/propagation/aws/README.md
+++ b/propagation/aws/README.md
@@ -25,10 +25,11 @@ There are a couple added utilities for parsing and generating an AWS trace ID st
 
 * `AWSPropagation.traceId` - used for correlation purposes and lookup in the X-Ray UI
 * `AWSPropagation.extract` - extracts a trace context from a string such as an environment variable.
+* `AWSPropagation.extractLambda` - special form of extract which reads from the standard lambda env.
 
-Ex. to extract a trace context from the built-in AWS Lambda variable
+For example, if you are in a lambda environment, you can read the incoming context like this:
 ```java
-extracted = AWSPropagation.extract(System.getenv("_X_AMZN_TRACE_ID"));
+span = tracer.nextSpan(AWSPropagation.extractLambda());
 ```
 
 ## Extra fields

--- a/propagation/aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
+++ b/propagation/aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
@@ -192,6 +192,21 @@ public class AWSPropagationTest {
         .contains(new StringBuilder(";Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo"));
   }
 
+  @Test public void toString_fields() throws Exception {
+    AWSPropagation.Extra extra = new AWSPropagation.Extra();
+    extra.fields = ";Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo";
+
+    assertThat(extra)
+        .hasToString("AWSPropagation{fields=" + extra.fields + "}");
+  }
+
+  @Test public void toString_none() throws Exception {
+    AWSPropagation.Extra extra = new AWSPropagation.Extra();
+
+    assertThat(extra)
+        .hasToString("AWSPropagation{}");
+  }
+
   @Test public void injectExtraStuff() throws Exception {
     AWSPropagation.Extra extra = new AWSPropagation.Extra();
     extra.fields = ";Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo";


### PR DESCRIPTION
The environment variables used in lambda are set per-request.
This change makes it clear that you read them per-root span.