### PR TITLE
Don't fail build on JDK 1.8

### DIFF
--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -1,6 +1,5 @@
 package brave.internal;
 
-import brave.Clock;
 import com.google.common.collect.Sets;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -41,7 +40,7 @@ public class PlatformTest {
   }
 
   @Test public void clock_hasNiceToString_jre9() {
-    Platform platform = Platform.Jre9.buildIfSupported(true);
+    Platform platform = new AutoValue_Platform_Jre9(true);
 
     assertThat(platform.clock())
         .hasToString("Clock.systemUTC().instant()");

--- a/pom.xml
+++ b/pom.xml
@@ -690,7 +690,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[9,)</version>
+                  <version>[1.8,10)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
We don't yet use any Java 9 apis compile-time (only runtime). Let's not
fail so harshly.