### PR TITLE
Removes propagation of the shared flag, which is only used internally

### DIFF
--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/Recorder.java
@@ -102,7 +102,7 @@ abstract class Recorder implements AnnotationSubmitter.Clock {
       // rather let the client do that. Worst case we were propagated an unreported ID and
       // Zipkin backfills timestamp and duration.
       synchronized (span) {
-        if (InternalSpan.instance.context(span).shared) {
+        if (span.isShared()) {
           for (int i = 0, length = span.getAnnotations().size(); i < length; i++) {
             if (span.getAnnotations().get(i).value.equals(Constants.SERVER_RECV)) {
               span.setTimestamp(null);

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
@@ -64,7 +64,6 @@ abstract class SpanFactory {
       return Brave.toSpan(maybeParent.toBuilder()
           .parentId(maybeParent.spanId)
           .spanId(newSpanId)
-          .shared(false)
           .build());
     }
 
@@ -74,11 +73,10 @@ abstract class SpanFactory {
       if (context.sampled() == null) {
         return Brave.toSpan(context.toBuilder()
             .sampled(sampler().isSampled(context.traceId))
-            .shared(false)
             .build());
       } else if (context.sampled()) {
         // We know an instrumented caller initiated the trace if they sampled it
-        return Brave.toSpan(context.toBuilder().shared(true).build());
+        return Brave.toSpan(context).setShared();
       } else {
         return Brave.toSpan(context);
       }

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
@@ -63,7 +63,6 @@ public final class SpanId {
     this.parentId = builder.nullableParentId != null ? builder.nullableParentId : this.traceId;
     this.spanId = builder.spanId;
     this.flags = builder.flags;
-    this.shared = builder.shared;
   }
 
   /** Deserializes this from a big-endian byte array */
@@ -184,15 +183,8 @@ public final class SpanId {
   /** Raw flags encoded in {@link #bytes()} */
   public final long flags;
 
-  /**
-   * True if we are contributing to a span started by another tracer (ex on a different host).
-   * Defaults to false.
-   *
-   * <p>When an RPC trace is client-originated, it will be sampled and the same span ID is used for
-   * the server side. However, the server shouldn't set span.timestamp or duration since it didn't
-   * start the span.
-   */
-  public final boolean shared;
+  /** @deprecated it is unnecessary overhead to propagate this property */
+  @Deprecated public final boolean shared = false;
 
   /** Serializes this into a big-endian byte array */
   public byte[] bytes() {
@@ -294,7 +286,7 @@ public final class SpanId {
       this.nullableParentId = source.nullableParentId();
       this.spanId = source.spanId;
       this.flags = source.flags;
-      this.shared = source.shared;
+      this.shared = false;
     }
 
     /** @see SpanId#traceIdHigh */
@@ -346,9 +338,8 @@ public final class SpanId {
       return this;
     }
 
-    /** @see SpanId#shared */
-    public Builder shared(boolean shared) {
-      this.shared = shared;
+    /** @deprecated it is unnecessary overhead to propagate this property */
+    @Deprecated public Builder shared(boolean shared) {
       return this;
     }
 

--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/TracerAdapter.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/TracerAdapter.java
@@ -90,8 +90,7 @@ public final class TracerAdapter {
         .parentId(spanId.nullableParentId())
         .spanId(spanId.spanId)
         .debug(spanId.debug())
-        .sampled(spanId.sampled())
-        .shared(spanId.shared).build();
+        .sampled(spanId.sampled()).build();
   }
 
   public static Span toSpan(TraceContext context) {
@@ -192,7 +191,6 @@ public final class TracerAdapter {
         .parentId(context.parentId())
         .spanId(context.spanId())
         .debug(context.debug())
-        .sampled(context.sampled())
-        .shared(context.shared()).build();
+        .sampled(context.sampled()).build();
   }
 }

--- a/archive/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/archive/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -61,6 +61,7 @@ public class Span implements Serializable {
   private List<Annotation> annotations = Collections.emptyList(); // required
   private List<BinaryAnnotation> binary_annotations = Collections.emptyList(); // required
   private Boolean debug; // optional
+  private Boolean shared; // optional
   private Long timestamp; // optional
   private Long duration; // optional
 
@@ -289,6 +290,15 @@ public class Span implements Serializable {
     return this;
   }
 
+  public boolean isShared() {
+    return this.shared != null && this.shared;
+  }
+
+  public Span setShared() {
+    this.shared = true;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;
@@ -303,7 +313,8 @@ public class Span implements Serializable {
         && equal(this.duration, that.duration)
         && equal(this.annotations, that.annotations)
         && equal(this.binary_annotations, that.binary_annotations)
-        && equal(this.debug, that.debug);
+        && equal(this.debug, that.debug)
+        && equal(this.shared, that.shared);
   }
 
   @Override
@@ -329,6 +340,8 @@ public class Span implements Serializable {
     h ^= (binary_annotations == null) ? 0 : binary_annotations.hashCode();
     h *= 1000003;
     h ^= (debug == null) ? 0 : debug.hashCode();
+    h *= 1000003;
+    h ^= (shared == null) ? 0 : shared.hashCode();
     return h;
   }
 

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -22,13 +22,17 @@ final class MutableSpan {
         .parentId(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null)
         .id(HexCodec.toLowerHex(context.spanId()))
         .debug(context.debug() ? true : null)
-        .shared(context.shared() ? true : null)
         .localEndpoint(localEndpoint);
     finished = false;
   }
 
   MutableSpan start() {
     return start(clock.currentTimeMicroseconds());
+  }
+
+  synchronized MutableSpan setShared() {
+    span.shared(true);
+    return this;
   }
 
   synchronized MutableSpan start(long timestamp) {

--- a/brave/src/main/java/brave/internal/recorder/Recorder.java
+++ b/brave/src/main/java/brave/internal/recorder/Recorder.java
@@ -2,6 +2,7 @@ package brave.internal.recorder;
 
 import brave.Clock;
 import brave.Span;
+import brave.Tracer;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
@@ -44,6 +45,18 @@ public final class Recorder {
   public Clock clock(TraceContext context) {
     if (noop.get()) return clock;
     return spanMap.getOrCreate(context).clock;
+  }
+
+  /**
+   * Indicates we are contributing to a span started by another tracer (ex on a different host).
+   * Defaults to false.
+   *
+   * @see Tracer#joinSpan(TraceContext)
+   * @see zipkin2.Span#shared()
+   */
+  public void setShared(TraceContext context) {
+    if (noop.get()) return;
+    spanMap.getOrCreate(context).setShared();
   }
 
   /** @see brave.Span#start() */

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -61,7 +61,7 @@ public abstract class TraceContext extends SamplingFlags {
   }
 
   public static Builder newBuilder() {
-    return new AutoValue_TraceContext.Builder().traceIdHigh(0L).debug(false).shared(false)
+    return new AutoValue_TraceContext.Builder().traceIdHigh(0L).debug(false)
         .extra(Collections.emptyList());
   }
 
@@ -84,15 +84,10 @@ public abstract class TraceContext extends SamplingFlags {
    */
   public abstract long spanId();
 
-  /**
-   * True if we are contributing to a span started by another tracer (ex on a different host).
-   * Defaults to false.
-   *
-   * <p>When an RPC trace is client-originated, it will be sampled and the same span ID is used for
-   * the server side. However, the server shouldn't set span.timestamp or duration since it didn't
-   * start the span.
-   */
-  public abstract boolean shared();
+  /** @deprecated it is unnecessary overhead to propagate this property */
+  @Deprecated public final boolean shared() {
+    return false; // shared is set internally on Tracer.join
+  }
 
   /**
    * Returns a list of additional data propagated through this trace.
@@ -158,8 +153,11 @@ public abstract class TraceContext extends SamplingFlags {
     /** @see TraceContext#debug() */
     public abstract Builder debug(boolean debug);
 
-    /** @see TraceContext#shared() */
-    public abstract Builder shared(boolean shared);
+    /** @deprecated it is unnecessary overhead to propagate this property */
+    @Deprecated public final Builder shared(boolean shared) {
+      // this is not a propagated property, rather set internal to Tracer.join
+      return this;
+    }
 
     /** @see TraceContext#extra() */
     public abstract Builder extra(List<Object> extra);

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -69,7 +69,6 @@ public class OpenTracingAdapterTest {
         .isEqualTo(TraceContext.newBuilder()
             .traceId(1L)
             .spanId(2L)
-            .shared(true)
             .sampled(true).build());
   }
 

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -147,9 +147,9 @@ public class MutableSpanTest {
 
   // This prevents the server timestamp from overwriting the client one on the collector
   @Test public void reportsSharedStatus() {
-    MutableSpan span =
-        new MutableSpan(() -> 0L, context.toBuilder().shared(true).build(), localEndpoint);
+    MutableSpan span = new MutableSpan(() -> 0L, context.toBuilder().build(), localEndpoint);
 
+    span.setShared();
     span.start(1L);
     span.kind(SERVER);
     span.finish(2L);


### PR DESCRIPTION
Tracer.join implies notifying the reporter (via a field) that the span
is shared. Nothing further in-band needs access to this property, so
propagating it was unnecessary overhead.

Fixes #530