### PR TITLE
Makes Tracer's toString include info helpful in troubleshooting

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -384,10 +384,11 @@ public final class Tracer {
   @Override public String toString() {
     TraceContext currentSpan = currentTraceContext.get();
     List<zipkin2.Span> inFlight = recorder.snapshot();
-    return "Tracer{reporter=" + reporter
-        + (currentSpan != null ? (", currentSpan=" + currentSpan) : "")
-        + (inFlight.size() > 0 ? (", inFlight=" + inFlight) : "")
-        + (noop.get() ? ", noop=true" : "")
+    return "Tracer{"
+        + (currentSpan != null ? ("currentSpan=" + currentSpan + ", ") : "")
+        + (inFlight.size() > 0 ? ("inFlight=" + inFlight + ", ") : "")
+        + (noop.get() ? "noop=true, " : "")
+        + "reporter=" + reporter
         + "}";
   }
 

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -127,6 +127,7 @@ public final class Tracer {
   }
 
   final Clock clock;
+  final Reporter<zipkin2.Span> reporter; // for toString
   final Recorder recorder;
   final Sampler sampler;
   final CurrentTraceContext currentTraceContext;
@@ -138,6 +139,7 @@ public final class Tracer {
     this.noop = noop;
     this.supportsJoin = builder.supportsJoin && builder.propagationFactory.supportsJoin();
     this.clock = builder.clock;
+    this.reporter = builder.reporter;
     this.recorder = new Recorder(builder.localEndpoint, clock, builder.reporter, this.noop);
     this.sampler = builder.sampler;
     this.currentTraceContext = builder.currentTraceContext;
@@ -377,6 +379,16 @@ public final class Tracer {
     @Override public String toString() {
       return scope.toString();
     }
+  }
+
+  @Override public String toString() {
+    TraceContext currentSpan = currentTraceContext.get();
+    List<zipkin2.Span> inFlight = recorder.snapshot();
+    return "Tracer{reporter=" + reporter
+        + (currentSpan != null ? (", currentSpan=" + currentSpan) : "")
+        + (inFlight.size() > 0 ? (", inFlight=" + inFlight) : "")
+        + (noop.get() ? ", noop=true" : "")
+        + "}";
   }
 
   static TraceContext appendExtra(TraceContext context, List<Object> extra) {

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -251,14 +251,14 @@ public abstract class Tracing implements Closeable {
     }
 
     public Tracing build() {
-      if (clock == null) clock = Platform.get();
+      if (clock == null) clock = Platform.get().clock();
       if (localEndpoint == null) {
         localEndpoint = Platform.get().localEndpoint();
         if (localServiceName != null) {
           localEndpoint = localEndpoint.toBuilder().serviceName(localServiceName).build();
         }
       }
-      if (reporter == null) reporter = Platform.get();
+      if (reporter == null) reporter = Platform.get().reporter();
       return new Default(this);
     }
 

--- a/brave/src/main/java/brave/internal/recorder/Recorder.java
+++ b/brave/src/main/java/brave/internal/recorder/Recorder.java
@@ -4,13 +4,14 @@ import brave.Clock;
 import brave.Span;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import zipkin2.Endpoint;
 import zipkin2.reporter.Reporter;
 
 /** Dispatches mutations on a span to a shared object per trace/span id. */
 public final class Recorder {
-
   final MutableSpanMap spanMap;
   final Reporter<zipkin2.Span> reporter;
   final AtomicBoolean noop;
@@ -103,5 +104,14 @@ public final class Recorder {
       span.finish(null);
       reporter.report(span.toSpan());
     }
+  }
+
+  /** Exposes which spans are in-flight, mostly for testing. */
+  public List<zipkin2.Span> snapshot() {
+    List<zipkin2.Span> result = new ArrayList<>();
+    for (MutableSpan value : spanMap.delegate.values()) {
+      result.add(value.toSpan());
+    }
+    return result;
   }
 }

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -12,14 +12,25 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TracerTest {
-  Tracer tracer = Tracing.newBuilder().build().tracer();
+  Tracer tracer = Tracing.newBuilder()
+      .spanReporter(new Reporter<zipkin2.Span>() {
+        @Override public void report(zipkin2.Span span) {
+        }
 
-  @After public void close(){
+        @Override public String toString() {
+          return "MyReporter{}";
+        }
+      })
+      .localEndpoint(Endpoint.newBuilder().serviceName("my-service").build())
+      .build().tracer();
+
+  @After public void close() {
     Tracing.current().close();
   }
 
@@ -44,6 +55,8 @@ public class TracerTest {
   }
 
   @Test public void localServiceName_defaultIsUnknown() {
+    tracer = Tracing.newBuilder().build().tracer();
+
     assertThat(tracer).extracting("recorder.spanMap.localEndpoint.serviceName")
         .containsExactly("unknown");
   }
@@ -144,7 +157,7 @@ public class TracerTest {
   @Test public void join_createsChildWhenUnsupportedByPropagation() {
     List<zipkin2.Span> spans = new ArrayList<>();
     tracer = Tracing.newBuilder()
-        .propagationFactory(new Propagation.Factory(){
+        .propagationFactory(new Propagation.Factory() {
           @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
             return B3Propagation.FACTORY.create(keyFactory);
           }
@@ -351,6 +364,31 @@ public class TracerTest {
 
     // context was cleared
     assertThat(tracer.currentSpan()).isNull();
+  }
+
+  @Test public void toString_withSpanInScope() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(10L).build();
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(tracer.toSpan(context))) {
+      assertThat(tracer.toString()).hasToString(
+          "Tracer{reporter=MyReporter{}, currentSpan=0000000000000001/000000000000000a}"
+      );
+    }
+  }
+
+  @Test public void toString_withSpanInFlight() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(10L).sampled(true).build();
+    Span span = tracer.toSpan(context);
+    span.start(1L); // didn't set anything else! this is to help ensure no NPE
+
+    assertThat(tracer).hasToString(
+        "Tracer{reporter=MyReporter{}, inFlight=[{\"traceId\":\"0000000000000001\",\"id\":\"000000000000000a\",\"timestamp\":1,\"localEndpoint\":{\"serviceName\":\"my-service\"}}]}"
+    );
+
+    span.finish();
+
+    assertThat(tracer).hasToString(
+        "Tracer{reporter=MyReporter{}}"
+    );
   }
 
   @Test public void withSpanInScope_nested() {

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -370,7 +370,7 @@ public class TracerTest {
     TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(10L).build();
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(tracer.toSpan(context))) {
       assertThat(tracer.toString()).hasToString(
-          "Tracer{reporter=MyReporter{}, currentSpan=0000000000000001/000000000000000a}"
+          "Tracer{currentSpan=0000000000000001/000000000000000a, reporter=MyReporter{}}"
       );
     }
   }
@@ -381,13 +381,21 @@ public class TracerTest {
     span.start(1L); // didn't set anything else! this is to help ensure no NPE
 
     assertThat(tracer).hasToString(
-        "Tracer{reporter=MyReporter{}, inFlight=[{\"traceId\":\"0000000000000001\",\"id\":\"000000000000000a\",\"timestamp\":1,\"localEndpoint\":{\"serviceName\":\"my-service\"}}]}"
+        "Tracer{inFlight=[{\"traceId\":\"0000000000000001\",\"id\":\"000000000000000a\",\"timestamp\":1,\"localEndpoint\":{\"serviceName\":\"my-service\"}}], reporter=MyReporter{}}"
     );
 
     span.finish();
 
     assertThat(tracer).hasToString(
         "Tracer{reporter=MyReporter{}}"
+    );
+  }
+
+  @Test public void toString_whenNoop() {
+    Tracing.current().setNoop(true);
+
+    assertThat(tracer).hasToString(
+        "Tracer{noop=true, reporter=MyReporter{}}"
     );
   }
 

--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -55,7 +55,35 @@ public class PlatformTest {
 
     when(System.nanoTime()).thenReturn(1000L); // 1 microsecond
 
-    assertThat(platform.currentTimeMicroseconds()).isEqualTo(1);
+    assertThat(platform.clock().currentTimeMicroseconds()).isEqualTo(1);
+  }
+
+  @Test public void clock_hasNiceToString() {
+    mockStatic(System.class);
+    when(System.currentTimeMillis()).thenReturn(123L);
+    when(System.nanoTime()).thenReturn(456L);
+
+    Platform platform = new Platform() {
+      @Override public boolean zipkinV1Present() {
+        return true;
+      }
+
+      @Override public long randomLong() {
+        return 1L;
+      }
+
+      @Override public long nextTraceIdHigh() {
+        return 1L;
+      }
+    };
+
+    assertThat(platform.clock())
+        .hasToString("TickClock{baseEpochMicros=123000, tickNanos=456}");
+  }
+
+  @Test public void reporter_hasNiceToString() {
+    assertThat(platform.reporter())
+        .hasToString("LoggingReporter{name=brave.Tracer}");
   }
 
   // example from X-Amzn-Trace-Id: Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1


### PR DESCRIPTION
Problems can occur when state isn't cleaned up. This adds minimal info
to determine if there's leaked state or not. This should help debugging
problems including circleci.