### PR TITLE
Prevents java.lang.NoClassDefFoundError when searching for platform

### DIFF
--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -7,7 +7,6 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.Callable;
@@ -40,7 +39,7 @@ public class PlatformTest {
   }
 
   @Test public void clock_hasNiceToString_jre9() {
-    Platform platform = new AutoValue_Platform_Jre9(true);
+    Platform platform = new Platform.Jre9(true);
 
     assertThat(platform.clock())
         .hasToString("Clock.systemUTC().instant()");
@@ -65,10 +64,8 @@ public class PlatformTest {
   @Test public void randomLong_whenRandomIsMostNegative() {
     mockStatic(System.class);
     when(System.currentTimeMillis()).thenReturn(1465510280_000L);
-    Random prng = mock(Random.class);
-    when(prng.nextInt()).thenReturn(0xffffffff);
 
-    long traceIdHigh = Platform.nextTraceIdHigh(prng);
+    long traceIdHigh = Platform.nextTraceIdHigh(0xffffffff);
 
     assertThat(HexCodec.toLowerHex(traceIdHigh))
         .isEqualTo("5759e988ffffffff");

--- a/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
@@ -35,7 +35,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class PlatformBenchmarks {
-  static final Platform jre6 = Platform.Jre6.build(false);
+  static final Platform jre6 = new Platform.Jre6(false);
   static final Platform jre7 = Platform.Jre7.buildIfSupported(false);
   static final Platform jre9 = Platform.Jre9.buildIfSupported(false);
   static final Clock jre7Clock = jre7.clock();


### PR DESCRIPTION
Recently, we added `Platform.nextTraceIdHigh()`, which compiled against
a JDK 7 type `ThreadLocalRandom` due to being indirectly referenced in
a utility method. This changes the signature such that it can't imply
this anymore.

This also removes AutoValue from platform as it adds unnecessary classes
to the jar.

Fixes #599