### PR TITLE
Deprecates Tracing.Builder.localEndpoint to avoid zipkin v1 dep

### DIFF
--- a/brave/src/it/nozipkin1/src/test/java/brave/nozipkin1/DoesntRequireV1ClassesTest.java
+++ b/brave/src/it/nozipkin1/src/test/java/brave/nozipkin1/DoesntRequireV1ClassesTest.java
@@ -7,7 +7,7 @@ public class DoesntRequireV1ClassesTest {
   /** Compiles and runs as long as we don't use any overloaded methods with zipkin v1 types */
   @Test public void doesntBreak() {
     try (Tracing tracing = Tracing.newBuilder()
-        .localServiceName("foo") // can't use localEndpoint: it's overloaded, so requires v1 types
+        .endpoint(zipkin2.Endpoint.newBuilder().serviceName("foo").ip("1.2.3.4").build())
         .spanReporter(zipkin2.reporter.Reporter.NOOP)
         .build()) {
       tracing.tracer()

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -64,18 +64,22 @@ public final class Tracer {
       return this;
     }
 
-    /**
-     * @deprecated use {@link #localEndpoint(Endpoint)}, possibly with {@link
-     * zipkin.Endpoint#toV2()}
-     */
+    /** @deprecated use {@link #endpoint(Endpoint)}, possibly with {@link zipkin.Endpoint#toV2()} */
     @Deprecated
     public Builder localEndpoint(zipkin.Endpoint localEndpoint) {
-      return localEndpoint(localEndpoint.toV2());
+      return endpoint(localEndpoint.toV2());
     }
 
-    /** @see Tracing.Builder#localEndpoint(Endpoint) */
+    /** @deprecated use {@link #endpoint(Endpoint)} */
+    @Deprecated
     public Builder localEndpoint(Endpoint localEndpoint) {
-      delegate.localEndpoint(localEndpoint);
+      delegate.endpoint(localEndpoint);
+      return this;
+    }
+
+    /** @see Tracing.Builder#endpoint(Endpoint) */
+    public Builder endpoint(Endpoint endpoint) {
+      delegate.endpoint(endpoint);
       return this;
     }
 
@@ -142,7 +146,7 @@ public final class Tracer {
     this.supportsJoin = builder.supportsJoin && propagationFactory.supportsJoin();
     this.clock = clock;
     this.reporter = builder.reporter;
-    this.recorder = new Recorder(builder.localEndpoint, clock, builder.reporter, this.noop);
+    this.recorder = new Recorder(builder.endpoint, clock, builder.reporter, this.noop);
     this.sampler = builder.sampler;
     this.currentTraceContext = builder.currentTraceContext;
     this.traceId128Bit = builder.traceId128Bit || propagationFactory.requires128BitTraceId();

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -114,7 +114,7 @@ public abstract class Tracing implements Closeable {
 
   public static final class Builder {
     String localServiceName;
-    Endpoint localEndpoint;
+    Endpoint endpoint;
     Reporter<zipkin2.Span> reporter;
     Clock clock;
     Sampler sampler = Sampler.ALWAYS_SAMPLE;
@@ -125,7 +125,7 @@ public abstract class Tracing implements Closeable {
 
     /**
      * Controls the name of the service being traced, while still using a default site-local IP.
-     * This is an alternative to {@link #localEndpoint(Endpoint)}.
+     * This is an alternative to {@link #endpoint(Endpoint)}.
      *
      * @param localServiceName name of the service being traced. Defaults to "unknown".
      */
@@ -135,22 +135,29 @@ public abstract class Tracing implements Closeable {
       return this;
     }
 
-    /**
-     * @deprecated use {@link #localEndpoint(Endpoint)}, possibly with {@link
-     * zipkin.Endpoint#toV2()}
-     */
+    /** @deprecated use {@link #endpoint(Endpoint)}, possibly with {@link zipkin.Endpoint#toV2()} */
     @Deprecated
     public Builder localEndpoint(zipkin.Endpoint localEndpoint) {
       if (localEndpoint == null) throw new NullPointerException("localEndpoint == null");
-      return localEndpoint(localEndpoint.toV2());
+      return endpoint(localEndpoint.toV2());
+    }
+
+    /** @deprecated use {@link #endpoint(Endpoint)} which compiles without io.zipkin.java:zipkin */
+    // compiling a call to an overloaded method requires all types on the classpath.
+    @Deprecated
+    public Builder localEndpoint(Endpoint localEndpoint) {
+      return endpoint(localEndpoint);
     }
 
     /**
-     * @param localEndpoint Endpoint of the local service being traced. Defaults to site local.
+     * Sets the {@link zipkin2.Span#localEndpoint Endpoint of the local service} being traced.
+     * Defaults to a site local IP.
+     *
+     * <p>Use {@link #localServiceName} when only effecting the service name.
      */
-    public Builder localEndpoint(Endpoint localEndpoint) {
-      if (localEndpoint == null) throw new NullPointerException("localEndpoint == null");
-      this.localEndpoint = localEndpoint;
+    public Builder endpoint(Endpoint endpoint) {
+      if (endpoint == null) throw new NullPointerException("endpoint == null");
+      this.endpoint = endpoint;
       return this;
     }
 
@@ -269,10 +276,10 @@ public abstract class Tracing implements Closeable {
 
     public Tracing build() {
       if (clock == null) clock = Platform.get().clock();
-      if (localEndpoint == null) {
-        localEndpoint = Platform.get().localEndpoint();
+      if (endpoint == null) {
+        endpoint = Platform.get().endpoint();
         if (localServiceName != null) {
-          localEndpoint = localEndpoint.toBuilder().serviceName(localServiceName).build();
+          endpoint = endpoint.toBuilder().serviceName(localServiceName).build();
         }
       }
       if (reporter == null) reporter = Platform.get().reporter();

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -26,7 +26,7 @@ public abstract class Platform {
 
   private static final Platform PLATFORM = findPlatform();
 
-  volatile Endpoint localEndpoint;
+  volatile Endpoint endpoint;
 
   /** Ensure we don't raise a {@linkplain ClassNotFoundException} calling deprecated methods */
   public abstract boolean zipkinV1Present();
@@ -49,19 +49,19 @@ public abstract class Platform {
     }
   }
 
-  public Endpoint localEndpoint() {
+  public Endpoint endpoint() {
     // uses synchronized variant of double-checked locking as getting the endpoint can be expensive
-    if (localEndpoint == null) {
+    if (endpoint == null) {
       synchronized (this) {
-        if (localEndpoint == null) {
-          localEndpoint = produceLocalEndpoint();
+        if (endpoint == null) {
+          endpoint = produceEndpoint();
         }
       }
     }
-    return localEndpoint;
+    return endpoint;
   }
 
-  Endpoint produceLocalEndpoint() {
+  Endpoint produceEndpoint() {
     Endpoint.Builder builder = Endpoint.newBuilder().serviceName("unknown");
     try {
       Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();

--- a/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
@@ -30,18 +30,18 @@ final class MutableSpanMap extends ReferenceQueue<TraceContext> {
 
   // Eventhough we only put by RealKey, we allow get and remove by LookupKey
   final ConcurrentMap<Object, MutableSpan> delegate = new ConcurrentHashMap<>(64);
-  final Endpoint localEndpoint;
+  final Endpoint endpoint;
   final Clock clock;
   final Reporter<zipkin2.Span> reporter;
   final AtomicBoolean noop;
 
   MutableSpanMap(
-      Endpoint localEndpoint,
+      Endpoint endpoint,
       Clock clock,
       Reporter<zipkin2.Span> reporter,
       AtomicBoolean noop
   ) {
-    this.localEndpoint = localEndpoint;
+    this.endpoint = endpoint;
     this.clock = clock;
     this.reporter = reporter;
     this.noop = noop;
@@ -63,7 +63,7 @@ final class MutableSpanMap extends ReferenceQueue<TraceContext> {
       clock = new TickClock(this.clock.currentTimeMicroseconds(), System.nanoTime());
     }
 
-    MutableSpan newSpan = new MutableSpan(clock, context, localEndpoint);
+    MutableSpan newSpan = new MutableSpan(clock, context, endpoint);
     MutableSpan previousSpan = delegate.putIfAbsent(new RealKey(context, this), newSpan);
     if (previousSpan != null) return previousSpan; // lost race
     return newSpan;

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -33,7 +33,7 @@ public class TracerTest {
         }
       })
       .currentTraceContext(new StrictCurrentTraceContext())
-      .localEndpoint(Endpoint.newBuilder().serviceName("my-service").build())
+      .endpoint(Endpoint.newBuilder().serviceName("my-service").build())
       .build().tracer();
 
   @After public void close() {
@@ -56,24 +56,23 @@ public class TracerTest {
   @Test public void localServiceName() {
     tracer = Tracing.newBuilder().localServiceName("my-foo").build().tracer();
 
-    assertThat(tracer).extracting("recorder.spanMap.localEndpoint.serviceName")
+    assertThat(tracer).extracting("recorder.spanMap.endpoint.serviceName")
         .containsExactly("my-foo");
   }
 
   @Test public void localServiceName_defaultIsUnknown() {
     tracer = Tracing.newBuilder().build().tracer();
 
-    assertThat(tracer).extracting("recorder.spanMap.localEndpoint.serviceName")
+    assertThat(tracer).extracting("recorder.spanMap.endpoint.serviceName")
         .containsExactly("unknown");
   }
 
   @Test public void localServiceName_ignoredWhenGivenLocalEndpoint() {
-    Endpoint localEndpoint = Endpoint.newBuilder().serviceName("my-bar").build();
-    tracer = Tracing.newBuilder().localServiceName("my-foo")
-        .localEndpoint(localEndpoint).build().tracer();
+    Endpoint endpoint = Endpoint.newBuilder().serviceName("my-bar").build();
+    tracer = Tracing.newBuilder().localServiceName("my-foo").endpoint(endpoint).build().tracer();
 
-    assertThat(tracer).extracting("recorder.spanMap.localEndpoint")
-        .containsExactly(localEndpoint);
+    assertThat(tracer).extracting("recorder.spanMap.endpoint")
+        .containsExactly(endpoint);
   }
 
   @Test public void clock() {

--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -84,22 +84,22 @@ public class PlatformTest {
   }
 
   @Test public void localEndpoint_lazySet() {
-    assertThat(platform.localEndpoint).isNull(); // sanity check setup
+    assertThat(platform.endpoint).isNull(); // sanity check setup
 
-    assertThat(platform.localEndpoint())
+    assertThat(platform.endpoint())
         .isNotNull();
   }
 
   @Test public void localEndpoint_sameInstance() {
-    assertThat(platform.localEndpoint())
-        .isSameAs(platform.localEndpoint());
+    assertThat(platform.endpoint())
+        .isSameAs(platform.endpoint());
   }
 
   @Test public void produceLocalEndpoint_exceptionReadingNics() throws Exception {
     mockStatic(NetworkInterface.class);
     when(NetworkInterface.getNetworkInterfaces()).thenThrow(SocketException.class);
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint);
   }
 
@@ -110,13 +110,13 @@ public class PlatformTest {
     when(NetworkInterface.getNetworkInterfaces())
         .thenReturn(null);
 
-    assertThat(platform.localEndpoint())
+    assertThat(platform.endpoint())
         .isEqualTo(unknownEndpoint);
 
     when(NetworkInterface.getNetworkInterfaces())
         .thenReturn(new Vector<NetworkInterface>().elements());
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint);
   }
 
@@ -124,14 +124,14 @@ public class PlatformTest {
   @Test public void produceLocalEndpoint_noAddresses() throws Exception {
     nicWithAddress(null);
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint);
   }
 
   @Test public void produceLocalEndpoint_siteLocal_ipv4() throws Exception {
     nicWithAddress(InetAddress.getByAddress("local", new byte[] {(byte) 192, (byte) 168, 0, 1}));
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint.toBuilder().ip("192.168.0.1").build());
   }
 
@@ -139,21 +139,21 @@ public class PlatformTest {
     InetAddress ipv6 = Inet6Address.getByName("fec0:db8::c001");
     nicWithAddress(ipv6);
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint.toBuilder().ip(ipv6).build());
   }
 
   @Test public void produceLocalEndpoint_notSiteLocal_ipv4() throws Exception {
     nicWithAddress(InetAddress.getByAddress("external", new byte[] {1, 2, 3, 4}));
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint);
   }
 
   @Test public void produceLocalEndpoint_notSiteLocal_ipv6() throws Exception {
     nicWithAddress(Inet6Address.getByName("2001:db8::c001"));
 
-    assertThat(platform.produceLocalEndpoint())
+    assertThat(platform.produceEndpoint())
         .isEqualTo(unknownEndpoint);
   }
 
@@ -167,7 +167,7 @@ public class PlatformTest {
     // create all the tasks up front so that they are executed with no delay
     List<Callable<Endpoint>> tasks = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      tasks.add(() -> platform.localEndpoint());
+      tasks.add(() -> platform.endpoint());
     }
 
     ExecutorService executor = Executors.newFixedThreadPool(tasks.size());

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -15,7 +15,7 @@ import static brave.Span.Kind.SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MutableSpanTest {
-  Endpoint localEndpoint = Platform.get().localEndpoint();
+  Endpoint localEndpoint = Platform.get().endpoint();
   TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
 
   @After public void close() {

--- a/brave/src/test/java/brave/internal/recorder/RecorderTest.java
+++ b/brave/src/test/java/brave/internal/recorder/RecorderTest.java
@@ -14,7 +14,7 @@ import zipkin2.Endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RecorderTest {
-  Endpoint localEndpoint = Platform.get().localEndpoint();
+  Endpoint localEndpoint = Platform.get().endpoint();
   List<zipkin2.Span> spans = new ArrayList<>();
   TraceContext context = Tracing.newBuilder().build().tracer().newTrace().context();
   Recorder recorder = new Recorder(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));

--- a/instrumentation/http/src/test/java/brave/http/features/RequestSamplingTest.java
+++ b/instrumentation/http/src/test/java/brave/http/features/RequestSamplingTest.java
@@ -29,7 +29,7 @@ public class RequestSamplingTest {
 
   ConcurrentLinkedDeque<zipkin2.Span> spans = new ConcurrentLinkedDeque<>();
   Tracing tracing = Tracing.newBuilder()
-      .localEndpoint(Endpoint.newBuilder().serviceName("server").build())
+      .endpoint(Endpoint.newBuilder().serviceName("server").build())
       .spanReporter(spans::push)
       .build();
   HttpTracing httpTracing = HttpTracing.newBuilder(tracing)

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -32,12 +32,6 @@
       <artifactId>zipkin-reporter-spring-beans</artifactId>
       <version>${zipkin-reporter2.version}</version>
     </dependency>
-    <!-- to compile against Span.remoteEndpoint(zipkin.Span) -->
-    <dependency>
-      <groupId>io.zipkin.java</groupId>
-      <artifactId>zipkin</artifactId>
-      <optional>true</optional>
-    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>

--- a/spring-beans/src/main/java/brave/spring/beans/TracingFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/TracingFactoryBean.java
@@ -14,7 +14,7 @@ import zipkin2.reporter.Reporter;
 public class TracingFactoryBean extends AbstractFactoryBean {
 
   String localServiceName;
-  Endpoint localEndpoint;
+  Endpoint localEndpoint, endpoint;
   Reporter<Span> spanReporter;
   Clock clock;
   Sampler sampler;
@@ -26,7 +26,8 @@ public class TracingFactoryBean extends AbstractFactoryBean {
   @Override protected Tracing createInstance() throws Exception {
     Tracing.Builder builder = Tracing.newBuilder();
     if (localServiceName != null) builder.localServiceName(localServiceName);
-    if (localEndpoint != null) builder.localEndpoint(localEndpoint);
+    if (localEndpoint != null) builder.endpoint(localEndpoint);
+    if (endpoint != null) builder.endpoint(endpoint);
     if (spanReporter != null) builder.spanReporter(spanReporter);
     if (clock != null) builder.clock(clock);
     if (sampler != null) builder.sampler(sampler);
@@ -55,6 +56,10 @@ public class TracingFactoryBean extends AbstractFactoryBean {
 
   public void setLocalEndpoint(Endpoint localEndpoint) {
     this.localEndpoint = localEndpoint;
+  }
+
+  public void setEndpoint(Endpoint endpoint) {
+    this.endpoint = endpoint;
   }
 
   public void setSpanReporter(Reporter<Span> spanReporter) {

--- a/spring-beans/src/test/java/brave/spring/beans/EndpointFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/EndpointFactoryBeanTest.java
@@ -17,24 +17,24 @@ public class EndpointFactoryBeanTest {
 
   @Test public void serviceName() {
     context = new XmlBeans(""
-        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "<bean id=\"endpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
         + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
         + "</bean>"
     );
 
-    assertThat(context.getBean("localEndpoint", Endpoint.class))
+    assertThat(context.getBean("endpoint", Endpoint.class))
         .isEqualTo(Endpoint.newBuilder().serviceName("brave-webmvc-example").build());
   }
 
   @Test public void ip() {
     context = new XmlBeans(""
-        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "<bean id=\"endpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
         + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
         + "  <property name=\"ip\" value=\"1.2.3.4\"/>\n"
         + "</bean>"
     );
 
-    assertThat(context.getBean("localEndpoint", Endpoint.class))
+    assertThat(context.getBean("endpoint", Endpoint.class))
         .isEqualTo(Endpoint.newBuilder()
             .serviceName("brave-webmvc-example")
             .ip("1.2.3.4")
@@ -43,14 +43,14 @@ public class EndpointFactoryBeanTest {
 
   @Test public void ip_malformed() {
     context = new XmlBeans(""
-        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "<bean id=\"endpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
         + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
         + "  <property name=\"ip\" value=\"localhost\"/>\n"
         + "</bean>"
     );
 
     try {
-      context.getBean("localEndpoint", Endpoint.class);
+      context.getBean("endpoint", Endpoint.class);
       failBecauseExceptionWasNotThrown(BeanCreationException.class);
     } catch (BeanCreationException e) {
       assertThat(e)
@@ -60,14 +60,14 @@ public class EndpointFactoryBeanTest {
 
   @Test public void port() {
     context = new XmlBeans(""
-        + "<bean id=\"localEndpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "<bean id=\"endpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
         + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
         + "  <property name=\"ip\" value=\"1.2.3.4\"/>\n"
         + "  <property name=\"port\" value=\"8080\"/>\n"
         + "</bean>"
     );
 
-    assertThat(context.getBean("localEndpoint", Endpoint.class))
+    assertThat(context.getBean("endpoint", Endpoint.class))
         .isEqualTo(Endpoint.newBuilder()
             .serviceName("brave-webmvc-example")
             .ip("1.2.3.4")

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -45,7 +45,7 @@ public class TracingFactoryBeanTest {
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
-        .extracting("tracer.recorder.spanMap.localEndpoint")
+        .extracting("tracer.recorder.spanMap.endpoint")
         .extracting("serviceName")
         .containsExactly("brave-webmvc-example");
   }
@@ -64,7 +64,28 @@ public class TracingFactoryBeanTest {
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
-        .extracting("tracer.recorder.spanMap.localEndpoint")
+        .extracting("tracer.recorder.spanMap.endpoint")
+        .containsExactly(Endpoint.newBuilder()
+            .serviceName("brave-webmvc-example")
+            .ip("1.2.3.4")
+            .port(8080).build());
+  }
+
+  @Test public void endpoint() {
+    context = new XmlBeans(""
+        + "<bean id=\"endpoint\" class=\"brave.spring.beans.EndpointFactoryBean\">\n"
+        + "  <property name=\"serviceName\" value=\"brave-webmvc-example\"/>\n"
+        + "  <property name=\"ip\" value=\"1.2.3.4\"/>\n"
+        + "  <property name=\"port\" value=\"8080\"/>\n"
+        + "</bean>"
+        , ""
+        + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
+        + "  <property name=\"endpoint\" ref=\"endpoint\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("tracing", Tracing.class))
+        .extracting("tracer.recorder.spanMap.endpoint")
         .containsExactly(Endpoint.newBuilder()
             .serviceName("brave-webmvc-example")
             .ip("1.2.3.4")


### PR DESCRIPTION
`Tracing.Builder.localEndpoint` is an overloaded method, accepting both
v1 and v2 types. This means anyone that compiles against this requires
an optional dep on v1 (io.zipkin.java:zipkin). While frameworks
typically handle this, questions have come up routinely enough to
warrant introducing a new method name (like we did with spanReporter),
just to avoid the compilation concern.

A future version of brave can then just remove the deprecated methods.

Fixes #570