### PR TITLE
Implements parsing of http route and uses it by default for span name

### DIFF
--- a/instrumentation/benchmarks/src/main/java/brave/jersey/server/FakeExtendedUriInfo.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jersey/server/FakeExtendedUriInfo.java
@@ -1,0 +1,139 @@
+package brave.jersey.server;
+
+import java.net.URI;
+import java.util.List;
+import java.util.regex.MatchResult;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.UriBuilder;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.server.model.ResourceMethod;
+import org.glassfish.jersey.server.model.RuntimeResource;
+import org.glassfish.jersey.uri.UriTemplate;
+
+class FakeExtendedUriInfo implements ExtendedUriInfo {
+  final URI baseURI;
+  final List<UriTemplate> matchedTemplates;
+
+  FakeExtendedUriInfo(URI baseURI, List<UriTemplate> matchedTemplates) {
+    this.baseURI = baseURI;
+    this.matchedTemplates = matchedTemplates;
+  }
+
+  @Override public Throwable getMappedThrowable() {
+    return null;
+  }
+
+  @Override public List<MatchResult> getMatchedResults() {
+    return null;
+  }
+
+  @Override public List<UriTemplate> getMatchedTemplates() {
+    return matchedTemplates;
+  }
+
+  @Override public List<PathSegment> getPathSegments(String name) {
+    return null;
+  }
+
+  @Override public List<PathSegment> getPathSegments(String name, boolean decode) {
+    return null;
+  }
+
+  @Override public List<RuntimeResource> getMatchedRuntimeResources() {
+    return null;
+  }
+
+  @Override public ResourceMethod getMatchedResourceMethod() {
+    return null;
+  }
+
+  @Override public Resource getMatchedModelResource() {
+    return null;
+  }
+
+  @Override public List<ResourceMethod> getMatchedResourceLocators() {
+    return null;
+  }
+
+  @Override public List<Resource> getLocatorSubResources() {
+    return null;
+  }
+
+  @Override public String getPath() {
+    return null;
+  }
+
+  @Override public String getPath(boolean decode) {
+    return null;
+  }
+
+  @Override public List<PathSegment> getPathSegments() {
+    return null;
+  }
+
+  @Override public List<PathSegment> getPathSegments(boolean decode) {
+    return null;
+  }
+
+  @Override public URI getRequestUri() {
+    return null;
+  }
+
+  @Override public UriBuilder getRequestUriBuilder() {
+    return null;
+  }
+
+  @Override public URI getAbsolutePath() {
+    return null;
+  }
+
+  @Override public UriBuilder getAbsolutePathBuilder() {
+    return null;
+  }
+
+  @Override public URI getBaseUri() {
+    return baseURI;
+  }
+
+  @Override public UriBuilder getBaseUriBuilder() {
+    return null;
+  }
+
+  @Override public MultivaluedMap<String, String> getPathParameters() {
+    return null;
+  }
+
+  @Override public MultivaluedMap<String, String> getPathParameters(boolean decode) {
+    return null;
+  }
+
+  @Override public MultivaluedMap<String, String> getQueryParameters() {
+    return null;
+  }
+
+  @Override public MultivaluedMap<String, String> getQueryParameters(boolean decode) {
+    return null;
+  }
+
+  @Override public List<String> getMatchedURIs() {
+    return null;
+  }
+
+  @Override public List<String> getMatchedURIs(boolean decode) {
+    return null;
+  }
+
+  @Override public List<Object> getMatchedResources() {
+    return null;
+  }
+
+  @Override public URI resolve(URI uri) {
+    return null;
+  }
+
+  @Override public URI relativize(URI uri) {
+    return null;
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/jersey/server/TracingApplicationEventListenerAdapterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jersey/server/TracingApplicationEventListenerAdapterBenchmarks.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jersey.server;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.glassfish.jersey.internal.MapPropertiesDelegate;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.uri.PathTemplate;
+import org.jboss.resteasy.core.ServerResponse;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class TracingApplicationEventListenerAdapterBenchmarks {
+  FakeExtendedUriInfo uriInfo = new FakeExtendedUriInfo(URI.create("/"),
+      Arrays.asList(
+          new PathTemplate("/"),
+          new PathTemplate("/items/{itemId}")
+      )
+  );
+  ContainerResponse response = new ContainerResponse(
+      new ContainerRequest(
+          URI.create("/"), null, null, null, new MapPropertiesDelegate()
+      ) {
+        @Override public ExtendedUriInfo getUriInfo() {
+          return uriInfo;
+        }
+      }, new ServerResponse());
+
+  FakeExtendedUriInfo nestedUriInfo = new FakeExtendedUriInfo(URI.create("/"),
+      Arrays.asList(
+          new PathTemplate("/"),
+          new PathTemplate("/items/{itemId}"),
+          new PathTemplate("/"),
+          new PathTemplate("/nested")
+      )
+  );
+  ContainerResponse nestedResponse = new ContainerResponse(
+      new ContainerRequest(
+          URI.create("/"), null, null, null, new MapPropertiesDelegate()
+      ) {
+        @Override public ExtendedUriInfo getUriInfo() {
+          return nestedUriInfo;
+        }
+      }, new ServerResponse());
+
+  TracingApplicationEventListener.Adapter adapter = new TracingApplicationEventListener.Adapter();
+
+  @Benchmark public String parseRoute() {
+    return adapter.route(response);
+  }
+
+  @Benchmark public String parseRoute_nested() {
+    return adapter.route(nestedResponse);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + TracingApplicationEventListenerAdapterBenchmarks.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITServlet25Container.java
@@ -97,6 +97,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
   @Override
   public void init(ServletContextHandler handler) {
     // add servlets for the test resource
+    handler.addServlet(new ServletHolder(new StatusServlet(404)), "/*");
     handler.addServlet(new ServletHolder(new StatusServlet(200)), "/foo");
     handler.addServlet(new ServletHolder(new ExtraServlet()), "/extra");
     handler.addServlet(new ServletHolder(new StatusServlet(400)), "/badrequest");

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -9,13 +9,16 @@ instructions on what to put into http spans, and sampling policy.
 
 ## Span data policy
 By default, the following are added to both http client and server spans:
-* Span.name as the http method in lowercase: ex "get"
+* Span.name is the http method in lowercase: ex "get" or a route described below
 * Tags/binary annotations:
   * "http.method", eg "GET"
   * "http.path", which does not include query parameters.
   * "http.status_code" when the status us not success.
   * "error", when there is an exception or status is >=400
 * Remote IP and port information
+
+A route based span name looks like "/users/{userId}", "not_found" or
+"redirected". There's a longer section on Http Route later in this doc.
 
 Naming and tags are configurable in a library-agnostic way. For example,
 the same `HttpTracing` component configures OkHttp or Apache HttpClient
@@ -29,6 +32,7 @@ httpTracing = httpTracing.toBuilder()
     .clientParser(new HttpClientParser() {
       @Override
       public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
+        customizer.name(spanName(adapter, req)); // default span name
         customizer.tag(TraceKeys.HTTP_URL, adapter.url(req)); // the whole url, not just the path
       }
     })
@@ -45,13 +49,20 @@ Ex:
 ```java
 overrideSpanName = new HttpClientParser() {
   @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
-    return adapter.method(req).toLowerCase() + " " + adapter.path(req);
+    // If using JAX-RS, maybe we want to use the resource method
+    if (adapter instanceof ContainerAdapter) {
+      Method method = ((ContainerAdapter) adapter).resourceMethod(req);
+      return method.getName().toLowerCase();
+    }
+    // If not using framework-specific knowledge, we can use http
+    // attributes or go with the default.
+    return super.spanName(adapter, req);
   }
 };
 ```
 
 Note that span name can be overwritten any time, for example, when
-parsing the response.
+parsing the response, which is the case when route-based names are used.
 
 ## Sampling Policy
 The default sampling policy is to use the default (trace ID) sampler for
@@ -87,6 +98,31 @@ httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
   .addRule("POST", "/bar", 0.1f)
   .build());
 ```
+
+## Http Route
+The http route is an expression such as `/items/:itemId` representing an
+application endpoint. `HttpAdapter.route()` parses this from a response,
+returning the route that matched the request, empty if no route matched,
+or null if routes aren't supported. This value is either used to create
+a tag "http.route" or as an input to a span naming function.
+
+### Http route cardinality
+The http route groups similar requests together, so results in limited
+cardinality, often a better choice for a span name vs the http method.
+
+For example, the route `/users/{userId}`, matches `/users/25f4c31d` and
+`/users/e3c553be`. If a span name function used the http path instead,
+it could DOS-style attack vector on your span name index, as it would
+grow unbounded vs `/users/{userId}`. Even if different frameworks use
+different formats, such as `/users/[0-9a-f]+` or `/users/:userId`, the
+cardinality is still fixed with regards to request count.
+
+The http route can be "" (empty) on redirect or not-found. If you use
+http route for metrics, coerce empty to constants like "redirected" or
+"not_found" with the http status. Knowing the difference between not
+found and redirected can be a simple intrusion detection signal. The
+default span name policy uses constants when a route isn't known for
+reasons including sharing the span name as a metrics correlation field.
 
 # Developing new instrumentation
 
@@ -181,3 +217,75 @@ try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) { // 2.
   handler.handleSend(response, error, span); // 5.
 }
 ```
+
+### Supporting HttpAdapter.route(response)
+
+Although the route is associated with the request, not the response,
+it is parsed from the response object. The reason is that many server
+implementations process the request before they can identify the route.
+
+Instrumentation authors implement support via extending HttpAdapter
+accordingly. There are a few patterns which might help.
+
+#### Callback with non-final type
+When a framework uses an callback model, you are in control of the type
+being parsed. If the response type isn't final, simply subclass it with
+the route data.
+
+For example, if Spring MVC, it would be this:
+```java
+    // check for a wrapper type which holds the template
+    handler = HttpServerHandler.create(httpTracing, new HttpServletAdapter() {
+      @Override public String template(HttpServletResponse response) {
+        return response instanceof HttpServletResponseWithTemplate
+            ? ((HttpServletResponseWithTemplate) response).route : null;
+      }
+
+      @Override public String toString() {
+        return "WebMVCAdapter{}";
+      }
+    });
+
+--snip--
+
+// when parsing the response, scope the route from the request
+
+    Object template = request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
+    if (route != null) {
+      response = new HttpServletResponseWithTemplate(response, route.toString());
+    }
+    handler.handleSend(response, ex, span);
+```
+
+#### Callback with final type
+If the response type is final, you may be able to make a copy and stash
+the route as a synthetic header. Since this is a copy of the response,
+there's no chance a user will receive this header in a real response.
+
+Here's an example for Play, where the header "brave-http-template" holds
+the route temporarily until the parser can read it.
+```scala
+    result.onComplete {
+      case Failure(t) => handler.handleSend(null, t, span)
+      case Success(r) => {
+        // add a synthetic header if there was a routing path set
+        var resp = template.map(t => r.withHeaders("brave-http-template" -> t)).getOrElse(r)
+        handler.handleSend(resp, null, span)
+      }
+    }
+--snip--
+    override def template(response: Result): String =
+      response.header.headers.apply("brave-http-template")
+```
+
+#### Common mistakes
+
+For grouping to work, we want routes that are effectively the same, to
+in fact be the same. Here are a couple things on that.
+
+* Always start with a leading slash
+  * This allows you to differentiate the root path from empty (no route)
+  * This prevents accidental partitioning like `users/:userId` from `/users/:userId`
+* Take care not to duplicate slashes
+  * When joining nested paths, avoid writing templates like `/nested//users/:userId`
+  * The `ITHttpServer` test will catch some of this

--- a/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
@@ -38,6 +38,22 @@ public abstract class HttpAdapter<Req, Resp> {
   @Nullable public abstract String requestHeader(Req request, String name);
 
   /**
+   * Returns an expression such as "/items/:itemId" representing an application endpoint,
+   * conventionally associated with the tag key "http.route". If no route matched, "" (empty string)
+   * is returned. Null indicates this instrumentation doesn't understand http routes.
+   *
+   * <p>Eventhough the route is associated with the request, not the response, this is present
+   * on the response object. The reasons is that many server implementations process the request
+   * before they can identify the route route.
+   */
+  // BRAVE5: It isn't possible for a user to easily consume HttpServerAdapter, which is why this
+  // method, while generally about the server, is pushed up to the HttpAdapter. The signatures for
+  // sampling and parsing could be changed to make it more convenient.
+  @Nullable public String route(Resp response) {
+    return null;
+  }
+
+  /**
    * The HTTP status code or null if unreadable.
    *
    * <p>Conventionally associated with the key "http.status_code"

--- a/instrumentation/http/src/main/java/brave/http/HttpParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpParser.java
@@ -33,8 +33,15 @@ public class HttpParser {
 
   /**
    * Override to change what data from the http response or error are parsed into the span modeling
-   * it. By default, this tags "http.status_code" when it is not 2xx. If there's an exception or the
-   * status code is neither 2xx nor 3xx, it tags "error".
+   * it.
+   *
+   * <p>By default, this tags "http.status_code" when it is not 2xx. If there's an exception or the
+   * status code is neither 2xx nor 3xx, it tags "error". This also overrides the span name based on
+   * the {@link HttpAdapter#route(Object)} where possible.
+   *
+   * <p>If routing is supported, but didn't match due to 404, the span name will be "not_found". If
+   * it didn't match due to redirect, the span name will be "redirected". If routing is not
+   * supported, the span name is left alone.
    *
    * <p>If you only want to change how exceptions are parsed, override {@link #error(Integer,
    * Throwable, SpanCustomizer)} instead.
@@ -50,11 +57,21 @@ public class HttpParser {
     int statusCode = 0;
     if (res != null) {
       statusCode = adapter.statusCodeAsInt(res);
+      String nameFromRoute = spanNameFromRoute(adapter.route(res), statusCode);
+      if (nameFromRoute != null) customizer.name(nameFromRoute);
       if (statusCode != 0 && (statusCode < 200 || statusCode > 299)) {
         customizer.tag("http.status_code", String.valueOf(statusCode));
       }
     }
     error(statusCode, error, customizer);
+  }
+
+  static String spanNameFromRoute(String route, int statusCode) {
+    if (route == null) return null; // don't undo a valid name elsewhere
+    if (!"".equals(route)) return route;
+    if (statusCode / 100 == 3) return "redirected";
+    if (statusCode == 404) return "not_found";
+    return null; // unexpected
   }
 
   /**

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -7,15 +7,19 @@ import brave.http.HttpServerHandler;
 import brave.http.HttpTracing;
 import brave.propagation.Propagation.Getter;
 import brave.propagation.TraceContext;
+import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.ExtendedUriInfo;
 import org.glassfish.jersey.server.ManagedAsync;
+import org.glassfish.jersey.server.internal.routing.RoutingContext;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
+import org.glassfish.jersey.uri.UriTemplate;
 
 @Provider
 public final class TracingApplicationEventListener implements ApplicationEventListener {
@@ -73,6 +77,40 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
 
     @Override public String requestHeader(ContainerRequest request, String name) {
       return request.getHeaderString(name);
+    }
+
+    /**
+     * This returns the matched template as defined by a base URL and path expressions.
+     *
+     * <p>Matched templates are pairs of (resource path, method path) added with
+     * {@link RoutingContext#pushTemplates(UriTemplate, UriTemplate)}.
+     * This code skips redundant slashes from either source caused by Path("/") or Path("").
+     */
+    @Override public String route(ContainerResponse response) {
+      ExtendedUriInfo uriInfo = response.getRequestContext().getUriInfo();
+      List<UriTemplate> templates = uriInfo.getMatchedTemplates();
+      int templateCount = templates.size();
+      if (templateCount == 0) return "";
+      assert templateCount % 2 == 0 : "expected matched templates to be resource/method pairs";
+      StringBuilder builder = null; // don't allocate unless you need it!
+      String basePath = uriInfo.getBaseUri().getPath();
+      String result = null;
+      if (!"/".equals(basePath)) { // skip empty base paths
+        result = basePath;
+      }
+      for (int i = templateCount - 1; i >= 0; i--) {
+        String template = templates.get(i).getTemplate();
+        if ("/".equals(template)) continue; // skip allocation
+        if (builder != null) {
+          builder.append(template);
+        } else if (result != null) {
+          builder = new StringBuilder(result).append(template);
+          result = null;
+        } else {
+          result = template;
+        }
+      }
+      return result != null ? result : builder != null ? builder.toString() : "";
     }
 
     @Override public Integer statusCode(ContainerResponse response) {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -7,6 +7,7 @@ import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -73,15 +74,14 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
 
     @GET
     @Path("async")
-    public void async(@Suspended AsyncResponse response) throws IOException {
-      System.err.println("ASDFASDFASDFASDFASD " + Thread.currentThread());
+    public void async(@Suspended AsyncResponse response) {
       new Thread(() -> response.resume("foo")).start();
     }
 
     @GET
     @Path("managedAsync")
     @ManagedAsync
-    public void managedAsync(@Suspended AsyncResponse response) throws IOException {
+    public void managedAsync(@Suspended AsyncResponse response) {
       response.resume("foo");
     }
 
@@ -92,9 +92,28 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
     }
 
     @GET
+    @Path("items/{itemId}")
+    public String item(@PathParam("itemId") String itemId) {
+      return itemId;
+    }
+
+    @GET
     @Path("exceptionAsync")
-    public void disconnectAsync(@Suspended AsyncResponse response) throws IOException {
+    public void disconnectAsync(@Suspended AsyncResponse response) {
       new Thread(() -> response.resume(new IOException())).start();
+    }
+
+    public static class NestedResource {
+      @GET
+      @Path("items/{itemId}")
+      public String item(@PathParam("itemId") String itemId) {
+        return itemId;
+      }
+    }
+
+    @Path("nested")
+    public NestedResource nestedResource() {
+      return new NestedResource();
     }
   }
 }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
@@ -2,8 +2,11 @@ package brave.jersey.server;
 
 import brave.jersey.server.TracingApplicationEventListener.Adapter;
 import java.net.URI;
+import java.util.Arrays;
 import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.uri.PathTemplate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -17,12 +20,89 @@ import static org.mockito.Mockito.when;
 public class TracingApplicationEventListenerAdapterTest {
   Adapter adapter = new Adapter();
   @Mock ContainerRequest request;
+  @Mock ContainerResponse response;
 
   @Test public void path_prefixesSlashWhenMissing() {
     when(request.getPath(false)).thenReturn("bar");
 
     assertThat(adapter.path(request))
         .isEqualTo("/bar");
+  }
+
+  @Test public void route() {
+    when(response.getRequestContext()).thenReturn(request);
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/items/{itemId}")
+    ));
+
+    assertThat(adapter.route(response))
+        .isEqualTo("/items/{itemId}");
+  }
+
+  /** not sure it is even possible for a template to match "/" "/".. */
+  @Test public void route_invalid() {
+    when(response.getRequestContext()).thenReturn(request);
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/")
+    ));
+
+    assertThat(adapter.route(response))
+        .isEmpty();
+  }
+
+  @Test public void route_basePath() {
+    when(response.getRequestContext()).thenReturn(request);
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/base"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/items/{itemId}")
+    ));
+
+    assertThat(adapter.route(response))
+        .isEqualTo("/base/items/{itemId}");
+  }
+
+  @Test public void route_nested() {
+    when(response.getRequestContext()).thenReturn(request);
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/items/{itemId}"),
+        new PathTemplate("/"),
+        new PathTemplate("/nested")
+    ));
+
+    assertThat(adapter.route(response))
+        .isEqualTo("/nested/items/{itemId}");
+  }
+
+  /** when the path expression is on the type not on the method */
+  @Test public void route_nested_reverse() {
+    when(response.getRequestContext()).thenReturn(request);
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/items/{itemId}"),
+        new PathTemplate("/"),
+        new PathTemplate("/nested"),
+        new PathTemplate("/")
+    ));
+
+    assertThat(adapter.route(response))
+        .isEqualTo("/nested/items/{itemId}");
   }
 
   @Test public void url_derivedFromExtendedUriInfo() {

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/TestHandler.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/TestHandler.java
@@ -40,18 +40,18 @@ class TestHandler extends ChannelInboundHandlerAdapter {
       String uri = req.uri();
       String content = null;
       HttpResponseStatus status = OK;
-      if (uri.startsWith("/foo")) {
+      if (uri.equals("/foo")) {
         content = "bar";
-      } else if (uri.startsWith("/extra")) {
+      } else if (uri.equals("/extra")) {
         content = ExtraFieldPropagation.get(EXTRA_KEY);
-      } else if (uri.startsWith("/child")) {
+      } else if (uri.equals("/child")) {
         httpTracing.tracing().tracer().nextSpan().name("child").start().finish();
         content = "happy";
-      } else if (uri.startsWith("/exception")) {
+      } else if (uri.equals("/exception")) {
         throw new IOException("exception");
-      } else if (uri.startsWith("/async")) {
+      } else if (uri.equals("/async")) {
         content = "async";
-      } else if (uri.startsWith("/badrequest")) {
+      } else if (uri.equals("/badrequest")) {
         status = BAD_REQUEST;
       } else {
         status = NOT_FOUND;

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
@@ -7,8 +7,7 @@ import zipkin2.Endpoint;
 
 /** This can also parse the remote IP of the client. */
 // public for others like sparkjava to use
-public final class HttpServletAdapter
-    extends HttpServerAdapter<HttpServletRequest, HttpServletResponse> {
+public class HttpServletAdapter extends HttpServerAdapter<HttpServletRequest, HttpServletResponse> {
   final ServletRuntime servlet = ServletRuntime.get();
 
   /**

--- a/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc25/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc25/ITTracingHandlerInterceptor.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.AssumptionViolatedException;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -22,6 +23,18 @@ import static org.springframework.web.servlet.DispatcherServlet.HANDLER_ADAPTER_
 import static org.springframework.web.servlet.DispatcherServlet.HANDLER_MAPPING_BEAN_NAME;
 
 public class ITTracingHandlerInterceptor extends ITServletContainer {
+
+  @Override public void notFound(){
+    throw new AssumptionViolatedException("TODO: add MVC handling for not found");
+  }
+
+  @Override public void httpRoute() {
+    throw new AssumptionViolatedException("HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE doesn't exist until Spring 3");
+  }
+
+  @Override public void httpRoute_nested() {
+    throw new AssumptionViolatedException("HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE doesn't exist until Spring 3");
+  }
 
   @Controller
   public static class TestController {

--- a/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/main/java/brave/spring/webmvc/TracingHandlerInterceptor.java
@@ -11,12 +11,16 @@ import brave.propagation.TraceContext;
 import brave.servlet.HttpServletAdapter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
 /** Tracing interceptor for Spring Web MVC {@link HandlerInterceptor}. */
 public final class TracingHandlerInterceptor implements HandlerInterceptor {
+  // redefined from HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE as doesn't exist until Spring 3
+  static final String BEST_MATCHING_PATTERN_ATTRIBUTE =
+      "org.springframework.web.servlet.HandlerMapping.bestMatchingPattern";
   static final Propagation.Getter<HttpServletRequest, String> GETTER =
       new Propagation.Getter<HttpServletRequest, String>() {
         @Override public String get(HttpServletRequest carrier, String key) {
@@ -42,7 +46,16 @@ public final class TracingHandlerInterceptor implements HandlerInterceptor {
 
   @Autowired TracingHandlerInterceptor(HttpTracing httpTracing) { // internal
     tracer = httpTracing.tracing().tracer();
-    handler = HttpServerHandler.create(httpTracing, new HttpServletAdapter());
+    handler = HttpServerHandler.create(httpTracing, new HttpServletAdapter() {
+      @Override public String route(HttpServletResponse response) {
+        return response instanceof HttpServletResponseWithTemplate
+            ? ((HttpServletResponseWithTemplate) response).template : null;
+      }
+
+      @Override public String toString() {
+        return "WebMVCAdapter{}";
+      }
+    });
     extractor = httpTracing.tracing().propagation().extractor(GETTER);
   }
 
@@ -59,7 +72,7 @@ public final class TracingHandlerInterceptor implements HandlerInterceptor {
 
   @Override
   public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-      ModelAndView modelAndView) throws Exception {
+      ModelAndView modelAndView) {
   }
 
   @Override
@@ -68,6 +81,19 @@ public final class TracingHandlerInterceptor implements HandlerInterceptor {
     Span span = tracer.currentSpan();
     if (span == null) return;
     ((SpanInScope) request.getAttribute(SpanInScope.class.getName())).close();
+    Object template = request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
+    if (template != null) {
+      response = new HttpServletResponseWithTemplate(response, template.toString());
+    }
     handler.handleSend(response, ex, span);
+  }
+
+  static class HttpServletResponseWithTemplate extends HttpServletResponseWrapper {
+    final String template;
+
+    HttpServletResponseWithTemplate(HttpServletResponse response, String template) {
+      super(response);
+      this.template = template;
+    }
   }
 }

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingAsyncHandlerInterceptor.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.AssumptionViolatedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
@@ -24,6 +26,10 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 public class ITTracingAsyncHandlerInterceptor extends ITServletContainer {
+
+  @Override public void notFound(){
+    throw new AssumptionViolatedException("TODO: add MVC handling for not found");
+  }
 
   @Controller static class TestController {
     final Tracer tracer;
@@ -68,6 +74,20 @@ public class ITTracingAsyncHandlerInterceptor extends ITServletContainer {
       return () -> {
         throw new IOException();
       };
+    }
+
+    @RequestMapping(value = "/items/{itemId}")
+    public ResponseEntity<String> items(@PathVariable String itemId) {
+      return new ResponseEntity<String>(itemId, HttpStatus.OK);
+    }
+
+    @Controller
+    @RequestMapping(value = "/nested")
+    static class NestedController {
+      @RequestMapping(value = "/items/{itemId}")
+      public ResponseEntity<String> items(@PathVariable String itemId) {
+        return new ResponseEntity<String>(itemId, HttpStatus.OK);
+      }
     }
   }
 

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.AssumptionViolatedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
@@ -24,6 +26,10 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 public class ITTracingHandlerInterceptor extends ITServletContainer {
+
+  @Override public void notFound(){
+    throw new AssumptionViolatedException("TODO: add MVC handling for not found");
+  }
 
   @Controller static class TestController {
     final Tracer tracer;
@@ -68,6 +74,20 @@ public class ITTracingHandlerInterceptor extends ITServletContainer {
       return () -> {
         throw new IOException();
       };
+    }
+
+    @RequestMapping(value = "/items/{itemId}")
+    public ResponseEntity<String> items(@PathVariable String itemId) {
+      return new ResponseEntity<String>(itemId, HttpStatus.OK);
+    }
+
+    @Controller
+    @RequestMapping(value = "/nested")
+    static class NestedController {
+      @RequestMapping(value = "/items/{itemId}")
+      public ResponseEntity<String> items(@PathVariable String itemId) {
+        return new ResponseEntity<String>(itemId, HttpStatus.OK);
+      }
     }
   }
 

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -23,6 +23,17 @@ import zipkin2.Endpoint;
  *
  * <p>The hint that we need to re-attach the headers handler on re-route came from looking at
  * {@code TracingHandler} in https://github.com/opentracing-contrib/java-vertx-web
+ *
+ * <h3>Why use a thread local for the http route when parsing {@linkplain HttpServerResponse}?</h3>
+ * <p>When parsing the response, we use a thread local to make the current route's path visible.
+ * This is an alternative to wrapping {@linkplain HttpServerResponse} or declaring a custom type.
+ * We don't wrap {@linkplain HttpServerResponse}, because this would lock the instrumentation to the
+ * signatures currently present on it (for example, if a method is added, we'd have to recompile).
+ * If a wrapper is eventually provided by vertx, we could use that, but it didn't exist at the time.
+ * We could also define a custom composite type like ResponseWithTemplate. However, this would
+ * interfere with people using "instanceof" in http samplers or parsers: they'd have to depend on a
+ * brave type. The least impact means was to use a thread local, as eventhough this costs a little,
+ * it prevents revision lock or routine use of custom types.
  */
 final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   static final Getter<HttpServerRequest, String> GETTER = new Getter<HttpServerRequest, String>() {
@@ -36,12 +47,14 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   };
 
   final Tracer tracer;
+  final ThreadLocal<String> currentTemplate;
   final HttpServerHandler<HttpServerRequest, HttpServerResponse> serverHandler;
   final TraceContext.Extractor<HttpServerRequest> extractor;
 
   TracingRoutingContextHandler(HttpTracing httpTracing) {
     tracer = httpTracing.tracing().tracer();
-    serverHandler = HttpServerHandler.create(httpTracing, new Adapter());
+    currentTemplate = new ThreadLocal<>();
+    serverHandler = HttpServerHandler.create(httpTracing, new Adapter(currentTemplate));
     extractor = httpTracing.tracing().propagation().extractor(GETTER);
   }
 
@@ -80,11 +93,27 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
 
     @Override public void handle(Void aVoid) {
       if (!context.request().isEnded()) return;
-      serverHandler.handleSend(context.response(), context.failure(), span);
+      String template = context.currentRoute().getPath();
+      if (template == null) { // skip thread-local overhead if there's no attribute
+        serverHandler.handleSend(context.response(), context.failure(), span);
+        return;
+      }
+      try {
+        currentTemplate.set(template);
+        serverHandler.handleSend(context.response(), context.failure(), span);
+      } finally {
+        currentTemplate.remove();
+      }
     }
   }
 
   static final class Adapter extends HttpServerAdapter<HttpServerRequest, HttpServerResponse> {
+    final ThreadLocal<String> currentTemplate;
+
+    Adapter(ThreadLocal<String> currentTemplate) {
+      this.currentTemplate = currentTemplate;
+    }
+
     @Override public String method(HttpServerRequest request) {
       return request.method().name();
     }
@@ -99,6 +128,11 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
 
     @Override public String requestHeader(HttpServerRequest request, String name) {
       return request.headers().get(name);
+    }
+
+    @Override public String route(HttpServerResponse response) {
+      String result = currentTemplate.get();
+      return result != null ? result : "";
     }
 
     @Override public Integer statusCode(HttpServerResponse response) {


### PR DESCRIPTION
"http.route" is an expression such as "/items/:itemId" representing an application endpoint. This adds support for parsing this, employing it as the default span name policy when present. A route based span name looks like "/users/{userId}", "not_found" or "redirected".  More below:

## Http Route
The http route is an expression such as `/items/:itemId` representing an
application endpoint. `HttpAdapter.route()` parses this from a response,
returning the route that matched the request, empty if no route matched,
or null if routes aren't supported. This value is either used to create
a tag "http.route" or as an input to a span naming function.

### Http route cardinality
The http route groups similar requests together, so results in limited
cardinality, often a better choice for a span name vs the http method.

For example, the route `/users/{userId}`, matches `/users/25f4c31d` and
`/users/e3c553be`. If a span name function used the http path instead,
it could DOS-style attack vector on your span name index, as it would
grow unbounded vs `/users/{userId}`. Even if different frameworks use
different formats, such as `/users/[0-9a-f]+` or `/users/:userId`, the
cardinality is still fixed with regards to request count.

The http route can be "" (empty) on redirect or not-found. If you use
http route for metrics, coerce empty to constants like "redirected" or
"not_found" with the http status. Knowing the difference between not
found and redirected can be a simple intrusion detection signal. The
default span name policy uses constants when a route isn't known for
reasons including sharing the span name as a metrics correlation field.

### Supporting HttpAdapter.route(response)

Although the route is associated with the request, not the response,
it is parsed from the response object. The reason is that many server
implementations process the request before they can identify the route.

Instrumentation authors implement support via extending HttpAdapter
accordingly. There are a few patterns which might help.

#### Callback with non-final type
When a framework uses an callback model, you are in control of the type
being parsed. If the response type isn't final, simply subclass it with
the route data.

For example, if Spring MVC, it would be this:
```java
    // check for a wrapper type which holds the template
    handler = HttpServerHandler.create(httpTracing, new HttpServletAdapter() {
      @Override public String template(HttpServletResponse response) {
        return response instanceof HttpServletResponseWithTemplate
            ? ((HttpServletResponseWithTemplate) response).route : null;
      }

      @Override public String toString() {
        return "WebMVCAdapter{}";
      }
    });

--snip--

// when parsing the response, scope the route from the request

    Object template = request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
    if (route != null) {
      response = new HttpServletResponseWithTemplate(response, route.toString());
    }
    handler.handleSend(response, ex, span);
```

#### Callback with final type
If the response type is final, you may be able to make a copy and stash
the route as a synthetic header. Since this is a copy of the response,
there's no chance a user will receive this header in a real response.

Here's an example for Play, where the header "brave-http-template" holds
the route temporarily until the parser can read it.
```scala
    result.onComplete {
      case Failure(t) => handler.handleSend(null, t, span)
      case Success(r) => {
        // add a synthetic header if there was a routing path set
        var resp = template.map(t => r.withHeaders("brave-http-template" -> t)).getOrElse(r)
        handler.handleSend(resp, null, span)
      }
    }
--snip--
    override def template(response: Result): String =
      response.header.headers.apply("brave-http-template")
```

#### Common mistakes

For grouping to work, we want routes that are effectively the same, to
in fact be the same. Here are a couple things on that.

* Always start with a leading slash
  * This allows you to differentiate the root path from empty (no route)
  * This prevents accidental partitioning like `users/:userId` from `/users/:userId`
* Take care not to duplicate slashes
  * When joining nested paths, avoid writing templates like `/nested//users/:userId`
  * The `ITHttpServer` test will catch some of this

Fixes https://github.com/openzipkin/zipkin/issues/1874