### PR TITLE
Adds zipkin2 support to Brave 3 api and removes internal package sharing

### DIFF
--- a/archive/brave-core/pom.xml
+++ b/archive/brave-core/pom.xml
@@ -20,6 +20,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+    <dependency>
         <groupId>io.zipkin.java</groupId>
         <artifactId>zipkin</artifactId>
     </dependency>
@@ -27,6 +31,7 @@
       <groupId>io.zipkin.reporter</groupId>
       <artifactId>zipkin-reporter</artifactId>
       <version>${zipkin-reporter.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/AnnotationSubmitter.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave;
 
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/ClientTracer.java
@@ -1,12 +1,13 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.Nullable;
+import com.github.kristofa.brave.internal.V2SpanConverter;
 import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
 import java.util.Random;
 import zipkin.Constants;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 /**
  * Low level api that deals with client side of a request:
@@ -69,15 +70,36 @@ public abstract class ClientTracer extends AnnotationSubmitter {
             return this;
         }
 
-        public final Builder reporter(Reporter<zipkin.Span> reporter) {
+        public Builder spanReporter(Reporter<zipkin2.Span> reporter) {
+            if (reporter == null) throw new NullPointerException("spanReporter == null");
             this.reporter = reporter;
             return this;
         }
 
-        /** @deprecated use {@link #reporter(Reporter)} */
+        /** @deprecated use {@link #spanReporter(Reporter)} */
+        @Deprecated
+        public Builder reporter(final zipkin.reporter.Reporter<zipkin.Span> reporter) {
+            if (reporter == null) throw new NullPointerException("spanReporter == null");
+            if (reporter == zipkin.reporter.Reporter.NOOP) {
+                this.reporter = Reporter.NOOP;
+                return this;
+            }
+            this.reporter = new Reporter<zipkin2.Span>() {
+                @Override public void report(zipkin2.Span span) {
+                    reporter.report(V2SpanConverter.toSpan(span));
+                }
+
+                @Override public String toString() {
+                    return reporter.toString();
+                }
+            };
+            return this;
+        }
+
+        /** @deprecated use {@link #spanReporter(Reporter)} */
         @Deprecated
         public final Builder spanCollector(SpanCollector spanCollector) {
-            return reporter(new SpanCollectorReporterAdapter(spanCollector));
+            return spanReporter(new SpanCollectorReporterAdapter(spanCollector));
         }
 
         public final Builder clock(Clock clock) {

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
@@ -2,13 +2,15 @@ package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.InternalSpan;
 import com.github.kristofa.brave.internal.Nullable;
+import com.github.kristofa.brave.internal.V2SpanConverter;
 import com.google.auto.value.AutoValue;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.BinaryAnnotation;
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
+import java.util.List;
 import zipkin.Constants;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.DefaultSpanCodec.toZipkin;
 
@@ -39,7 +41,7 @@ abstract class Recorder implements AnnotationSubmitter.Clock {
 
     abstract AnnotationSubmitter.Clock clock();
 
-    abstract Reporter<zipkin.Span> reporter();
+    abstract Reporter<zipkin2.Span> reporter();
 
     @Override public long currentTimeMicroseconds() {
       return clock().currentTimeMicroseconds();
@@ -109,7 +111,10 @@ abstract class Recorder implements AnnotationSubmitter.Clock {
           }
         }
       }
-      reporter().report(toZipkin(span));
+      List<zipkin2.Span> toReport = V2SpanConverter.fromSpan(toZipkin(span));
+      for (int i = 0, length = toReport.size(); i < length; i++) {
+        reporter().report(toReport.get(i));
+      }
     }
   }
 }

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorReporterAdapter.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanCollectorReporterAdapter.java
@@ -1,12 +1,13 @@
 package com.github.kristofa.brave;
 
 import com.github.kristofa.brave.internal.DefaultSpanCodec;
+import com.github.kristofa.brave.internal.V2SpanConverter;
 import com.twitter.zipkin.gen.Span;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
