### PR TITLE
Guards against malformed trace extraction without allocating exceptions

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
@@ -48,4 +48,27 @@ public class B3PropagationTest extends PropagationTest<String> {
     assertThat(result)
         .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
+
+  @Test public void extractTraceContext_malformed() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124"); // ok
+    map.put("X-B3-SpanId",  "48485a3953bb6124"); // ok
+    map.put("X-B3-ParentSpanId", "-"); // not ok
+
+    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void extractTraceContext_malformed_sampled() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("X-B3-TraceId", "-"); // not ok
+    map.put("X-B3-Sampled", "1"); // ok
+
+    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
 }

--- a/brave/src/main/java/brave/internal/HexCodec.java
+++ b/brave/src/main/java/brave/internal/HexCodec.java
@@ -22,16 +22,24 @@ public final class HexCodec {
    * specified index.
    */
   public static long lowerHexToUnsignedLong(CharSequence lowerHex, int index) {
+    int endIndex = Math.min(index + 16, lowerHex.length());
+    long result = lenientLowerHexToUnsignedLong(lowerHex, index, endIndex);
+    if (result == 0) throw isntLowerHexLong(lowerHex);
+    return result;
+  }
+
+  /** Like {@link #lowerHexToUnsignedLong(CharSequence, int)}, but returns zero on invalid input */
+  public static long lenientLowerHexToUnsignedLong(CharSequence lowerHex, int index, int endIndex) {
     long result = 0;
-    for (int endIndex = Math.min(index + 16, lowerHex.length()); index < endIndex; index++) {
-      char c = lowerHex.charAt(index);
+    while (index < endIndex) {
+      char c = lowerHex.charAt(index++);
       result <<= 4;
       if (c >= '0' && c <= '9') {
         result |= c - '0';
       } else if (c >= 'a' && c <= 'f') {
         result |= c - 'a' + 10;
       } else {
-        throw isntLowerHexLong(lowerHex);
+        return 0;
       }
     }
     return result;

--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -1,7 +1,10 @@
 package brave.propagation;
 
 import brave.internal.Nullable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 import static brave.internal.HexCodec.writeHexLong;
 
 /**
@@ -10,6 +13,7 @@ import static brave.internal.HexCodec.writeHexLong;
  */
 //@Immutable
 public final class TraceIdContext extends SamplingFlags {
+  static final Logger LOG = Logger.getLogger(TraceIdContext.class.getName());
 
   public static Builder newBuilder() {
     return new Builder();
@@ -53,10 +57,7 @@ public final class TraceIdContext extends SamplingFlags {
     return new String(result);
   }
 
-  public static final class Builder {
-    long traceIdHigh, traceId;
-    int flags = 0; // bit field for sampled and debug
-
+  public static final class Builder extends InternalBuilder {
     Builder(TraceIdContext context) { // no external implementations
       traceIdHigh = context.traceIdHigh;
       traceId = context.traceId;
@@ -76,36 +77,30 @@ public final class TraceIdContext extends SamplingFlags {
     }
 
     /** @see TraceIdContext#sampled() */
-    public Builder sampled(boolean sampled) {
-      flags |= FLAG_SAMPLED_SET;
-      if (sampled) {
-        flags |= FLAG_SAMPLED;
-      } else {
-        flags &= ~FLAG_SAMPLED;
-      }
+    @Override public Builder sampled(boolean sampled) {
+      super.sampled(sampled);
       return this;
     }
 
     /** @see TraceIdContext#sampled() */
-    public Builder sampled(@Nullable Boolean sampled) {
-      if (sampled != null) return sampled((boolean) sampled);
-      flags &= ~FLAG_SAMPLED_SET;
+    @Override public Builder sampled(@Nullable Boolean sampled) {
+      super.sampled(sampled);
       return this;
     }
 
     /** @see TraceIdContext#debug() */
-    public Builder debug(boolean debug) {
-      if (debug) {
-        flags |= FLAG_DEBUG;
-      } else {
-        flags &= ~FLAG_DEBUG;
-      }
+    @Override public Builder debug(boolean debug) {
+      super.debug(debug);
       return this;
     }
 
     public final TraceIdContext build() {
       if (traceId == 0L) throw new IllegalStateException("Missing: traceId");
       return new TraceIdContext(this);
+    }
+
+    @Override Logger logger() {
+      return LOG;
     }
 
     Builder() { // no external implementations
@@ -137,5 +132,105 @@ public final class TraceIdContext extends SamplingFlags {
     h *= 1000003;
     h ^= (int) ((traceId >>> 32) ^ traceId);
     return h;
+  }
+
+  static abstract class InternalBuilder {
+    abstract Logger logger();
+
+    long traceIdHigh, traceId;
+    int flags = 0; // bit field for sampled and debug
+
+    /**
+     * Returns true when {@link TraceContext#traceId()} and potentially also {@link TraceContext#traceIdHigh()}
+     * were parsed from the input. This assumes the input is valid, an up to 32 character lower-hex
+     * string.
+     *
+     * <p>Returns boolean, not this, for conditional, exception free parsing:
+     *
+     * <p>Example use:
+     * <pre>{@code
+     * // Attempt to parse the trace ID or break out if unsuccessful for any reason
+     * String traceIdString = getter.get(carrier, key);
+     * if (!builder.parseTraceId(traceIdString, propagation.traceIdKey)) {
+     *   return TraceContextOrSamplingFlags.EMPTY;
+     * }
+     * }</pre>
+     *
+     * @param traceIdString the 1-32 character lowerhex string
+     * @param key the name of the propagation field representing the trace ID; only using in logging
+     * @return false if the input is null or malformed
+     */
+    // temporarily package protected until we figure out if this is reusable enough to expose
+    final boolean parseTraceId(String traceIdString, Object key) {
+      if (isNull(key, traceIdString)) return false;
+      int length = traceIdString.length();
+      if (invalidIdLength(key, length, 32)) return false;
+
+      // left-most characters, if any, are the high bits
+      int traceIdIndex = Math.max(0, length - 16);
+      if (traceIdIndex > 0) {
+        traceIdHigh = lenientLowerHexToUnsignedLong(traceIdString, 0, traceIdIndex);
+        if (traceIdHigh == 0) {
+          maybeLogNotLowerHex(key, traceIdString);
+          return false;
+        }
+      }
+
+      // right-most up to 16 characters are the low bits
+      traceId = lenientLowerHexToUnsignedLong(traceIdString, traceIdIndex, length);
+      if (traceId == 0) {
+        maybeLogNotLowerHex(key, traceIdString);
+        return false;
+      }
+      return true;
+    }
+
+    boolean invalidIdLength(Object key, int length, int max) {
+      if (length > 1 && length <= max) return false;
+      Logger log = logger();
+      if (log.isLoggable(Level.FINE)) {
+        log.fine(key + " should be a 1 to " + max + " character lower-hex string with no prefix");
+      }
+      return true;
+    }
+
+    boolean isNull(Object key, String maybeNull) {
+      if (maybeNull != null) return false;
+      Logger log = logger();
+      if (log.isLoggable(Level.FINE)) log.fine(key + " was null");
+      return true;
+    }
+
+    void maybeLogNotLowerHex(Object key, String notLowerHex) {
+      Logger log = logger();
+      if (log.isLoggable(Level.FINE)) {
+        log.fine(key + ": " + notLowerHex + " is not a lower-hex string");
+      }
+    }
+
+    InternalBuilder sampled(boolean sampled) {
+      flags |= FLAG_SAMPLED_SET;
+      if (sampled) {
+        flags |= FLAG_SAMPLED;
+      } else {
+        flags &= ~FLAG_SAMPLED;
+      }
+      return this;
+    }
+
+    InternalBuilder sampled(@Nullable Boolean sampled) {
+      if (sampled != null) return sampled((boolean) sampled);
+      flags &= ~FLAG_SAMPLED_SET;
+      return this;
+    }
+
+    InternalBuilder debug(boolean debug) {
+      if (debug) {
+        flags |= FLAG_DEBUG;
+      } else {
+        flags &= ~FLAG_DEBUG;
+      }
+      return this;
+    }
   }
 }

--- a/brave/src/test/java/brave/internal/HexCodecTest.java
+++ b/brave/src/test/java/brave/internal/HexCodecTest.java
@@ -19,8 +19,13 @@ public class HexCodecTest {
   @Test
   public void lowerHexToUnsignedLongTest() {
     assertThat(lowerHexToUnsignedLong("ffffffffffffffff")).isEqualTo(-1);
-    assertThat(lowerHexToUnsignedLong("0")).isEqualTo(0);
     assertThat(lowerHexToUnsignedLong(Long.toHexString(Long.MAX_VALUE))).isEqualTo(Long.MAX_VALUE);
+
+    try {
+      lowerHexToUnsignedLong("0"); // invalid
+      failBecauseExceptionWasNotThrown(NumberFormatException.class);
+    } catch (NumberFormatException e) {
+    }
 
     try {
       lowerHexToUnsignedLong("fffffffffffffffffffffffffffffffff"); // too long

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -1,8 +1,11 @@
 package brave.propagation;
 
+import brave.internal.HexCodec;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,7 +83,7 @@ public class TraceContextTest {
         .debug(true)
         .build();
 
-    TraceContext objects =  base.toBuilder()
+    TraceContext objects = base.toBuilder()
         .parentId(Long.valueOf(1L))
         .sampled(Boolean.TRUE)
         .debug(Boolean.TRUE)
@@ -95,11 +98,167 @@ public class TraceContextTest {
         .parentId(null)
         .build();
 
-    TraceContext zeros =  base.toBuilder()
+    TraceContext zeros = base.toBuilder()
         .parentId(0L)
         .build();
 
     assertThat(nulls)
         .isEqualToComparingFieldByField(zeros);
+  }
+
+  @Test public void parseSpanId() {
+    String spanIdString = "48485a3953bb6124";
+
+    TestBuilder builder = parseGoodSpanId(spanIdString);
+
+    assertThat(HexCodec.toLowerHex(builder.spanId))
+        .isEqualTo(spanIdString);
+  }
+
+  @Test public void parseSpanId_short64bit() {
+    String spanIdString = "6124";
+
+    TestBuilder builder = parseGoodSpanId(spanIdString);
+
+    assertThat(HexCodec.toLowerHex(builder.spanId))
+        .isEqualTo("000000000000" + spanIdString);
+  }
+
+  /**
+   * Span ID is a required parameter, so it cannot be null empty malformed or other nonsense.
+   *
+   * <p>Notably, this shouldn't throw exception or allocate anything
+   */
+  @Test public void parseSpanId_malformedReturnsFalse() {
+    parseBadSpanId("463acL$c9f6413ad");
+    parseBadSpanId("holy 💩");
+    parseBadSpanId("-");
+    parseBadSpanId("");
+    parseBadSpanId(null);
+
+    assertThat(messages).containsExactly(
+        "span-id: 463acL$c9f6413ad is not a lower-hex string",
+        "span-id: holy 💩 is not a lower-hex string",
+        "span-id should be a 1 to 16 character lower-hex string with no prefix",
+        "span-id should be a 1 to 16 character lower-hex string with no prefix",
+        "span-id was null"
+    );
+  }
+
+  @Test public void parseSpanId_whenFineDisabledNoLogs() {
+    logger.setLevel(Level.INFO);
+
+    parseBadSpanId("463acL$c9f6413ad");
+    parseBadSpanId("holy 💩");
+    parseBadSpanId("-");
+    parseBadSpanId("");
+    parseBadSpanId(null);
+
+    assertThat(messages).isEmpty();
+  }
+
+  TestBuilder parseGoodSpanId(String spanIdString) {
+    TestBuilder builder = new TestBuilder();
+    Propagation.Getter<String, String> getter = (c, k) -> c;
+    assertThat(builder.parseSpanId(getter, spanIdString, "span-id"))
+        .isTrue();
+    return builder;
+  }
+
+  void parseBadSpanId(String spanIdString) {
+    TestBuilder builder = new TestBuilder();
+    Propagation.Getter<String, String> getter = (c, k) -> c;
+    assertThat(builder.parseSpanId(getter, spanIdString, "span-id"))
+        .isFalse();
+    assertThat(builder.spanId).isZero();
+  }
+
+  @Test public void parseParentId() {
+    String parentIdString = "48485a3953bb6124";
+
+    TestBuilder builder = parseGoodParentId(parentIdString);
+
+    assertThat(HexCodec.toLowerHex(builder.parentId))
+        .isEqualTo(parentIdString);
+  }
+
+  @Test public void parseParentId_null_is_ok() {
+    TestBuilder builder = parseGoodParentId(null);
+
+    assertThat(builder.parentId).isZero();
+  }
+
+  @Test public void parseParentId_short64bit() {
+    String parentIdString = "6124";
+
+    TestBuilder builder = parseGoodParentId(parentIdString);
+
+    assertThat(HexCodec.toLowerHex(builder.parentId))
+        .isEqualTo("000000000000" + parentIdString);
+  }
+
+  /**
+   * Parent Span ID is an optional parameter, but it cannot be empty malformed or other nonsense.
+   *
+   * <p>Notably, this shouldn't throw exception or allocate anything
+   */
+  @Test public void parseParentId_malformedReturnsFalse() {
+    parseBadParentId("463acL$c9f6413ad");
+    parseBadParentId("holy 💩");
+    parseBadParentId("-");
+    parseBadParentId("");
+
+    assertThat(messages).containsExactly(
+        "parent-id: 463acL$c9f6413ad is not a lower-hex string",
+        "parent-id: holy 💩 is not a lower-hex string",
+        "parent-id should be a 1 to 16 character lower-hex string with no prefix",
+        "parent-id should be a 1 to 16 character lower-hex string with no prefix"
+    );
+  }
+
+  @Test public void parseParentId_whenFineDisabledNoLogs() {
+    logger.setLevel(Level.INFO);
+
+    parseBadParentId("463acL$c9f6413ad");
+    parseBadParentId("holy 💩");
+    parseBadParentId("-");
+    parseBadParentId("");
+
+    assertThat(messages).isEmpty();
+  }
+
+  TestBuilder parseGoodParentId(String parentIdString) {
+    TestBuilder builder = new TestBuilder();
+    Propagation.Getter<String, String> getter = (c, k) -> c;
+    assertThat(builder.parseParentId(getter, parentIdString, "parent-id"))
+        .isTrue();
+    return builder;
+  }
+
+  void parseBadParentId(String parentIdString) {
+    TestBuilder builder = new TestBuilder();
+    Propagation.Getter<String, String> getter = (c, k) -> c;
+    assertThat(builder.parseParentId(getter, parentIdString, "parent-id"))
+        .isFalse();
+    assertThat(builder.parentId).isZero();
+  }
+
+  List<String> messages = new ArrayList<>();
+
+  Logger logger = new Logger("", null) {
+    {
+      setLevel(Level.ALL);
+    }
+
+    @Override public void log(Level level, String msg) {
+      assertThat(level).isEqualTo(Level.FINE);
+      messages.add(msg);
+    }
+  };
+
+  class TestBuilder extends TraceContext.InternalBuilder {
+    @Override Logger logger() {
+      return logger;
+    }
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceIdContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceIdContextTest.java
@@ -1,5 +1,10 @@
 package brave.propagation;
 
+import brave.internal.HexCodec;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,12 +38,121 @@ public class TraceIdContextTest {
         .debug(true)
         .build();
 
-    TraceIdContext objects =  context.toBuilder()
+    TraceIdContext objects = context.toBuilder()
         .sampled(Boolean.TRUE)
         .debug(Boolean.TRUE)
         .build();
 
     assertThat(primitives)
         .isEqualToComparingFieldByField(objects);
+  }
+
+  @Test public void parseTraceId_128bit() {
+    String traceIdString = "463ac35c9f6413ad48485a3953bb6124";
+
+    TestBuilder builder = parseGoodTraceID(traceIdString);
+
+    assertThat(HexCodec.toLowerHex(builder.traceIdHigh))
+        .isEqualTo("463ac35c9f6413ad");
+    assertThat(HexCodec.toLowerHex(builder.traceId))
+        .isEqualTo("48485a3953bb6124");
+  }
+
+  @Test public void parseTraceId_64bit() {
+    String traceIdString = "48485a3953bb6124";
+
+    TestBuilder builder = parseGoodTraceID(traceIdString);
+
+    assertThat(builder.traceIdHigh).isZero();
+    assertThat(HexCodec.toLowerHex(builder.traceId))
+        .isEqualTo(traceIdString);
+  }
+
+  @Test public void parseTraceId_short128bit() {
+    String traceIdString = "3ac35c9f6413ad48485a3953bb6124";
+
+    TestBuilder builder = parseGoodTraceID(traceIdString);
+
+    assertThat(HexCodec.toLowerHex(builder.traceIdHigh))
+        .isEqualTo("003ac35c9f6413ad");
+    assertThat(HexCodec.toLowerHex(builder.traceId))
+        .isEqualTo("48485a3953bb6124");
+  }
+
+  @Test public void parseTraceId_short64bit() {
+    String traceIdString = "6124";
+
+    TestBuilder builder = parseGoodTraceID(traceIdString);
+
+    assertThat(builder.traceIdHigh).isZero();
+    assertThat(HexCodec.toLowerHex(builder.traceId))
+        .isEqualTo("000000000000" + traceIdString);
+  }
+
+  /**
+   * Trace ID is a required parameter, so it cannot be null empty malformed or other nonsense.
+   *
+   * <p>Notably, this shouldn't throw exception or allocate anything
+   */
+  @Test public void parseTraceId_malformedReturnsFalse() {
+    parseBadTraceId("463acL$c9f6413ad48485a3953bb6124");
+    parseBadTraceId("holy 💩");
+    parseBadTraceId("-");
+    parseBadTraceId("");
+    parseBadTraceId(null);
+
+    assertThat(messages).containsExactly(
+        "trace-id: 463acL$c9f6413ad48485a3953bb6124 is not a lower-hex string",
+        "trace-id: holy 💩 is not a lower-hex string",
+        "trace-id should be a 1 to 32 character lower-hex string with no prefix",
+        "trace-id should be a 1 to 32 character lower-hex string with no prefix",
+        "trace-id was null"
+    );
+  }
+
+  @Test public void parseTraceId_whenFineDisabledNoLogs() {
+    logger.setLevel(Level.INFO);
+
+    parseBadTraceId("463acL$c9f6413ad48485a3953bb6124");
+    parseBadTraceId("holy 💩");
+    parseBadTraceId("-");
+    parseBadTraceId("");
+    parseBadTraceId(null);
+
+    assertThat(messages).isEmpty();
+  }
+
+  TestBuilder parseGoodTraceID(String traceIdString) {
+    TestBuilder builder = new TestBuilder();
+    assertThat(builder.parseTraceId(traceIdString, "trace-id"))
+        .isTrue();
+    return builder;
+  }
+
+  void parseBadTraceId(String traceIdString) {
+    TestBuilder builder = new TestBuilder();
+    assertThat(builder.parseTraceId(traceIdString, "trace-id"))
+        .isFalse();
+    assertThat(builder.traceIdHigh).isZero();
+    assertThat(builder.traceId).isZero();
+  }
+
+  List<String> messages = new ArrayList<>();
+
+  Logger logger = new Logger("", null) {
+    {
+      setLevel(Level.ALL);
+    }
+
+    @Override public void log(Level level, String msg) {
+      assertThat(level).isEqualTo(Level.FINE);
+      messages.add(msg);
+    }
+  };
+
+  class TestBuilder extends TraceIdContext.InternalBuilder {
+    @Override Logger logger() {
+      return logger;
+    }
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/internal/PropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/PropagationBenchmarks.java
@@ -80,6 +80,15 @@ public class PropagationBenchmarks {
     }
   };
 
+  static final Map<String, String> incomingMalformed = new LinkedHashMap<String, String>() {
+    {
+      put("x-amzn-trace-id", "Sampled=-;Parent=463ac35%Af6413ad;Root=1-??-abc!#%0123456789123456");
+      put("X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124"); // ok
+      put("X-B3-SpanId",  "48485a3953bb6124"); // ok
+      put("X-B3-ParentSpanId", "-"); // not ok
+    }
+  };
+
   static final Map<String, String> nothingIncoming = Collections.emptyMap();
 
   Map<String, String> carrier = new LinkedHashMap<>();
@@ -122,6 +131,14 @@ public class PropagationBenchmarks {
 
   @Benchmark public TraceContextOrSamplingFlags extract_aws_nothing() {
     return awsExtractor.extract(nothingIncoming);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_b3_malformed() {
+    return b3Extractor.extract(incomingMalformed);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_aws_malformed() {
+    return awsExtractor.extract(incomingMalformed);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract_awsExtraB3_nothing() {

--- a/propagation/aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
+++ b/propagation/aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
@@ -35,12 +35,12 @@ public class AWSPropagationTest {
       .extra(AWSPropagation.DEFAULT_EXTRA)
       .build();
 
-  @Test public void traceId() throws Exception {
+  @Test public void traceId() {
     assertThat(AWSPropagation.traceId(sampledContext))
         .isEqualTo("1-67891233-abcdef012345678912345678");
   }
 
-  @Test public void traceIdWhenPassThrough() throws Exception {
+  @Test public void traceIdWhenPassThrough() {
     carrier.put("x-amzn-trace-id", "Robot=Hello;Self=1-582113d1-1e48b74b3603af8479078ed6;  " +
         "Root=1-58211399-36d228ad5d99923122bbe354;  " +
         "TotalTimeSoFar=112ms;CalledFrom=Foo");
@@ -51,7 +51,7 @@ public class AWSPropagationTest {
         .isEqualTo("1-58211399-36d228ad5d99923122bbe354");
   }
 
-  @Test public void traceIdWhenPassThrough_nullOnTruncated() throws Exception {
+  @Test public void traceIdWhenPassThrough_nullOnTruncated() {
     carrier.put("x-amzn-trace-id", "Root=1-58211399-36d228ad5d99923122bbe3");
 
     TraceContext context = contextWithPassThrough();
@@ -81,13 +81,13 @@ public class AWSPropagationTest {
         .build();
   }
 
-  @Test public void traceId_null_if_not_aws() throws Exception {
+  @Test public void traceId_null_if_not_aws() {
     TraceContext notAWS = sampledContext.toBuilder().extra(Collections.emptyList()).build();
     assertThat(AWSPropagation.traceId(notAWS))
         .isNull();
   }
 
-  @Test public void currentTraceId() throws Exception {
+  @Test public void currentTraceId() {
     try (Tracing t = Tracing.newBuilder().propagationFactory(AWSPropagation.FACTORY).build();
          CurrentTraceContext.Scope scope = t.currentTraceContext().newScope(sampledContext)) {
       assertThat(AWSPropagation.currentTraceId())
@@ -95,32 +95,32 @@ public class AWSPropagationTest {
     }
   }
 
-  @Test public void currentTraceId_null_if_no_current_context() throws Exception {
+  @Test public void currentTraceId_null_if_no_current_context() {
     try (Tracing t = Tracing.newBuilder().propagationFactory(AWSPropagation.FACTORY).build()) {
       assertThat(AWSPropagation.currentTraceId())
           .isNull();
     }
   }
 
-  @Test public void currentTraceId_null_if_nothing_current() throws Exception {
+  @Test public void currentTraceId_null_if_nothing_current() {
     assertThat(AWSPropagation.currentTraceId())
         .isNull();
   }
 
-  @Test public void inject() throws Exception {
+  @Test public void inject() {
     injector.inject(sampledContext, carrier);
 
     assertThat(carrier).containsEntry("x-amzn-trace-id", sampledTraceId);
   }
 
-  @Test public void extract() throws Exception {
+  @Test public void extract() {
     carrier.put("x-amzn-trace-id", sampledTraceId);
 
     assertThat(extractor.extract(carrier).context())
         .isEqualTo(sampledContext);
   }
 
-  @Test public void extract_containsMarker() throws Exception {
+  @Test public void extract_containsMarker() {
     carrier.put("x-amzn-trace-id", sampledTraceId);
 
     TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
@@ -129,18 +129,18 @@ public class AWSPropagationTest {
   }
 
   /** If invoked extract, a 128-bit trace ID will be created, compatible with AWS format */
-  @Test public void extract_fail_containsMarker() throws Exception {
+  @Test public void extract_fail_containsMarker() {
     TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
     assertThat(extracted.extra())
         .containsExactly(AWSPropagation.MARKER);
   }
 
-  @Test public void extract_static() throws Exception {
+  @Test public void extract_static() {
     assertThat(AWSPropagation.extract(sampledTraceId).context())
         .isEqualTo(sampledContext);
   }
 
-  @Test public void extractDifferentOrder() throws Exception {
+  @Test public void extractDifferentOrder() {
     carrier.put("x-amzn-trace-id",
         "Sampled=1;Parent=463ac35c9f6413ad;Root=1-67891233-abcdef012345678912345678");
 
@@ -148,7 +148,7 @@ public class AWSPropagationTest {
         .isEqualTo(sampledContext);
   }
 
-  @Test public void extract_noParent() throws Exception {
+  @Test public void extract_noParent() {
     carrier.put("x-amzn-trace-id", "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1");
 
     assertThat(extractor.extract(carrier).traceIdContext())
@@ -159,14 +159,14 @@ public class AWSPropagationTest {
             .build());
   }
 
-  @Test public void extract_noSamplingDecision() throws Exception {
+  @Test public void extract_noSamplingDecision() {
     carrier.put("x-amzn-trace-id", sampledTraceId.replace("Sampled=1", "Sampled=?"));
 
     assertThat(extractor.extract(carrier).context())
         .isEqualTo(sampledContext.toBuilder().sampled(null).build());
   }
 
-  @Test public void extract_sampledFalse() throws Exception {
+  @Test public void extract_sampledFalse() {
     carrier.put("x-amzn-trace-id", sampledTraceId.replace("Sampled=1", "Sampled=0"));
 
     assertThat(extractor.extract(carrier).context())
@@ -175,7 +175,7 @@ public class AWSPropagationTest {
 
   /** Shows we skip whitespace and extra fields like self or custom ones */
   // https://aws.amazon.com/blogs/aws/application-performance-percentiles-and-request-tracing-for-aws-application-load-balancer/
-  @Test public void extract_skipsSelfField() throws Exception {
+  @Test public void extract_skipsSelfField() {
     // TODO: check with AWS if it is valid to have arbitrary fields in front of standard ones.
     // we currently permit them
     carrier.put("x-amzn-trace-id", "Robot=Hello;Self=1-582113d1-1e48b74b3603af8479078ed6;  " +
@@ -193,7 +193,7 @@ public class AWSPropagationTest {
         .contains(new StringBuilder(";Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo"));
   }
 
-  @Test public void toString_fields() throws Exception {
+  @Test public void toString_fields() {
     AWSPropagation.Extra extra = new AWSPropagation.Extra();
     extra.fields = ";Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo";
 
@@ -201,14 +201,14 @@ public class AWSPropagationTest {
         .hasToString("AWSPropagation{fields=" + extra.fields + "}");
   }
 
-  @Test public void toString_none() throws Exception {
+  @Test public void toString_none() {
     AWSPropagation.Extra extra = new AWSPropagation.Extra();
 
     assertThat(extra)
         .hasToString("AWSPropagation{}");
   }
 
-  @Test public void injectExtraStuff() throws Exception {
+  @Test public void injectExtraStuff() {
     AWSPropagation.Extra extra = new AWSPropagation.Extra();
     extra.fields = ";Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo";
     TraceContext extraContext = sampledContext.toBuilder().extra(Arrays.asList(extra)).build();
@@ -219,36 +219,51 @@ public class AWSPropagationTest {
             "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1;Robot=Hello;TotalTimeSoFar=112ms;CalledFrom=Foo");
   }
 
-  @Test public void extract_skipsLaterVersion() throws Exception {
+  @Test public void extract_skipsLaterVersion() {
     carrier.put("x-amzn-trace-id", "Root=2-58211399-36d228ad5d99923122bbe354");
 
     assertThat(extractor.extract(carrier).samplingFlags())
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
-  @Test public void extract_skipsTruncatedId() throws Exception {
+  @Test public void extract_skipsTruncatedId() {
     carrier.put("x-amzn-trace-id", "Root=1-58211399-36d228ad5d99923122bbe35");
 
     assertThat(extractor.extract(carrier).samplingFlags())
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
-  @Test public void extract_skips_leadingEquals() throws Exception {
+  @Test public void extract_skips_leadingEquals() {
     carrier.put("x-amzn-trace-id", "=Root=1-58211399-36d228ad5d99923122bbe354");
 
     assertThat(extractor.extract(carrier).samplingFlags())
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
-  @Test public void extract_skips_doubleEquals() throws Exception {
+  @Test public void extract_skips_doubleEquals() {
     carrier.put("x-amzn-trace-id", "Root==1-58211399-36d228ad5d99923122bbe354");
 
     assertThat(extractor.extract(carrier).samplingFlags())
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
-  @Test public void extract_skips_noEquals() throws Exception {
+  @Test public void extract_skips_noEquals() {
     carrier.put("x-amzn-trace-id", "1-58211399-36d228ad5d99923122bbe354");
+
+    assertThat(extractor.extract(carrier).samplingFlags())
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void extract_skips_malformed() {
+    carrier.put("x-amzn-trace-id",
+        "Sampled=-;Parent=463ac35%Af6413ad;Root=1-??-abc!#%0123456789123456");
+
+    assertThat(extractor.extract(carrier).samplingFlags())
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void extract_skips_really_malformed() {
+    carrier.put("x-amzn-trace-id", "holy 💩");
 
     assertThat(extractor.extract(carrier).samplingFlags())
         .isEqualTo(SamplingFlags.EMPTY);


### PR DESCRIPTION
This makes sure when we parse bad data, we can log, but don't do things
expensive in the mean time. This does so by inlining parsing.

Fixes #625