### PR TITLE
Corrects default encoding in spring-beans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.1.4.Final</resteasy.version>
     <zipkin.version>2.4.1</zipkin.version>
-    <zipkin-reporter2.version>2.2.0</zipkin-reporter2.version>
+    <zipkin-reporter2.version>2.2.1</zipkin-reporter2.version>
     <zipkin-reporter.version>1.1.2</zipkin-reporter.version>
     <finagle.version>6.45.0</finagle.version>
     <log4j.version>2.8.2</log4j.version>

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -17,8 +17,7 @@ Here are some example beans using the factories in this module:
   <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
     <property name="localServiceName" value="brave-webmvc-example"/>
     <property name="spanReporter">
-      <bean class="brave.spring.beans.AsyncReporterFactoryBean">
-        <property name="encoder" value="JSON_V2"/>
+      <bean class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
         <property name="sender" ref="sender"/>
         <!-- wait up to half a second for any in-flight spans on close -->
         <property name="closeTimeout" value="500"/>

--- a/spring-beans/src/main/java/brave/spring/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/AsyncReporterFactoryBean.java
@@ -1,6 +1,12 @@
 package brave.spring.beans;
 
+import zipkin2.codec.SpanBytesEncoder;
+
 /** @deprecated use {@link zipkin2.reporter.beans.AsyncReporterFactoryBean} */
 @Deprecated
 public class AsyncReporterFactoryBean extends zipkin2.reporter.beans.AsyncReporterFactoryBean {
+  public AsyncReporterFactoryBean() {
+    // This bean factory defaulted to the old format in the past. The new doesn't
+    setEncoder(SpanBytesEncoder.JSON_V1);
+  }
 }


### PR DESCRIPTION
While our old bean factory defaulted to json v1, the new one doesn't.