### PR TITLE
Deflakes async tests by switching to concurrent blocking queue

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpAsyncClient.java
@@ -1,0 +1,54 @@
+package brave.http;
+
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.internal.HexCodec;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
+
+  protected abstract void getAsync(C client, String pathIncludingQuery) throws Exception;
+
+  /**
+   * This tests that the parent is determined at the time the request was made, not when the request
+   * was executed.
+   */
+  @Test public void usesParentFromInvocationTime() throws Exception {
+    Tracer tracer = httpTracing.tracing().tracer();
+    server.enqueue(new MockResponse().setBodyDelay(300, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse());
+
+    brave.Span parent = tracer.newTrace().name("test").start();
+    try (SpanInScope ws = tracer.withSpanInScope(parent)) {
+      getAsync(client, "/items/1");
+      getAsync(client, "/items/2");
+    } finally {
+      parent.finish();
+    }
+
+    brave.Span otherSpan = tracer.newTrace().name("test2").start();
+    try (SpanInScope ws = tracer.withSpanInScope(otherSpan)) {
+      for (int i = 0; i < 2; i++) {
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("x-b3-traceId"))
+            .isEqualTo(parent.context().traceIdString());
+        assertThat(request.getHeader("x-b3-parentspanid"))
+            .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+      }
+    } finally {
+      otherSpan.finish();
+    }
+
+    // Check we reported 2 local spans and 2 client spans
+    assertThat(Arrays.asList(takeSpan(), takeSpan(), takeSpan(), takeSpan()))
+        .extracting(Span::kind)
+        .containsOnly(null, Span.Kind.CLIENT);
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITServlet25Container.java
@@ -88,6 +88,8 @@ public abstract class ITServlet25Container extends ITServletContainer {
       assertThat(response.header(EXTRA_KEY))
           .isEqualTo("abcdefg");
     }
+
+    takeSpan();
   }
 
   @Override

