### PR TITLE
Adds Dubbo instrumentation 新年快乐

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -5,6 +5,7 @@ example, the directory "servlet" includes the artifact "brave-instrumentation-se
 
 Here's a brief overview of what's packaged here:
 
+* [dubbo-rpc](dubbo-rpc/README.md) - Tracing filter for RPC providers and consumers in [Dubbo](http://dubbo.io/books/dubbo-user-book-en/)
 * [grpc](grpc/README.md) - Tracing client and server interceptors for [grpc](github.com/grpc/grpc-java)
 * [httpasyncclient](httpasyncclient/README.md) - Tracing decorator for [Apache HttpClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+
 * [httpclient](httpclient/README.md) - Tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+

--- a/instrumentation/dubbo-rpc/README.md
+++ b/instrumentation/dubbo-rpc/README.md
@@ -1,4 +1,4 @@
-# brave-instrumentation-dubbo-grpc
+# brave-instrumentation-dubbo-rpc
 This is a tracing filter for RPC providers and consumers in [Dubbo](http://dubbo.io/books/dubbo-dev-book-en/impls/filter.html)
 
 When used on a consumer, `TracingFilter` adds trace state as attachments

--- a/instrumentation/dubbo-rpc/README.md
+++ b/instrumentation/dubbo-rpc/README.md
@@ -1,0 +1,28 @@
+# brave-instrumentation-dubbo-grpc
+This is a tracing filter for RPC providers and consumers in [Dubbo](http://dubbo.io/books/dubbo-dev-book-en/impls/filter.html)
+
+When used on a consumer, `TracingFilter` adds trace state as attachments
+to outgoing requests. When a provider, it extracts trace state from
+incoming requests. In either case, the filter reports to Zipkin how long
+each request took, along with any error information.
+
+Note: A Dubbo Provider is a server, and a Dubbo Consumer is a client in
+Zipkin terminology.
+
+## Configuration
+
+The filter "tracing" requires an extension of type `Tracing` configured.
+Most typically, this is provided by Spring, so have this in place before
+proceeding. Here's an example in [XML](../../spring-beans/README.md).
+
+Then, configure the filter named "tracing" in your producer or consumer.
+
+Here's an example of using Spring 2.5+ XML
+```xml
+<!-- a provider -->
+<dubbo:service filter="tracing" interface="com.alibaba.dubbo.demo.DemoService" ref="demoService"/>
+
+<!-- or a consumer -->
+<dubbo:reference filter="tracing" id="demoService" check="false" interface="com.alibaba.dubbo.demo.DemoService"/>
+```
+

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.16.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-dubbo-rpc</artifactId>
+  <name>Brave Instrumentation: Dubbo RPC</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+    <dubbo.version>2.6.0</dubbo.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>dubbo</artifactId>
+      <version>${dubbo.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -1,0 +1,153 @@
+package brave.dubbo.rpc;
+
+import brave.Span;
+import brave.Span.Kind;
+import brave.SpanCustomizer;
+import brave.Tracer;
+import brave.Tracing;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.extension.Activate;
+import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+import com.alibaba.dubbo.rpc.Filter;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcContext;
+import com.alibaba.dubbo.rpc.RpcException;
+import com.alibaba.dubbo.rpc.protocol.dubbo.FutureAdapter;
+import com.alibaba.dubbo.rpc.support.RpcUtils;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.Future;
+import zipkin2.Endpoint;
+
+@Activate(group = {Constants.PROVIDER, Constants.CONSUMER}, value = "tracing")
+// http://dubbo.io/books/dubbo-dev-book-en/impls/filter.html
+// public constructor permitted to allow dubbo to instantiate this
+public final class TracingFilter implements Filter {
+
+  Tracer tracer;
+  TraceContext.Extractor<Map<String, String>> extractor;
+  TraceContext.Injector<Map<String, String>> injector;
+
+  /** {@link ExtensionLoader} supplies the tracing implementation, for example by Spring. */
+  public void setTracing(Tracing tracing) {
+    tracer = tracing.tracer();
+    extractor = tracing.propagation().extractor(GETTER);
+    injector = tracing.propagation().injector(SETTER);
+  }
+
+  @Override
+  public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+    if (tracer == null) return invoker.invoke(invocation);
+
+    RpcContext rpcContext = RpcContext.getContext();
+    Kind kind = rpcContext.isProviderSide() ? Kind.SERVER : Kind.CLIENT;
+    final Span span;
+    if (kind.equals(Kind.CLIENT)) {
+      span = tracer.nextSpan();
+      injector.inject(span.context(), invocation.getAttachments());
+    } else {
+      TraceContextOrSamplingFlags extracted = extractor.extract(invocation.getAttachments());
+      span = extracted.context() != null
+          ? tracer.joinSpan(extracted.context())
+          : tracer.nextSpan(extracted);
+    }
+
+    if (!span.isNoop()) {
+      span.kind(kind).start();
+      String service = invoker.getInterface().getSimpleName();
+      String method = RpcUtils.getMethodName(invocation);
+
+      span.kind(kind);
+      span.name(service + "/" + method);
+
+      InetSocketAddress remoteAddress = rpcContext.getRemoteAddress();
+      Endpoint.Builder remoteEndpoint = Endpoint.newBuilder().port(remoteAddress.getPort());
+      if (!remoteEndpoint.parseIp(remoteAddress.getAddress())) {
+        remoteEndpoint.parseIp(remoteAddress.getHostName());
+      }
+      span.remoteEndpoint(remoteEndpoint.build());
+    }
+
+    boolean isOneway = false, deferFinish = false;
+    try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
+      Result result = invoker.invoke(invocation);
+      if (result.hasException()) {
+        onError(result.getException(), span);
+      }
+      isOneway = RpcUtils.isOneway(invoker.getUrl(), invocation);
+      Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
+      if (future instanceof FutureAdapter) {
+        deferFinish = true;
+        ((FutureAdapter) future).getFuture().setCallback(new FinishSpanCallback(span));
+      }
+      return result;
+    } catch (Error | RuntimeException e) {
+      onError(e, span);
+      throw e;
+    } finally {
+      if (isOneway) {
+        span.flush();
+      } else if (!deferFinish) {
+        span.finish();
+      }
+    }
+  }
+
+  static void onError(Throwable error, SpanCustomizer span) {
+    String message = error.getMessage();
+    if (message == null) message = error.getClass().getSimpleName();
+    if (error instanceof RpcException) {
+      span.tag("dubbo.error_code", Integer.toString(((RpcException) error).getCode()));
+    }
+    span.tag("error", message);
+  }
+
+  static final Propagation.Getter<Map<String, String>, String> GETTER =
+      new Propagation.Getter<Map<String, String>, String>() {
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+
+        @Override
+        public String toString() {
+          return "Map::get";
+        }
+      };
+
+  static final Propagation.Setter<Map<String, String>, String> SETTER =
+      new Propagation.Setter<Map<String, String>, String>() {
+        @Override
+        public void put(Map<String, String> carrier, String key, String value) {
+          carrier.put(key, value);
+        }
+
+        @Override
+        public String toString() {
+          return "Map::set";
+        }
+      };
+
+  static final class FinishSpanCallback implements ResponseCallback {
+    final Span span;
+
+    FinishSpanCallback(Span span) {
+      this.span = span;
+    }
+
+    @Override public void done(Object response) {
+      span.finish();
+    }
+
+    @Override public void caught(Throwable exception) {
+      onError(exception, span);
+      span.finish();
+    }
+  }
+}

--- a/instrumentation/dubbo-rpc/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.rpc.Filter
+++ b/instrumentation/dubbo-rpc/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.rpc.Filter
@@ -1,0 +1,1 @@
+tracing=brave.dubbo.rpc.TracingFilter

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/GraterService.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/GraterService.java
@@ -1,0 +1,5 @@
+package brave.dubbo.rpc;
+
+public interface GraterService {
+  String sayHello(String name);
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/GreeterService.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/GreeterService.java
@@ -1,0 +1,5 @@
+package brave.dubbo.rpc;
+
+public interface GreeterService {
+  String sayHello(String name);
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -1,0 +1,63 @@
+package brave.dubbo.rpc;
+
+import brave.Tracing;
+import brave.propagation.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.config.ReferenceConfig;
+import com.alibaba.dubbo.rpc.Filter;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class ITTracingFilter {
+  /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
+  BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+
+  Tracing tracing;
+  TestServer server = new TestServer();
+  ReferenceConfig<GreeterService> client;
+
+  @After public void stop() {
+    if (client != null) client.destroy();
+    server.stop();
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
+  }
+
+  // See brave.http.ITHttp for rationale on polling after tests complete
+  @Rule public TestRule assertSpansEmpty = new TestWatcher() {
+    // only check success path to avoid masking assertion errors or exceptions
+    @Override protected void succeeded(Description description) {
+      try {
+        assertThat(spans.poll(100, TimeUnit.MILLISECONDS))
+            .withFailMessage("Span remaining in queue. Check for redundant reporting")
+            .isNull();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+  };
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .spanReporter(spans::add)
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .sampler(sampler);
+  }
+
+  void setTracing(Tracing tracing) {
+    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+        .getExtension("tracing"))
+        .setTracing(tracing);
+    this.tracing = tracing;
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Producer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Producer.java
@@ -1,0 +1,185 @@
+package brave.dubbo.rpc;
+
+import brave.Tracer;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.Sampler;
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ReferenceConfig;
+import com.alibaba.dubbo.rpc.RpcContext;
+import com.alibaba.dubbo.rpc.RpcException;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class ITTracingFilter_Producer extends ITTracingFilter {
+
+  @Before public void setup() {
+    setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+    server.start();
+
+    client = new ReferenceConfig<>();
+    client.setApplication(new ApplicationConfig("bean-consumer"));
+    client.setFilter("tracing");
+    client.setInterface(GreeterService.class);
+    client.setUrl("dubbo://127.0.0.1:" + server.port() + "?scope=remote&generic=bean");
+  }
+
+  @Test public void propagatesSpan() throws Exception {
+    client.get().sayHello("jorge");
+
+    TraceContext context = server.takeRequest().context();
+    assertThat(context.parentId()).isNull();
+    assertThat(context.sampled()).isTrue();
+
+    spans.take();
+  }
+
+  @Test public void makesChildOfCurrentSpan() throws Exception {
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      client.get().sayHello("jorge");
+    } finally {
+      parent.finish();
+    }
+
+    TraceContext context = server.takeRequest().context();
+    assertThat(context.traceId())
+        .isEqualTo(parent.context().traceId());
+    assertThat(context.parentId())
+        .isEqualTo(parent.context().spanId());
+
+    // we report one local and one client span
+    assertThat(Arrays.asList(spans.take(), spans.take()))
+        .extracting(Span::kind)
+        .containsOnly(null, Span.Kind.CLIENT);
+  }
+
+  /**
+   * This tests that the parent is determined at the time the request was made, not when the request
+   * was executed.
+   */
+  @Test public void usesParentFromInvocationTime() throws Exception {
+    server.enqueueDelay(TimeUnit.SECONDS.toMillis(1));
+
+    brave.Span parent = tracing.tracer().newTrace().name("test").start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(parent)) {
+      RpcContext.getContext().asyncCall(new Callable<String>() {
+        public String call() throws Exception {
+          return client.get().sayHello("jorge");
+        }
+      });
+      RpcContext.getContext().asyncCall(new Callable<String>() {
+        public String call() throws Exception {
+          return client.get().sayHello("romeo");
+        }
+      });
+    } finally {
+      parent.finish();
+    }
+
+    brave.Span otherSpan = tracing.tracer().newTrace().name("test2").start();
+    try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(otherSpan)) {
+      for (int i = 0; i < 2; i++) {
+        TraceContext context = server.takeRequest().context();
+        assertThat(context.traceId())
+            .isEqualTo(parent.context().traceId());
+        assertThat(context.parentId())
+            .isEqualTo(parent.context().spanId());
+      }
+    } finally {
+      otherSpan.finish();
+    }
+
+    // Check we reported 2 local spans and 2 client spans
+    assertThat(Arrays.asList(spans.take(), spans.take(), spans.take(), spans.take()))
+        .extracting(Span::kind)
+        .containsOnly(null, Span.Kind.CLIENT);
+  }
+
+  /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
+  @Test public void propagates_sampledFalse() throws Exception {
+    setTracing(tracingBuilder(Sampler.NEVER_SAMPLE).build());
+
+    client.get().sayHello("jorge");
+    TraceContextOrSamplingFlags extracted = server.takeRequest();
+    assertThat(extracted.sampled()).isFalse();
+
+    // @After will check that nothing is reported
+  }
+
+  @Test public void reportsClientKindToZipkin() throws Exception {
+    client.get().sayHello("jorge");
+
+    Span span = spans.take();
+    assertThat(span.kind())
+        .isEqualTo(Span.Kind.CLIENT);
+  }
+
+  @Test public void defaultSpanNameIsMethodName() throws Exception {
+    client.get().sayHello("jorge");
+
+    Span span = spans.take();
+    assertThat(span.name())
+        .isEqualTo("greeterservice/sayhello");
+  }
+
+  @Test public void onTransportException_addsErrorTag() throws Exception {
+    server.stop();
+
+    try {
+      client.get().sayHello("jorge");
+      failBecauseExceptionWasNotThrown(RpcException.class);
+    } catch (RpcException e) {
+    }
+
+    Span span = spans.take();
+    assertThat(span.tags().get("error"))
+        .contains("RemotingException");
+  }
+
+  @Test public void onTransportException_addsErrorTag_async() throws Exception {
+    server.stop();
+
+    RpcContext.getContext().asyncCall(() -> client.get().sayHello("romeo"));
+
+    Span span = spans.take();
+    assertThat(span.tags().get("error"))
+        .contains("RemotingException");
+  }
+
+  @Test public void flushesSpanOneWay() throws Exception {
+    RpcContext.getContext().asyncCall(() -> {
+      client.get().sayHello("romeo");
+    });
+
+    Span span = spans.take();
+    assertThat(span.duration())
+        .isNull();
+  }
+
+  @Test public void addsErrorTag_onUnimplemented() throws Exception {
+    server.stop();
+    server = new TestServer();
+    server.service.setRef((method, parameterTypes, args) -> args);
+    server.start();
+
+    try {
+      client.get().sayHello("jorge");
+      failBecauseExceptionWasNotThrown(RpcException.class);
+    } catch (RpcException e) {
+    }
+
+    Span span = spans.take();
+    assertThat(span.tags().get("dubbo.error_code"))
+        .isEqualTo("1");
+    assertThat(span.tags().get("error"))
+        .contains("Not found exported service");
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/PickUnusedPort.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/PickUnusedPort.java
@@ -1,0 +1,17 @@
+package brave.dubbo.rpc;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+class PickUnusedPort {
+  static int get() {
+    try {
+      ServerSocket serverSocket = new ServerSocket(0);
+      int port = serverSocket.getLocalPort();
+      serverSocket.close();
+      return port;
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
@@ -1,0 +1,64 @@
+package brave.dubbo.rpc;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ProtocolConfig;
+import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.config.ServiceConfig;
+import com.alibaba.dubbo.rpc.RpcContext;
+import com.alibaba.dubbo.rpc.service.GenericService;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+class TestServer {
+  BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
+  BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
+  TraceContext.Extractor<Map<String, String>> extractor =
+      B3Propagation.B3_STRING.extractor(TracingFilter.GETTER);
+  ServiceConfig<GenericService> service;
+
+  TestServer() {
+    service = new ServiceConfig<>();
+    service.setApplication(new ApplicationConfig("bean-provider"));
+    service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
+    service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
+    service.setInterface(GreeterService.class.getName());
+    service.setRef((method, parameterTypes, args) -> {
+      Long delay = delayQueue.poll();
+      if (delay != null) {
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new AssertionError("interrupted sleeping " + delay);
+        }
+      }
+      requestQueue.add(extractor.extract(RpcContext.getContext().getAttachments()));
+
+      return args[0];
+    });
+  }
+
+  void start() {
+    service.export();
+  }
+
+  void stop() {
+    service.unexport();
+  }
+
+  int port() {
+    return service.getProtocol().getPort();
+  }
+
+  TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
+    return requestQueue.take();
+  }
+
+  void enqueueDelay(long millis) {
+    this.delayQueue.add(millis);
+  }
+}

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -20,6 +20,7 @@
     <module>benchmarks</module>
     <module>http</module>
     <module>http-tests</module>
+    <module>dubbo-rpc</module>
     <module>grpc</module>
     <module>httpasyncclient</module>
     <module>httpclient</module>


### PR DESCRIPTION
This is a Tracing filter for RPC providers and consumers in [Dubbo](http://dubbo.io/books/dubbo-dev-book-en/impls/filter.html)

When used on a consumer, `TracingFilter` adds trace state as attachments
to outgoing requests. When a provider, it extracts trace state from
incoming requests. In either case, the filter reports to Zipkin how long
each request took, along with any error information.

Note: A Dubbo Provider is a server, and a Dubbo Consumer is a client in
Zipkin terminology.

<img width="675" alt="screen shot 2018-02-25 at 3 12 09 pm" src="https://user-images.githubusercontent.com/64215/36643246-8feeb396-1a83-11e8-8937-68d44eeaad8a.png">

## Configuration

The filter "tracing" requires an extension of type `Tracing` configured.
Most typically, this is provided by Spring, so have this in place before
proceeding. Here's an example in [XML](https://github.com/openzipkin/brave/tree/master/spring-beans/README.md).

Then, configure the filter named "tracing" in your producer or consumer.

Here's an example of using Spring 2.5+ XML
```xml
<!-- a provider -->
<dubbo:service filter="tracing" interface="com.alibaba.dubbo.demo.DemoService" ref="demoService"/>

<!-- or a consumer -->
<dubbo:reference filter="tracing" id="demoService" check="false" interface="com.alibaba.dubbo.demo.DemoService"/>
```


谢谢 @blacklau @sdcuike and @jessyZu who wrote dubbo filters for Brave in the past

Fixes #504