### PR TITLE
Makes extra fields visible from an extraction result

### DIFF
--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -183,20 +183,16 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     return getAll(context);
   }
 
-  /** Returns a mapping of fields in the given trace context, or empty if there are none. */
+  /** Returns a mapping of any fields in the extraction result. */
+  public static Map<String, String> getAll(TraceContextOrSamplingFlags extracted) {
+    if (extracted == null) throw new NullPointerException("extracted == null");
+    return extracted.context() != null ? getAll(extracted.context()) : getAll(extracted.extra());
+  }
+
+  /** Returns a mapping of any fields in the trace context. */
   public static Map<String, String> getAll(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
-    Extra extra = findExtra(context.extra());
-    if (extra == null) return Collections.emptyMap();
-    String[] elements = extra.values;
-    if (elements == null) return Collections.emptyMap();
-
-    Map<String, String> result = new LinkedHashMap<>();
-    for (int i = 0, length = elements.length; i<length; i++) {
-      String value = elements[i];
-      if (value != null) result.put(extra.fieldNames[i], value);
-    }
-    return result;
+    return getAll(context.extra());
   }
 
   @Nullable static TraceContext currentTraceContext() {
@@ -460,6 +456,20 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       name = name.trim();
       if (name.isEmpty()) throw new IllegalArgumentException("names[" + i + "] is empty");
       result[i] = name.toLowerCase(Locale.ROOT);
+    }
+    return result;
+  }
+
+  static Map<String, String> getAll(List<Object> extraList) {
+    Extra extra = findExtra(extraList);
+    if (extra == null) return Collections.emptyMap();
+    String[] elements = extra.values;
+    if (elements == null) return Collections.emptyMap();
+
+    Map<String, String> result = new LinkedHashMap<>();
+    for (int i = 0, length = elements.length; i<length; i++) {
+      String value = elements[i];
+      if (value != null) result.put(extra.fieldNames[i], value);
     }
     return result;
   }

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -311,6 +311,27 @@ public class ExtraFieldPropagationTest {
         .containsEntry("x-amzn-trace-id", awsTraceId);
   }
 
+  @Test public void getAll_extracted() {
+    injector.inject(context, carrier);
+    carrier.put("x-amzn-trace-id", awsTraceId);
+
+    TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
+
+    assertThat(ExtraFieldPropagation.getAll(extracted))
+        .hasSize(1)
+        .containsEntry("x-amzn-trace-id", awsTraceId);
+  }
+
+  @Test public void getAll_extractedWithContext() {
+    carrier.put("x-amzn-trace-id", awsTraceId);
+
+    TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
+
+    assertThat(ExtraFieldPropagation.getAll(extracted))
+        .hasSize(1)
+        .containsEntry("x-amzn-trace-id", awsTraceId);
+  }
+
   @Test public void getAll_two() {
     injector.inject(context, carrier);
     carrier.put("x-amzn-trace-id", awsTraceId);


### PR DESCRIPTION
This is to satisfy OpenTracing's SpanContext api where no span IDs were
present.

See https://github.com/openzipkin-contrib/brave-opentracing/issues/67