### PR TITLE
Makes end-to-end benchmarks more realistic

### DIFF
--- a/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/EndToEndBenchmarks.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Reporter;
 
 import static javax.servlet.DispatcherType.REQUEST;
@@ -63,19 +64,27 @@ public class EndToEndBenchmarks extends HttpServerBenchmarks {
 
   public static class Unsampled extends ForwardingTracingFilter {
     public Unsampled() {
-      super(Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(Reporter.NOOP).build());
+      super(Tracing.newBuilder()
+          .sampler(Sampler.NEVER_SAMPLE)
+          .spanReporter(AsyncReporter.create(new NoopSender()))
+          .build());
     }
   }
 
   public static class Traced extends ForwardingTracingFilter {
     public Traced() {
-      super(Tracing.newBuilder().spanReporter(Reporter.NOOP).build());
+      super(Tracing.newBuilder()
+          .spanReporter(AsyncReporter.create(new NoopSender()))
+          .build());
     }
   }
 
   public static class Traced128 extends ForwardingTracingFilter {
     public Traced128() {
-      super(Tracing.newBuilder().traceId128Bit(true).spanReporter(Reporter.NOOP).build());
+      super(Tracing.newBuilder()
+          .traceId128Bit(true)
+          .spanReporter(AsyncReporter.create(new NoopSender()))
+          .build());
     }
   }
 
@@ -83,7 +92,7 @@ public class EndToEndBenchmarks extends HttpServerBenchmarks {
     public TracedAWS() {
       super(Tracing.newBuilder()
           .propagationFactory(AWSPropagation.FACTORY)
-          .spanReporter(Reporter.NOOP)
+          .spanReporter(AsyncReporter.create(new NoopSender()))
           .build());
     }
   }

--- a/instrumentation/benchmarks/src/main/java/brave/NoopSender.java
+++ b/instrumentation/benchmarks/src/main/java/brave/NoopSender.java
@@ -1,0 +1,46 @@
+package brave;
+
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.CheckResult;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.Sender;
+
+final class NoopSender extends Sender {
+
+  final Encoding encoding = Encoding.JSON;
+  final BytesMessageEncoder messageEncoder = BytesMessageEncoder.forEncoding(encoding);
+
+  /** close is typically called from a different thread */
+  volatile boolean closeCalled;
+
+  @Override public int messageMaxBytes() {
+    return 1024;
+  }
+
+  @Override public Encoding encoding() {
+    return encoding;
+  }
+
+  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
+    return encoding().listSizeInBytes(encodedSpans);
+  }
+
+  @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+    messageEncoder.encode(encodedSpans);
+    return Call.create(null);
+  }
+
+  @Override public CheckResult check() {
+    return CheckResult.OK;
+  }
+
+  @Override public void close() {
+    closeCalled = true;
+  }
+
+  @Override public String toString() {
+    return "NoopSender";
+  }
+}


### PR DESCRIPTION
Chat with @wu-sheng made me realize our end-to-end benchmarks were not
that realistic, on account of using a noop reporter. Most people use
`AsyncReporter` and eventhough that code lives outside Brave, it is a
very important factor in latency which should be included.

For example, here's with 1KiB message size (to avoid GC thrash in JMH)
```
Benchmark                                           Mode  Cnt    Score    Error  Units
EndToEndBenchmarks.server_get                       avgt   15  159.013 ±  9.592  us/op
EndToEndBenchmarks.traced128Server_get              avgt   15  223.974 ± 14.517  us/op
EndToEndBenchmarks.traced128Server_get_resumeTrace  avgt   15  226.344 ±  9.706  us/op
EndToEndBenchmarks.tracedServer_get                 avgt   15  220.218 ±  6.028  us/op
EndToEndBenchmarks.tracedServer_get_resumeTrace     avgt   15  218.240 ±  2.942  us/op
EndToEndBenchmarks.tracedawsServer_get              avgt   15  218.895 ±  6.939  us/op
EndToEndBenchmarks.tracedawsServer_get_resumeTrace  avgt   15  219.882 ± 12.913  us/op
EndToEndBenchmarks.unsampledServer_get              avgt   15  166.991 ±  2.342  us/op
```

Overhead without the async reporter is usually up to 30us. The above
shows significant opportunity to reduce overhead there. FWIW, it is
mainly due to encoding spans on the calling thread. There are other
ways to accomplish the goal of memory-bounding now that the data
structures are simpler (in zipkin v2).