### PR TITLE
Prioritizes assertion errors over span reporting errors

### DIFF
--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
@@ -35,7 +35,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import zipkin2.Span;
 
 import static brave.grpc.GreeterImpl.HELLO_REQUEST;
@@ -66,13 +70,23 @@ public class ITTracingClientInterceptor {
   @After public void close() throws Exception {
     closeClient(client);
     server.stop();
-    // From brave.http.ITHttp.close
-    assertThat(spans.poll(100, TimeUnit.MILLISECONDS))
-        .withFailMessage("Span remaining in queue. Check for exception or redundant reporting")
-        .isNull();
     Tracing current = Tracing.current();
     if (current != null) current.close();
   }
+
+  // See brave.http.ITHttp for rationale on polling after tests complete
+  @Rule public TestRule assertSpansEmpty = new TestWatcher() {
+    // only check success path to avoid masking assertion errors or exceptions
+    @Override protected void succeeded(Description description) {
+      try {
+        assertThat(spans.poll(100, TimeUnit.MILLISECONDS))
+            .withFailMessage("Span remaining in queue. Check for redundant reporting")
+            .isNull();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+  };
 
   ManagedChannel newClient() {
     return newClient(tracing.newClientInterceptor());

--- a/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/http/ITHttpClient.java
@@ -264,7 +264,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
     checkReportsSpanOnTransportException();
   }
 
-  Span checkReportsSpanOnTransportException() throws InterruptedException {
+  protected Span checkReportsSpanOnTransportException() throws InterruptedException {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
     try {

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
@@ -10,8 +10,10 @@ import javax.ws.rs.client.Entity;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.AssumptionViolatedException;
 import org.junit.Ignore;
 import org.junit.Test;
+import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,11 +77,7 @@ public class ITTracingFeature_Client extends ITHttpAsyncClient<Client> {
   public void reportsServerAddress() {
   }
 
-  @Override @Ignore("doesn't yet close a span on exception")
-  public void reportsSpanOnTransportException() {
-  }
-
-  @Override @Ignore("doesn't yet close a span on exception")
-  public void addsErrorTagOnTransportException() {
+  @Override protected Span checkReportsSpanOnTransportException() throws InterruptedException {
+    throw new AssumptionViolatedException("doesn't yet close a span on exception");
   }
 }

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -2,22 +2,16 @@ package brave.sparkjava;
 
 import brave.http.ITHttpServer;
 import brave.propagation.ExtraFieldPropagation;
+import okhttp3.Response;
 import org.junit.After;
-import org.junit.Ignore;
+import org.junit.AssumptionViolatedException;
 import spark.Spark;
 
 public class ITSparkTracing extends ITHttpServer {
 
-  @Override @Ignore("ignored until https://github.com/perwendel/spark/issues/208")
-  public void async() {
-  }
-
-  @Override @Ignore("ignored until https://github.com/perwendel/spark/issues/208")
-  public void addsErrorTagOnException_async() {
-  }
-
-  @Override @Ignore("ignored until https://github.com/perwendel/spark/issues/208")
-  public void reportsSpanOnException_async() {
+  @Override protected Response get(String path) throws Exception {
+    if (path.toLowerCase().indexOf("async") == -1) return super.get(path);
+    throw new AssumptionViolatedException("ignored until https://github.com/perwendel/spark/issues/208");
   }
 
   @Override protected void init() throws Exception {


### PR DESCRIPTION
Before state checking happened regardless of test success of failure. This caused state errors to mask more meaningful assertions. This uses a test watcher instead, as it can filter to only verify state on successful runs.