### PR TITLE
Ensures there's no NPE propagation constant is referenced before tracing

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -3,6 +3,7 @@ package brave;
 import brave.internal.Internal;
 import brave.internal.Nullable;
 import brave.internal.Platform;
+import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
@@ -112,7 +113,7 @@ public abstract class Tracing implements Closeable {
     CurrentTraceContext currentTraceContext = CurrentTraceContext.Default.inheritable();
     boolean traceId128Bit = false;
     boolean supportsJoin = true;
-    Propagation.Factory propagationFactory = Propagation.Factory.B3;
+    Propagation.Factory propagationFactory = B3Propagation.FACTORY;
 
     /**
      * Controls the name of the service being traced, while still using a default site-local IP.
@@ -218,7 +219,7 @@ public abstract class Tracing implements Closeable {
 
     /**
      * Controls how trace contexts are injected or extracted from remote requests, such as from http
-     * headers. Defaults to {@link Propagation.Factory#B3}
+     * headers. Defaults to {@link B3Propagation#FACTORY}
      */
     public Builder propagationFactory(Propagation.Factory propagationFactory) {
       if (propagationFactory == null) throw new NullPointerException("propagationFactory == null");

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -21,6 +21,8 @@ public interface Propagation<K> {
   Propagation<String> B3_STRING = B3Propagation.FACTORY.create(Propagation.KeyFactory.STRING);
 
   abstract class Factory {
+    /** @deprecated use {@link B3Propagation#FACTORY} to avoid initialization race condition */
+    @Deprecated
     public static final Factory B3 = B3Propagation.FACTORY;
 
     /**

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -6,13 +6,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
-import static brave.propagation.Propagation.Factory.B3;
 import static brave.propagation.Propagation.KeyFactory.STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExtraFieldPropagationTest {
-  Propagation.Factory factory =
-      ExtraFieldPropagation.newFactory(B3, "x-vcap-request-id", "x-amzn-trace-id");
+  Propagation.Factory factory = ExtraFieldPropagation.newFactory(
+      B3Propagation.FACTORY, "x-vcap-request-id", "x-amzn-trace-id"
+  );
   Map<String, String> carrier = new LinkedHashMap<>();
   TraceContext.Injector<Map<String, String>> injector = factory.create(STRING).injector(Map::put);
   TraceContext.Extractor<Map<String, String>> extractor =

--- a/brave/src/test/java/brave/propagation/PropagationConstantsTest.java
+++ b/brave/src/test/java/brave/propagation/PropagationConstantsTest.java
@@ -1,0 +1,13 @@
+package brave.propagation;
+
+import brave.Tracing;
+import org.junit.Test;
+
+/** Ensures there's no NPE when tracing builder uses defaults */
+public class PropagationConstantsTest {
+
+  @Test public void eagerReferencePropagationConstantPriorToUse() {
+    Propagation<String> foo = Propagation.B3_STRING;
+    Tracing.newBuilder().build().close();
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
@@ -1,6 +1,6 @@
 package brave.grpc;
 
-import brave.propagation.Propagation;
+import brave.propagation.B3Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.grpc.Metadata;
@@ -18,7 +18,7 @@ class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
   BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
   TraceContext.Extractor<Metadata> extractor =
-      Propagation.Factory.B3.create(AsciiMetadataKeyFactory.INSTANCE).extractor(Metadata::get);
+      B3Propagation.FACTORY.create(AsciiMetadataKeyFactory.INSTANCE).extractor(Metadata::get);
 
   Server server = ServerBuilder.forPort(PickUnusedPort.get())
       .addService(ServerInterceptors.intercept(new GreeterImpl(null), new ServerInterceptor() {

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
@@ -1,9 +1,9 @@
 package brave.http;
 
 import brave.Tracing;
+import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ExtraFieldPropagation;
-import brave.propagation.Propagation;
 import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
@@ -43,7 +43,7 @@ public abstract class ITHttp {
           }
           spans.add(s);
         })
-        .propagationFactory(ExtraFieldPropagation.newFactory(Propagation.Factory.B3, "user-id"))
+        .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "user-id"))
         .currentTraceContext(currentTraceContext)
         .sampler(sampler);
   }

--- a/propagation/aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
+++ b/propagation/aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
@@ -1,6 +1,7 @@
 package brave.propagation.aws;
 
 import brave.Tracing;
+import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
@@ -60,7 +61,7 @@ public class AWSPropagationTest {
   }
 
   TraceContext contextWithPassThrough() {
-    extractor = ExtraFieldPropagation.newFactory(Propagation.Factory.B3, "x-amzn-trace-id")
+    extractor = ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-amzn-trace-id")
         .create(Propagation.KeyFactory.STRING).extractor(Map::get);
 
     TraceContextOrSamplingFlags extracted = extractor.extract(carrier);


### PR DESCRIPTION

Fixes #565