--- a/instrumentation/http-tests/src/main/java/brave/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITServlet3Container.java
@@ -13,8 +13,6 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.AfterClass;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public abstract class ITServlet3Container extends ITServlet25Container {
   static ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -32,13 +30,13 @@ public abstract class ITServlet3Container extends ITServlet25Container {
   @Test public void forward() throws Exception {
     get("/forward");
 
-    assertThat(spans).hasSize(1);
+    takeSpan();
   }
 
   @Test public void forwardAsync() throws Exception {
     get("/forwardAsync");
 
-    assertThat(spans).hasSize(1);
+    takeSpan();
   }
 
   static class ForwardServlet extends HttpServlet {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -4,7 +4,6 @@ import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.internal.Nullable;
-import brave.internal.Platform;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import zipkin2.Endpoint;
@@ -34,7 +33,12 @@ public final class HttpServerHandler<Req, Resp> {
 
   public static <Req, Resp> HttpServerHandler create(HttpTracing httpTracing,
       HttpServerAdapter<Req, Resp> adapter) {
-    return new HttpServerHandler<>(httpTracing, adapter);
+    return new HttpServerHandler<>(
+        httpTracing.tracing().tracer(),
+        httpTracing.serverSampler(),
+        httpTracing.serverParser(),
+        adapter
+    );
   }
 
   final Tracer tracer;
@@ -42,10 +46,15 @@ public final class HttpServerHandler<Req, Resp> {
   final HttpServerParser parser;
   final HttpServerAdapter<Req, Resp> adapter;
 
-  HttpServerHandler(HttpTracing httpTracing, HttpServerAdapter<Req, Resp> adapter) {
-    this.tracer = httpTracing.tracing().tracer();
-    this.sampler = httpTracing.serverSampler();
-    this.parser = httpTracing.serverParser();
+  HttpServerHandler(
+      Tracer tracer,
+      HttpSampler sampler,
+      HttpServerParser parser,
+      HttpServerAdapter<Req, Resp> adapter
+  ) {
+    this.tracer = tracer;
+    this.sampler = sampler;
+    this.parser = parser;
     this.adapter = adapter;
   }
 
@@ -63,6 +72,8 @@ public final class HttpServerHandler<Req, Resp> {
    * Like {@link #handleReceive(TraceContext.Extractor, Object)}, except for when the carrier of
    * trace data is not the same as the request.
    *
+   * <p>Request data is parsed before the span is started.
+   *
    * @see HttpServerParser#request(HttpAdapter, Object, SpanCustomizer)
    */
   public <C> Span handleReceive(TraceContext.Extractor<C> extractor, C carrier, Req request) {
@@ -71,7 +82,13 @@ public final class HttpServerHandler<Req, Resp> {
 
     // all of the parsing here occur before a timestamp is recorded on the span
     span.kind(Span.Kind.SERVER);
+    parseRequest(request, span);
 
+    return span.start();
+  }
+
+  void parseRequest(Req request, Span span) {
+    if (span.isNoop()) return;
     // Ensure user-code can read the current trace context
     Tracer.SpanInScope ws = tracer.withSpanInScope(span);
     try {
@@ -84,7 +101,6 @@ public final class HttpServerHandler<Req, Resp> {
     if (adapter.parseClientAddress(request, remoteEndpoint)) {
       span.remoteEndpoint(remoteEndpoint.build());
     }
-    return span.start();
   }
 
   /** Creates a potentially noop span representing this request */

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -1,6 +1,6 @@
 package brave.httpasyncclient;
 
-import brave.http.ITHttpClient;
+import brave.http.ITHttpAsyncClient;
 import java.io.IOException;
 import java.net.URI;
 import okhttp3.mockwebserver.MockResponse;
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ITTracingHttpAsyncClientBuilder extends ITHttpClient<CloseableHttpAsyncClient> {
+public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<CloseableHttpAsyncClient> {
 
   @Override protected CloseableHttpAsyncClient newClient(int port) {
     CloseableHttpAsyncClient result = TracingHttpAsyncClientBuilder.create(httpTracing).build();
@@ -60,5 +60,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpClient<CloseableHttpA
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(request.getHeader("my-id"));
+
+    takeSpan();
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -10,7 +10,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 
 import static org.apache.http.util.EntityUtils.consume;
@@ -38,10 +37,6 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
     consume(client.execute(post).getEntity());
   }
 
-  @Override protected void getAsync(CloseableHttpClient client, String pathIncludingQuery) {
-    throw new AssumptionViolatedException("This is not an async library");
-  }
-
   @Test public void currentSpanVisibleToUserFilters() throws Exception {
     server.enqueue(new MockResponse());
     closeClient(client);
@@ -56,5 +51,7 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(request.getHeader("my-id"));
+
+    takeSpan();
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
@@ -1,7 +1,6 @@
 package brave.jaxrs2;
 
-import brave.http.ITHttpClient;
-import java.io.IOException;
+import brave.http.ITHttpAsyncClient;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -11,11 +10,12 @@ import javax.ws.rs.client.Entity;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ITTracingFeature_Client extends ITHttpClient<Client> {
+public class ITTracingFeature_Client extends ITHttpAsyncClient<Client> {
 
   ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -27,17 +27,16 @@ public class ITTracingFeature_Client extends ITHttpClient<Client> {
         .build();
   }
 
-  @Override protected void closeClient(Client client) throws IOException {
+  @Override protected void closeClient(Client client) {
     client.close();
     executor.shutdown();
   }
 
-  @Override protected void get(Client client, String pathIncludingQuery) throws IOException {
+  @Override protected void get(Client client, String pathIncludingQuery) {
     client.target(url(pathIncludingQuery)).request().buildGet().invoke().close();
   }
 
-  @Override protected void post(Client client, String pathIncludingQuery, String body)
-      throws Exception {
+  @Override protected void post(Client client, String pathIncludingQuery, String body) {
     client.target(url(pathIncludingQuery)).request()
         .buildPost(Entity.text(body))
         .invoke().close();
@@ -64,25 +63,23 @@ public class ITTracingFeature_Client extends ITHttpClient<Client> {
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(request.getHeader("my-id"));
+
+    takeSpan();
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void redirect() throws Exception { // blind to the implementation of redirects
-    super.redirect();
+  @Override @Ignore("blind to the implementation of redirects")
+  public void redirect() {
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void reportsServerAddress() throws Exception { // doesn't know the remote address
-    super.reportsServerAddress();
+  @Override @Ignore("doesn't know the remote address")
+  public void reportsServerAddress() {
   }
 
-  @Override @Test(expected = AssertionError.class) // doesn't yet close a span on exception
-  public void reportsSpanOnTransportException() throws Exception {
-    super.reportsSpanOnTransportException();
+  @Override @Ignore("doesn't yet close a span on exception")
+  public void reportsSpanOnTransportException() {
   }
 
-  @Override @Test(expected = AssertionError.class) // doesn't yet close a span on exception
-  public void addsErrorTagOnTransportException() throws Exception {
-    super.addsErrorTagOnTransportException();
+  @Override @Ignore("doesn't yet close a span on exception")
+  public void addsErrorTagOnTransportException() {
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
@@ -93,9 +93,9 @@ public class ITTracingFeature_Container extends ITServletContainer {
 
     get("/foo");
 
-    assertThat(spans)
-        .extracting(Span::name)
-        .containsExactly("foo");
+    Span span = takeSpan();
+    assertThat(span.name())
+        .isEqualTo("foo");
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
@@ -9,7 +9,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.ArrayList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,7 +22,8 @@ import static org.junit.Assume.assumeTrue;
 public class ITTracingStatementInterceptor {
   static final String QUERY = "select 'hello world'";
 
-  ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+  /** JDBC is synchronous and we aren't using thread pools: everything happens on the main thread */
+  ArrayList<Span> spans = new ArrayList<>();
 
   Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
   Connection connection;

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
@@ -9,7 +9,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.ArrayList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +23,8 @@ import static org.junit.Assume.assumeTrue;
 public class ITTracingStatementInterceptor {
   static final String QUERY = "select 'hello world'";
 
-  ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+  /** JDBC is synchronous and we aren't using thread pools: everything happens on the main thread */
+  ArrayList<Span> spans = new ArrayList<>();
 
   Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
   Connection connection;

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/NettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/NettyHttpTracing.java
@@ -1,6 +1,7 @@
 package brave.netty.http;
 
 import brave.Span;
+import brave.Tracer.SpanInScope;
 import brave.Tracing;
 import brave.http.HttpTracing;
 import io.netty.channel.ChannelDuplexHandler;
@@ -8,6 +9,8 @@ import io.netty.util.AttributeKey;
 
 public final class NettyHttpTracing {
   static final AttributeKey<Span> SPAN_ATTRIBUTE = AttributeKey.valueOf(Span.class.getName());
+  static final AttributeKey<SpanInScope> SPAN_IN_SCOPE_ATTRIBUTE =
+      AttributeKey.valueOf(SpanInScope.class.getName());
 
   public static NettyHttpTracing create(Tracing tracing) {
     return new NettyHttpTracing(HttpTracing.create(tracing));

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -1,6 +1,6 @@
 package brave.okhttp3;
 
-import brave.http.ITHttpClient;
+import brave.http.ITHttpAsyncClient;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
@@ -12,7 +12,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-public class ITTracingInterceptor extends ITHttpClient<Call.Factory> {
+public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
 
   @Override protected Call.Factory newClient(int port) {
     return new OkHttpClient.Builder()
@@ -44,8 +44,7 @@ public class ITTracingInterceptor extends ITHttpClient<Call.Factory> {
         .execute();
   }
 
-  @Override protected void getAsync(Call.Factory client, String pathIncludingQuery)
-      throws Exception {
+  @Override protected void getAsync(Call.Factory client, String pathIncludingQuery) {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
         .enqueue(new Callback() {
           @Override public void onFailure(Call call, IOException e) {

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -9,7 +9,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.ArrayList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +27,8 @@ public class ITTracingP6Factory {
     DerbyUtils.disableLog();
   }
 
-  ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+  /** JDBC is synchronous and we aren't using thread pools: everything happens on the main thread */
+  ArrayList<Span> spans = new ArrayList<>();
 
   Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE, spans).build();
   Connection connection;
@@ -103,7 +104,7 @@ public class ITTracingP6Factory {
     }
   }
 
-  static Tracing.Builder tracingBuilder(Sampler sampler, ConcurrentLinkedDeque<Span> spans) {
+  static Tracing.Builder tracingBuilder(Sampler sampler, ArrayList<Span> spans) {
     return Tracing.newBuilder()
         .spanReporter(spans::add)
         .currentTraceContext(new StrictCurrentTraceContext())

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/TracingJdbcEventListenerTest.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/TracingJdbcEventListenerTest.java
@@ -9,7 +9,7 @@ import com.p6spy.engine.common.StatementInformation;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -119,7 +119,7 @@ public class TracingJdbcEventListenerTest {
   }
 
   @Test public void nullSqlWontNPE() throws SQLException {
-    ConcurrentLinkedDeque<zipkin2.Span> spans = new ConcurrentLinkedDeque<>();
+    ArrayList<zipkin2.Span> spans = new ArrayList<>();
     try (Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE, spans).build()) {
 
       when(statementInformation.getSql()).thenReturn(null);
@@ -137,8 +137,7 @@ public class TracingJdbcEventListenerTest {
   }
 
   @Test public void handleAfterExecute_without_beforeExecute_getting_called() {
-    ConcurrentLinkedDeque<zipkin2.Span> spans = new ConcurrentLinkedDeque<>();
-    Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE, spans).build();
+    Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE, new ArrayList<>()).build();
     Span span = tracing.tracer().nextSpan().start();
     try (SpanInScope spanInScope = tracing.tracer().withSpanInScope(span)) {
       TracingJdbcEventListener listener = new TracingJdbcEventListener("", false);

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -3,19 +3,21 @@ package brave.sparkjava;
 import brave.http.ITHttpServer;
 import brave.propagation.ExtraFieldPropagation;
 import org.junit.After;
-import org.junit.ComparisonFailure;
-import org.junit.Test;
+import org.junit.Ignore;
 import spark.Spark;
 
 public class ITSparkTracing extends ITHttpServer {
 
-  /**
-   * Async tests are ignored until https://github.com/perwendel/spark/issues/208
-   */
-  @Override
-  @Test(expected = ComparisonFailure.class)
-  public void async() throws Exception {
-    super.async();
+  @Override @Ignore("ignored until https://github.com/perwendel/spark/issues/208")
+  public void async() {
+  }
+
+  @Override @Ignore("ignored until https://github.com/perwendel/spark/issues/208")
+  public void addsErrorTagOnException_async() {
+  }
+
+  @Override @Ignore("ignored until https://github.com/perwendel/spark/issues/208")
+  public void reportsSpanOnException_async() {
   }
 
   @Override protected void init() throws Exception {

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -46,10 +46,6 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     restTemplate.postForObject(url(uri), content, String.class);
   }
 
-  @Override protected void getAsync(ClientHttpRequestFactory client, String uri) {
-    throw new AssumptionViolatedException("TODO: async rest template has its own interceptor");
-  }
-
   @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
     server.enqueue(new MockResponse());
 
@@ -64,6 +60,8 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(request.getHeader("my-id"));
+
+    takeSpan();
   }
 
   @Override @Test(expected = AssertionError.class)

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -1,12 +1,12 @@
 package brave.spring.web;
 
-import brave.http.ITHttpClient;
+import brave.http.ITHttpAsyncClient;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.client.AsyncClientHttpRequestFactory;
@@ -18,7 +18,7 @@ import org.springframework.web.client.AsyncRestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITTracingAsyncClientHttpRequestInterceptor
-    extends ITHttpClient<AsyncClientHttpRequestFactory> {
+    extends ITHttpAsyncClient<AsyncClientHttpRequestFactory> {
   AsyncClientHttpRequestInterceptor interceptor;
 
   AsyncClientHttpRequestFactory configureClient(AsyncClientHttpRequestInterceptor interceptor) {
@@ -42,25 +42,15 @@ public class ITTracingAsyncClientHttpRequestInterceptor
       throws Exception {
     AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));
-    try {
-      restTemplate.getForEntity(url(pathIncludingQuery), String.class).get();
-    } finally {
-      // TODO: understand why we need sleeps. maybe there's an executor we can change to same thread
-      Thread.sleep(100);
-    }
+    restTemplate.getForEntity(url(pathIncludingQuery), String.class).get();
   }
 
   @Override protected void post(AsyncClientHttpRequestFactory client, String uri, String content)
       throws Exception {
     AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));
-    try {
-      restTemplate.postForEntity(url(uri), RequestEntity.post(URI.create(url(uri))).body(content),
-          String.class).get();
-    } finally {
-      // TODO: understand why we need sleeps. maybe there's an executor we can change to same thread
-      Thread.sleep(100);
-    }
+    restTemplate.postForEntity(url(uri), RequestEntity.post(URI.create(url(uri))).body(content),
+        String.class).get();
   }
 
   @Override protected void getAsync(AsyncClientHttpRequestFactory client, String uri) {
@@ -83,15 +73,15 @@ public class ITTracingAsyncClientHttpRequestInterceptor
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(request.getHeader("my-id"));
+
+    takeSpan();
   }
 
-  @Override @Test(expected = ExecutionException.class)
-  public void redirect() throws Exception { // blind to the implementation of redirects
-    super.redirect();
+  @Override @Ignore("blind to the implementation of redirects")
+  public void redirect() {
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void reportsServerAddress() throws Exception { // doesn't know the remote address
-    super.reportsServerAddress();
+  @Override @Ignore("doesn't know the remote address")
+  public void reportsServerAddress() {
   }
 }

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.AssumptionViolatedException;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -45,10 +45,6 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     restTemplate.postForObject(url(uri), content, String.class);
   }
 
-  @Override protected void getAsync(ClientHttpRequestFactory client, String uri) {
-    throw new AssumptionViolatedException("TODO: async rest template has its own interceptor");
-  }
-
   @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
     server.enqueue(new MockResponse());
 
@@ -63,15 +59,15 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(request.getHeader("my-id"));
+
+    takeSpan();
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void redirect() throws Exception { // blind to the implementation of redirects
-    super.redirect();
+  @Override @Ignore("blind to the implementation of redirects")
+  public void redirect() {
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void reportsServerAddress() throws Exception { // doesn't know the remote address
-    super.reportsServerAddress();
+  @Override @Ignore("doesn't know the remote address")
+  public void reportsServerAddress() {
   }
 }

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -15,7 +15,14 @@ import io.vertx.ext.web.RoutingContext;
 import zipkin2.Endpoint;
 
 /**
- * Idea for how to address re-route was from {@code TracingHandler} in https://github.com/opentracing-contrib/java-vertx-web
+ * <h3>Why not rely on {@code context.request().endHandler()} to finish a span?</h3>
+ * <p>There can be only one {@link HttpServerRequest#endHandler(Handler) end handler}. We can't rely
+ * on {@code endHandler()} as a user can override it in their route. If they did, we'd leak an
+ * unfinished span. For this reason, we speculatively use both an end handler and an end header
+ * handler.
+ *
+ * <p>The hint that we need to re-attach the headers handler on re-route came from looking at
+ * {@code TracingHandler} in https://github.com/opentracing-contrib/java-vertx-web
  */
 final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   static final Getter<HttpServerRequest, String> GETTER = new Getter<HttpServerRequest, String>() {
@@ -29,68 +36,84 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   };
 
   final Tracer tracer;
-  final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
+  final HttpServerHandler<HttpServerRequest, HttpServerResponse> serverHandler;
   final TraceContext.Extractor<HttpServerRequest> extractor;
 
   TracingRoutingContextHandler(HttpTracing httpTracing) {
     tracer = httpTracing.tracing().tracer();
-    handler = HttpServerHandler.create(httpTracing, ADAPTER);
+    serverHandler = HttpServerHandler.create(httpTracing, new Adapter());
     extractor = httpTracing.tracing().propagation().extractor(GETTER);
   }
 
   @Override public void handle(RoutingContext context) {
-    boolean newRequest = false;
-    Span span = context.get(Span.class.getName());
-    if (span == null) {
-      newRequest = true;
-      span = handler.handleReceive(extractor, context.request());
-      context.put(Span.class.getName(), span);
+    TracingHandler tracingHandler = context.get(TracingHandler.class.getName());
+    if (tracingHandler != null) { // then we already have a span
+      if (!context.failed()) { // re-routed, so re-attach the end handler
+        context.addHeadersEndHandler(tracingHandler);
+      }
+      context.next();
+      return;
     }
 
-    if (newRequest || !context.failed()) { // re-routed, so re-attach the end handler
-      // Note: In Brave, finishing a client span after headers sent is normal.
-      context.addHeadersEndHandler(finishHttpSpan(context, span));
-    }
+    Span span = serverHandler.handleReceive(extractor, context.request());
+    TracingHandler handler = new TracingHandler(context, span);
+    context.put(TracingHandler.class.getName(), handler);
+
+    // When a route ends a request directly, this will finish the span
+    context.request().endHandler(handler);
+    // When a route overwrites the above endHandler, this will finish the span
+    context.addHeadersEndHandler(handler);
 
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
       context.next();
-    } catch (RuntimeException | Error e) {
-      handler.handleSend(null, e, span);
-      throw e;
     }
   }
 
-  Handler<Void> finishHttpSpan(RoutingContext context, Span span) {
-    return v -> handler.handleSend(context.response(), context.failure(), span);
+  class TracingHandler implements Handler<Void> {
+    final RoutingContext context;
+    final Span span;
+
+    TracingHandler(RoutingContext context, Span span) {
+      this.context = context;
+      this.span = span;
+    }
+
+    @Override public void handle(Void aVoid) {
+      if (!context.request().isEnded()) return;
+      serverHandler.handleSend(context.response(), context.failure(), span);
+    }
   }
 
-  static final HttpServerAdapter<HttpServerRequest, HttpServerResponse> ADAPTER =
-      new HttpServerAdapter<HttpServerRequest, HttpServerResponse>() {
-        @Override public String method(HttpServerRequest request) {
-          return request.method().name();
-        }
+  static final class Adapter extends HttpServerAdapter<HttpServerRequest, HttpServerResponse> {
+    @Override public String method(HttpServerRequest request) {
+      return request.method().name();
+    }
 
-        @Override public String url(HttpServerRequest request) {
-          return request.absoluteURI();
-        }
+    @Override public String path(HttpServerRequest request) {
+      return request.path();
+    }
 
-        @Override public String requestHeader(HttpServerRequest request, String name) {
-          return request.headers().get(name);
-        }
+    @Override public String url(HttpServerRequest request) {
+      return request.absoluteURI();
+    }
 
-        @Override public Integer statusCode(HttpServerResponse response) {
-          return response.getStatusCode();
-        }
+    @Override public String requestHeader(HttpServerRequest request, String name) {
+      return request.headers().get(name);
+    }
 
-        @Override
-        public boolean parseClientAddress(HttpServerRequest req, Endpoint.Builder builder) {
-          if (super.parseClientAddress(req, builder)) return true;
-          SocketAddress addr = req.remoteAddress();
-          if (builder.parseIp(addr.host())) {
-            builder.port(addr.port());
-            return true;
-          }
-          return false;
-        }
-      };
+    @Override public Integer statusCode(HttpServerResponse response) {
+      return response.getStatusCode();
+    }
+
+    @Override
+    public boolean parseClientAddress(HttpServerRequest req, Endpoint.Builder builder) {
+      if (super.parseClientAddress(req, builder)) return true;
+      SocketAddress addr = req.remoteAddress();
+      if (builder.parseIp(addr.host())) {
+        builder.port(addr.port());
+        return true;
+      }
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
This removes some Thread.sleep and other guards from tests by changing
assertions to use a blocking queue. It also improves some of the state
checking, particularly around leaked trace contexts. This uncovered two
where async instrumentation (vertx and netty) redundantly scoped a span.