### PR TITLE
Adds TracingAsyncClientHttpRequestInterceptor for spring-web

### DIFF
--- a/instrumentation/benchmarks/src/main/java/brave/spring/web/AsyncRestTemplateBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/spring/web/AsyncRestTemplateBenchmarks.java
@@ -1,0 +1,47 @@
+package brave.spring.web;
+
+import brave.http.HttpClientBenchmarks;
+import brave.http.HttpTracing;
+import java.util.Collections;
+import okhttp3.OkHttpClient;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.web.client.AsyncRestTemplate;
+
+public class AsyncRestTemplateBenchmarks extends HttpClientBenchmarks<AsyncRestTemplate> {
+
+  OkHttpClient ok = new OkHttpClient();
+
+  @Override protected AsyncRestTemplate newClient(HttpTracing httpTracing) {
+    OkHttp3ClientHttpRequestFactory factory = new OkHttp3ClientHttpRequestFactory(ok);
+    AsyncRestTemplate result = new AsyncRestTemplate(factory);
+    result.setInterceptors(Collections.singletonList(
+        TracingAsyncClientHttpRequestInterceptor.create(httpTracing
+        )));
+    return result;
+  }
+
+  @Override protected AsyncRestTemplate newClient() {
+    return new AsyncRestTemplate(new OkHttp3ClientHttpRequestFactory(ok));
+  }
+
+  @Override protected void get(AsyncRestTemplate client) throws Exception {
+    client.getForEntity(baseUrl(), String.class).get();
+  }
+
+  @Override protected void close(AsyncRestTemplate client) {
+    ok.dispatcher().executorService().shutdownNow();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + AsyncRestTemplateBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
@@ -7,7 +7,6 @@ import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import okhttp3.mockwebserver.MockWebServer;
@@ -27,7 +26,7 @@ public abstract class ITHttp {
   protected CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
   protected HttpTracing httpTracing;
 
-  @After public void close() throws IOException {
+  @After public void close() throws Exception {
     Tracing current = Tracing.current();
     if (current != null) current.close();
   }

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -5,7 +5,6 @@ import brave.Tracer;
 import brave.Tracer.SpanInScope;
 import brave.internal.HexCodec;
 import brave.sampler.Sampler;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -30,7 +29,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
   /** Make sure the client you return has retries disabled. */
   protected abstract C newClient(int port);
 
-  protected abstract void closeClient(C client) throws IOException;
+  protected abstract void closeClient(C client) throws Exception;
 
   protected abstract void get(C client, String pathIncludingQuery) throws Exception;
 
@@ -38,7 +37,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
   protected abstract void getAsync(C client, String pathIncludingQuery) throws Exception;
 
-  @Override @After public void close() throws IOException {
+  @Override @After public void close() throws Exception {
     closeClient(client);
     super.close();
   }
@@ -200,7 +199,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
     try {
       get(client, "/foo");
-    } catch (RuntimeException e) {
+    } catch (Exception e) {
       // some clients think 400 is an error
     }
 

--- a/instrumentation/spring-web/README.md
+++ b/instrumentation/spring-web/README.md
@@ -1,8 +1,8 @@
 # brave-instrumentation-spring-web
-This module contains a tracing interceptor for [Spring RestTemplate](https://spring.io/guides/gs/consuming-rest/).
-`TracingClientHttpRequestInterceptor` adds trace headers to outgoing
-requests. It then reports to Zipkin how long each request takes, along
-with relevant tags like the http url.
+This module contains tracing interceptors for [Spring RestTemplate](https://spring.io/guides/gs/consuming-rest/).
+`TracingClientHttpRequestInterceptor` and `TracingAsyncClientHttpRequestInterceptor` add trace
+headers to outgoing requests. They then report to Zipkin how long each request took, along with
+relevant tags like the http url.
 
 ## Configuration
 
@@ -10,4 +10,5 @@ Tracing always needs a bean of type `HttpTracing` configured. Make sure
 it is in place before proceeding. Here's an example in [XML](https://github.com/openzipkin/brave-webmvc-example/blob/master/webmvc25/src/main/webapp/WEB-INF/spring-webmvc-servlet.xml) and [Java](https://github.com/openzipkin/brave-webmvc-example/blob/master/webmvc4/src/main/java/brave/webmvc/TracingConfiguration.java).
 
 Then, wire `TracingClientHttpRequestInterceptor` and add it with the
-`RestTemplate.setInterceptors` method.
+`RestTemplate.setInterceptors` method. If you are using `AsyncRestTemplate` and Spring 4.3+, you can
+wire `AsyncTracingClientHttpRequestInterceptor` and add it via `AsyncRestTemplate.setInterceptors`.

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -57,4 +57,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -24,7 +24,16 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
+      <version>${spring4.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- needed for AsyncClientHttpRequestInterceptor -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring4.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -40,6 +49,11 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/spring-web/src/it/spring3/README.md
+++ b/instrumentation/spring-web/src/it/spring3/README.md
@@ -1,0 +1,2 @@
+# spring3
+This tests that TracingClientHttpRequestInterceptor can be used without Spring 4

--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>spring-web-spring3</artifactId>
+  <version>@project.version@</version>
+  <name>spring-web-spring3</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>@spring.version@</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-spring-web</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>@maven-failsafe-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -1,0 +1,78 @@
+package brave.spring.web3;
+
+import brave.http.ITHttpClient;
+import brave.spring.web.TracingClientHttpRequestInterceptor;
+import java.util.Arrays;
+import java.util.Collections;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHttpRequestFactory> {
+  ClientHttpRequestInterceptor interceptor;
+
+  ClientHttpRequestFactory configureClient(ClientHttpRequestInterceptor interceptor) {
+    HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+    factory.setReadTimeout(1000);
+    factory.setConnectTimeout(1000);
+    this.interceptor = interceptor;
+    return factory;
+  }
+
+  @Override protected ClientHttpRequestFactory newClient(int port) {
+    return configureClient(TracingClientHttpRequestInterceptor.create(httpTracing));
+  }
+
+  @Override protected void closeClient(ClientHttpRequestFactory client) throws Exception {
+    ((HttpComponentsClientHttpRequestFactory) client).destroy();
+  }
+
+  @Override protected void get(ClientHttpRequestFactory client, String pathIncludingQuery) {
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.getForObject(url(pathIncludingQuery), String.class);
+  }
+
+  @Override protected void post(ClientHttpRequestFactory client, String uri, String content) {
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.postForObject(url(uri), content, String.class);
+  }
+
+  @Override protected void getAsync(ClientHttpRequestFactory client, String uri) {
+    throw new AssumptionViolatedException("TODO: async rest template has its own interceptor");
+  }
+
+  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+    server.enqueue(new MockResponse());
+
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Arrays.asList(interceptor, (request, body, execution) -> {
+      request.getHeaders()
+          .add("my-id", currentTraceContext.get().traceIdString());
+      return execution.execute(request, body);
+    }));
+    restTemplate.getForObject(server.url("/foo").toString(), String.class);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+
+  @Override @Test(expected = AssertionError.class)
+  public void redirect() throws Exception { // blind to the implementation of redirects
+    super.redirect();
+  }
+
+  @Override @Test(expected = AssertionError.class)
+  public void reportsServerAddress() throws Exception { // doesn't know the remote address
+    super.reportsServerAddress();
+  }
+}

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptor.java
@@ -1,0 +1,75 @@
+package brave.spring.web;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.http.HttpClientHandler;
+import brave.http.HttpTracing;
+import brave.propagation.TraceContext;
+import brave.spring.web.TracingClientHttpRequestInterceptor.HttpAdapter;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.AsyncClientHttpRequestExecution;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+import static brave.spring.web.TracingClientHttpRequestInterceptor.SETTER;
+
+public final class TracingAsyncClientHttpRequestInterceptor
+    implements AsyncClientHttpRequestInterceptor {
+
+  public static AsyncClientHttpRequestInterceptor create(Tracing tracing) {
+    return create(HttpTracing.create(tracing));
+  }
+
+  public static AsyncClientHttpRequestInterceptor create(HttpTracing httpTracing) {
+    return new TracingAsyncClientHttpRequestInterceptor(httpTracing);
+  }
+
+  final Tracer tracer;
+  final HttpClientHandler<HttpRequest, ClientHttpResponse> handler;
+  final TraceContext.Injector<HttpHeaders> injector;
+
+  @Autowired TracingAsyncClientHttpRequestInterceptor(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    handler = HttpClientHandler.create(httpTracing, new HttpAdapter());
+    injector = httpTracing.tracing().propagation().injector(SETTER);
+  }
+
+  @Override public ListenableFuture<ClientHttpResponse> intercept(HttpRequest request,
+      byte[] body, AsyncClientHttpRequestExecution execution) throws IOException {
+    Span span = handler.handleSend(injector, request.getHeaders(), request);
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      ListenableFuture<ClientHttpResponse> result = execution.executeAsync(request, body);
+      result.addCallback(new TraceListenableFutureCallback(span, handler));
+      return result;
+    } catch (IOException | RuntimeException | Error e) {
+      handler.handleReceive(null, e, span);
+      throw e;
+    }
+  }
+
+  static final class TraceListenableFutureCallback
+      implements ListenableFutureCallback<ClientHttpResponse> {
+    final Span span;
+    final HttpClientHandler<HttpRequest, ClientHttpResponse> handler;
+
+    TraceListenableFutureCallback(Span span,
+        HttpClientHandler<HttpRequest, ClientHttpResponse> handler) {
+      this.span = span;
+      this.handler = handler;
+    }
+
+    @Override public void onFailure(Throwable ex) {
+      handler.handleReceive(null, ex, span);
+    }
+
+    @Override public void onSuccess(ClientHttpResponse result) {
+      handler.handleReceive(result, null, span);
+    }
+  }
+}

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -1,0 +1,97 @@
+package brave.spring.web;
+
+import brave.http.ITHttpClient;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.client.AsyncClientHttpRequestFactory;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
+import org.springframework.http.client.HttpComponentsAsyncClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.AsyncRestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITTracingAsyncClientHttpRequestInterceptor
+    extends ITHttpClient<AsyncClientHttpRequestFactory> {
+  AsyncClientHttpRequestInterceptor interceptor;
+
+  AsyncClientHttpRequestFactory configureClient(AsyncClientHttpRequestInterceptor interceptor) {
+    HttpComponentsAsyncClientHttpRequestFactory factory =
+        new HttpComponentsAsyncClientHttpRequestFactory();
+    factory.setReadTimeout(1000);
+    factory.setConnectTimeout(1000);
+    this.interceptor = interceptor;
+    return factory;
+  }
+
+  @Override protected AsyncClientHttpRequestFactory newClient(int port) {
+    return configureClient(TracingAsyncClientHttpRequestInterceptor.create(httpTracing));
+  }
+
+  @Override protected void closeClient(AsyncClientHttpRequestFactory client) throws Exception {
+    ((HttpComponentsClientHttpRequestFactory) client).destroy();
+  }
+
+  @Override protected void get(AsyncClientHttpRequestFactory client, String pathIncludingQuery)
+      throws Exception {
+    AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    try {
+      restTemplate.getForEntity(url(pathIncludingQuery), String.class).get();
+    } finally {
+      // TODO: understand why we need sleeps. maybe there's an executor we can change to same thread
+      Thread.sleep(100);
+    }
+  }
+
+  @Override protected void post(AsyncClientHttpRequestFactory client, String uri, String content)
+      throws Exception {
+    AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    try {
+      restTemplate.postForEntity(url(uri), RequestEntity.post(URI.create(url(uri))).body(content),
+          String.class).get();
+    } finally {
+      // TODO: understand why we need sleeps. maybe there's an executor we can change to same thread
+      Thread.sleep(100);
+    }
+  }
+
+  @Override protected void getAsync(AsyncClientHttpRequestFactory client, String uri) {
+    AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.getForEntity(url(uri), String.class);
+  }
+
+  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+    server.enqueue(new MockResponse());
+
+    AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
+    restTemplate.setInterceptors(Arrays.asList(interceptor, (request, body, execution) -> {
+      request.getHeaders()
+          .add("my-id", currentTraceContext.get().traceIdString());
+      return execution.executeAsync(request, body);
+    }));
+    restTemplate.getForEntity(server.url("/foo").toString(), String.class).get();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-b3-traceId"))
+        .isEqualTo(request.getHeader("my-id"));
+  }
+
+  @Override @Test(expected = ExecutionException.class)
+  public void redirect() throws Exception { // blind to the implementation of redirects
+    super.redirect();
+  }
+
+  @Override @Test(expected = AssertionError.class)
+  public void reportsServerAddress() throws Exception { // doesn't know the remote address
+    super.reportsServerAddress();
+  }
+}

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -15,7 +15,6 @@ import org.springframework.web.client.RestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHttpRequestFactory> {
-
   ClientHttpRequestInterceptor interceptor;
 
   ClientHttpRequestFactory configureClient(ClientHttpRequestInterceptor interceptor) {
@@ -30,12 +29,11 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     return configureClient(TracingClientHttpRequestInterceptor.create(httpTracing));
   }
 
-  @Override protected void closeClient(ClientHttpRequestFactory client) {
+  @Override protected void closeClient(ClientHttpRequestFactory client) throws Exception {
     ((HttpComponentsClientHttpRequestFactory) client).destroy();
   }
 
-  @Override protected void get(ClientHttpRequestFactory client, String pathIncludingQuery)
-      throws Exception {
+  @Override protected void get(ClientHttpRequestFactory client, String pathIncludingQuery) {
     RestTemplate restTemplate = new RestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));
     restTemplate.getForObject(url(pathIncludingQuery), String.class);

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptorAutowireTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptorAutowireTest.java
@@ -7,9 +7,9 @@ import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
 
-public class TracingClientHttpRequestInterceptorAutowireTest {
+public class TracingAsyncClientHttpRequestInterceptorAutowireTest {
 
   @Configuration static class HttpTracingConfiguration {
     @Bean HttpTracing httpTracing() {
@@ -20,10 +20,10 @@ public class TracingClientHttpRequestInterceptorAutowireTest {
   @Test public void autowiredWithBeanConfig() {
     AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
     ctx.register(HttpTracingConfiguration.class);
-    ctx.register(TracingClientHttpRequestInterceptor.class);
+    ctx.register(TracingAsyncClientHttpRequestInterceptor.class);
     ctx.refresh();
 
-    ctx.getBean(ClientHttpRequestInterceptor.class);
+    ctx.getBean(AsyncClientHttpRequestInterceptor.class);
   }
 
   @After public void close() {


### PR DESCRIPTION
This adds a tracing interceptor for those using AsyncRestTemplate.
This is a part of infrastructure needed to give parity with sleuth,
which is being ported over the Brave api now.

code is a direct port of temporary work by @marcingrzejszczak

See https://github.com/spring-cloud/spring-cloud-sleuth/issues/711