### PR TITLE
Http status is usually known, prefer using a primitive

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
@@ -41,8 +41,20 @@ public abstract class HttpAdapter<Req, Resp> {
    * The HTTP status code or null if unreadable.
    *
    * <p>Conventionally associated with the key "http.status_code"
+   *
+   * @see #statusCodeAsInt(Object)
    */
   @Nullable public abstract Integer statusCode(Resp response);
+
+  /**
+   * Like {@link #statusCode(Object)} except returns a primitive where zero implies absent.
+   *
+   * <p>Using this method usually avoids allocation, so is encouraged when parsing data.
+   */
+  public int statusCodeAsInt(Resp response) {
+    Integer maybeStatus = statusCode(response);
+    return maybeStatus != null ? maybeStatus : 0;
+  }
 
   HttpAdapter() {
   }

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -120,7 +120,7 @@ public class HttpClientHandlerTest {
   }
 
   @Test public void handleReceive_finishedEvenIfAdapterThrows() {
-    when(adapter.statusCode(response)).thenThrow(new RuntimeException());
+    when(adapter.statusCodeAsInt(response)).thenThrow(new RuntimeException());
 
     try {
       handler.handleReceive(response, null, span);

--- a/instrumentation/http/src/test/java/brave/http/HttpParserTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpParserTest.java
@@ -41,7 +41,7 @@ public class HttpParserTest {
   }
 
   @Test public void response_tagsStatusAndErrorOnResponseCode() {
-    when(adapter.statusCode(response)).thenReturn(400);
+    when(adapter.statusCodeAsInt(response)).thenReturn(400);
 
     parser.response(adapter, response, null, customizer);
 
@@ -56,7 +56,7 @@ public class HttpParserTest {
   }
 
   @Test public void response_tagsErrorPrefersExceptionVsResponseCode() {
-    when(adapter.statusCode(response)).thenReturn(400);
+    when(adapter.statusCodeAsInt(response)).thenReturn(400);
 
     parser.response(adapter, response, new RuntimeException("drat"), customizer);
 
@@ -64,7 +64,7 @@ public class HttpParserTest {
   }
 
   @Test public void response_tagsErrorOnExceptionEvenIfStatusOk() {
-    when(adapter.statusCode(response)).thenReturn(200);
+    when(adapter.statusCodeAsInt(response)).thenReturn(200);
 
     parser.response(adapter, response, new RuntimeException("drat"), customizer);
 

--- a/instrumentation/http/src/test/java/brave/http/HttpServerAdapterTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerAdapterTest.java
@@ -16,15 +16,24 @@ import static org.mockito.Mockito.when;
 public class HttpServerAdapterTest {
   @Mock HttpServerAdapter<Object, Object> adapter;
   Object request = new Object();
+  Object response = new Object();
 
   @Before public void callRealMethod() {
     when(adapter.parseClientAddress(eq(request), isA(Endpoint.Builder.class))).thenCallRealMethod();
     when(adapter.path(request)).thenCallRealMethod();
+    when(adapter.statusCodeAsInt(response)).thenCallRealMethod();
   }
 
   @Test public void path_doesntCrashOnNullUrl() {
     assertThat(adapter.path(request))
         .isNull();
+  }
+
+  @Test public void statusCodeAsInt_callsStatusCodeByDefault() {
+    when(adapter.statusCode(response)).thenReturn(400);
+
+    assertThat(adapter.statusCodeAsInt(response))
+        .isEqualTo(400);
   }
 
   @Test public void path_derivedFromUrl() {

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -147,7 +147,7 @@ public class HttpServerHandlerTest {
   }
 
   @Test public void handleSend_finishedEvenIfAdapterThrows() {
-    when(adapter.statusCode(response)).thenThrow(new RuntimeException());
+    when(adapter.statusCodeAsInt(response)).thenThrow(new RuntimeException());
 
     try {
       handler.handleSend(response, null, span);

--- a/instrumentation/http/src/test/java/brave/http/features/TracingDispatcher.java
+++ b/instrumentation/http/src/test/java/brave/http/features/TracingDispatcher.java
@@ -56,6 +56,10 @@ final class TracingDispatcher extends Dispatcher {
     }
 
     @Override public Integer statusCode(MockResponse response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(MockResponse response) {
       return Integer.parseInt(response.getStatus().split(" ")[1]);
     }
   }

--- a/instrumentation/http/src/test/java/brave/http/features/TracingInterceptor.java
+++ b/instrumentation/http/src/test/java/brave/http/features/TracingInterceptor.java
@@ -55,7 +55,11 @@ final class TracingInterceptor implements Interceptor {
       return request.header(name);
     }
 
-    @Override @Nullable public Integer statusCode(Response response) {
+    @Override public Integer statusCode(Response response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(Response response) {
       return response.code();
     }
   }

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -144,6 +144,10 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
     }
 
     @Override public Integer statusCode(HttpResponse response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(HttpResponse response) {
       return response.getStatusLine().getStatusCode();
     }
   }

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/HttpAdapter.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/HttpAdapter.java
@@ -42,6 +42,10 @@ final class HttpAdapter extends brave.http.HttpClientAdapter<HttpRequestWrapper,
   }
 
   @Override public Integer statusCode(HttpResponse response) {
+    return statusCodeAsInt(response);
+  }
+
+  @Override public int statusCodeAsInt(HttpResponse response) {
     return response.getStatusLine().getStatusCode();
   }
 }

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerAdapter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerAdapter.java
@@ -39,6 +39,10 @@ public final class ContainerAdapter
   }
 
   @Override public Integer statusCode(ContainerResponseContext response) {
+    return statusCodeAsInt(response);
+  }
+
+  @Override public int statusCodeAsInt(ContainerResponseContext response) {
     return response.getStatus();
   }
 

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -87,6 +87,10 @@ final class TracingClientFilter implements ClientRequestFilter, ClientResponseFi
     }
 
     @Override public Integer statusCode(ClientResponseContext response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(ClientResponseContext response) {
       return response.getStatus();
     }
   }

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -76,6 +76,10 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     }
 
     @Override public Integer statusCode(ContainerResponse response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(ContainerResponse response) {
       return response.getStatus();
     }
 

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/HttpNettyAdapter.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/HttpNettyAdapter.java
@@ -21,6 +21,10 @@ final class HttpNettyAdapter extends HttpServerAdapter<HttpRequest, HttpResponse
   }
 
   @Override public Integer statusCode(HttpResponse response) {
+    return statusCodeAsInt(response);
+  }
+
+  @Override public int statusCodeAsInt(HttpResponse response) {
     return response.status().code();
   }
 }

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
@@ -98,6 +98,10 @@ public final class TracingInterceptor implements Interceptor {
     }
 
     @Override public Integer statusCode(Response response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(Response response) {
       return response.code();
     }
   }

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -102,6 +102,10 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
     }
 
     @Override public Integer statusCode(HttpServerResponse response) {
+      return statusCodeAsInt(response);
+    }
+
+    @Override public int statusCodeAsInt(HttpServerResponse response) {
       return response.getStatusCode();
     }
 


### PR DESCRIPTION
There are only 2 instrumentations who don't always know the http status.
This changes to avoid boxing where possible, which can reduce memory
pressure. The status 0 is used when unknown.