### PR TITLE
Fixes bug where an incoming context missing sampled flag didn't sample

### DIFF
--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -190,6 +190,23 @@ public class TracerTest {
         .isEqualTo(notYetSampled.toBuilder().sampled(true).build());
   }
 
+  @Test public void newChild_ensuresSampling() {
+    TraceContext notYetSampled =
+        tracer.newTrace().context().toBuilder().sampled(null).build();
+
+    assertThat(tracer.newChild(notYetSampled).context().sampled())
+        .isTrue();
+  }
+
+  @Test public void nextSpan_ensuresSampling_whenCreatingNewChild() {
+    TraceContext notYetSampled =
+        tracer.newTrace().context().toBuilder().sampled(null).build();
+
+    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(notYetSampled);
+    assertThat(tracer.nextSpan(extracted).context().sampled())
+        .isTrue();
+  }
+
   @Test public void toSpan() {
     TraceContext context = tracer.newTrace().context();
 


### PR DESCRIPTION
If trace identifiers are propagated and Tracing.supportsJoin is false,
we didn't re-sample the child, which implied it was a NoopSpan. This
was an oversight noticed by @marcingrzejszczak in testing.