### PR TITLE
Adds CorrelationFields in support of in and between process propagation

### DIFF
--- a/brave/src/main/java/brave/internal/correlation/CorrelationFields.java
+++ b/brave/src/main/java/brave/internal/correlation/CorrelationFields.java
@@ -1,0 +1,127 @@
+package brave.internal.correlation;
+
+import brave.internal.Nullable;
+import brave.propagation.Propagation;
+import java.util.Map;
+
+/**
+ * Associates key/value pairs with the current trace context. Correlation fields are stored as a
+ * part of the trace context, adding overhead. For this reason, {@link #isNoop() noop mode} is
+ * default: correlation fields are opt-in.
+ *
+ * <p>Here's an example of instrumentation publishing a user ID field for downstream code to read
+ * with {@link CurrentCorrelationFields}.
+ * <pre>{@code
+ * // mutate the trace context's correlation fields
+ * span.context().correlationFields().set("user-id", currentUserId);
+ *
+ * // set the context in scope
+ * try (Scope scope = tracing.currentTraceContext().newScope(traceContext)) {
+ *   // downstream can read fields with CurrentCorrelationFields.get("user-id")
+ *   //                              or CurrentCorrelationFields.forEach((k, v) ->{});
+ * }
+ * // Repeating the same block might have different results as downstream code
+ * // or other threads can overwrite the key name "method"
+ * }</pre>
+ *
+ * <h3>Data constraints</h3>
+ *
+ * <p>This implementation is strict with regards to key and value policy. Currently limited to 255
+ * printable characters respectively. That said, there's no requirement for fields to end up on the
+ * wire with the same names. For example, in <a href="https://github.com/w3c/distributed-tracing/tree/master/correlation_context">Correlation-Context</a>,
+ * they are embedded in a single header, joined on semi-colon.
+ *
+ * <h3>Relationship to Span tags</h3>
+ *
+ * <p>{@link brave.Span#tag(String, String) tags} are different than correlation fields in the
+ * following ways:
+ * <pre>
+ * <ul>
+ *   <li>Tags are sent out-of-band where correlation fields are in-band, usually embedded in request headers</li>
+ *   <li>As correlation fields are used to synchronize other contexts, they support readback</li>
+ * </ul>
+ * </pre>
+ *
+ * Put another way, a metrics or logging context can readily access correlation fields once they are
+ * added.
+ *
+ * <h3>Relationship to Propagation injection and extraction</h3>
+ * {@link Propagation} injection and extraction is intentionally decoupled from correlation fields.
+ * The reason for this is we don't know what the encoding format would be, and if it correlation
+ * fields will be in a separate propagation field or not. For example, if the propagation format is
+ * Amazon's, correlation fields coexist in the same header field as trace identifiers. B3 has no
+ * correlation field format. However, you can add <a href="https://github.com/w3c/distributed-tracing/tree/master/correlation_context">Correlation-Context</a>
+ * to B3 to accomplish both.
+ *
+ * <h3>Application notes</h3>
+ *
+ * <p>Where possible, instrument nearest to the original request. For example, ordering before
+ * metrics can allow any extracted fields to be visible as a metrics dimension or logging context key.
+ *
+ * <p>Do not use correlation fields as ad-hoc storage, as they will add weight to the request and
+ * expose them to arbitrary access. A password would be a very bad example of a correlation field.
+ */
+public abstract class CorrelationFields implements Cloneable {
+
+  /** When true, no fields are recorded. Use this flag to avoid performing expensive computation. */
+  public abstract boolean isNoop();
+
+  // cannot depend on java 8 apis
+  public interface Consumer {
+    void accept(String name, String value);
+  }
+
+  public abstract void set(String name, String value);
+
+  /** Hidden as used for internal merging */
+  public abstract void setAll(CorrelationFields other);
+
+  /** Retrieves a correlation key by name or returns null if not found. */
+  @Nullable public abstract String get(String name);
+
+  public abstract boolean isEmpty();
+
+  /**
+   * Invokes the consumer for each propagation field.
+   *
+   * This is similar to {@link Map#forEach(java.util.function.BiConsumer)} and used to synchronize contexts like MDC.
+   */
+  public abstract void forEach(Consumer consumer);
+
+  @Override public abstract CorrelationFields clone();
+
+  public static final CorrelationFields NOOP = new CorrelationFields() {
+
+    @Override public boolean isNoop() {
+      return true;
+    }
+
+    @Override public void set(String name, String value) {
+    }
+
+    @Override public void setAll(CorrelationFields other) {
+    }
+
+    @Override public String get(String name) {
+      return null;
+    }
+
+    @Override public boolean isEmpty() {
+      return true;
+    }
+
+    @Override public void forEach(Consumer consumer) {
+    }
+
+    @Override public CorrelationFields clone() {
+      return this;
+    }
+
+    @Override public String toString() {
+      return "NoopCorrelationFields{}";
+    }
+  };
+
+  CorrelationFields() {
+  }
+}

