### PR TITLE
Reduces memory pressure by prefering primitives where possible

### DIFF
--- a/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
+++ b/archive/brave-core/src/main/java/com/github/kristofa/brave/SpanFactory.java
@@ -52,7 +52,13 @@ abstract class SpanFactory {
     abstract Sampler sampler();
 
     @Override Span nextSpan(@Nullable SpanId maybeParent) {
+
+      // Generates a new 64-bit ID, taking care to dodge zero which can be confused with absent
       long newSpanId = randomGenerator().nextLong();
+      while (newSpanId == 0L) {
+        newSpanId = randomGenerator().nextLong();
+      }
+
       if (maybeParent == null) { // new trace
         return Brave.toSpan(SpanId.builder()
             .traceIdHigh(traceId128Bit() ? nextTraceIdHigh(randomGenerator()) : 0L)

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -196,7 +196,7 @@ public final class Tracer {
     // If the sampled flag was left unset, we need to make the decision here
     if (context.sampled() == null) { // then the caller didn't contribute data
       context = context.toBuilder().sampled(sampler.isSampled(context.traceId())).build();
-    } else { // we are contributing to the same span ID
+    } else if (context.sampled()) { // we are recording and contributing to the same span ID
       recorder.setShared(context);
     }
     return toSpan(context);

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -248,7 +248,7 @@ public final class Tracer {
       // fall through, with an implicit parent, not an extracted one
       parent = appendExtra(implicitParent, extracted.extra());
     }
-    long nextId = Platform.get().randomLong();
+    long nextId = nextId();
     if (parent != null) {
       Boolean sampled = parent.sampled();
       if (sampled == null) sampled = sampler.isSampled(parent.traceId());
@@ -305,7 +305,7 @@ public final class Tracer {
   }
 
   TraceContext newRootContext(SamplingFlags samplingFlags, List<Object> extra) {
-    long nextId = Platform.get().randomLong();
+    long nextId = nextId();
     Boolean sampled = samplingFlags.sampled();
     if (sampled == null) sampled = sampler.isSampled(nextId);
     return TraceContext.newBuilder()
@@ -314,6 +314,15 @@ public final class Tracer {
         .spanId(nextId)
         .debug(samplingFlags.debug())
         .extra(extra).build();
+  }
+
+  /** Generates a new 64-bit ID, taking care to dodge zero which can be confused with absent */
+  long nextId() {
+    long nextId = Platform.get().randomLong();
+    while (nextId == 0L) {
+      nextId = Platform.get().randomLong();
+    }
+    return nextId;
   }
 
   /**

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -17,9 +17,10 @@ final class MutableSpan {
   // to reduce GC churn. This would involve calling span.clear and resetting the fields below.
   MutableSpan(Clock clock, TraceContext context, Endpoint localEndpoint) {
     this.clock = clock;
+    long parentId = context.parentIdAsLong();
     this.span = zipkin2.Span.newBuilder()
         .traceId(context.traceIdString())
-        .parentId(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null)
+        .parentId(parentId != 0L ? HexCodec.toLowerHex(parentId) : null)
         .id(HexCodec.toLowerHex(context.spanId()))
         .debug(context.debug() ? true : null)
         .localEndpoint(localEndpoint);

--- a/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
@@ -71,8 +71,8 @@ final class MutableSpanMap extends ReferenceQueue<TraceContext> {
 
   /** Trace contexts are equal only on trace ID and span ID. try to get the parent's clock */
   @Nullable Clock maybeClockFromParent(TraceContext context) {
-    Long parentId = context.parentId();
-    if (parentId == null) return null;
+    long parentId = context.parentIdAsLong();
+    if (parentId == 0L) return null;
     MutableSpan parent = delegate.get(new LookupKey(context.toBuilder().spanId(parentId).build()));
     return parent != null ? parent.clock : null;
   }

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -86,8 +86,9 @@ public final class B3Propagation<K> implements Propagation<K> {
     @Override public void inject(TraceContext traceContext, C carrier) {
       setter.put(carrier, propagation.traceIdKey, traceContext.traceIdString());
       setter.put(carrier, propagation.spanIdKey, toLowerHex(traceContext.spanId()));
-      if (traceContext.parentId() != null) {
-        setter.put(carrier, propagation.parentSpanIdKey, toLowerHex(traceContext.parentId()));
+      long parentId = traceContext.parentIdAsLong();
+      if (parentId != 0L) {
+        setter.put(carrier, propagation.parentSpanIdKey, toLowerHex(parentId));
       }
       if (traceContext.debug()) {
         setter.put(carrier, propagation.debugKey, "1");

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -75,4 +75,18 @@ public abstract class SamplingFlags {
 
   SamplingFlags() {
   }
+
+  static final int FLAG_SAMPLED = 1 << 1;
+  static final int FLAG_SAMPLED_SET = 1 << 2;
+  static final int FLAG_DEBUG = 1 << 3;
+
+  static Boolean sampled(int flags) {
+    return (flags & FLAG_SAMPLED_SET) == FLAG_SAMPLED_SET
+        ? (flags & FLAG_SAMPLED) == FLAG_SAMPLED
+        : null;
+  }
+
+  static boolean debug(int flags) {
+    return (flags & FLAG_DEBUG) == FLAG_DEBUG;
+  }
 }

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -109,12 +109,12 @@ public final class TraceContextOrSamplingFlags {
   @Deprecated
   public static TraceContextOrSamplingFlags create(TraceContext.Builder builder) {
     if (builder == null) throw new NullPointerException("builder == null");
-    try {
+    if (builder.traceId != 0L && builder.spanId != 0L) {
       return create(builder.build());
-    } catch (IllegalStateException e) { // no trace IDs, but it might have sampling flags
+    } else { // no trace IDs, but it might have sampling flags
       SamplingFlags flags = new SamplingFlags.Builder()
-          .sampled(builder.sampled())
-          .debug(builder.debug()).build();
+          .sampled(SamplingFlags.sampled(builder.flags))
+          .debug(SamplingFlags.debug(builder.flags)).build();
       return create(flags);
     }
   }

--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -1,7 +1,6 @@
 package brave.propagation;
 
 import brave.internal.Nullable;
-import com.google.auto.value.AutoValue;
 
 import static brave.internal.HexCodec.writeHexLong;
 
@@ -9,59 +8,134 @@ import static brave.internal.HexCodec.writeHexLong;
  * Contains inbound trace ID and sampling flags, used when users control the root trace ID, but not
  * the span ID (ex Amazon X-Ray or other correlation).
  */
-@AutoValue
 //@Immutable
-public abstract class TraceIdContext extends SamplingFlags {
+public final class TraceIdContext extends SamplingFlags {
 
   public static Builder newBuilder() {
-    return new AutoValue_TraceIdContext.Builder().traceIdHigh(0L).debug(false);
+    return new Builder();
   }
 
   /** When non-zero, the trace containing this span uses 128-bit trace identifiers. */
-  public abstract long traceIdHigh();
+  public long traceIdHigh() {
+    return traceIdHigh;
+  }
 
   /** Unique 8-byte identifier for a trace, set on all spans within it. */
-  public abstract long traceId();
+  public long traceId() {
+    return traceId;
+  }
 
-  // override as auto-value can't currently read the super-class's nullable annotation.
-  @Override @Nullable public abstract Boolean sampled();
+  /** {@inheritDoc} */
+  @Override @Nullable public Boolean sampled() {
+    return sampled(flags);
+  }
 
-  public abstract Builder toBuilder();
+  /** {@inheritDoc} */
+  @Override public boolean debug() {
+    return debug(flags);
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
 
   /** Returns {@code $traceId} */
   @Override
   public String toString() {
-    boolean traceHi = traceIdHigh() != 0;
+    boolean traceHi = traceIdHigh != 0;
     char[] result = new char[traceHi ? 32 : 16];
     int pos = 0;
     if (traceHi) {
-      writeHexLong(result, pos, traceIdHigh());
+      writeHexLong(result, pos, traceIdHigh);
       pos += 16;
     }
-    writeHexLong(result, pos, traceId());
+    writeHexLong(result, pos, traceId);
     return new String(result);
   }
 
-  @AutoValue.Builder
-  public static abstract class Builder {
+  public static final class Builder {
+    long traceIdHigh, traceId;
+    int flags = 0; // bit field for sampled and debug
+
+    Builder(TraceIdContext context) { // no external implementations
+      traceIdHigh = context.traceIdHigh;
+      traceId = context.traceId;
+      flags = context.flags;
+    }
+
     /** @see TraceIdContext#traceIdHigh() */
-    public abstract Builder traceIdHigh(long traceIdHigh);
+    public Builder traceIdHigh(long traceIdHigh) {
+      this.traceIdHigh = traceIdHigh;
+      return this;
+    }
 
     /** @see TraceIdContext#traceId() */
-    public abstract Builder traceId(long traceId);
+    public Builder traceId(long traceId) {
+      this.traceId = traceId;
+      return this;
+    }
 
-    /** @see TraceIdContext#sampled */
-    public abstract Builder sampled(@Nullable Boolean nullableSampled);
+    /** @see TraceIdContext#sampled() */
+    public Builder sampled(boolean sampled) {
+      flags |= FLAG_SAMPLED_SET;
+      if (sampled) {
+        flags |= FLAG_SAMPLED;
+      } else {
+        flags &= ~FLAG_SAMPLED;
+      }
+      return this;
+    }
+
+    /** @see TraceIdContext#sampled() */
+    public Builder sampled(@Nullable Boolean sampled) {
+      if (sampled != null) return sampled((boolean) sampled);
+      flags &= ~FLAG_SAMPLED_SET;
+      return this;
+    }
 
     /** @see TraceIdContext#debug() */
-    public abstract Builder debug(boolean debug);
+    public Builder debug(boolean debug) {
+      if (debug) {
+        flags |= FLAG_DEBUG;
+      } else {
+        flags &= ~FLAG_DEBUG;
+      }
+      return this;
+    }
 
-    public abstract TraceIdContext build();
+    public final TraceIdContext build() {
+      if (traceId == 0L) throw new IllegalStateException("Missing: traceId");
+      return new TraceIdContext(this);
+    }
 
     Builder() { // no external implementations
     }
   }
 
-  TraceIdContext() { // no external implementations
+  final long traceIdHigh, traceId;
+  final int flags; // bit field for sampled and debug
+
+  TraceIdContext(Builder builder) { // no external implementations
+    traceIdHigh = builder.traceIdHigh;
+    traceId = builder.traceId;
+    flags = builder.flags;
+  }
+
+  /** Only includes mandatory fields {@link #traceIdHigh()} and {@link #traceId()} */
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof TraceIdContext)) return false;
+    TraceIdContext that = (TraceIdContext) o;
+    return (traceIdHigh == that.traceIdHigh) && (traceId == that.traceId);
+  }
+
+  /** Only includes mandatory fields {@link #traceIdHigh()} and {@link #traceId()} */
+  @Override public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= (int) ((traceIdHigh >>> 32) ^ traceIdHigh);
+    h *= 1000003;
+    h ^= (int) ((traceId >>> 32) ^ traceId);
+    return h;
   }
 }

--- a/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
+++ b/brave/src/test/java/brave/features/finagle_context/FinagleContextInteropTest.java
@@ -140,7 +140,7 @@ public class FinagleContextInteropTest {
   static TraceId toTraceId(TraceContext context) {
     return new TraceId(
         Option.apply(SpanId.apply(context.traceId())),
-        Option.apply(context.parentId() == null ? null : SpanId.apply(context.parentId())),
+        Option.apply(context.parentIdAsLong() == 0L ? null : SpanId.apply(context.parentIdAsLong())),
         SpanId.apply(context.spanId()),
         Option.apply(context.sampled()),
         Flags$.MODULE$.apply(context.debug() ? 1 : 0)

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -8,9 +8,10 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TraceContextTest {
+  TraceContext base = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
 
   @Test public void compareUnequalIds() {
-    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(0L).build();
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(3L).build();
 
     assertThat(context)
         .isNotEqualTo(TraceContext.newBuilder().traceId(333L).spanId(1L).build());
@@ -70,5 +71,35 @@ public class TraceContextTest {
     List<Object> list = Collections.emptyList();
     assertThat(TraceContext.ensureImmutable(list))
         .isSameAs(list);
+  }
+
+  @Test public void canUsePrimitiveOverloads() {
+    TraceContext primitives = base.toBuilder()
+        .parentId(1L)
+        .sampled(true)
+        .debug(true)
+        .build();
+
+    TraceContext objects =  base.toBuilder()
+        .parentId(Long.valueOf(1L))
+        .sampled(Boolean.TRUE)
+        .debug(Boolean.TRUE)
+        .build();
+
+    assertThat(primitives)
+        .isEqualToComparingFieldByField(objects);
+  }
+
+  @Test public void nullToZero() {
+    TraceContext nulls = base.toBuilder()
+        .parentId(null)
+        .build();
+
+    TraceContext zeros =  base.toBuilder()
+        .parentId(0L)
+        .build();
+
+    assertThat(nulls)
+        .isEqualToComparingFieldByField(zeros);
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceIdContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceIdContextTest.java
@@ -26,4 +26,19 @@ public class TraceIdContextTest {
     assertThat(context.toBuilder().traceIdHigh(222L).build().toString())
         .isEqualTo("00000000000000de000000000000014d");
   }
+
+  @Test public void canUsePrimitiveOverloads() {
+    TraceIdContext primitives = context.toBuilder()
+        .sampled(true)
+        .debug(true)
+        .build();
+
+    TraceIdContext objects =  context.toBuilder()
+        .sampled(Boolean.TRUE)
+        .debug(Boolean.TRUE)
+        .build();
+
+    assertThat(primitives)
+        .isEqualToComparingFieldByField(objects);
+  }
 }

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
@@ -41,8 +41,8 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
 
     if (currentSpan != null) {
       MDC.put("traceId", currentSpan.traceIdString());
-      replace("parentId",
-          currentSpan.parentId() != null ? HexCodec.toLowerHex(currentSpan.parentId()) : null);
+      long parentId = currentSpan.parentIdAsLong();
+      replace("parentId", parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
       MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
     } else {
       MDC.remove("traceId");

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
@@ -30,8 +30,9 @@ public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(MDC.get("traceId"))
           .isEqualTo(context.traceIdString());
+      long parentId = context.parentIdAsLong();
       assertThat(MDC.get("parentId"))
-          .isEqualTo(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null);
+          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
       assertThat(MDC.get("spanId"))
           .isEqualTo(HexCodec.toLowerHex(context.spanId()));
     } else {

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -37,8 +37,8 @@ public final class ThreadContextCurrentTraceContext extends CurrentTraceContext 
 
     if (currentSpan != null) {
       ThreadContext.put("traceId", currentSpan.traceIdString());
-      replace("parentId",
-          currentSpan.parentId() != null ? HexCodec.toLowerHex(currentSpan.parentId()) : null);
+      long parentId = currentSpan.parentIdAsLong();
+      replace("parentId", parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
       ThreadContext.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
     } else {
       ThreadContext.remove("traceId");

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -19,8 +19,9 @@ public class ThreadContextCurrentTraceContextTest extends CurrentTraceContextTes
     if (context != null) {
       assertThat(ThreadContext.get("traceId"))
           .isEqualTo(context.traceIdString());
+      long parentId = context.parentIdAsLong();
       assertThat(ThreadContext.get("parentId"))
-          .isEqualTo(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null);
+          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
       assertThat(ThreadContext.get("spanId"))
           .isEqualTo(HexCodec.toLowerHex(context.spanId()));
     } else {

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -37,8 +37,8 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
 
     if (currentSpan != null) {
       MDC.put("traceId", currentSpan.traceIdString());
-      replace("parentId",
-          currentSpan.parentId() != null ? HexCodec.toLowerHex(currentSpan.parentId()) : null);
+      long parentId = currentSpan.parentIdAsLong();
+      replace("parentId", parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
       MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
     } else {
       MDC.remove("traceId");

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -19,8 +19,9 @@ public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(MDC.get("traceId"))
           .isEqualTo(context.traceIdString());
+      long parentId = context.parentIdAsLong();
       assertThat(MDC.get("parentId"))
-          .isEqualTo(context.parentId() != null ? HexCodec.toLowerHex(context.parentId()) : null);
+          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
       assertThat(MDC.get("spanId"))
           .isEqualTo(HexCodec.toLowerHex(context.spanId()));
     } else {


### PR DESCRIPTION
This weaves in work done in https://github.com/openzipkin/zipkin/pull/1890

Notably, we dodge ID zero, which we should have done anyway as finagle
does this. It dodges to avoid confusion in binary encodings where it is
difficult to differentiate absent from zero.