### PR TITLE
add null checks before putting values to MDC

### DIFF
--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -46,8 +46,12 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
     class MDCCurrentTraceContextScope implements Scope {
       @Override public void close() {
         scope.close();
-        MDC.put("traceId", previousTraceId);
-        MDC.put("spanId", previousSpanId);
+        if(previousTraceId != null) {
+          MDC.put("traceId", previousTraceId);
+        }
+        if(previousSpanId != null) {
+          MDC.put("spanId", previousSpanId);
+        }
       }
     }
     return new MDCCurrentTraceContextScope();

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -48,9 +48,13 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
         scope.close();
         if(previousTraceId != null) {
           MDC.put("traceId", previousTraceId);
+        } else {
+          MDC.remove("traceId");	
         }
         if(previousSpanId != null) {
           MDC.put("spanId", previousSpanId);
+        } else {
+          MDC.remove("spanId");
         }
       }
     }


### PR DESCRIPTION
Since JBoss Logging 3 does not support putting null values to MDC and it is not required by the SLF4J API I added simple null checks. As a result Brave SLF4J context can be used in conjuction with JBoss Logging 3.