### PR TITLE
Read system time once per trace, and use tick offsets thereafter

### DIFF
--- a/archive/brave-core/src/test/java/brave/interop/TracerAdapterTest.java
+++ b/archive/brave-core/src/test/java/brave/interop/TracerAdapterTest.java
@@ -217,8 +217,8 @@ public class TracerAdapterTest {
     assertSpansReported(context, span);
     assertThat(spans).first().satisfies(s -> {
           assertThat(s.name()).isEqualTo("get");
-          assertThat(s.timestamp()).isEqualTo(1L);
-          assertThat(s.duration()).isEqualTo(1L);
+          assertThat(s.timestamp()).isGreaterThan(1L);
+          assertThat(s.duration()).isNotZero();
           assertThat(s.kind()).isEqualTo(zipkin2.Span.Kind.CLIENT);
         }
     );
@@ -228,8 +228,8 @@ public class TracerAdapterTest {
     assertSpansReported(context, span);
     assertThat(spans).first().satisfies(s -> {
           assertThat(s.name()).isEqualTo("get");
-          assertThat(s.timestamp()).isEqualTo(1L);
-          assertThat(s.duration()).isEqualTo(1L);
+          assertThat(s.timestamp()).isGreaterThanOrEqualTo(1L);
+          assertThat(s.duration()).isNotZero();
           assertThat(s.kind()).isEqualTo(zipkin2.Span.Kind.SERVER);
         }
     );

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -9,12 +9,10 @@ import zipkin2.Endpoint;
 @AutoValue
 abstract class RealSpan extends Span {
 
-  abstract Clock clock();
-
   abstract Recorder recorder();
 
-  static RealSpan create(TraceContext context, Clock clock, Recorder recorder) {
-    return new AutoValue_RealSpan(context, clock, recorder);
+  static RealSpan create(TraceContext context, Recorder recorder) {
+    return new AutoValue_RealSpan(context, recorder);
   }
 
   @Override public boolean isNoop() {
@@ -22,7 +20,8 @@ abstract class RealSpan extends Span {
   }
 
   @Override public Span start() {
-    return start(clock().currentTimeMicroseconds());
+    recorder().start(context());
+    return this;
   }
 
   @Override public Span start(long timestamp) {
@@ -41,7 +40,8 @@ abstract class RealSpan extends Span {
   }
 
   @Override public Span annotate(String value) {
-    return annotate(clock().currentTimeMicroseconds(), value);
+    recorder().annotate(context(), value);
+    return this;
   }
 
   @Override public Span annotate(long timestamp, String value) {
@@ -60,7 +60,7 @@ abstract class RealSpan extends Span {
   }
 
   @Override public void finish() {
-    finish(clock().currentTimeMicroseconds());
+    recorder().finish(context());
   }
 
   @Override public void finish(long timestamp) {

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -135,10 +135,10 @@ public final class Tracer {
   final AtomicBoolean noop;
   final boolean supportsJoin;
 
-  Tracer(Tracing.Builder builder, AtomicBoolean noop) {
+  Tracer(Tracing.Builder builder, Clock clock, AtomicBoolean noop) {
     this.noop = noop;
     this.supportsJoin = builder.supportsJoin && builder.propagationFactory.supportsJoin();
-    this.clock = builder.clock;
+    this.clock = clock;
     this.reporter = builder.reporter;
     this.recorder = new Recorder(builder.localEndpoint, clock, builder.reporter, this.noop);
     this.sampler = builder.sampler;
@@ -295,7 +295,7 @@ public final class Tracer {
   public Span toSpan(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
     if (noop.get() == false && Boolean.TRUE.equals(context.sampled())) {
-      return RealSpan.create(context, clock, recorder);
+      return RealSpan.create(context, recorder);
     }
     return NoopSpan.create(context);
   }

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -282,11 +282,11 @@ public abstract class Tracing implements Closeable {
     final Clock clock;
 
     Default(Builder builder) {
-      this.tracer = new Tracer(builder, noop);
+      this.clock = builder.clock;
+      this.tracer = new Tracer(builder, clock, noop);
       this.propagationFactory = builder.propagationFactory;
       this.stringPropagation = builder.propagationFactory.create(Propagation.KeyFactory.STRING);
       this.currentTraceContext = builder.currentTraceContext;
-      this.clock = builder.clock;
       maybeSetCurrent();
     }
 

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -1,5 +1,6 @@
 package brave.internal.recorder;
 
+import brave.Clock;
 import brave.Span;
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
@@ -7,13 +8,15 @@ import brave.propagation.TraceContext;
 import zipkin2.Endpoint;
 
 final class MutableSpan {
+  final Clock clock;
   final zipkin2.Span.Builder span;
   boolean finished;
   long timestamp;
 
   // Since this is not exposed, this class could be refactored later as needed to act in a pool
   // to reduce GC churn. This would involve calling span.clear and resetting the fields below.
-  MutableSpan(TraceContext context, Endpoint localEndpoint) {
+  MutableSpan(Clock clock, TraceContext context, Endpoint localEndpoint) {
+    this.clock = clock;
     this.span = zipkin2.Span.newBuilder()
         .traceId(context.traceIdString())
         .parentId(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null)
@@ -22,6 +25,10 @@ final class MutableSpan {
         .shared(context.shared())
         .localEndpoint(localEndpoint);
     finished = false;
+  }
+
+  MutableSpan start() {
+    return start(clock.currentTimeMicroseconds());
   }
 
   synchronized MutableSpan start(long timestamp) {
@@ -41,6 +48,10 @@ final class MutableSpan {
       // TODO: log
     }
     return this;
+  }
+
+  MutableSpan annotate(String value) {
+    return annotate(clock.currentTimeMicroseconds(), value);
   }
 
   synchronized MutableSpan annotate(long timestamp, String value) {

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -178,6 +178,29 @@ public abstract class TraceContext extends SamplingFlags {
     }
   }
 
+  /** Only includes mandatory fields {@link #traceIdHigh()}, {@link #traceId()}, {@link #spanId()} */
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof TraceContext)) return false;
+    TraceContext that = (TraceContext) o;
+    return (this.traceIdHigh() == that.traceIdHigh())
+        && (this.traceId() == that.traceId())
+        && (this.spanId() == that.spanId());
+  }
+
+  /** Only includes mandatory fields {@link #traceIdHigh()}, {@link #traceId()}, {@link #spanId()} */
+  @Override public int hashCode() {
+    long traceIdHigh = traceIdHigh(), traceId = traceId(), spanId = spanId();
+    int h = 1;
+    h *= 1000003;
+    h ^= (int) ((traceIdHigh >>> 32) ^ traceIdHigh);
+    h *= 1000003;
+    h ^= (int) ((traceId >>> 32) ^ traceId);
+    h *= 1000003;
+    h ^= (int) ((spanId >>> 32) ^ spanId);
+    return h;
+  }
+
   TraceContext() { // no external implementations
   }
 

--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -35,58 +35,16 @@ public class PlatformTest {
   Endpoint unknownEndpoint = Endpoint.newBuilder().serviceName("unknown").build();
   Platform platform = Platform.Jre7.buildIfSupported(true);
 
-  @Test public void relativeTimestamp_incrementsAccordingToNanoTick_jre7() {
-    mockStatic(System.class);
-    when(System.currentTimeMillis()).thenReturn(0L);
-    when(System.nanoTime()).thenReturn(0L);
-
-    Clock clock = platform.clock();
-
-    when(System.nanoTime()).thenReturn(1000L); // 1 microsecond
-
-    assertThat(clock.currentTimeMicroseconds()).isEqualTo(1);
+  @Test public void clock_hasNiceToString_jre7() {
+    assertThat(platform.clock())
+        .hasToString("System.currentTimeMillis()");
   }
 
-  @Test public void relativeTimestamp_incrementsAccordingToNanoTick_jre9() {
-    mockStatic(System.class);
-    when(System.nanoTime()).thenReturn(0L); // base tick
-    Clock clock = Platform.Jre9.buildIfSupported(true).clock();
-
-    // java 9 should provide microsecond resolution
-    when(System.nanoTime()).thenReturn(1000L); // each currentTimeMicroseconds call reads nanoTime
-    long epochMicros = clock.currentTimeMicroseconds();
-    if (epochMicros % 1000 == 0) { // unlikely we are exactly at micros 0, try again
-      when(System.nanoTime()).thenReturn(1000L);
-      epochMicros = clock.currentTimeMicroseconds();
-      assertThat(epochMicros % 1000).isNotZero();
-    }
-
-    when(System.nanoTime()).thenReturn(2000L); // 1 microsecond later
-
-    assertThat(clock.currentTimeMicroseconds() - epochMicros).isEqualTo(1);
-  }
-
-  @Test public void clock_hasNiceToString() {
-    mockStatic(System.class);
-    when(System.currentTimeMillis()).thenReturn(123L);
-    when(System.nanoTime()).thenReturn(456L);
-
-    Platform platform = new Platform() {
-      @Override public boolean zipkinV1Present() {
-        return true;
-      }
-
-      @Override public long randomLong() {
-        return 1L;
-      }
-
-      @Override public long nextTraceIdHigh() {
-        return 1L;
-      }
-    };
+  @Test public void clock_hasNiceToString_jre9() {
+    Platform platform = Platform.Jre9.buildIfSupported(true);
 
     assertThat(platform.clock())
-        .hasToString("TickClock{baseEpochMicros=123000, tickNanos=456}");
+        .hasToString("Clock.systemUTC().instant()");
   }
 
   @Test public void reporter_hasNiceToString() {

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -147,7 +147,8 @@ public class MutableSpanTest {
 
   // This prevents the server timestamp from overwriting the client one on the collector
   @Test public void reportsSharedStatus() {
-    MutableSpan span = new MutableSpan(context.toBuilder().shared(true).build(), localEndpoint);
+    MutableSpan span =
+        new MutableSpan(() -> 0L, context.toBuilder().shared(true).build(), localEndpoint);
 
     span.start(1L);
     span.kind(SERVER);
@@ -170,6 +171,6 @@ public class MutableSpanTest {
   }
 
   MutableSpan newSpan() {
-    return new MutableSpan(context, localEndpoint);
+    return new MutableSpan(() -> 0L, context, localEndpoint);
   }
 }

--- a/brave/src/test/java/brave/internal/recorder/RecorderTest.java
+++ b/brave/src/test/java/brave/internal/recorder/RecorderTest.java
@@ -15,10 +15,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RecorderTest {
   Endpoint localEndpoint = Platform.get().localEndpoint();
-  List<zipkin2.Span> spans = new ArrayList();
+  List<zipkin2.Span> spans = new ArrayList<>();
   TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
-  Recorder recorder =
-      new Recorder(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));
+  Recorder recorder = new Recorder(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));
 
   @After public void close() {
     Tracing.current().close();

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -14,6 +14,8 @@ public class TraceContextTest {
 
     assertThat(context)
         .isNotEqualTo(TraceContext.newBuilder().traceId(333L).spanId(1L).build());
+    assertThat(context.hashCode())
+        .isNotEqualTo(TraceContext.newBuilder().traceId(333L).spanId(1L).build().hashCode());
   }
 
   @Test public void compareEqualIds() {
@@ -21,6 +23,17 @@ public class TraceContextTest {
 
     assertThat(context)
         .isEqualTo(TraceContext.newBuilder().traceId(333L).spanId(444L).build());
+    assertThat(context.hashCode())
+        .isEqualTo(TraceContext.newBuilder().traceId(333L).spanId(444L).build().hashCode());
+  }
+
+  @Test public void equalOnSameTraceIdSpanId() {
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(444L).build();
+
+    assertThat(context)
+        .isEqualTo(context.toBuilder().parentId(1L).build());
+    assertThat(context.hashCode())
+        .isEqualTo(context.toBuilder().parentId(1L).build().hashCode());
   }
 
   @Test

--- a/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
@@ -13,6 +13,7 @@
  */
 package brave.internal;
 
+import brave.Clock;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -36,6 +37,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 public class PlatformBenchmarks {
   static final Platform jre6 = Platform.Jre6.build(false);
   static final Platform jre7 = Platform.Jre7.buildIfSupported(false);
+  static final Platform jre9 = Platform.Jre9.buildIfSupported(false);
+  static final Clock jre7Clock = jre7.clock();
+  static final Clock jre9Clock = jre9.clock();
 
   @Benchmark @Group("no_contention") @GroupThreads(1)
   public long no_contention_nextTraceIdHigh_jre6() {
@@ -95,6 +99,36 @@ public class PlatformBenchmarks {
   @Benchmark @Group("high_contention") @GroupThreads(8)
   public long high_contention_randomLong_jre7() {
     return jre7.randomLong();
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public long no_contention_clock_jre7() {
+    return jre7Clock.currentTimeMicroseconds();
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public long mild_contention_clock_jre7() {
+    return jre7Clock.currentTimeMicroseconds();
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public long high_contention_clock_jre7() {
+    return jre7Clock.currentTimeMicroseconds();
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public long no_contention_clock_jre9() {
+    return jre9Clock.currentTimeMicroseconds();
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public long mild_contention_clock_jre9() {
+    return jre9Clock.currentTimeMicroseconds();
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public long high_contention_clock_jre9() {
+    return jre9Clock.currentTimeMicroseconds();
   }
 
   // Convenience main entry-point


### PR DESCRIPTION
This moves logic such that clock readings occur once per trace. In doing
so, we get clock consistency throughout the trace, without risk of 
becoming out-of-sync with NTP updates.

An expiring approach was considered for sharing of timestamps outside the scope of a trace. This intended to reduce the overhead of reading current time, yet allowing NTP updates to be visible. However, benchmarks showed the infrastructure needed to expire a timestamp under contention was more costly than reading time. Hence, this only locks time per-trace.

See #516

cc @jorgheymans @llinder 