### PR TITLE
Adds Jersey 2.x server tracing support

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -9,6 +9,7 @@ Here's a brief overview of what's packaged here:
 * [httpasyncclient](httpasyncclient/README.md) - Tracing decorator for [Apache HttpClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+
 * [httpclient](httpclient/README.md) - Tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+
 * [jaxrs2](jaxrs2/README.md) - Tracing filters and a feature to automatically configure them
+* [jersey-server](jersey-server/README.md) - Tracing application event listener for [Jersey Server](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
 * [kafka-clients](kafka-clients/README.md) - Tracing decorators for Kafka 0.11+ producers and consumers.
 * [mysql](mysql/README.md) - Tracing MySQL statement interceptor
 * [mysql6](mysql6/README.md) - Tracing MySQL v6 statement interceptor
@@ -19,6 +20,7 @@ Here's a brief overview of what's packaged here:
 * [sparkjava](sparkjava/README.md) - Tracing filters and exception handlers for [SparkJava](http://sparkjava.com/)
 * [spring-web](spring-web/README.md) - Tracing interceptor for [Spring RestTemplate](https://spring.io/guides/gs/consuming-rest/)
 * [spring-webmvc](spring-webmvc/README.md) - Tracing interceptor for [Spring WebMVC](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html)
+* [vertx-web](vertx-web/README.md) - Tracing routing context handler for [Vert.x Web](http://vertx.io/docs/vertx-web/js/)
 
 Here are other tools we provide for configuring or testing instrumentation:
 * [http](http/README.md) - `HttpTracing` that allows portable configuration of http instrumentation

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -116,6 +116,12 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-jersey-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-netty-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -119,6 +119,11 @@
       <artifactId>brave-instrumentation-jersey-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/instrumentation/benchmarks/src/main/java/brave/jersey/server/JerseyServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jersey/server/JerseyServerBenchmarks.java
@@ -1,0 +1,139 @@
+package brave.jersey.server;
+
+import brave.Tracing;
+import brave.http.HttpServerBenchmarks;
+import brave.jaxrs2.TracingFeature;
+import brave.propagation.B3Propagation;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.aws.AWSPropagation;
+import brave.sampler.Sampler;
+import io.undertow.servlet.api.DeploymentInfo;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.reporter.Reporter;
+
+import static io.undertow.servlet.Servlets.servlet;
+
+public class JerseyServerBenchmarks extends HttpServerBenchmarks {
+  @Path("")
+  public static class Resource {
+    @GET @Produces("text/plain; charset=UTF-8") public String get() {
+      // noop if not configured
+      ExtraFieldPropagation.set("country-code", "FO");
+      return "hello world";
+    }
+  }
+
+  @ApplicationPath("/nottraced")
+  public static class App extends Application {
+    @Override public Set<Object> getSingletons() {
+      return Collections.singleton(new Resource());
+    }
+  }
+
+  @ApplicationPath("/unsampled")
+  public static class Unsampled extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature
+          .create(
+              Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE).spanReporter(Reporter.NOOP).build()
+          )));
+    }
+  }
+
+  @ApplicationPath("/traced")
+  public static class TracedApp extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
+          Tracing.newBuilder().spanReporter(Reporter.NOOP).build()
+      )));
+    }
+  }
+
+  @ApplicationPath("/tracedextra")
+  public static class TracedExtraApp extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
+          Tracing.newBuilder()
+              .propagationFactory(ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+                  .addField("x-vcap-request-id")
+                  .addPrefixedFields("baggage-", Arrays.asList("country-code", "user-id"))
+                  .build()
+              )
+              .spanReporter(Reporter.NOOP)
+              .build()
+      )));
+    }
+  }
+
+  @ApplicationPath("/traced128")
+  public static class Traced128App extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
+          Tracing.newBuilder().traceId128Bit(true).spanReporter(Reporter.NOOP).build()
+      )));
+    }
+  }
+
+  @ApplicationPath("/tracedaws")
+  public static class TracedAWSApp extends Application {
+    @Override public Set<Object> getSingletons() {
+      return new LinkedHashSet<>(Arrays.asList(new Resource(), TracingFeature.create(
+          Tracing.newBuilder()
+              .propagationFactory(AWSPropagation.FACTORY)
+              .spanReporter(Reporter.NOOP)
+              .build()
+      )));
+    }
+  }
+
+  @Override protected void init(DeploymentInfo servletBuilder) {
+    servletBuilder.addServlets(
+        servlet("Unsampled", ServletContainer.class)
+            .setLoadOnStartup(1)
+            .addInitParam("javax.ws.rs.Application", Unsampled.class.getName())
+            .addMapping("/unsampled"),
+        servlet("Traced", ServletContainer.class)
+            .setLoadOnStartup(1)
+            .addInitParam("javax.ws.rs.Application", TracedApp.class.getName())
+            .addMapping("/traced"),
+        servlet("TracedExtra", ServletContainer.class)
+            .setLoadOnStartup(1)
+            .addInitParam("javax.ws.rs.Application", TracedExtraApp.class.getName())
+            .addMapping("/tracedextra"),
+        servlet("Traced128", ServletContainer.class)
+            .setLoadOnStartup(1)
+            .addInitParam("javax.ws.rs.Application", Traced128App.class.getName())
+            .addMapping("/traced128"),
+        servlet("TracedAWS", ServletContainer.class)
+            .setLoadOnStartup(1)
+            .addInitParam("javax.ws.rs.Application", TracedAWSApp.class.getName())
+            .addMapping("/tracedaws"),
+        servlet("App", ServletContainer.class)
+            .setLoadOnStartup(1)
+            .addInitParam("javax.ws.rs.Application", App.class.getName())
+            .addMapping("/*")
+    );
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + JerseyServerBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/jersey-server/README.md
+++ b/instrumentation/jersey-server/README.md
@@ -1,0 +1,35 @@
+# brave-instrumentation-jersey-server
+This module contains an application event listener for [Jersey Server 2.x](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
+
+`TracingApplicationEventListener` extracts trace state from incoming
+requests. Then, it reports Zipkin how long each request takes, along
+with relevant tags like the http url.
+
+To enable tracing, you need to register the `TracingApplicationEventListener`.
+
+## Configuration
+
+The `TracingApplicationEventListener` requires an instance of
+`HttpTracing` to operate. With that in mind, use [standard means](https://jersey.github.io/apidocs/2.26/jersey/org/glassfish/jersey/server/monitoring/ApplicationEventListener.html)
+to register the listener.
+
+For example, you could wire up like this:
+```java
+public class MyApplication extends Application {
+
+  public Set<Object> getSingletons() {
+    HttpTracing httpTracing = // configure me!
+    return new LinkedHashSet<>(Arrays.asList(
+      TracingApplicationEventListener.create(httpTracing),
+      new MyResource()
+    ));
+  }
+}
+```
+
+The tracing listener should be the only server instrumentation you use.
+For example, do *not* use brave-instrumentation-jaxrs2 also, as this will
+result in duplicate data.
+
+
+

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.15.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-jersey-server</artifactId>
+  <name>Brave Instrumentation: Jersey Server 2.x</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <!-- last version on jax-rs 2.0 per https://jersey.github.io/download.html -->
+    <jersey.version>2.25.1</jersey.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- to test the inject annotations -->
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -12,8 +12,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <!-- last version on jax-rs 2.0 per https://jersey.github.io/download.html -->
-    <jersey.version>2.25.1</jersey.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -23,23 +23,24 @@
       <version>${jersey.version}</version>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.glassfish.jersey.containers</groupId>
-      <artifactId>jersey-container-servlet</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
       <version>${project.version}</version>
     </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- to test the inject annotations -->
     <dependency>
       <groupId>com.google.inject</groupId>
@@ -48,4 +49,24 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jigsaw</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <!-- to prevent class not found in tests -->
+            <configuration>
+              <argLine>--add-modules java.xml.bind</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -1,0 +1,128 @@
+package brave.jersey.server;
+
+import brave.Span;
+import brave.Tracer;
+import brave.http.HttpServerAdapter;
+import brave.http.HttpServerHandler;
+import brave.http.HttpTracing;
+import brave.propagation.Propagation.Getter;
+import brave.propagation.TraceContext;
+import javax.inject.Inject;
+import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.ManagedAsync;
+import org.glassfish.jersey.server.monitoring.ApplicationEvent;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+@Provider
+public final class TracingApplicationEventListener implements ApplicationEventListener {
+  static final Getter<ContainerRequest, String> GETTER = new Getter<ContainerRequest, String>() {
+    @Override public String get(ContainerRequest carrier, String key) {
+      return carrier.getHeaderString(key);
+    }
+
+    @Override public String toString() {
+      return "ContainerRequest::getHeaderString";
+    }
+  };
+
+  final Tracer tracer;
+  final HttpServerHandler<ContainerRequest, ContainerResponse> serverHandler;
+  final TraceContext.Extractor<ContainerRequest> extractor;
+
+  @Inject TracingApplicationEventListener(HttpTracing httpTracing) {
+    tracer = httpTracing.tracing().tracer();
+    serverHandler = HttpServerHandler.create(httpTracing, new Adapter());
+    extractor = httpTracing.tracing().propagation().extractor(GETTER);
+  }
+
+  public static ApplicationEventListener create(HttpTracing httpTracing) {
+    return new TracingApplicationEventListener(httpTracing);
+  }
+
+  @Override public void onEvent(ApplicationEvent event) {
+    // only onRequest is used
+  }
+
+  @Override
+  public RequestEventListener onRequest(RequestEvent requestEvent) {
+    if (requestEvent.getType() == RequestEvent.Type.START) {
+      Span span = serverHandler.handleReceive(extractor, requestEvent.getContainerRequest());
+      return new TracingRequestEventListener(span, tracer.withSpanInScope(span));
+    }
+    return null;
+  }
+
+  static final class Adapter extends HttpServerAdapter<ContainerRequest, ContainerResponse> {
+
+    @Override public String method(ContainerRequest request) {
+      return request.getMethod();
+    }
+
+    @Override public String path(ContainerRequest request) {
+      String result = request.getPath(false);
+      return result.indexOf('/') == 0 ? result : "/" + result;
+    }
+
+    @Override public String url(ContainerRequest request) {
+      return request.getUriInfo().getRequestUri().toString();
+    }
+
+    @Override public String requestHeader(ContainerRequest request, String name) {
+      return request.getHeaderString(name);
+    }
+
+    @Override public Integer statusCode(ContainerResponse response) {
+      return response.getStatus();
+    }
+
+    // NOTE: this currently lacks remote socket parsing eventhough some platforms might work. For
+    // example, org.glassfish.grizzly.http.server.Request.getRemoteAddr or
+    // HttpServletRequest.getRemoteAddr
+  }
+
+  class TracingRequestEventListener implements RequestEventListener {
+    final Span span;
+    Tracer.SpanInScope spanInScope; // only mutated when this is a synchronous method
+
+    TracingRequestEventListener(Span span, Tracer.SpanInScope spanInScope) {
+      this.span = span;
+      this.spanInScope = spanInScope;
+    }
+
+    /**
+     * This keeps the span in scope as long as possible. In synchronous methods, the span remains
+     * in scope for the whole request/response lifecycle. {@linkplain ManagedAsync} requests are the
+     * worst case: the span is only visible until request filters complete.
+     */
+    @Override public void onEvent(RequestEvent event) {
+      // Note: until REQUEST_MATCHED, we don't know metadata such as if the request is async or not
+      switch (event.getType()) {
+        case REQUEST_FILTERED:
+          if (spanInScope == null) break;
+          // Jersey-specific @ManagedAsync stays on the request thread until REQUEST_FILTERED
+          if (event.getUriInfo().getMatchedResourceMethod().isManagedAsyncDeclared()) {
+            spanInScope.close();
+            spanInScope = null;
+          }
+          break;
+        case RESOURCE_METHOD_FINISHED:
+          if (spanInScope == null) break;
+          // A generic async method stays on the request thread until RESOURCE_METHOD_FINISHED
+          if (event.getUriInfo().getMatchedResourceMethod().isSuspendDeclared()) {
+            spanInScope.close();
+            spanInScope = null;
+          }
+          break;
+        case FINISHED:
+          if (spanInScope != null) spanInScope.close();
+          serverHandler.handleSend(event.getContainerResponse(), event.getException(), span);
+          break;
+        default:
+      }
+    }
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -1,0 +1,100 @@
+package brave.jersey.server;
+
+import brave.Tracer;
+import brave.http.HttpTracing;
+import brave.http.ITServletContainer;
+import brave.propagation.ExtraFieldPropagation;
+import java.io.IOException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.server.ManagedAsync;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+
+public class ITTracingApplicationEventListener extends ITServletContainer {
+
+  @Override @Test public void reportsClientAddress() {
+    throw new AssumptionViolatedException("TODO!");
+  }
+
+  /** Tests that the span propagates between under asynchronous callbacks managed by jersey. */
+  @Test public void managedAsync() throws Exception {
+    get("/managedAsync");
+
+    takeSpan();
+  }
+
+  @Override public void init(ServletContextHandler handler) {
+    ResourceConfig config = new ResourceConfig();
+    config.register(new TestResource(httpTracing));
+    config.register(TracingApplicationEventListener.create(httpTracing));
+    handler.addServlet(new ServletHolder(new ServletContainer(config)), "/*");
+  }
+
+  @Path("")
+  public static class TestResource {
+    final Tracer tracer;
+
+    TestResource(HttpTracing httpTracing) {
+      this.tracer = httpTracing.tracing().tracer();
+    }
+
+    @GET
+    @Path("foo")
+    public Response foo() {
+      return Response.ok().build();
+    }
+
+    @GET
+    @Path("extra")
+    public Response extra() {
+      return Response.ok(ExtraFieldPropagation.get(EXTRA_KEY)).build();
+    }
+
+    @GET
+    @Path("badrequest")
+    public Response badrequest() {
+      return Response.status(400).build();
+    }
+
+    @GET
+    @Path("child")
+    public Response child() {
+      tracer.nextSpan().name("child").start().finish();
+      return Response.status(200).build();
+    }
+
+    @GET
+    @Path("async")
+    public void async(@Suspended AsyncResponse response) throws IOException {
+      System.err.println("ASDFASDFASDFASDFASD " + Thread.currentThread());
+      new Thread(() -> response.resume("foo")).start();
+    }
+
+    @GET
+    @Path("managedAsync")
+    @ManagedAsync
+    public void managedAsync(@Suspended AsyncResponse response) throws IOException {
+      response.resume("foo");
+    }
+
+    @GET
+    @Path("exception")
+    public Response disconnect() throws IOException {
+      throw new IOException();
+    }
+
+    @GET
+    @Path("exceptionAsync")
+    public void disconnectAsync(@Suspended AsyncResponse response) throws IOException {
+      new Thread(() -> response.resume(new IOException())).start();
+    }
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
@@ -1,0 +1,36 @@
+package brave.jersey.server;
+
+import brave.jersey.server.TracingApplicationEventListener.Adapter;
+import java.net.URI;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracingApplicationEventListenerAdapterTest {
+  Adapter adapter = new Adapter();
+  @Mock ContainerRequest request;
+
+  @Test public void path_prefixesSlashWhenMissing() {
+    when(request.getPath(false)).thenReturn("bar");
+
+    assertThat(adapter.path(request))
+        .isEqualTo("/bar");
+  }
+
+  @Test public void url_derivedFromExtendedUriInfo() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getRequestUri()).thenReturn(URI.create("http://foo:8080/bar?hello=world"));
+
+    assertThat(adapter.url(request))
+        .isEqualTo("http://foo:8080/bar?hello=world");
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerInjectionTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerInjectionTest.java
@@ -1,0 +1,29 @@
+package brave.jersey.server;
+
+import brave.Tracing;
+import brave.http.HttpTracing;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracingApplicationEventListenerInjectionTest {
+
+  Injector injector = Guice.createInjector(new AbstractModule() {
+    @Override protected void configure() {
+      bind(HttpTracing.class).toInstance(HttpTracing.create(Tracing.newBuilder().build()));
+    }
+  });
+
+  @After public void close() {
+    Tracing.current().close();
+  }
+
+  @Test public void onlyRequiresHttpTracing() {
+    assertThat(injector.getInstance(TracingApplicationEventListener.class))
+        .isNotNull();
+  }
+}

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -24,6 +24,7 @@
     <module>httpasyncclient</module>
     <module>httpclient</module>
     <module>jaxrs2</module>
+    <module>jersey-server</module>
     <module>mysql</module>
     <module>mysql6</module>
     <module>okhttp3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,8 @@
     <assertj.version>3.9.0</assertj.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <javax.annotation-api.version>1.3.1</javax.annotation-api.version>
+    <!-- last version on jax-rs 2.0 per https://jersey.github.io/download.html -->
+    <jersey.version>2.25.1</jersey.version>
     <jmh.version>1.19</jmh.version>
 
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>


### PR DESCRIPTION
This uses an application event listener to do a better job tracing
Jersey servers than what can be done with JAX-RS. For example, the event
listener can handle errors natively, and act more precisely with regards
to jersey-specifics like `ManagedAsync`

Fixes #611