--- a/brave/src/main/java/brave/internal/correlation/CurrentCorrelationFields.java
+++ b/brave/src/main/java/brave/internal/correlation/CurrentCorrelationFields.java
@@ -1,0 +1,68 @@
+package brave.internal.correlation;
+
+import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+
+/**
+ * Provides a mechanism for end users to be able to customise the current correlation fields.
+ *
+ * <p>Handles the case of there being no current span in scope.
+ */
+public final class CurrentCorrelationFields extends CorrelationFields {
+
+  private final CurrentTraceContext currentTraceContext;
+
+  /** Affects the current span in scope if present */
+  public static CurrentCorrelationFields create(Tracing tracing) {
+    return new CurrentCorrelationFields(tracing);
+  }
+
+  CurrentCorrelationFields(Tracing tracing) {
+    this.currentTraceContext = tracing.currentTraceContext();
+  }
+
+  /** {@inheritDoc} */
+  @Override public boolean isNoop() {
+    TraceContext context = currentTraceContext.get();
+    return context != null || context.correlationFields().isNoop();
+  }
+
+  /** {@inheritDoc} */
+  @Override public void set(String name, String value) {
+    TraceContext context = currentTraceContext.get();
+    if (context == null) return;
+    context.correlationFields().set(name, value);
+  }
+
+  /** {@inheritDoc} */
+  @Override public void setAll(CorrelationFields other) {
+    TraceContext context = currentTraceContext.get();
+    if (context == null) return;
+    context.correlationFields().setAll(other);
+  }
+
+  /** {@inheritDoc} */
+  @Override public String get(String name) {
+    TraceContext context = currentTraceContext.get();
+    if (context == null) return null;
+    return context.correlationFields().get(name);
+  }
+
+  @Override public boolean isEmpty() {
+    TraceContext context = currentTraceContext.get();
+    if (context == null) return true;
+    return context.correlationFields().isEmpty();
+  }
+
+  /** {@inheritDoc} */
+  @Override public void forEach(Consumer consumer) {
+    TraceContext context = currentTraceContext.get();
+    if (context == null) return;
+    context.correlationFields().forEach(consumer);
+  }
+
+  @Override public CorrelationFields clone() {
+    return this;
+  }
+}