-final class SpanCollectorReporterAdapter implements SpanCollector, Reporter<zipkin.Span> {
+final class SpanCollectorReporterAdapter implements SpanCollector, Reporter<zipkin2.Span> {
 
   final SpanCollector delegate;
 
@@ -14,9 +15,9 @@ final class SpanCollectorReporterAdapter implements SpanCollector, Reporter<zipk
     this.delegate = checkNotNull(delegate, "span collector");
   }
 
-  @Override public void report(zipkin.Span span) {
+  @Override public void report(zipkin2.Span span) {
     checkNotNull(span, "Null span");
-    collect(DefaultSpanCodec.fromZipkin(span));
+    collect(DefaultSpanCodec.fromZipkin(V2SpanConverter.toSpan(span)));
   }
 
   @Override

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/internal/V2SpanConverter.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/internal/V2SpanConverter.java
@@ -1,0 +1,516 @@
+package com.github.kristofa.brave.internal;
+
+import com.github.kristofa.brave.IdConversion;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.Span.Kind;
+
+import static zipkin.BinaryAnnotation.Type.BOOL;
+import static zipkin.Constants.CLIENT_ADDR;
+import static zipkin.Constants.LOCAL_COMPONENT;
+import static zipkin.Constants.SERVER_ADDR;
+
+/**
+ * This converts {@link zipkin.Span} instances to {@link Span} and visa versa.
+ *
+ * <p/> Copy-pasted from zipkin.internal.V2SpanConverter version 2.2.2 to avoid shade setup
+ */
+public final class V2SpanConverter {
+
+  /**
+   * Converts the input, parsing RPC annotations into {@link Span#kind()}.
+   *
+   * @return a span for each unique {@link Annotation#endpoint annotation endpoint} service name.
+   */
+  public static List<Span> fromSpan(zipkin.Span source) {
+    Builders builders = new Builders(source);
+    // add annotations unless they are "core"
+    builders.processAnnotations(source);
+    // convert binary annotations to tags and addresses
+    builders.processBinaryAnnotations(source);
+    return builders.build();
+  }
+
+  static final class Builders {
+    final List<Span.Builder> spans = new ArrayList<>();
+    Annotation cs = null, sr = null, ss = null, cr = null, ms = null, mr = null, ws = null, wr =
+        null;
+
+    Builders(zipkin.Span source) {
+      this.spans.add(newBuilder(source));
+    }
+
+    void processAnnotations(zipkin.Span source) {
+      for (int i = 0, length = source.annotations.size(); i < length; i++) {
+        Annotation a = source.annotations.get(i);
+        Span.Builder currentSpan = forEndpoint(source, a.endpoint);
+        // core annotations require an endpoint. Don't give special treatment when that's missing
+        if (a.value.length() == 2 && a.endpoint != null) {
+          if (a.value.equals(Constants.CLIENT_SEND)) {
+            currentSpan.kind(Kind.CLIENT);
+            cs = a;
+          } else if (a.value.equals(Constants.SERVER_RECV)) {
+            currentSpan.kind(Kind.SERVER);
+            sr = a;
+          } else if (a.value.equals(Constants.SERVER_SEND)) {
+            currentSpan.kind(Kind.SERVER);
+            ss = a;
+          } else if (a.value.equals(Constants.CLIENT_RECV)) {
+            currentSpan.kind(Kind.CLIENT);
+            cr = a;
+          } else if (a.value.equals(Constants.MESSAGE_SEND)) {
+            currentSpan.kind(Kind.PRODUCER);
+            ms = a;
+          } else if (a.value.equals(Constants.MESSAGE_RECV)) {
+            currentSpan.kind(Kind.CONSUMER);
+            mr = a;
+          } else if (a.value.equals(Constants.WIRE_SEND)) {
+            ws = a;
+          } else if (a.value.equals(Constants.WIRE_RECV)) {
+            wr = a;
+          } else {
+            currentSpan.addAnnotation(a.timestamp, a.value);
+          }
+        } else {
+          currentSpan.addAnnotation(a.timestamp, a.value);
+        }
+      }
+
+      // When bridging between event and span model, you can end up missing a start annotation
+      if (cs == null && endTimestampReflectsSpanDuration(cr, source)) {
+        cs = Annotation.create(source.timestamp, "cs", cr.endpoint);
+      }
+      if (sr == null && endTimestampReflectsSpanDuration(ss, source)) {
+        sr = Annotation.create(source.timestamp, "sr", ss.endpoint);
+      }
+
+      if (cs != null && sr != null) {
+        // in a shared span, the client side owns span duration by annotations or explicit timestamp
+        maybeTimestampDuration(source, cs, cr);
+
+        // special-case loopback: We need to make sure on loopback there are two span2s
+        Span.Builder client = forEndpoint(source, cs.endpoint);
+        Span.Builder server;
+        if (closeEnough(cs.endpoint, sr.endpoint)) {
+          client.kind(Kind.CLIENT);
+          // fork a new span for the server side
+          server = newSpanBuilder(source, sr.endpoint.toV2()).kind(Kind.SERVER);
+        } else {
+          server = forEndpoint(source, sr.endpoint);
+        }
+
+        // the server side is smaller than that, we have to read annotations to find out
+        server.shared(true).timestamp(sr.timestamp);
+        if (ss != null) server.duration(ss.timestamp - sr.timestamp);
+        if (cr == null && source.duration == null) client.duration(null); // one-way has no duration
+      } else if (cs != null && cr != null) {
+        maybeTimestampDuration(source, cs, cr);
+      } else if (sr != null && ss != null) {
+        maybeTimestampDuration(source, sr, ss);
+      } else { // otherwise, the span is incomplete. revert special-casing
+        for (Span.Builder next : spans) {
+          if (Kind.CLIENT.equals(next.kind())) {
+            if (cs != null) next.timestamp(cs.timestamp);
+            if (cr != null) next.addAnnotation(cr.timestamp, cr.value);
+          } else if (Kind.SERVER.equals(next.kind())) {
+            if (sr != null) next.timestamp(sr.timestamp);
+            if (ss != null) next.addAnnotation(ss.timestamp, ss.value);
+          }
+        }
+
+        if (source.timestamp != null) {
+          spans.get(0).timestamp(source.timestamp).duration(source.duration);
+        }
+      }
+
+      // Span v1 format did not have a shared flag. By convention, span.timestamp being absent
+      // implied shared. When we only see the server-side, carry this signal over.
+      if (cs == null && (sr != null && source.timestamp == null)) {
+        forEndpoint(source, sr.endpoint).shared(true);
+      }
+
+      // ms and mr are not supposed to be in the same span, but in case they are..
+      if (ms != null && mr != null) {
+        // special-case loopback: We need to make sure on loopback there are two span2s
+        Span.Builder producer = forEndpoint(source, ms.endpoint);
+        Span.Builder consumer;
+        if (closeEnough(ms.endpoint, mr.endpoint)) {
+          producer.kind(Kind.PRODUCER);
+          // fork a new span for the consumer side
+          consumer = newSpanBuilder(source, mr.endpoint.toV2()).kind(Kind.CONSUMER);
+        } else {
+          consumer = forEndpoint(source, mr.endpoint);
+        }
+
+        consumer.shared(true);
+        if (wr != null) {
+          consumer.timestamp(wr.timestamp).duration(mr.timestamp - wr.timestamp);
+        } else {
+          consumer.timestamp(mr.timestamp);
+        }
+
+        producer.timestamp(ms.timestamp).duration(ws != null ? ws.timestamp - ms.timestamp : null);
+      } else if (ms != null) {
+        maybeTimestampDuration(source, ms, ws);
+      } else if (mr != null) {
+        if (wr != null) {
+          maybeTimestampDuration(source, wr, mr);
+        } else {
+          maybeTimestampDuration(source, mr, null);
+        }
+      } else {
+        if (ws != null) forEndpoint(source, ws.endpoint).addAnnotation(ws.timestamp, ws.value);
+        if (wr != null) forEndpoint(source, wr.endpoint).addAnnotation(wr.timestamp, wr.value);
+      }
+    }
+
+    void maybeTimestampDuration(zipkin.Span source, Annotation begin, @Nullable Annotation end) {
+      Span.Builder span2 = forEndpoint(source, begin.endpoint);
+      if (source.timestamp != null && source.duration != null) {
+        span2.timestamp(source.timestamp).duration(source.duration);
+      } else {
+        span2.timestamp(begin.timestamp);
+        if (end != null) span2.duration(end.timestamp - begin.timestamp);
+      }
+    }
+
+    void processBinaryAnnotations(zipkin.Span source) {
+      zipkin.Endpoint ca = null, sa = null, ma = null;
+      for (int i = 0, length = source.binaryAnnotations.size(); i < length; i++) {
+        BinaryAnnotation b = source.binaryAnnotations.get(i);
+        if (b.type == BOOL) {
+          if (Constants.CLIENT_ADDR.equals(b.key)) {
+            ca = b.endpoint;
+          } else if (Constants.SERVER_ADDR.equals(b.key)) {
+            sa = b.endpoint;
+          } else if (Constants.MESSAGE_ADDR.equals(b.key)) {
+            ma = b.endpoint;
+          } else {
+            forEndpoint(source, b.endpoint).putTag(b.key, b.value[0] == 1 ? "true" : "false");
+          }
+          continue;
+        }
+
+        Span.Builder currentSpan = forEndpoint(source, b.endpoint);
+        switch (b.type) {
+          case BOOL:
+            break; // already handled
+          case STRING:
+            // don't add marker "lc" tags
+            if (Constants.LOCAL_COMPONENT.equals(b.key) && b.value.length == 0) continue;
+            currentSpan.putTag(b.key, new String(b.value, Util.UTF_8));
+            break;
+          case BYTES:
+            currentSpan.putTag(b.key, writeBase64Url(b.value));
+            break;
+          case I16:
+            currentSpan.putTag(b.key, Short.toString(ByteBuffer.wrap(b.value).getShort()));
+            break;
+          case I32:
+            currentSpan.putTag(b.key, Integer.toString(ByteBuffer.wrap(b.value).getInt()));
+            break;
+          case I64:
+            currentSpan.putTag(b.key, Long.toString(ByteBuffer.wrap(b.value).getLong()));
+            break;
+          case DOUBLE:
+            double wrapped = Double.longBitsToDouble(ByteBuffer.wrap(b.value).getLong());
+            currentSpan.putTag(b.key, Double.toString(wrapped));
+            break;
+        }
+      }
+
+      // special-case when we are missing core annotations, but we have both address annotations
+      if ((cs == null && sr == null) && (ca != null && sa != null)) {
+        forEndpoint(source, ca).remoteEndpoint(sa.toV2());
+        return;
+      }
+
+      if (sa != null) {
+        if (cs != null && !closeEnough(sa, cs.endpoint)) {
+          forEndpoint(source, cs.endpoint).remoteEndpoint(sa.toV2());
+        } else if (cr != null && !closeEnough(sa, cr.endpoint)) {
+          forEndpoint(source, cr.endpoint).remoteEndpoint(sa.toV2());
+        } else if (cs == null && cr == null && sr == null && ss == null) { // no core annotations
+          forEndpoint(source, null)
+              .kind(Kind.CLIENT)
+              .remoteEndpoint(sa.toV2());
+        }
+      }
+
+      if (ca != null) {
+        if (sr != null && !closeEnough(ca, sr.endpoint)) {
+          forEndpoint(source, sr.endpoint).remoteEndpoint(ca.toV2());
+        } if (ss != null && !closeEnough(ca, ss.endpoint)) {
+          forEndpoint(source, ss.endpoint).remoteEndpoint(ca.toV2());
+        } else if (cs == null && cr == null && sr == null && ss == null) { // no core annotations
+          forEndpoint(source, null)
+              .kind(Kind.SERVER)
+              .remoteEndpoint(ca.toV2());
+        }
+      }
+
+      if (ma != null){
+        if (ms != null && !closeEnough(ma, ms.endpoint)) {
+          forEndpoint(source, ms.endpoint).remoteEndpoint(ma.toV2());
+        }
+        if (mr != null && !closeEnough(ma, mr.endpoint)) {
+          forEndpoint(source, mr.endpoint).remoteEndpoint(ma.toV2());
+        }
+      }
+    }
+
+    Span.Builder forEndpoint(zipkin.Span source, @Nullable zipkin.Endpoint e) {
+      if (e == null) return spans.get(0); // allocate missing endpoint data to first span
+      Endpoint converted = e.toV2();
+      for (int i = 0, length = spans.size(); i < length; i++) {
+        Span.Builder next = spans.get(i);
+        Endpoint nextLocalEndpoint = next.localEndpoint();
+        if (nextLocalEndpoint == null) {
+          next.localEndpoint(converted);
+          return next;
+        } else if (closeEnough(toEndpoint(nextLocalEndpoint), e)) {
+          return next;
+        }
+      }
+      return newSpanBuilder(source, converted);
+    }
+
+    Span.Builder newSpanBuilder(zipkin.Span source, Endpoint e) {
+      Span.Builder result = newBuilder(source).localEndpoint(e);
+      spans.add(result);
+      return result;
+    }
+
+    List<Span> build() {
+      int length = spans.size();
+      if (length == 1) return Collections.singletonList(spans.get(0).build());
+      List<Span> result = new ArrayList<>(length);
+      for (int i = 0; i < length; i++) {
+        result.add(spans.get(i).build());
+      }
+      return result;
+    }
+  }
+
+  static boolean closeEnough(zipkin.Endpoint left, zipkin.Endpoint right) {
+    return left.serviceName.equals(right.serviceName);
+  }
+
+  static Span.Builder newBuilder(zipkin.Span source) {
+    return Span.newBuilder()
+        .traceId(source.traceIdString())
+        .parentId(source.parentId != null ? IdConversion.convertToString(source.parentId) : null)
+        .id(IdConversion.convertToString(source.id))
+        .name(source.name)
+        .debug(source.debug);
+  }
+
+  /** Converts the input, parsing {@link Span#kind()} into RPC annotations. */
+  public static zipkin.Span toSpan(Span in) {
+    String traceId = in.traceId();
+    zipkin.Span.Builder result = zipkin.Span.builder()
+      .traceId(IdConversion.convertToLong(traceId))
+      .parentId(in.parentId() != null ? IdConversion.convertToLong(in.parentId()) : null)
+      .id(IdConversion.convertToLong(in.id()))
+      .debug(in.debug())
+      .name(in.name() != null ? in.name() : ""); // avoid a NPE
+
+    if (traceId.length() == 32) {
+      result.traceIdHigh(IdConversion.convertToLong(traceId, 0));
+    }
+
+    long startTs = in.timestamp() == null ? 0L : in.timestamp();
+    Long endTs = in.duration() == null ? 0L : in.timestamp() + in.duration();
+    if (startTs != 0L) {
+      result.timestamp(startTs);
+      result.duration(in.duration());
+    }
+
+    zipkin.Endpoint local = in.localEndpoint() != null ? toEndpoint(in.localEndpoint()) : null;
+    zipkin.Endpoint remote = in.remoteEndpoint() != null ? toEndpoint(in.remoteEndpoint()) : null;
+    Kind kind = in.kind();
+    Annotation
+      cs = null, sr = null, ss = null, cr = null, ms = null, mr = null, ws = null, wr = null;
+    String remoteEndpointType = null;
+
+    boolean wroteEndpoint = false;
+
+    for (int i = 0, length = in.annotations().size(); i < length; i++) {
+      zipkin2.Annotation input = in.annotations().get(i);
+      Annotation a = Annotation.create(input.timestamp(), input.value(), local);
+      if (a.value.length() == 2) {
+        if (a.value.equals(Constants.CLIENT_SEND)) {
+          kind = Kind.CLIENT;
+          cs = a;
+          remoteEndpointType = SERVER_ADDR;
+        } else if (a.value.equals(Constants.SERVER_RECV)) {
+          kind = Kind.SERVER;
+          sr = a;
+          remoteEndpointType = CLIENT_ADDR;
+        } else if (a.value.equals(Constants.SERVER_SEND)) {
+          kind = Kind.SERVER;
+          ss = a;
+        } else if (a.value.equals(Constants.CLIENT_RECV)) {
+          kind = Kind.CLIENT;
+          cr = a;
+        } else if (a.value.equals(Constants.MESSAGE_SEND)) {
+          kind = Kind.PRODUCER;
+          ms = a;
+        } else if (a.value.equals(Constants.MESSAGE_RECV)) {
+          kind = Kind.CONSUMER;
+          mr = a;
+        } else if (a.value.equals(Constants.WIRE_SEND)) {
+          ws = a;
+        } else if (a.value.equals(Constants.WIRE_RECV)) {
+          wr = a;
+        } else {
+          wroteEndpoint = true;
+          result.addAnnotation(a);
+        }
+      } else {
+        wroteEndpoint = true;
+        result.addAnnotation(a);
+      }
+    }
+
+    if (kind != null) {
+      switch (kind) {
+        case CLIENT:
+          remoteEndpointType = Constants.SERVER_ADDR;
+          if (startTs != 0L) cs = Annotation.create(startTs, Constants.CLIENT_SEND, local);
+          if (endTs != 0L) cr = Annotation.create(endTs, Constants.CLIENT_RECV, local);
+          break;
+        case SERVER:
+          remoteEndpointType = Constants.CLIENT_ADDR;
+          if (startTs != 0L) sr = Annotation.create(startTs, Constants.SERVER_RECV, local);
+          if (endTs != 0L) ss = Annotation.create(endTs, Constants.SERVER_SEND, local);
+          break;
+        case PRODUCER:
+          remoteEndpointType = Constants.MESSAGE_ADDR;
+          if (startTs != 0L) ms = Annotation.create(startTs, Constants.MESSAGE_SEND, local);
+          if (endTs != 0L) ws = Annotation.create(endTs, Constants.WIRE_SEND, local);
+          break;
+        case CONSUMER:
+          remoteEndpointType = Constants.MESSAGE_ADDR;
+          if (startTs != 0L && endTs != 0L) {
+            wr = Annotation.create(startTs, Constants.WIRE_RECV, local);
+            mr = Annotation.create(endTs, Constants.MESSAGE_RECV, local);
+          } else if (startTs != 0L) {
+            mr = Annotation.create(startTs, Constants.MESSAGE_RECV, local);
+          }
+          break;
+        default:
+          throw new AssertionError("update kind mapping");
+      }
+    }
+
+    for (Map.Entry<String, String> tag : in.tags().entrySet()) {
+      wroteEndpoint = true;
+      result.addBinaryAnnotation(BinaryAnnotation.create(tag.getKey(), tag.getValue(), local));
+    }
+
+    if (cs != null
+      || sr != null
+      || ss != null
+      || cr != null
+      || ws != null
+      || wr != null
+      || ms != null
+      || mr != null) {
+      if (cs != null) result.addAnnotation(cs);
+      if (sr != null) result.addAnnotation(sr);
+      if (ss != null) result.addAnnotation(ss);
+      if (cr != null) result.addAnnotation(cr);
+      if (ws != null) result.addAnnotation(ws);
+      if (wr != null) result.addAnnotation(wr);
+      if (ms != null) result.addAnnotation(ms);
+      if (mr != null) result.addAnnotation(mr);
+      wroteEndpoint = true;
+    } else if (local != null && remote != null) {
+      // special-case when we are missing core annotations, but we have both address annotations
+      result.addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, local));
+      wroteEndpoint = true;
+      remoteEndpointType = SERVER_ADDR;
+    }
+
+    if (remoteEndpointType != null && remote != null) {
+      result.addBinaryAnnotation(BinaryAnnotation.address(remoteEndpointType, remote));
+    }
+
+    // don't report server-side timestamp on shared or incomplete spans
+    if (Boolean.TRUE.equals(in.shared()) && sr != null) {
+      result.timestamp(null).duration(null);
+    }
+    if (local != null && !wroteEndpoint) { // create a dummy annotation
+      result.addBinaryAnnotation(BinaryAnnotation.create(LOCAL_COMPONENT, "", local));
+    }
+    return result.build();
+  }
+
+  static zipkin.Endpoint toEndpoint(Endpoint input) {
+    zipkin.Endpoint.Builder result = zipkin.Endpoint.builder()
+      .serviceName(input.serviceName() != null ? input.serviceName() : "")
+      .port(input.port() != null ? input.port() : 0);
+    if (input.ipv6() != null) {
+      result.parseIp(input.ipv6()); // parse first in case there's a mapped IP
+    }
+    if (input.ipv4() != null) {
+      result.parseIp(input.ipv4());
+    }
+    return result.build();
+  }
+
+  static boolean endTimestampReflectsSpanDuration(Annotation end, zipkin.Span source) {
+    return end != null
+        && source.timestamp != null
+        && source.duration != null
+        && source.timestamp + source.duration == end.timestamp;
+  }
+
+  /**
+   * Adapted from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+   *
+   * <p>Original author: Alexander Y. Kleymenov
+   */
+  static String writeBase64Url(byte[] in) {
+    char[] result = new char[(in.length + 2) / 3 * 4];
+    int end = in.length - in.length % 3;
+    int pos = 0;
+    for (int i = 0; i < end; i += 3) {
+      result[pos++] = URL_MAP[(in[i] & 0xff) >> 2];
+      result[pos++] = URL_MAP[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      result[pos++] = URL_MAP[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      result[pos++] = URL_MAP[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        result[pos++] = URL_MAP[(in[end] & 0xff) >> 2];
+        result[pos++] = URL_MAP[(in[end] & 0x03) << 4];
+        result[pos++] = '=';
+        result[pos] = '=';
+        break;
+      case 2:
+        result[pos++] = URL_MAP[(in[end] & 0xff) >> 2];
+        result[pos++] = URL_MAP[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        result[pos++] = URL_MAP[((in[end + 1] & 0x0f) << 2)];
+        result[pos] = '=';
+        break;
+    }
+    return new String(result);
+  }
+
+  static final char[] URL_MAP = new char[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+      '5', '6', '7', '8', '9', '-', '_'
+  };
+}

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/AnnotationSubmitterTest.java
@@ -32,7 +32,7 @@ public class AnnotationSubmitterTest {
         Endpoint.builder().serviceName("foobar").ipv4(127 << 24 | 1).port(9999).build();
     private Span span = Brave.toSpan(SpanId.builder().spanId(1).build());
     private AnnotationSubmitter annotationSubmitter;
-    private List<zipkin.Span> spans = new ArrayList<>();
+    private List<zipkin2.Span> spans = new ArrayList<>();
 
     @Before
     public void setup() {
@@ -114,8 +114,8 @@ public class AnnotationSubmitterTest {
         annotationSubmitter.submitEndAnnotation(Constants.SERVER_SEND);
         assertThat(spans).allSatisfy(
             span -> {
-                assertThat(span.timestamp).isNull();
-                assertThat(span.duration).isNull();
+                assertThat(span.timestamp()).isNull();
+                assertThat(span.duration()).isNull();
             }
         );
     }
@@ -126,7 +126,7 @@ public class AnnotationSubmitterTest {
 
         annotationSubmitter.submitStartAnnotation(Constants.SERVER_RECV);
         annotationSubmitter.submitEndAnnotation(Constants.SERVER_SEND);
-        assertThat(spans).extracting(s -> s.duration)
+        assertThat(spans).extracting(zipkin2.Span::duration)
             .containsExactly(1L);
     }
 
@@ -138,7 +138,7 @@ public class AnnotationSubmitterTest {
 
         annotationSubmitter.submitStartAnnotation(Constants.SERVER_RECV);
         annotationSubmitter.submitEndAnnotation(Constants.SERVER_SEND);
-        assertThat(spans).extracting(s -> s.duration)
+        assertThat(spans).extracting(zipkin2.Span::duration)
             .containsExactly(1L);
     }
 

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ClientTracerTest.java
@@ -11,7 +11,7 @@ public class Brave4ClientTracerTest extends ClientTracerTest {
         .clock(new AnnotationSubmitter.DefaultClock()::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
         .clock(clock::currentTimeMicroseconds)
-        .reporter((Reporter<Span>) spans::add).build().tracer());
+        .spanReporter(spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4LocalTracerTest.java
@@ -2,22 +2,20 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
-import zipkin.Span;
-import zipkin.reporter.Reporter;
 
 public class Brave4LocalTracerTest extends LocalTracerTest {
   @Override Brave newBrave() {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter((Reporter<Span>) spans::add).build().tracer());
+        .spanReporter(spans::add).build().tracer());
   }
 
   @Override Brave newBrave(ServerClientAndLocalSpanState state) {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter((Reporter<Span>) spans::add).build().tracer(), state);
+        .spanReporter(spans::add).build().tracer(), state);
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerRequestInterceptorTest.java
@@ -2,14 +2,12 @@ package com.github.kristofa.brave;
 
 import brave.Tracing;
 import org.junit.After;
-import zipkin.Span;
-import zipkin.reporter.Reporter;
 
 public class Brave4ServerRequestInterceptorTest extends ServerRequestInterceptorTest {
   @Override Brave newBrave() {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter((Reporter<Span>) spans::add).build().tracer());
+        .spanReporter(spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/Brave4ServerTracerTest.java
@@ -8,7 +8,7 @@ public class Brave4ServerTracerTest extends ServerTracerTest {
     return TracerAdapter.newBrave(Tracing.newBuilder()
         .clock(clock::currentTimeMicroseconds)
         .localEndpoint(ZIPKIN_ENDPOINT)
-        .reporter(spans::add)
+        .spanReporter(spans::add)
         .supportsJoin(supportsJoin)
         .build().tracer());
   }

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/BraveCallableTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/BraveCallableTest.java
@@ -5,14 +5,14 @@ import com.twitter.zipkin.gen.Span;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import org.junit.Test;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BraveCallableTest {
 
   Brave brave = new Brave.Builder(new TestServerClientAndLocalSpanStateCompilation())
-      .reporter(Reporter.NOOP)
+      .spanReporter(Reporter.NOOP)
       .traceSampler(Sampler.ALWAYS_SAMPLE).build();
 
   Supplier<Span> currentServerSpan =

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/BraveExecutorServiceTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/BraveExecutorServiceTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.junit.Test;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,7 +20,7 @@ public class BraveExecutorServiceTest {
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
   // Ensures things don't accidentally work due to inheritable thread locals!
   Brave brave = new Brave.Builder(new TestServerClientAndLocalSpanStateCompilation())
-      .reporter(Reporter.NOOP)
+      .spanReporter(Reporter.NOOP)
       .traceSampler(Sampler.ALWAYS_SAMPLE).build();
   BlockingQueue<Span> spanQueue = new LinkedBlockingQueue();
   Supplier<Span> currentServerSpan =

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/BraveRunnableTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/BraveRunnableTest.java
@@ -4,14 +4,14 @@ import com.github.kristofa.brave.example.TestServerClientAndLocalSpanStateCompil
 import com.twitter.zipkin.gen.Span;
 import java.util.function.Supplier;
 import org.junit.Test;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BraveRunnableTest {
 
   Brave brave = new Brave.Builder(new TestServerClientAndLocalSpanStateCompilation())
-      .reporter(Reporter.NOOP)
+      .spanReporter(Reporter.NOOP)
       .traceSampler(Sampler.ALWAYS_SAMPLE).build();
 
   Supplier<Span> currentServerSpan =

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/ITAnnotationSubmitterConcurrency.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Future;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import zipkin.reporter.Reporter;
+import zipkin2.reporter.Reporter;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/Brave4MaybeAddClientAddressTest.java
@@ -8,8 +8,7 @@ import zipkin.reporter.Reporter;
 
 public class Brave4MaybeAddClientAddressTest extends MaybeAddClientAddressTest {
   public Brave4MaybeAddClientAddressTest() {
-    brave = TracerAdapter.newBrave(
-        Tracing.newBuilder().reporter((Reporter<Span>) spans::add).build().tracer());
+    brave = TracerAdapter.newBrave(Tracing.newBuilder().spanReporter(spans::add).build().tracer());
   }
 
   @After public void close(){

--- a/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/InternalTest.java
+++ b/archive/brave-core/src/test/java/com/github/kristofa/brave/internal/InternalTest.java
@@ -20,8 +20,8 @@ public class InternalTest {
   SpanId context = SpanId.builder().spanId(1L).build();
   Span span = InternalSpan.instance.toSpan(context);
 
-  List<zipkin.Span> spans = new ArrayList<>();
-  Brave brave = new Brave.Builder().reporter(spans::add).build();
+  List<zipkin2.Span> spans = new ArrayList<>();
+  Brave brave = new Brave.Builder().spanReporter(spans::add).build();
 
   @Before
   public void setup() {
@@ -37,8 +37,8 @@ public class InternalTest {
 
     brave.serverTracer().setServerSend(); // flush
 
-    assertThat(spans.get(0).binaryAnnotations).containsExactly(
-        zipkin.BinaryAnnotation.address("ca", zipkin.Endpoint.create("foo", 127 << 24 | 1))
+    assertThat(spans.get(0).remoteEndpoint()).isEqualTo(
+        zipkin2.Endpoint.newBuilder().serviceName("foo").ip("127.0.0.1").build()
     );
   }
 }

--- a/archive/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/TraceFilters.java
+++ b/archive/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/TraceFilters.java
@@ -7,12 +7,12 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import java.util.Collections;
-import zipkin.storage.InMemoryStorage;
+import zipkin2.storage.InMemoryStorage;
 
 public enum TraceFilters {
   INSTANCE;
 
-  final InMemoryStorage storage = new InMemoryStorage();
+  final InMemoryStorage storage = InMemoryStorage.newBuilder().build();
   final ServletTraceFilter server;
   final JerseyClientTraceFilter client;
 
@@ -20,7 +20,7 @@ public enum TraceFilters {
     Injector injector = Guice.createInjector(new AbstractModule() {
       @Override protected void configure() {
         bind(Brave.class).toInstance(new Brave.Builder("brave-jersey")
-                .reporter(s -> storage.spanConsumer().accept(Collections.singletonList(s))).build());
+                .spanReporter(s -> storage.spanConsumer().accept(Collections.singletonList(s))).build());
         bind(SpanNameProvider.class).to(DefaultSpanNameProvider.class);
       }
     });

--- a/archive/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
+++ b/archive/brave-web-servlet-filter/src/test/java/com/github/kristofa/brave/servlet/internal/MaybeAddClientAddressFromRequestTest.java
@@ -15,7 +15,6 @@ package com.github.kristofa.brave.servlet.internal;
 
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ThreadLocalServerClientAndLocalSpanState;
-import java.net.Inet6Address;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,8 +28,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class MaybeAddClientAddressFromRequestTest {
-  List<zipkin.Span> spans = new ArrayList<>();
-  Brave brave = new Brave.Builder().reporter(spans::add).build();
+  List<zipkin2.Span> spans = new ArrayList<>();
+  Brave brave = new Brave.Builder().spanReporter(spans::add).build();
 
   @Before
   public void clearState() {
@@ -59,7 +58,7 @@ public final class MaybeAddClientAddressFromRequestTest {
 
       // shouldn't add anything to the span
       brave.serverTracer().setServerSend();
-      assertThat(spans.get(0).binaryAnnotations).isEmpty();
+      assertThat(spans.get(0).remoteEndpoint()).isNull();
     }
   }
 
@@ -72,8 +71,8 @@ public final class MaybeAddClientAddressFromRequestTest {
     addressFunction.accept(request);
     brave.serverTracer().setServerSend();
 
-    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
-        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+    assertThat(spans.get(0).remoteEndpoint().ipv4())
+        .isEqualTo("1.2.3.4");
   }
 
   @Test
@@ -85,8 +84,8 @@ public final class MaybeAddClientAddressFromRequestTest {
     addressFunction.accept(request);
     brave.serverTracer().setServerSend();
 
-    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
-        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+    assertThat(spans.get(0).remoteEndpoint().ipv4())
+        .isEqualTo("1.2.3.4");
   }
 
   @Test
@@ -97,8 +96,8 @@ public final class MaybeAddClientAddressFromRequestTest {
     addressFunction.accept(request);
     brave.serverTracer().setServerSend();
 
-    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv6)
-        .containsExactly(Inet6Address.getByName("2001:db8::c001").getAddress());
+    assertThat(spans.get(0).remoteEndpoint().ipv6())
+        .isEqualTo("2001:db8::c001");
   }
 
   @Test
@@ -109,8 +108,8 @@ public final class MaybeAddClientAddressFromRequestTest {
     addressFunction.accept(request);
     brave.serverTracer().setServerSend();
 
-    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
-        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+    assertThat(spans.get(0).remoteEndpoint().ipv4())
+        .isEqualTo("1.2.3.4");
   }
 
   @Test
@@ -121,8 +120,8 @@ public final class MaybeAddClientAddressFromRequestTest {
     addressFunction.accept(request);
     brave.serverTracer().setServerSend();
 
-    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.ipv4)
-        .containsExactly(1 << 24 | 2 << 16 | 3 << 8 | 4);
+    assertThat(spans.get(0).remoteEndpoint().ipv4())
+        .isEqualTo("1.2.3.4");
   }
 
   @Test
@@ -134,7 +133,7 @@ public final class MaybeAddClientAddressFromRequestTest {
     addressFunction.accept(request);
     brave.serverTracer().setServerSend();
 
-    assertThat(spans.get(0).binaryAnnotations).extracting(b -> b.endpoint.port)
-        .containsExactly((short) 124);
+    assertThat(spans.get(0).remoteEndpoint().port())
+        .isEqualTo(124);
   }
 }

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -20,8 +20,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.zipkin.java</groupId>
       <artifactId>zipkin</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter</groupId>
@@ -117,6 +122,7 @@
         <configuration>
           <obrRepository>NONE</obrRepository>
           <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <_include>-bnd.bnd</_include>
           </instructions>
         </configuration>
@@ -126,47 +132,6 @@
             <goals>
               <goal>manifest</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Repackage internal zipkin classes -->
-      <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <minimizeJar>true</minimizeJar>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <relocations>
-                <relocation>
-                  <pattern>zipkin.internal</pattern>
-                  <shadedPattern>brave.internal.zipkin</shadedPattern>
-                </relocation>
-              </relocations>
-              <artifactSet>
-                <includes>
-                  <include>io.zipkin.java:zipkin</include>
-                </includes>
-              </artifactSet>
-              <filters>
-                <filter>
-                  <!-- Shade references to internal classes -->
-                  <artifact>io.zipkin.java:zipkin</artifact>
-                  <includes>
-                    <include>zipkin/internal/V2SpanConverter*.class</include>
-                    <!-- TODO: V2 currently indirectly references Util -->
-                    <include>zipkin/internal/Util.class</include>
-                  </includes>
-                  <excludes>
-                    <exclude>*</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -178,7 +178,7 @@ public abstract class Tracing implements Closeable {
       }
       this.reporter = new Reporter<zipkin2.Span>() {
         @Override public void report(zipkin2.Span span) {
-          reporter.report(zipkin.internal.V2SpanConverter.toSpan(span));
+          reporter.report(brave.internal.V2SpanConverter.toSpan(span));
         }
 
         @Override public String toString() {

--- a/brave/src/main/java/brave/internal/V2SpanConverter.java
+++ b/brave/src/main/java/brave/internal/V2SpanConverter.java
@@ -1,0 +1,176 @@
+package brave.internal;
+
+import java.util.Map;
+import zipkin.Annotation;
+import zipkin.BinaryAnnotation;
+import zipkin.Constants;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.Span.Kind;
+
+import static zipkin.Constants.CLIENT_ADDR;
+import static zipkin.Constants.LOCAL_COMPONENT;
+import static zipkin.Constants.SERVER_ADDR;
+
+/**
+ * This converts {@link zipkin.Span} instances to {@link Span} and visa versa.
+ *
+ * <p/> Copy-pasted from zipkin.internal.V2SpanConverter version 2.2.2 to avoid shade setup
+ */
+public final class V2SpanConverter {
+
+  /** Converts the input, parsing {@link Span#kind()} into RPC annotations. */
+  public static zipkin.Span toSpan(Span in) {
+    String traceId = in.traceId();
+    zipkin.Span.Builder result = zipkin.Span.builder()
+      .traceId(HexCodec.lowerHexToUnsignedLong(traceId))
+      .parentId(in.parentId() != null ? HexCodec.lowerHexToUnsignedLong(in.parentId()) : null)
+      .id(HexCodec.lowerHexToUnsignedLong(in.id()))
+      .debug(in.debug())
+      .name(in.name() != null ? in.name() : ""); // avoid a NPE
+
+    if (traceId.length() == 32) {
+      result.traceIdHigh(HexCodec.lowerHexToUnsignedLong(traceId, 0));
+    }
+
+    long startTs = in.timestamp() == null ? 0L : in.timestamp();
+    Long endTs = in.duration() == null ? 0L : in.timestamp() + in.duration();
+    if (startTs != 0L) {
+      result.timestamp(startTs);
+      result.duration(in.duration());
+    }
+
+    zipkin.Endpoint local = in.localEndpoint() != null ? toEndpoint(in.localEndpoint()) : null;
+    zipkin.Endpoint remote = in.remoteEndpoint() != null ? toEndpoint(in.remoteEndpoint()) : null;
+    Kind kind = in.kind();
+    Annotation
+      cs = null, sr = null, ss = null, cr = null, ms = null, mr = null, ws = null, wr = null;
+    String remoteEndpointType = null;
+
+    boolean wroteEndpoint = false;
+
+    for (int i = 0, length = in.annotations().size(); i < length; i++) {
+      zipkin2.Annotation input = in.annotations().get(i);
+      Annotation a = Annotation.create(input.timestamp(), input.value(), local);
+      if (a.value.length() == 2) {
+        if (a.value.equals(Constants.CLIENT_SEND)) {
+          kind = Kind.CLIENT;
+          cs = a;
+          remoteEndpointType = SERVER_ADDR;
+        } else if (a.value.equals(Constants.SERVER_RECV)) {
+          kind = Kind.SERVER;
+          sr = a;
+          remoteEndpointType = CLIENT_ADDR;
+        } else if (a.value.equals(Constants.SERVER_SEND)) {
+          kind = Kind.SERVER;
+          ss = a;
+        } else if (a.value.equals(Constants.CLIENT_RECV)) {
+          kind = Kind.CLIENT;
+          cr = a;
+        } else if (a.value.equals(Constants.MESSAGE_SEND)) {
+          kind = Kind.PRODUCER;
+          ms = a;
+        } else if (a.value.equals(Constants.MESSAGE_RECV)) {
+          kind = Kind.CONSUMER;
+          mr = a;
+        } else if (a.value.equals(Constants.WIRE_SEND)) {
+          ws = a;
+        } else if (a.value.equals(Constants.WIRE_RECV)) {
+          wr = a;
+        } else {
+          wroteEndpoint = true;
+          result.addAnnotation(a);
+        }
+      } else {
+        wroteEndpoint = true;
+        result.addAnnotation(a);
+      }
+    }
+
+    if (kind != null) {
+      switch (kind) {
+        case CLIENT:
+          remoteEndpointType = Constants.SERVER_ADDR;
+          if (startTs != 0L) cs = Annotation.create(startTs, Constants.CLIENT_SEND, local);
+          if (endTs != 0L) cr = Annotation.create(endTs, Constants.CLIENT_RECV, local);
+          break;
+        case SERVER:
+          remoteEndpointType = Constants.CLIENT_ADDR;
+          if (startTs != 0L) sr = Annotation.create(startTs, Constants.SERVER_RECV, local);
+          if (endTs != 0L) ss = Annotation.create(endTs, Constants.SERVER_SEND, local);
+          break;
+        case PRODUCER:
+          remoteEndpointType = Constants.MESSAGE_ADDR;
+          if (startTs != 0L) ms = Annotation.create(startTs, Constants.MESSAGE_SEND, local);
+          if (endTs != 0L) ws = Annotation.create(endTs, Constants.WIRE_SEND, local);
+          break;
+        case CONSUMER:
+          remoteEndpointType = Constants.MESSAGE_ADDR;
+          if (startTs != 0L && endTs != 0L) {
+            wr = Annotation.create(startTs, Constants.WIRE_RECV, local);
+            mr = Annotation.create(endTs, Constants.MESSAGE_RECV, local);
+          } else if (startTs != 0L) {
+            mr = Annotation.create(startTs, Constants.MESSAGE_RECV, local);
+          }
+          break;
+        default:
+          throw new AssertionError("update kind mapping");
+      }
+    }
+
+    for (Map.Entry<String, String> tag : in.tags().entrySet()) {
+      wroteEndpoint = true;
+      result.addBinaryAnnotation(BinaryAnnotation.create(tag.getKey(), tag.getValue(), local));
+    }
+
+    if (cs != null
+      || sr != null
+      || ss != null
+      || cr != null
+      || ws != null
+      || wr != null
+      || ms != null
+      || mr != null) {
+      if (cs != null) result.addAnnotation(cs);
+      if (sr != null) result.addAnnotation(sr);
+      if (ss != null) result.addAnnotation(ss);
+      if (cr != null) result.addAnnotation(cr);
+      if (ws != null) result.addAnnotation(ws);
+      if (wr != null) result.addAnnotation(wr);
+      if (ms != null) result.addAnnotation(ms);
+      if (mr != null) result.addAnnotation(mr);
+      wroteEndpoint = true;
+    } else if (local != null && remote != null) {
+      // special-case when we are missing core annotations, but we have both address annotations
+      result.addBinaryAnnotation(BinaryAnnotation.address(CLIENT_ADDR, local));
+      wroteEndpoint = true;
+      remoteEndpointType = SERVER_ADDR;
+    }
+
+    if (remoteEndpointType != null && remote != null) {
+      result.addBinaryAnnotation(BinaryAnnotation.address(remoteEndpointType, remote));
+    }
+
+    // don't report server-side timestamp on shared or incomplete spans
+    if (Boolean.TRUE.equals(in.shared()) && sr != null) {
+      result.timestamp(null).duration(null);
+    }
+    if (local != null && !wroteEndpoint) { // create a dummy annotation
+      result.addBinaryAnnotation(BinaryAnnotation.create(LOCAL_COMPONENT, "", local));
+    }
+    return result.build();
+  }
+
+  static zipkin.Endpoint toEndpoint(Endpoint input) {
+    zipkin.Endpoint.Builder result = zipkin.Endpoint.builder()
+      .serviceName(input.serviceName() != null ? input.serviceName() : "")
+      .port(input.port() != null ? input.port() : 0);
+    if (input.ipv6() != null) {
+      result.parseIp(input.ipv6()); // parse first in case there's a mapped IP
+    }
+    if (input.ipv4() != null) {
+      result.parseIp(input.ipv4());
+    }
+    return result.build();
+  }
+}

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -21,8 +21,8 @@ final class MutableSpan {
         .traceId(context.traceIdString())
         .parentId(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null)
         .id(HexCodec.toLowerHex(context.spanId()))
-        .debug(context.debug())
-        .shared(context.shared())
+        .debug(context.debug() ? true : null)
+        .shared(context.shared() ? true : null)
         .localEndpoint(localEndpoint);
     finished = false;
   }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
@@ -2,6 +2,7 @@ package brave.kafka.clients;
 
 import brave.Tracing;
 import com.google.common.base.Charsets;
+import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -9,10 +10,10 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.junit.After;
-import zipkin.internal.Util;
 import zipkin2.Span;
 
 abstract class BaseTracingTest {
+  static final Charset UTF_8 = Charset.forName("UTF-8");
   static String TRACE_ID = "463ac35c9f6413ad";
   static String PARENT_ID = "463ac35c9f6413ab";
   static String SPAN_ID = "48485a3953bb6124";
@@ -35,10 +36,10 @@ abstract class BaseTracingTest {
 
   static <K, V> void addB3Headers(ConsumerRecord<K, V> record) {
     record.headers()
-        .add("X-B3-TraceId", TRACE_ID.getBytes(Util.UTF_8))
-        .add("X-B3-ParentSpanId", PARENT_ID.getBytes(Util.UTF_8))
-        .add("X-B3-SpanId", SPAN_ID.getBytes(Util.UTF_8))
-        .add("X-B3-Sampled", SAMPLED.getBytes(Util.UTF_8));
+        .add("X-B3-TraceId", TRACE_ID.getBytes(UTF_8))
+        .add("X-B3-ParentSpanId", PARENT_ID.getBytes(UTF_8))
+        .add("X-B3-SpanId", SPAN_ID.getBytes(UTF_8))
+        .add("X-B3-Sampled", SAMPLED.getBytes(UTF_8));
   }
 
   static Set<Map.Entry<String, String>> lastHeaders(Headers headers) {

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -31,7 +31,6 @@ import zipkin2.Span;
 
 import static brave.kafka.clients.KafkaTags.KAFKA_TOPIC_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin.internal.Util.lowerHexToUnsignedLong;
 
 public class ITKafkaTracing {
 
@@ -197,7 +196,7 @@ public class ITKafkaTracing {
         String result = getter.get(carrier, key);
         if (result == null) return TraceContextOrSamplingFlags.create(SamplingFlags.EMPTY);
         return TraceContextOrSamplingFlags.create(TraceIdContext.newBuilder()
-            .traceId(lowerHexToUnsignedLong(result))
+            .traceId(HexCodec.lowerHexToUnsignedLong(result))
             .build());
       };
     }

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -63,5 +63,11 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>brave</artifactId>
     </dependency>
+    <!-- to compile against Span.remoteEndpoint(zipkin.Span) -->
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
@@ -17,10 +17,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-/**
- * Tracing interceptor for Spring Web MVC, which can be used as both an {@link
- * AsyncHandlerInterceptor} or a normal {@link HandlerInterceptor}.
- */
+/** Tracing interceptor for Spring Web MVC {@link HandlerInterceptor}. */
 public final class TracingHandlerInterceptor implements HandlerInterceptor {
   static final Propagation.Getter<HttpServletRequest, String> GETTER =
       new Propagation.Getter<HttpServletRequest, String>() {

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.1.4.Final</resteasy.version>
-    <zipkin.version>2.4.1</zipkin.version>
-    <zipkin-reporter2.version>2.2.1</zipkin-reporter2.version>
+    <zipkin.version>2.4.2</zipkin.version>
+    <zipkin-reporter2.version>2.2.2</zipkin-reporter2.version>
     <zipkin-reporter.version>1.1.2</zipkin-reporter.version>
     <finagle.version>6.45.0</finagle.version>
     <log4j.version>2.8.2</log4j.version>
@@ -192,6 +192,11 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>brave-http-tests</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.zipkin2</groupId>
+            <artifactId>zipkin</artifactId>
+            <version>${zipkin.version}</version>
         </dependency>
         <dependency>
             <groupId>io.zipkin.java</groupId>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -32,6 +32,12 @@
       <artifactId>zipkin-reporter-spring-beans</artifactId>
       <version>${zipkin-reporter2.version}</version>
     </dependency>
+    <!-- to compile against Span.remoteEndpoint(zipkin.Span) -->
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>


### PR DESCRIPTION
This removes the need to share internal packages between the brave 3 and
4 apis and zipkin. In doing so, it unlocks some OSGi problems.

This also makes it easier to transition to zipkin2 by allowing reporter2
as a Brave.Builder.spanReporter arg.

See https://github.com/apache/camel/pull/2151