### PR TITLE
Allows propagation decoration of local trace contexts

### DIFF
--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -26,6 +27,9 @@ import java.util.Map;
  *
  * // later, you can tag that request ID or use it in log correlation
  * requestId = ExtraFieldPropagation.current("x-vcap-request-id");
+ *
+ * // You can also set or override the value similarly, which might be needed if a new request
+ * ExtraFieldPropagation.current("x-country-code", "FO");
  * }</pre>
  *
  * <p>You may also need to propagate a trace context you aren't using. For example, you may be in an
@@ -39,50 +43,66 @@ import java.util.Map;
  * }</pre>
  */
 public final class ExtraFieldPropagation<K> implements Propagation<K> {
-
   /** Wraps an underlying propagation implementation, pushing one or more fields */
-  public static Propagation.Factory newFactory(Propagation.Factory delegate, String... names) {
-    return new Factory(delegate, Arrays.asList(names));
+  public static Propagation.Factory newFactory(Propagation.Factory delegate, String... validNames) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    if (validNames == null) throw new NullPointerException("validNames == null");
+    return new Factory(delegate, ensureLowerCase(Arrays.asList(validNames)));
   }
 
   /** Wraps an underlying propagation implementation, pushing one or more fields */
-  public static Propagation.Factory newFactory(Propagation.Factory delegate, Collection<String> names) {
-    return new Factory(delegate, names);
+  public static Propagation.Factory newFactory(Propagation.Factory delegate,
+      Collection<String> validNames) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    if (validNames == null) throw new NullPointerException("validNames == null");
+    return new Factory(delegate, ensureLowerCase(validNames));
   }
 
   /** Returns the value of the field with the specified key or null if not available */
   @Nullable public static String current(String name) {
+    TraceContext context = currentTraceContext();
+    return context != null ? get(context, name) : null;
+  }
+
+  /** Sets the current value of the field with the specified key */
+  @Nullable public static void current(String name, String value) {
+    TraceContext context = currentTraceContext();
+    if (context != null) set(context, name, value);
+  }
+
+  @Nullable static TraceContext currentTraceContext() {
     Tracing tracing = Tracing.current();
-    if (tracing == null) return null;
-    TraceContext context = tracing.currentTraceContext().get();
-    if (context == null) return null;
-    return get(context, name);
+    return tracing != null ? tracing.currentTraceContext().get() : null;
   }
 
   /** Returns the value of the field with the specified key or null if not available */
   @Nullable public static String get(TraceContext context, String name) {
     if (context == null) throw new NullPointerException("context == null");
     if (name == null) throw new NullPointerException("name == null");
-    name = name.toLowerCase(Locale.ROOT); // since not all propagation handle mixed case
-    for (Object extra : context.extra()) {
-      if (extra instanceof Extra) return ((Extra) extra).get(name);
-    }
-    return null;
+    Extra extra = findExtra(context.extra());
+    if (extra == null) return null;
+    int index = extra.indexOf(name.toLowerCase(Locale.ROOT));
+    return index != -1 ? extra.get(index) : null;
+  }
+
+  /** Returns the value of the field with the specified key or null if not available */
+  @Nullable public static void set(TraceContext context, String name, String value) {
+    if (context == null) throw new NullPointerException("context == null");
+    if (name == null) throw new NullPointerException("name == null");
+    if (value == null) throw new NullPointerException("value == null");
+    Extra extra = findExtra(context.extra());
+    if (extra == null) return;
+    int index = extra.indexOf(name.toLowerCase(Locale.ROOT));
+    extra.set(index, value);
   }
 
   static final class Factory extends Propagation.Factory {
     final Propagation.Factory delegate;
-    final List<String> names;
+    final String[] validNames;
 
-    Factory(Propagation.Factory delegate, Collection<String> names) {
-      if (delegate == null) throw new NullPointerException("field == null");
-      if (names == null) throw new NullPointerException("names == null");
-      if (names.isEmpty()) throw new NullPointerException("names.length == 0");
+    Factory(Propagation.Factory delegate, String[] validNames) {
       this.delegate = delegate;
-      this.names = new ArrayList<>();
-      for (String name : names) {
-        this.names.add(name.toLowerCase(Locale.ROOT));
-      }
+      this.validNames = validNames;
     }
 
     @Override public boolean supportsJoin() {
@@ -94,145 +114,219 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     }
 
     @Override public final <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-      Map<String, K> names = new LinkedHashMap<>();
-      for (String name : this.names) {
-        names.put(name, keyFactory.create(name));
+      int length = validNames.length;
+      List<K> keys = new ArrayList<>(length);
+      for (int i = 0; i < length; i++) {
+        keys.add(keyFactory.create(validNames[i]));
       }
-      return new ExtraFieldPropagation<>(delegate.create(keyFactory), names);
+      return new ExtraFieldPropagation<>(delegate.create(keyFactory), validNames, keys);
+    }
+
+    @Override public TraceContext decorate(TraceContext context) {
+      TraceContext result = delegate.decorate(context);
+      int extraIndex = indexOfExtra(result.extra());
+      if (extraIndex != -1) {
+        Extra extra = (Extra) result.extra().get(extraIndex);
+        if (!Arrays.equals(extra.validNames, validNames)) {
+          throw new IllegalStateException(
+              String.format("Mixed name configuration unsupported: found %s, expected %s",
+                  Arrays.asList(extra.validNames), Arrays.asList(validNames))
+          );
+        }
+
+        // If this extra is unassociated (due to remote extraction),
+        // or it is the same span ID, re-use the instance.
+        if (extra.tryAssociate(context)) return context;
+      }
+      // otherwise, we are creating a new instance of
+      List<Object> copyOfExtra = new ArrayList<>(result.extra());
+      Extra extra;
+      if (extraIndex != -1) {
+        extra = ((Extra) copyOfExtra.get(extraIndex)).clone();
+        copyOfExtra.set(extraIndex, extra);
+      } else {
+        extra = new Extra(validNames);
+        copyOfExtra.add(extra);
+      }
+      extra.context = context;
+      return result.toBuilder().extra(Collections.unmodifiableList(copyOfExtra)).build();
     }
   }
 
   final Propagation<K> delegate;
-  final List<K> keys;
-  final Map<String, K> nameToKey;
+  final String[] validNames;
+  final List<K> keys, allKeys;
 
-  ExtraFieldPropagation(Propagation<K> delegate, Map<String, K> nameToKey) {
+  ExtraFieldPropagation(Propagation<K> delegate, String[] validNames, List<K> keys) {
     this.delegate = delegate;
-    this.nameToKey = nameToKey;
-    List<K> keys = new ArrayList<>(delegate.keys());
-    keys.addAll(nameToKey.values());
-    this.keys = Collections.unmodifiableList(keys);
+    this.validNames = validNames;
+    this.keys = keys;
+    List<K> allKeys = new ArrayList<>(delegate.keys());
+    allKeys.addAll(keys);
+    this.allKeys = allKeys;
   }
 
   @Override public List<K> keys() {
-    return keys;
+    return allKeys;
   }
 
   @Override public <C> Injector<C> injector(Setter<C, K> setter) {
-    return new ExtraFieldInjector<>(delegate.injector(setter), setter, nameToKey);
+    return new ExtraFieldInjector<>(this, setter);
   }
 
   @Override public <C> Extractor<C> extractor(Getter<C, K> getter) {
-    Extractor<C> extractorDelegate = delegate.extractor(getter);
-    return new ExtraFieldExtractor<>(extractorDelegate, getter, nameToKey);
+    return new ExtraFieldExtractor<>(this, getter);
   }
 
-  static abstract class Extra { // internal marker type
-    abstract void put(String field, String value);
+  /** Copy-on-write keeps propagation changes in a child context from affecting its parent */
+  static final class Extra implements Cloneable {
+    final String[] validNames;
+    volatile String[] values; // guarded by this, copy on write
+    TraceContext context; // guarded by this
 
-    abstract String get(String field);
-
-    abstract <C, K> void setAll(C carrier, Setter<C, K> setter, Map<String, K> nameToKey);
-  }
-
-  static final class One extends Extra {
-    String name, value;
-
-    @Override void put(String name, String value) {
-      this.name = name;
-      this.value = value;
+    Extra(String[] validNames) {
+      this.validNames = validNames;
     }
 
-    @Override String get(String name) {
-      return name.equals(this.name) ? value : null;
-    }
-
-    @Override <C, K> void setAll(C carrier, Setter<C, K> setter, Map<String, K> nameToKey) {
-      K key = nameToKey.get(name);
-      if (key == null) return;
-      setter.put(carrier, key, value);
-    }
-
-    @Override public String toString() {
-      return "ExtraFieldPropagation{" + name + "=" + value + "}";
-    }
-  }
-
-  static final class Many extends Extra {
-    final LinkedHashMap<String, String> fields = new LinkedHashMap<>();
-
-    @Override void put(String name, String value) {
-      fields.put(name, value);
-    }
-
-    @Override String get(String name) {
-      return fields.get(name);
-    }
-
-    @Override <C, K> void setAll(C carrier, Setter<C, K> setter, Map<String, K> nameToKey) {
-      for (Map.Entry<String, String> field : fields.entrySet()) {
-        K key = nameToKey.get(field.getKey());
-        if (key == null) continue;
-        setter.put(carrier, nameToKey.get(field.getKey()), field.getValue());
+    /** Extra data are extracted before a context is created. We need to lazy set the context */
+    boolean tryAssociate(TraceContext newContext) {
+      synchronized (this) {
+        if (context == null) {
+          context = newContext;
+          return true;
+        }
+        return context.traceId() == newContext.traceId()
+            && context.spanId() == newContext.spanId();
       }
     }
 
+    int indexOf(String name) {
+      for (int i = 0, length = validNames.length; i < length; i++) {
+        if (validNames[i].equals(name)) return i;
+      }
+      return -1;
+    }
+
+    void set(int index, String value) {
+      synchronized (this) {
+        String[] elements = values;
+        if (elements == null) {
+          elements = new String[validNames.length];
+          elements[index] = value;
+        } else if (!value.equals(elements[index])) {
+          // this is the copy-on-write part
+          elements = Arrays.copyOf(elements, elements.length);
+          elements[index] = value;
+        }
+        values = elements;
+      }
+    }
+
+    String get(int index) {
+      final String result;
+      synchronized (this) {
+        String[] elements = values;
+        result = elements != null ? elements[index] : null;
+      }
+      return result;
+    }
+
     @Override public String toString() {
-      return "ExtraFieldPropagation" + fields;
+      String[] elements;
+      synchronized (this) {
+        elements = values;
+      }
+
+      Map<String, String> contents = new LinkedHashMap<>();
+      for (int i = 0, length = validNames.length; i < length; i++) {
+        String maybeValue = elements[i];
+        if (maybeValue == null) continue;
+        contents.put(validNames[i], maybeValue);
+      }
+      return "ExtraFieldPropagation" + contents;
+    }
+
+    @Override public Extra clone() {
+      Extra result = new Extra(validNames);
+      result.values = values;
+      return result;
     }
   }
 
   static final class ExtraFieldInjector<C, K> implements Injector<C> {
     final Injector<C> delegate;
     final Propagation.Setter<C, K> setter;
-    final Map<String, K> nameToKey;
+    final String[] validNames;
+    final List<K> keys;
 
-    ExtraFieldInjector(Injector<C> delegate, Setter<C, K> setter, Map<String, K> nameToKey) {
-      this.delegate = delegate;
+    ExtraFieldInjector(ExtraFieldPropagation<K> propagation, Setter<C, K> setter) {
+      this.delegate = propagation.delegate.injector(setter);
+      this.validNames = propagation.validNames;
+      this.keys = propagation.keys;
       this.setter = setter;
-      this.nameToKey = nameToKey;
     }
 
     @Override public void inject(TraceContext traceContext, C carrier) {
-      for (Object extra : traceContext.extra()) {
-        if (extra instanceof Extra) {
-          ((Extra) extra).setAll(carrier, setter, nameToKey);
-          break;
-        }
-      }
       delegate.inject(traceContext, carrier);
+      int extraIndex = indexOfExtra(traceContext.extra());
+      if (extraIndex == -1) return;
+      Extra extra = (Extra) traceContext.extra().get(extraIndex);
+      for (int i = 0, length = keys.size(); i < length; i++) {
+        String maybeValue = extra.get(i);
+        if (maybeValue == null) continue;
+        setter.put(carrier, keys.get(i), maybeValue);
+      }
     }
   }
 
   static final class ExtraFieldExtractor<C, K> implements Extractor<C> {
+    final ExtraFieldPropagation<K> propagation;
     final Extractor<C> delegate;
     final Propagation.Getter<C, K> getter;
-    final Map<String, K> names;
 
-    ExtraFieldExtractor(Extractor<C> delegate, Getter<C, K> getter, Map<String, K> names) {
-      this.delegate = delegate;
+    ExtraFieldExtractor(ExtraFieldPropagation<K> propagation, Getter<C, K> getter) {
+      this.propagation = propagation;
+      this.delegate = propagation.delegate.extractor(getter);
       this.getter = getter;
-      this.names = names;
     }
 
     @Override public TraceContextOrSamplingFlags extract(C carrier) {
       TraceContextOrSamplingFlags result = delegate.extract(carrier);
 
-      Extra extra = null;
-      for (Map.Entry<String, K> field : names.entrySet()) {
-        String maybeValue = getter.get(carrier, field.getValue());
+      // always allocate in case fields are added late
+      Extra extra = new Extra(propagation.validNames);
+      for (int i = 0, length = propagation.validNames.length; i < length; i++) {
+        String maybeValue = getter.get(carrier, propagation.keys.get(i));
         if (maybeValue == null) continue;
-        if (extra == null) {
-          extra = new One();
-        } else if (extra instanceof One) {
-          One one = (One) extra;
-          extra = new Many();
-          extra.put(one.name, one.value);
-        }
-        extra.put(field.getKey(), maybeValue);
+        extra.set(i, maybeValue);
       }
-      if (extra == null) return result;
       return result.toBuilder().addExtra(extra).build();
     }
+  }
+
+  static Extra findExtra(List<Object> extra) {
+    int i = indexOfExtra(extra);
+    return i != -1 ? (Extra) extra.get(i) : null;
+  }
+
+  static int indexOfExtra(List<Object> extra) {
+    for (int i = 0, length = extra.size(); i < length; i++) {
+      if (extra.get(i) instanceof Extra) return i;
+    }
+    return -1;
+  }
+
+  static String[] ensureLowerCase(Collection<String> names) {
+    if (names.isEmpty()) throw new IllegalArgumentException("names is empty");
+    Iterator<String> nextName = names.iterator();
+    String[] result = new String[names.size()];
+    for (int i = 0; nextName.hasNext(); i++) {
+      String name = nextName.next();
+      if (name == null) throw new NullPointerException("names[" + i + "] == null");
+      name = name.trim();
+      if (name.isEmpty()) throw new IllegalArgumentException("names[" + i + "] is empty");
+      result[i] = name.toLowerCase(Locale.ROOT);
+    }
+    return result;
   }
 }

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -46,6 +46,22 @@ public interface Propagation<K> {
     }
 
     public abstract <K> Propagation<K> create(KeyFactory<K> keyFactory);
+
+    /**
+     * Decorates the input such that it can propagate extra data, such as a timestamp or a carrier
+     * for extra fields.
+     *
+     * <p>Implementations should be idempotent, returning the same instance where needed.
+     * Implementations are responsible for data scoping, if relevant. For example, if only global
+     * configuration is present, it could suffice to simply ensure that data is present. If data
+     * is span-scoped, an implementation might compare the context to its last span ID, copying on
+     * write or otherwise to ensure writes to one context don't affect another.
+     *
+     * @see TraceContext#extra()
+     */
+    public TraceContext decorate(TraceContext context) {
+      return context;
+    }
   }
 
   /** Creates keys for use in propagated contexts */

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -100,6 +100,9 @@ public abstract class TraceContext extends SamplingFlags {
    * <p>The contents are intentionally opaque, deferring to {@linkplain Propagation} to define. An
    * example implementation could be storing a class containing a correlation value, which is
    * extracted from incoming requests and injected as-is onto outgoing requests.
+   *
+   * <p>Implementations are responsible for scoping any data stored here. This can be performed when
+   * {@link Propagation.Factory#decorate(TraceContext)} is called.
    */
   public abstract List<Object> extra();
 

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -22,26 +22,104 @@ public class ExtraFieldPropagationTest {
       "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1";
   String uuid = "f4308d05-2228-4468-80f6-92a8377ba193";
 
-  TraceContext context = TraceContext.newBuilder()
+  TraceContext context = factory.decorate(TraceContext.newBuilder()
       .traceId(1L)
       .spanId(2L)
       .sampled(true)
-      .build();
+      .build());
 
-  @Test public void get() throws Exception {
-    context = contextWithAmazonTraceId();
+  @Test public void contextsAreIndependent() {
+    try (Tracing tracing = Tracing.newBuilder().propagationFactory(factory).build()) {
+
+      TraceContext context1 = tracing.tracer().nextSpan().context();
+      ExtraFieldPropagation.set(context1, "x-vcap-request-id", "foo");
+      TraceContext context2 = tracing.tracer().newChild(context1).context();
+
+      // same values when propagating down
+      assertThat(ExtraFieldPropagation.get(context1, "x-vcap-request-id"))
+          .isEqualTo(ExtraFieldPropagation.get(context2, "x-vcap-request-id"))
+          .isEqualTo("foo");
+
+      ExtraFieldPropagation.set(context1, "x-vcap-request-id", "bar");
+      ExtraFieldPropagation.set(context2, "x-vcap-request-id", "baz");
+
+      assertThat(ExtraFieldPropagation.get(context1, "x-vcap-request-id"))
+          .isEqualTo("bar");
+      assertThat(ExtraFieldPropagation.get(context2, "x-vcap-request-id"))
+          .isEqualTo("baz");
+    }
+  }
+
+  @Test public void contextIsntBrokenWithSmallChanges() {
+    try (Tracing tracing = Tracing.newBuilder().propagationFactory(factory).build()) {
+
+      TraceContext context1 = tracing.tracer().nextSpan().context();
+      ExtraFieldPropagation.set(context1, "x-vcap-request-id", "foo");
+
+      TraceContext context2 =
+          tracing.tracer().toSpan(context1.toBuilder().sampled(false).build()).context();
+      ExtraFieldPropagation.Extra extra1 = (ExtraFieldPropagation.Extra) context1.extra().get(0);
+      ExtraFieldPropagation.Extra extra2 = (ExtraFieldPropagation.Extra) context2.extra().get(0);
+
+      // we have the same span ID, so we should couple our extra fields
+      assertThat(extra1).isSameAs(extra2);
+
+      // we no longer have the same span ID, so we should decouple our extra fields
+      TraceContext context3 =
+          tracing.tracer().toSpan(context1.toBuilder().spanId(1L).build()).context();
+      ExtraFieldPropagation.Extra extra3 = (ExtraFieldPropagation.Extra) context3.extra().get(0);
+
+      // we have different instances of extra
+      assertThat(extra1).isNotSameAs(extra3);
+
+      // however, the values inside are the same until a write occurs
+      assertThat(extra1.values).isSameAs(extra3.values);
+
+      // inside the span, the same change is present, but the other span has the old values
+      ExtraFieldPropagation.set(context1, "x-vcap-request-id", "1");
+      assertThat(extra1.values).isSameAs(extra2.values);
+      assertThat(extra1.values).isNotSameAs(extra3.values);
+    }
+  }
+
+  @Test public void downcasesNames() {
+    ExtraFieldPropagation.Factory factory =
+        (ExtraFieldPropagation.Factory) ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,
+            "X-FOO");
+    assertThat(factory.validNames)
+        .containsExactly("x-foo");
+  }
+
+  @Test public void trimsNames() {
+    ExtraFieldPropagation.Factory factory =
+        (ExtraFieldPropagation.Factory) ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,
+            " x-foo  ");
+    assertThat(factory.validNames)
+        .containsExactly("x-foo");
+  }
+
+  @Test(expected = NullPointerException.class) public void rejectsNull() {
+    ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-me", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void rejectsEmpty() {
+    ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "x-me", " ");
+  }
+
+  @Test public void get() {
+    context = extractWithAmazonTraceId();
 
     assertThat(ExtraFieldPropagation.get(context, "x-amzn-trace-id"))
         .isEqualTo(awsTraceId);
   }
 
-  @Test public void get_null_if_not_extraField() throws Exception {
+  @Test public void get_null_if_not_extraField() {
     assertThat(ExtraFieldPropagation.get(context, "x-amzn-trace-id"))
         .isNull();
   }
 
-  @Test public void current() throws Exception {
-    context = contextWithAmazonTraceId();
+  @Test public void current_get() {
+    context = extractWithAmazonTraceId();
 
     try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build();
          CurrentTraceContext.Scope scope = t.currentTraceContext().newScope(context)) {
@@ -50,51 +128,71 @@ public class ExtraFieldPropagationTest {
     }
   }
 
-  @Test public void current_null_if_no_current_context() throws Exception {
+  @Test public void current_get_null_if_no_current_context() {
     try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build()) {
       assertThat(ExtraFieldPropagation.current("x-amzn-trace-id"))
           .isNull();
     }
   }
 
-  @Test public void current_null_if_nothing_current() throws Exception {
+  @Test public void current_get_null_if_nothing_current() {
     assertThat(ExtraFieldPropagation.current("x-amzn-trace-id"))
         .isNull();
   }
 
-  @Test public void toString_one() throws Exception {
-    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.One();
-    extra.put("x-vcap-request-id", uuid);
+  @Test public void current_set() {
+    try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build();
+         CurrentTraceContext.Scope scope = t.currentTraceContext().newScope(context)) {
+      ExtraFieldPropagation.current("x-amzn-trace-id", awsTraceId);
+
+      assertThat(ExtraFieldPropagation.current("x-amzn-trace-id"))
+          .isEqualTo(awsTraceId);
+    }
+  }
+
+  @Test public void current_set_noop_if_no_current_context() {
+    try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build()) {
+      ExtraFieldPropagation.current("x-amzn-trace-id", awsTraceId); // doesn't throw
+    }
+  }
+
+  @Test public void current_set_noop_if_nothing_current() {
+    ExtraFieldPropagation.current("x-amzn-trace-id", awsTraceId); // doesn't throw
+  }
+
+  @Test public void toString_extra() {
+    String[] validNames = {"x-vcap-request-id"};
+    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.Extra(validNames);
+    extra.set(0, uuid);
 
     assertThat(extra)
         .hasToString("ExtraFieldPropagation{x-vcap-request-id=" + uuid + "}");
   }
 
-  @Test public void toString_two() throws Exception {
-    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.Many();
-    extra.put("x-amzn-trace-id", awsTraceId);
-    extra.put("x-vcap-request-id", uuid);
+  @Test public void toString_two() {
+    String[] validNames = {"x-amzn-trace-id", "x-vcap-request-id"};
+    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.Extra(validNames);
+    extra.set(0, awsTraceId);
+    extra.set(1, uuid);
 
     assertThat(extra).hasToString(
         "ExtraFieldPropagation{x-amzn-trace-id=" + awsTraceId + ", x-vcap-request-id=" + uuid + "}"
     );
   }
 
-  @Test public void inject_one() throws Exception {
-    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.One();
-    extra.put("x-vcap-request-id", uuid);
-    context = context.toBuilder().extra(Collections.singletonList(extra)).build();
+  @Test public void inject_extra() {
+    ExtraFieldPropagation.Extra extra = ExtraFieldPropagation.findExtra(context.extra());
+    extra.set(0, uuid);
 
     injector.inject(context, carrier);
 
     assertThat(carrier).containsEntry("x-vcap-request-id", uuid);
   }
 
-  @Test public void inject_two() throws Exception {
-    ExtraFieldPropagation.Extra extra = new ExtraFieldPropagation.Many();
-    extra.put("x-amzn-trace-id", awsTraceId);
-    extra.put("x-vcap-request-id", uuid);
-    context = context.toBuilder().extra(Collections.singletonList(extra)).build();
+  @Test public void inject_two() {
+    ExtraFieldPropagation.Extra extra = ExtraFieldPropagation.findExtra(context.extra());
+    extra.set(0, uuid);
+    extra.set(1, awsTraceId);
 
     injector.inject(context, carrier);
 
@@ -103,7 +201,17 @@ public class ExtraFieldPropagationTest {
         .containsEntry("x-vcap-request-id", uuid);
   }
 
-  @Test public void extract_one() throws Exception {
+  /** it is illegal to mix naming configuration in the same span */
+  @Test(expected = IllegalStateException.class)
+  public void mixed_names_unsupported() {
+    Propagation.Factory otherFactory = ExtraFieldPropagation.newFactory(
+        B3Propagation.FACTORY, "foo", "bar"
+    );
+
+    otherFactory.decorate(context);
+  }
+
+  @Test public void extract_extra() {
     Propagation.B3_STRING.<Map<String, String>>injector(Map::put).inject(context, carrier);
     carrier.put("x-amzn-trace-id", awsTraceId);
 
@@ -113,14 +221,13 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().extra())
         .hasSize(1);
 
-    ExtraFieldPropagation.One one = (ExtraFieldPropagation.One) extracted.context().extra().get(0);
-    assertThat(one.name)
-        .isEqualTo("x-amzn-trace-id");
-    assertThat(one.value)
-        .isEqualTo(awsTraceId);
+    ExtraFieldPropagation.Extra extra =
+        (ExtraFieldPropagation.Extra) extracted.context().extra().get(0);
+    assertThat(extra.values)
+        .contains(awsTraceId);
   }
 
-  @Test public void extract_two() throws Exception {
+  @Test public void extract_two() {
     Propagation.B3_STRING.<Map<String, String>>injector(Map::put).inject(context, carrier);
     carrier.put("x-amzn-trace-id", awsTraceId);
     carrier.put("x-vcap-request-id", uuid);
@@ -131,14 +238,13 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().extra())
         .hasSize(1);
 
-    ExtraFieldPropagation.Many many =
-        (ExtraFieldPropagation.Many) extracted.context().extra().get(0);
-    assertThat(many.fields)
-        .containsEntry("x-amzn-trace-id", awsTraceId)
-        .containsEntry("x-vcap-request-id", uuid);
+    ExtraFieldPropagation.Extra extra =
+        (ExtraFieldPropagation.Extra) extracted.context().extra().get(0);
+    assertThat(extra.values)
+        .containsExactly(uuid, awsTraceId);
   }
 
-  TraceContext contextWithAmazonTraceId() {
+  TraceContext extractWithAmazonTraceId() {
     Propagation.B3_STRING.<Map<String, String>>injector(Map::put).inject(context, carrier);
     carrier.put("x-amzn-trace-id", awsTraceId);
     return extractor.extract(carrier).context();

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttp.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class ITHttp {
   @Rule public ExpectedException thrown = ExpectedException.none();
   @Rule public MockWebServer server = new MockWebServer();
+  public static String EXTRA_KEY = "user-id";
 
   protected ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
 
@@ -42,7 +43,7 @@ public abstract class ITHttp {
           }
           spans.add(s);
         })
-        .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "user-id"))
+        .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, EXTRA_KEY))
         .currentTraceContext(currentTraceContext)
         .sampler(sampler);
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
@@ -5,6 +5,7 @@ import brave.http.HttpAdapter;
 import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
 import brave.http.ITServletContainer;
+import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import javax.ws.rs.GET;
@@ -38,7 +39,13 @@ public class ITTracingFeature_Container extends ITServletContainer {
     @GET
     @Path("foo")
     public Response foo() {
-      return Response.status(200).build();
+      return Response.ok().build();
+    }
+
+    @GET
+    @Path("extra")
+    public Response extra() {
+      return Response.ok(ExtraFieldPropagation.current(EXTRA_KEY)).build();
     }
 
     @GET

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -1,6 +1,7 @@
 package brave.sparkjava;
 
 import brave.http.ITHttpServer;
+import brave.propagation.ExtraFieldPropagation;
 import org.junit.After;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
@@ -29,6 +30,7 @@ public class ITSparkTracing extends ITHttpServer {
     Spark.afterAfter(spark.afterAfter());
 
     Spark.get("/foo", (req, res) -> "bar");
+    Spark.get("/extra", (req, res) -> ExtraFieldPropagation.current(EXTRA_KEY));
     Spark.get("/badrequest", (req, res) -> {
       res.status(400);
       return res;

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingAsyncHandlerInterceptor.java
@@ -3,6 +3,7 @@ package brave.spring.webmvc;
 import brave.Tracer;
 import brave.http.HttpTracing;
 import brave.http.ITServletContainer;
+import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -32,12 +33,17 @@ public class ITTracingAsyncHandlerInterceptor extends ITServletContainer {
     }
 
     @RequestMapping(value = "/foo")
-    public ResponseEntity<Void> foo() throws IOException {
+    public ResponseEntity<Void> foo() {
       return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @RequestMapping(value = "/extra")
+    public ResponseEntity<String> extra() {
+      return new ResponseEntity<>(ExtraFieldPropagation.current(EXTRA_KEY), HttpStatus.OK);
+    }
+
     @RequestMapping(value = "/badrequest")
-    public ResponseEntity<Void> badrequest() throws IOException {
+    public ResponseEntity<Void> badrequest() {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
@@ -48,7 +54,7 @@ public class ITTracingAsyncHandlerInterceptor extends ITServletContainer {
     }
 
     @RequestMapping(value = "/async")
-    public Callable<ResponseEntity<Void>> async() throws IOException {
+    public Callable<ResponseEntity<Void>> async() {
       return () -> new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -58,7 +64,7 @@ public class ITTracingAsyncHandlerInterceptor extends ITServletContainer {
     }
 
     @RequestMapping(value = "/exceptionAsync")
-    public Callable<ResponseEntity<Void>> disconnectAsync() throws IOException {
+    public Callable<ResponseEntity<Void>> disconnectAsync() {
       return () -> {
         throw new IOException();
       };

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
@@ -3,6 +3,7 @@ package brave.spring.webmvc;
 import brave.Tracer;
 import brave.http.HttpTracing;
 import brave.http.ITServletContainer;
+import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -34,6 +35,11 @@ public class ITTracingHandlerInterceptor extends ITServletContainer {
     @RequestMapping(value = "/foo")
     public ResponseEntity<Void> foo() throws IOException {
       return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/extra")
+    public ResponseEntity<String> extra() throws IOException {
+      return new ResponseEntity<>(ExtraFieldPropagation.current(EXTRA_KEY), HttpStatus.OK);
     }
 
     @RequestMapping(value = "/badrequest")

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -5,7 +5,6 @@ import brave.Tracing;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.StrictCurrentTraceContext;
 import brave.sampler.Sampler;
-import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.Endpoint;
@@ -148,9 +147,9 @@ public class TracingFactoryBeanTest {
 
     assertThat(context.getBean("tracing", Tracing.class).propagation())
         .isInstanceOf(ExtraFieldPropagation.class)
-        .extracting("nameToKey")
-        .allSatisfy(m -> assertThat((Map) m)
-            .containsOnlyKeys("x-vcap-request-id", "x-amzn-trace-id"));
+        .extracting("validNames")
+        .allSatisfy(m -> assertThat((String[]) m)
+            .containsExactly("x-vcap-request-id", "x-amzn-trace-id"));
   }
 
   @Test public void traceId128Bit() {


### PR DESCRIPTION
Before, Propagation implementations could not add "extra" data to trace
implementations unless they were extracted from a remote request. This
meant local traces could not propagate extra data.

To fix this, we add a lifecycle hook that decorates the trace context
directly before a span is returned. The first use of this is
`ExtraFieldsPropagation` which can now set fields after a request
started.