### PR TITLE
Adds vertx-web module

### DIFF
--- a/instrumentation/netty-codec-http/README.md
+++ b/instrumentation/netty-codec-http/README.md
@@ -2,9 +2,6 @@
 
 This module contains a tracing decorators for [Netty's Http Codec](https://github.com/netty/netty/tree/4.1/codec-http) 4.x.
 
-This module contains JAX-RS 2.x compatible tracing filters and a feature
-to automatically configure them.
-
 `NettyHttpTracing.serverHandler()` extracts trace state from incoming requests,
 and reports to Zipkin how long each take, along with relevant tags like the
 http url.

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -34,6 +34,7 @@
     <module>spring-webmvc</module>
     <module>kafka-clients</module>
     <module>netty-codec-http</module>
+    <module>vertx-web</module>
   </modules>
 
   <!-- ${project.groupId}:brave version is set in the root pom.

--- a/instrumentation/vertx-web/README.md
+++ b/instrumentation/vertx-web/README.md
@@ -1,0 +1,23 @@
+# brave-instrumentation-vertx-web
+
+This module contains a routing context handler for [Vert.x Web](http://vertx.io/docs/vertx-web/js/)
+This extracts trace state from incoming requests. Then, it reports to
+Zipkin how long each request takes, along with relevant tags like the
+http url. Register this as an failure handler to ensure any errors are
+also sent to Zipkin.
+
+To enable tracing you need to set `order`, `handler` and `failureHandler`
+hooks:
+```java
+vertxWebTracing = VertxWebTracing.create(httpTracing);
+routingContextHandler = vertxWebTracing.routingContextHandler();
+router.route()
+      .order(-1) // applies before routes
+      .handler(routingContextHandler)
+      .failureHandler(routingContextHandler);
+
+// any routes you add are now traced, such as the below
+router.route("/foo").handler(ctx -> {
+    ctx.response().end("bar");
+});
+```

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.14.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-vertx-web</artifactId>
+  <name>Brave Instrumentation: Vert.x Web</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <vertx.version>3.4.2</vertx.version>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>${vertx.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -1,0 +1,96 @@
+package brave.vertx.web;
+
+import brave.Span;
+import brave.Tracer;
+import brave.http.HttpServerAdapter;
+import brave.http.HttpServerHandler;
+import brave.http.HttpTracing;
+import brave.propagation.Propagation.Getter;
+import brave.propagation.TraceContext;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import zipkin2.Endpoint;
+
+/**
+ * Idea for how to address re-route was from {@code TracingHandler} in https://github.com/opentracing-contrib/java-vertx-web
+ */
+final class TracingRoutingContextHandler implements Handler<RoutingContext> {
+  static final Getter<HttpServerRequest, String> GETTER = new Getter<HttpServerRequest, String>() {
+    @Override public String get(HttpServerRequest carrier, String key) {
+      return carrier.getHeader(key);
+    }
+
+    @Override public String toString() {
+      return "HttpServerRequest::getHeader";
+    }
+  };
+
+  final Tracer tracer;
+  final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
+  final TraceContext.Extractor<HttpServerRequest> extractor;
+
+  TracingRoutingContextHandler(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    handler = HttpServerHandler.create(httpTracing, ADAPTER);
+    extractor = httpTracing.tracing().propagation().extractor(GETTER);
+  }
+
+  @Override public void handle(RoutingContext context) {
+    boolean newRequest = false;
+    Span span = context.get(Span.class.getName());
+    if (span == null) {
+      newRequest = true;
+      span = handler.handleReceive(extractor, context.request());
+      context.put(Span.class.getName(), span);
+    }
+
+    if (newRequest || !context.failed()) { // re-routed, so re-attach the end handler
+      // Note: In Brave, finishing a client span after headers sent is normal.
+      context.addHeadersEndHandler(finishHttpSpan(context, span));
+    }
+
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      context.next();
+    } catch (RuntimeException | Error e) {
+      handler.handleSend(null, e, span);
+      throw e;
+    }
+  }
+
+  Handler<Void> finishHttpSpan(RoutingContext context, Span span) {
+    return v -> handler.handleSend(context.response(), context.failure(), span);
+  }
+
+  static final HttpServerAdapter<HttpServerRequest, HttpServerResponse> ADAPTER =
+      new HttpServerAdapter<HttpServerRequest, HttpServerResponse>() {
+        @Override public String method(HttpServerRequest request) {
+          return request.method().name();
+        }
+
+        @Override public String url(HttpServerRequest request) {
+          return request.absoluteURI();
+        }
+
+        @Override public String requestHeader(HttpServerRequest request, String name) {
+          return request.headers().get(name);
+        }
+
+        @Override public Integer statusCode(HttpServerResponse response) {
+          return response.getStatusCode();
+        }
+
+        @Override
+        public boolean parseClientAddress(HttpServerRequest req, Endpoint.Builder builder) {
+          if (super.parseClientAddress(req, builder)) return true;
+          SocketAddress addr = req.remoteAddress();
+          if (builder.parseIp(addr.host())) {
+            builder.port(addr.port());
+            return true;
+          }
+          return false;
+        }
+      };
+}

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxWebTracing.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxWebTracing.java
@@ -1,0 +1,39 @@
+package brave.vertx.web;
+
+import brave.Tracing;
+import brave.http.HttpTracing;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+public final class VertxWebTracing {
+  public static VertxWebTracing create(Tracing tracing) {
+    return new VertxWebTracing(HttpTracing.create(tracing));
+  }
+
+  public static VertxWebTracing create(HttpTracing httpTracing) {
+    return new VertxWebTracing(httpTracing);
+  }
+
+  final Handler<RoutingContext> routingContextHandler;
+
+  VertxWebTracing(HttpTracing httpTracing) {
+    routingContextHandler = new TracingRoutingContextHandler(httpTracing);
+  }
+
+  /**
+   * Returns a routing context handler that traces {@link HttpServerRequest} messages.
+   *
+   * <p>Ensure you install this both as a handler and an failure handler, ordered before routes.
+   * <pre>{@code
+   * routingContextHandler = vertxWebTracing.routingContextHandler();
+   * router.route()
+   *       .order(-1) // applies before routes
+   *       .handler(routingContextHandler)
+   *       .failureHandler(routingContextHandler);
+   * }</pre>
+   */
+  public Handler<RoutingContext> routingContextHandler() {
+    return routingContextHandler;
+  }
+}

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -1,0 +1,108 @@
+package brave.vertx.web;
+
+import brave.http.ITHttpServer;
+import brave.propagation.ExtraFieldPropagation;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class ITVertxWebTracing extends ITHttpServer {
+  Vertx vertx;
+  HttpServer server;
+  volatile int port;
+
+  @Override protected void init() throws Exception {
+    stop();
+    vertx = Vertx.vertx(new VertxOptions());
+
+    Router router = Router.router(vertx);
+    router.route("/foo").handler(ctx -> {
+      ctx.response().end("bar");
+    });
+    router.route("/async").handler(ctx -> {
+      ctx.request().endHandler(v -> ctx.response().end("bar"));
+    });
+    router.route("/reroute").handler(ctx -> {
+      ctx.reroute("/foo");
+    });
+    router.route("/extra").handler(ctx -> {
+      ctx.response().end(ExtraFieldPropagation.get(EXTRA_KEY));
+    });
+    router.route("/badrequest").handler(ctx -> {
+      ctx.response().setStatusCode(400).end();
+    });
+    router.route("/child").handler(ctx -> {
+      httpTracing.tracing().tracer().nextSpan().name("child").start().finish();
+      ctx.response().end("happy");
+    });
+    router.route("/exception").handler(ctx -> {
+      ctx.fail(new Exception());
+    });
+    router.route("/exceptionAsync").handler(ctx -> {
+      ctx.request().endHandler(v -> ctx.fail(new Exception()));
+    });
+
+
+    Handler<RoutingContext> routingContextHandler =
+        VertxWebTracing.create(httpTracing).routingContextHandler();
+    router.route()
+        .order(-1).handler(routingContextHandler)
+        .failureHandler(routingContextHandler);
+
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(0).setHost("localhost"));
+
+    CountDownLatch latch = new CountDownLatch(1);
+    server.requestHandler(router::accept).listen(async -> {
+      port = async.result().actualPort();
+      latch.countDown();
+    });
+
+    assertThat(latch.await(10, TimeUnit.SECONDS))
+        .withFailMessage("server didn't start")
+        .isTrue();
+  }
+
+  // makes sure we don't accidentally rewrite the incoming http path
+  @Test public void handlesReroute() throws Exception {
+    get("/reroute");
+
+    assertThat(spans)
+        .hasSize(1)
+        .flatExtracting(s -> s.tags().entrySet())
+        .contains(entry("http.path", "/reroute"));
+  }
+
+  @Override
+  protected String url(String path) {
+    return "http://127.0.0.1:" + port + path;
+  }
+
+  @After public void stop() throws Exception {
+    if (server != null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      server.close(ar -> {
+        latch.countDown();
+      });
+      latch.await(10, TimeUnit.SECONDS);
+    }
+    if (vertx != null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      vertx.close(ar -> {
+        latch.countDown();
+      });
+      latch.await(10, TimeUnit.SECONDS);
+      vertx = null;
+    }
+  }
+}


### PR DESCRIPTION
This adds support for vertx-web's Routing Context. This was developed
while looking at prior work in the following repositories:
* https://github.com/emmanuelidi/vertx-zipkin/tree/master/src/main/java/io/vertx/ext/zipkin/web
* https://github.com/opentracing-contrib/java-vertx-web

Notably, the latter had notes about rerouting, which were helpful as we
don't yet have a generic http test for forwarding/re-routing.

Fixes #307