--- a/brave/src/main/java/brave/internal/correlation/RealCorrelationFields.java
+++ b/brave/src/main/java/brave/internal/correlation/RealCorrelationFields.java
@@ -1,0 +1,96 @@
+package brave.internal.correlation;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public final class RealCorrelationFields extends CorrelationFields {
+  public static CorrelationFields create() {
+    return new RealCorrelationFields();
+  }
+
+  // TODO: consider if we shouldn't use array offset storage to reduce memory and cloning cost
+  final LinkedHashMap<String, String> storage = new LinkedHashMap<>();
+
+  @Override public boolean isNoop() {
+    return false;
+  }
+
+  @Override public void set(String name, String value) {
+    if (!checkValid(name, "name")) return;
+    if (!checkValid(value, "value")) return;
+    synchronized (storage) {
+      storage.put(name, value);
+    }
+  }
+
+  @Override public void setAll(CorrelationFields other) {
+    if (other.isEmpty()) return;
+    // bug if cast fail as this is a package-sealed type and noop is always empty
+    RealCorrelationFields realOther = (RealCorrelationFields) other;
+    synchronized (storage) {
+      storage.putAll(realOther.storage);
+    }
+  }
+
+  @Override public String get(String name) {
+    if (!checkValid(name, "name")) return null;
+    final String result;
+    synchronized (storage) {
+      result = storage.get(name);
+    }
+    return result;
+  }
+
+  @Override public boolean isEmpty() {
+    final boolean result;
+    synchronized (storage) {
+      result = storage.isEmpty();
+    }
+    return result;
+  }
+
+  @Override public void forEach(Consumer consumer) {
+    final Set<Map.Entry<String, String>> entrySet;
+    synchronized (storage) {
+      entrySet = new LinkedHashSet<>(storage.entrySet());
+    }
+    for (Map.Entry<String, String> entry : entrySet) {
+      consumer.accept(entry.getKey(), entry.getValue());
+    }
+  }
+
+  @Override public CorrelationFields clone() {
+    RealCorrelationFields result = new RealCorrelationFields();
+    synchronized (storage) {
+      result.storage.putAll(storage);
+    }
+    return result;
+  }
+
+  /** borrowed from census in order to be defensive and error early while testing this feature */
+  static boolean checkValid(String input, String type) {
+    if (input == null) return log(type + " == null");
+    int size = input.length();
+    if (size == 0) return log(type + " was empty");
+    if (size > 255) return log(type + " is longer than 255 characters");
+    for (int i = 0; i < size; i++) {
+      char c = input.charAt(i);
+      if (c >= ' ' && c <= '~') continue;
+      return log(type + " " + input + " contains an unprintable character");
+    }
+    return true;
+  }
+
+  private static boolean log(String message) {
+    return false; // TODO: log
+  }
+
+  @Override public String toString() {
+    return "RealCorrelationFields" + storage;
+  }
+
+  RealCorrelationFields() {
+  }
+}

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -87,6 +87,10 @@ public interface Propagation<K> {
    * <p>For example, if the carrier is a single-use or immutable request object, you don't need to
    * clear fields as they couldn't have been set before. If it is a mutable, retryable object,
    * successive calls should clear these fields first.
+   *
+   * <p>Important: the names of keys should be treated opaquely as they may be prefixed, or have
+   * values that contain multiple entries. For example, the {@code x-amzn-trace-id} header includes
+   * both trace identifiers and arbitrary fields in one propagation field.
    */
   // The use cases of this are:
   // * allow pre-allocation of fields, especially in systems like gRPC Metadata

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -1,6 +1,7 @@
 package brave.propagation;
 
 import brave.internal.Nullable;
+import brave.internal.correlation.CorrelationFields;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -121,7 +122,7 @@ public final class TraceContext extends SamplingFlags {
    * Returns a list of additional data propagated through this trace.
    *
    * <p>The contents are intentionally opaque, deferring to {@linkplain Propagation} to define. An
-   * example implementation could be storing a class containing a correlation value, which is
+   * example implementation could be storing a class containing propagation-format specific data,
    * extracted from incoming requests and injected as-is onto outgoing requests.
    *
    * <p>Implementations are responsible for scoping any data stored here. This can be performed when
@@ -129,6 +130,11 @@ public final class TraceContext extends SamplingFlags {
    */
   public List<Object> extra() {
     return extra;
+  }
+
+  /** Returns a potentially no-op handler for {@link CorrelationFields correlation fields}. */
+  public CorrelationFields correlationFields() {
+    return correlationFields;
   }
 
   public Builder toBuilder() {
@@ -167,6 +173,7 @@ public final class TraceContext extends SamplingFlags {
 
   public static final class Builder extends InternalBuilder {
     List<Object> extra = Collections.emptyList();
+    CorrelationFields correlationFields = CorrelationFields.NOOP;
 
     Builder(TraceContext context) { // no external implementations
       traceIdHigh = context.traceIdHigh;
@@ -175,6 +182,7 @@ public final class TraceContext extends SamplingFlags {
       spanId = context.spanId;
       flags = context.flags;
       extra = context.extra;
+      correlationFields = context.correlationFields;
     }
 
     /** @see TraceContext#traceIdHigh() */
@@ -242,6 +250,12 @@ public final class TraceContext extends SamplingFlags {
       return this;
     }
 
+    /** @see TraceContext#correlationFields() */
+    public Builder correlationFields(CorrelationFields correlationFields) {
+      this.correlationFields = correlationFields;
+      return this;
+    }
+
     public final TraceContext build() {
       String missing = "";
       if (traceId == 0L) missing += " traceId";
@@ -256,6 +270,7 @@ public final class TraceContext extends SamplingFlags {
 
   final long traceIdHigh, traceId, parentId, spanId;
   final List<Object> extra;
+  final CorrelationFields correlationFields;
 
   TraceContext(Builder builder) { // no external implementations
     super(builder.flags);
@@ -264,6 +279,7 @@ public final class TraceContext extends SamplingFlags {
     parentId = builder.parentId;
     spanId = builder.spanId;
     extra = builder.extra;
+    correlationFields = builder.correlationFields;
   }
 
 

--- a/brave/src/test/java/brave/correlation/RealCorrelationFieldsTest.java
+++ b/brave/src/test/java/brave/correlation/RealCorrelationFieldsTest.java
@@ -1,0 +1,7 @@
+package brave.correlation;
+
+import brave.internal.correlation.RealCorrelationFields;
+
+public class RealCorrelationFieldsTest {
+  RealCorrelationFields fields = (RealCorrelationFields) RealCorrelationFields.create();
+}


### PR DESCRIPTION
## Overview
This change aims to support correlation fields which may be request-scoped (and propagated downstream), or locally scoped (propagated in process, but not to the next). Example use cases include request-scoped fields like current game or country code, or local fields, such as the current operation name. Where cross-process propagation is desired, the ideal encoding is the [w3c Correlation Context](https://github.com/w3c/distributed-tracing/tree/master/correlation_context).

## Background on existing work in Brave
The first propagation mechanics of brave included propagation of the [TraceContext](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/propagation/TraceContext.java) in and to the next process. This object's duty is to place spans in the correct position in a potentially distributed operation (via parent IDs). Secondary duties include consistent sampling decisions, and correlation with other contexts such as logging. The data is mostly the same as the [trace-context](https://github.com/w3c/distributed-tracing) header being defined in w3c.

Brave has two roles in propagation: making data visible in-process, and injecting and extracting data out of process.

The [CurrentTraceContext](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/propagation/CurrentTraceContext.java) plugin synchronizes a `TraceContext` struct with implicitly visible state, such as a thread local or a logging context. Users can then call `Tracer.getCurrentSpan` for example, or read the logging context variable `traceId`. This in-process propagation is critical for correlation between systems, as often libraries have no other means to coordinate.

The [Propagation](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/propagation/Propagation.java) plugin connects traces across message boundaries by injecting or extracting the trace context from headers. For example, an incoming trace from another process is extracted from headers, the tracer creates a child, and later instrumentation use the above `CurrentTraceContext` to synchronize the current trace ID with whatever contexts that need to see it.

Notably due to demand created by OpenTracing and Sleuth, we have had requests to push arbitrary data along with the trace-context (implicitly via the above apis described). We've also had a number of non-arbitrary requests to [propagate extra data](https://github.com/openzipkin/brave/issues/390). For example, domain-specific data like the current playstation game, or extra properties needed for Amazon X-Ray.

Towards that end, we added an extension to our trace context object called "extra". [Extra](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/propagation/TraceContext.java#L107) is a list of opaque data plugins can use to ensure their propagation needs are met. 

We also added a default implementation that handles the common use-case of sending a mix of system and user fields. Here's an example:

Setup your tracing instance with allowed fields:
```java
tracingBuilder.propagationFactory(
  ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
                       .addField("x-vcap-request-id")
                       .addPrefixedFields("baggage-", Arrays.asList("country-code", "user-id"))
                       .build()
);
```

Later, you can call below to affect the country code of the current trace context
```java
ExtraFieldPropagation.set("country-code", "FO");
String countryCode = ExtraFieldPropagation.get("country-code");
```
 
## Why a change is needed
The current code is ok, but limited in implementation which makes it difficult to integrate with metrics contexts and scopes smaller than trace.

Using `ExtraFieldPropagation`, correlation with other fields involve the following trade-offs:
* In `ExtraFieldPropagation` (and OpenTracing) propagating something in-process also means adding overhead out of process
* `ExtraFieldPropagation` is harder to manage systematically as it uses a separate header per field
* `ExtraFieldPropagation` coupling with propagation fields implies a whitelist approach
* Users would want to wrap `ExtraFieldPropagation` as it isn't a great user-level api

For example, if you propagate the span name, to export changes to it for log correlation, you'll need to customize the log correlation plugins and also end up with another header on the wire that isn't useful on the other side.

On the other hand, with a `CorrelationFields` type, we can decouple the usage of propagated tags, their policy and their encoding scheme (defaulting to the correlation-context header). Like `ExtraFieldPropagation`, this could be added to B3, allowing a clean transition. In fact, `ExtraFieldPropagation` could be an implementation. At the end of the day, we end up with flexibly scoped propagation code with coherent usage patterns for context synchronization.

## Scoping constraints
An understood limitation is that since this api exists in the scope of Brave (a tracing api), Correlation fields cannot be added before a trace context has been created. For example, an integration with metrics context could imply ordering metrics after tracing, eager provision of an unstarted trace context, or an integration to copy currently scoped metrics tags into the a newly provisioned `CorrelationFields` object.

## See also
A lot of this work is biased towards the emerging [w3c Correlation Context](https://github.com/w3c/distributed-tracing/tree/master/correlation_context) specification.

This also has feature overlap (and integration possibilities) with Baggage (both [the original](http://brownsys.github.io/tracing-framework/docs/tutorials/baggage.html) and [OpenTracing](http://opentracing.io/documentation/pages/api/cross-process-tracing.html)) and [OpenCensus Tags](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md). Note that feature overlap isn't 100% between any of these.