### PR TITLE
Removes temporary measure to migrate http middleware to zipkin v2

### DIFF
--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -31,7 +31,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({Platform.class, NetworkInterface.class})
 public class PlatformTest {
   Endpoint unknownEndpoint = Endpoint.newBuilder().serviceName("unknown").build();
-  Platform platform = Platform.Jre7.buildIfSupported(true);
+  Platform platform = Platform.Jre7.buildIfSupported();
 
   @Test public void clock_hasNiceToString_jre7() {
     assertThat(platform.clock())
@@ -39,7 +39,7 @@ public class PlatformTest {
   }
 
   @Test public void clock_hasNiceToString_jre9() {
-    Platform platform = new Platform.Jre9(true);
+    Platform platform = new Platform.Jre9();
 
     assertThat(platform.clock())
         .hasToString("Clock.systemUTC().instant()");
@@ -56,7 +56,7 @@ public class PlatformTest {
     when(System.currentTimeMillis())
         .thenReturn(1465510280_000L); // Thursday, June 9, 2016 10:11:20 PM
 
-    long traceIdHigh = Platform.Jre7.buildIfSupported(true).nextTraceIdHigh();
+    long traceIdHigh = Platform.Jre7.buildIfSupported().nextTraceIdHigh();
 
     assertThat(HexCodec.toLowerHex(traceIdHigh)).startsWith("5759e988");
   }
@@ -69,15 +69,6 @@ public class PlatformTest {
 
     assertThat(HexCodec.toLowerHex(traceIdHigh))
         .isEqualTo("5759e988ffffffff");
-  }
-
-  @Test public void zipkinV1Absent() throws ClassNotFoundException {
-    mockStatic(Class.class);
-    when(Class.forName(zipkin.Endpoint.class.getName()))
-        .thenThrow(ClassNotFoundException.class);
-
-    assertThat(Platform.findPlatform().zipkinV1Present())
-        .isFalse();
   }
 
   @Test public void localEndpoint_lazySet() {

--- a/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/PlatformBenchmarks.java
@@ -35,9 +35,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class PlatformBenchmarks {
-  static final Platform jre6 = new Platform.Jre6(false);
-  static final Platform jre7 = Platform.Jre7.buildIfSupported(false);
-  static final Platform jre9 = Platform.Jre9.buildIfSupported(false);
+  static final Platform jre6 = new Platform.Jre6();
+  static final Platform jre7 = Platform.Jre7.buildIfSupported();
+  static final Platform jre9 = Platform.Jre9.buildIfSupported();
   static final Clock jre7Clock = jre7.clock();
   static final Clock jre9Clock = jre9.clock();
 

--- a/instrumentation/http/src/main/java/brave/http/HttpClientAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientAdapter.java
@@ -7,10 +7,4 @@ public abstract class HttpClientAdapter<Req, Resp> extends HttpAdapter<Req, Resp
   public boolean parseServerAddress(Req req, Endpoint.Builder builder) {
     return false;
   }
-
-  /** @deprecated please use {@link #parseServerAddress(Object, zipkin2.Endpoint.Builder)}*/
-  @Deprecated
-  public boolean parseServerAddress(Req req, zipkin.Endpoint.Builder builder) {
-    return false;
-  }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -4,7 +4,6 @@ import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.internal.Nullable;
-import brave.internal.Platform;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
@@ -109,19 +108,9 @@ public final class HttpClientHandler<Req, Resp> {
       ws.close();
     }
 
-    boolean parsedEndpoint = false;
-    if (Platform.get().zipkinV1Present()) {
-      zipkin.Endpoint.Builder deprecatedEndpoint = zipkin.Endpoint.builder()
-          .serviceName(serverNameSet ? serverName : "");
-      if ((parsedEndpoint = adapter.parseServerAddress(request, deprecatedEndpoint))) {
-        span.remoteEndpoint(deprecatedEndpoint.serviceName(serverName).build());
-      }
-    }
-    if (!parsedEndpoint) {
-      Endpoint.Builder remoteEndpoint = Endpoint.newBuilder().serviceName(serverName);
-      if (adapter.parseServerAddress(request, remoteEndpoint) || serverNameSet) {
-        span.remoteEndpoint(remoteEndpoint.build());
-      }
+    Endpoint.Builder remoteEndpoint = Endpoint.newBuilder().serviceName(serverName);
+    if (adapter.parseServerAddress(request, remoteEndpoint) || serverNameSet) {
+      span.remoteEndpoint(remoteEndpoint.build());
     }
     return span.start();
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerAdapter.java
@@ -12,10 +12,4 @@ public abstract class HttpServerAdapter<Req, Resp> extends HttpAdapter<Req, Resp
     String xForwardedFor = requestHeader(req, "X-Forwarded-For");
     return xForwardedFor != null && builder.parseIp(xForwardedFor);
   }
-
-  /** @deprecated Please use {@link #parseClientAddress(Object, Endpoint.Builder)} */
-  @Deprecated
-  public boolean parseClientAddress(Req req, zipkin.Endpoint.Builder builder) {
-    return false;
-  }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -80,18 +80,9 @@ public final class HttpServerHandler<Req, Resp> {
       ws.close();
     }
 
-    boolean parsedEndpoint = false;
-    if (Platform.get().zipkinV1Present()) {
-      zipkin.Endpoint.Builder deprecatedEndpoint = zipkin.Endpoint.builder().serviceName("");
-      if ((parsedEndpoint = adapter.parseClientAddress(request, deprecatedEndpoint))) {
-        span.remoteEndpoint(deprecatedEndpoint.build());
-      }
-    }
-    if (!parsedEndpoint) {
-      Endpoint.Builder remoteEndpoint = Endpoint.newBuilder();
-      if (adapter.parseClientAddress(request, remoteEndpoint)) {
-        span.remoteEndpoint(remoteEndpoint.build());
-      }
+    Endpoint.Builder remoteEndpoint = Endpoint.newBuilder();
+    if (adapter.parseClientAddress(request, remoteEndpoint)) {
+      span.remoteEndpoint(remoteEndpoint.build());
     }
     return span.start();
   }


### PR DESCRIPTION
http client and server middleware incubated with zipkin v1 apis. To
give people time to update, we deprecated hooks to parse remote
endpoints using v1 types. All but two projects on github have migrated
off those types, obviating the special handling.

Note: this doesn't remove any common-course support for v1 endpoint,
such as users adding it to a span or to a tracer, eventhough those are
deprecated, too. This only removes from middleware plugins to simplify
their build scripts, removing a quite usualy source of an optional
dependency.

I think we can merge and cut this once the below are migrated:
https://github.com/xjdr/xio/issues/174 cc @pdex
https://github.com/dreamming/dmz-inward-/issues/1 cc @yinming