### PR TITLE
Fix result type of HttpServerHandler.create()

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -33,7 +33,7 @@ import zipkin2.Endpoint;
  */
 public final class HttpClientHandler<Req, Resp> {
 
-  public static <Req, Resp> HttpClientHandler create(HttpTracing httpTracing,
+  public static <Req, Resp> HttpClientHandler<Req, Resp> create(HttpTracing httpTracing,
       HttpClientAdapter<Req, Resp> adapter) {
     return new HttpClientHandler<>(httpTracing, adapter);
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -31,7 +31,7 @@ import zipkin2.Endpoint;
  */
 public final class HttpServerHandler<Req, Resp> {
 
-  public static <Req, Resp> HttpServerHandler create(HttpTracing httpTracing,
+  public static <Req, Resp> HttpServerHandler<Req, Resp> create(HttpTracing httpTracing,
       HttpServerAdapter<Req, Resp> adapter) {
     return new HttpServerHandler<>(
         httpTracing.tracing().tracer(),


### PR DESCRIPTION
Fix result type of `HttpServerHandler.create()` to expose type parameters.