### PR TITLE
Remove unneeded @Autowired annotation

### DIFF
--- a/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
@@ -40,7 +40,7 @@ public final class TracingHandlerInterceptor implements HandlerInterceptor {
   final HttpServerHandler<HttpServletRequest, HttpServletResponse> handler;
   final TraceContext.Extractor<HttpServletRequest> extractor;
 
-  @Autowired TracingHandlerInterceptor(HttpTracing httpTracing) { // internal
+  TracingHandlerInterceptor(HttpTracing httpTracing) { // internal
     tracer = httpTracing.tracing().tracer();
     handler = HttpServerHandler.create(httpTracing, new HttpServletAdapter());
     extractor = httpTracing.tracing().propagation().extractor(GETTER);


### PR DESCRIPTION
The TracingHandlerInterceptor is not annotated with one of the Spring
stereotype annotations and is instead created explicitly using Java
Config or XML config, therefore there is no need have the constructor
annotated with @Autowired