### PR TITLE
WIP on BOM

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -1,18 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-pom-parent</artifactId>
     <version>4.16.3-SNAPSHOT</version>
-    <relativePath>../../brave-parent</relativePath>
+    <relativePath>../brave-parent</relativePath>
   </parent>
 
-  <artifactId>brave-instrumentation-bom</artifactId>
-  <name>Brave Instrumentation BOM</name>
-  <description>Bill Of Materials POM for all Brave instrumentation artifacts</description>
+  <artifactId>brave-bom</artifactId>
+  <name>Brave BOM</name>
+  <description>Bill Of Materials POM for all Brave artifacts</description>
   <packaging>pom</packaging>
 
   <properties>
@@ -21,6 +21,26 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-context-log4j2</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-context-log4j12</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-context-sld4j</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>brave-instrumentation-dubbo-rpc</artifactId>
@@ -109,6 +129,16 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>brave-instrumentation-vertx-web</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-propagation-aws</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-spring-beans</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>

--- a/brave-parent/pom.xml
+++ b/brave-parent/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.zipkin.brave</groupId>
+  <artifactId>brave-pom-parent</artifactId>
+  <version>4.16.3-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Brave (parent)</name>
+  <description>
+    Java implementation of Dapper (http://research.google.com/pubs/pub36356.html) compatible with Zipkin (https://github.com/twitter/zipkin/).
+  </description>
+  <url>https://github.com/openzipkin/brave</url>
+
+  <organization>
+    <name>OpenZipkin</name>
+    <url>http://zipkin.io/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <url>https://github.com/openzipkin/brave</url>
+    <connection>scm:git:https://github.com/openzipkin/brave.git</connection>
+    <developerConnection>scm:git:https://github.com/openzipkin/brave.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <!-- Developer section is needed for Maven Central, but doesn't need to include each person -->
+  <developers>
+    <developer>
+      <id>openzipkin</id>
+      <name>OpenZipkin Gitter</name>
+      <url>https://gitter.im/openzipkin/zipkin</url>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <repository>
+      <id>bintray</id>
+      <url>https://api.bintray.com/maven/openzipkin/maven/brave/;publish=1</url>
+    </repository>
+    <snapshotRepository>
+      <id>jfrog-snapshots</id>
+      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <issueManagement>
+    <system>Github</system>
+    <url>https://github.com/openzipkin/brave/issues</url>
+  </issueManagement>
+
+</project>

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>brave-instrumentation-bom</artifactId>
+        <artifactId>brave-bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/instrumentation/bom/pom.xml
+++ b/instrumentation/bom/pom.xml
@@ -2,10 +2,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>io.zipkin.brave</groupId>
-    <artifactId>brave-parent</artifactId>
+    <artifactId>brave-pom-parent</artifactId>
     <version>4.16.3-SNAPSHOT</version>
+    <relativePath>../../brave-parent</relativePath>
   </parent>
 
   <artifactId>brave-instrumentation-bom</artifactId>

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -17,7 +17,6 @@
   </properties>
 
   <modules>
-    <module>bom</module>
     <module>benchmarks</module>
     <module>http</module>
     <module>http-tests</module>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
 
   <modules>
     <module>brave</module>
+    <module>brave-parent</module>
     <module>brave-tests</module>
     <module>context</module>
     <module>instrumentation</module>
@@ -128,7 +129,7 @@
   </issueManagement>
 
   <dependencyManagement>
-  	<dependencies>
+    <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>brave</artifactId>
@@ -313,7 +314,7 @@
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.0.1</version>
         </dependency>
-  	</dependencies>
+    </dependencies>
   </dependencyManagement>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
 
   <modules>
     <module>brave</module>
+    <module>brave-bom</module>
     <module>brave-parent</module>
     <module>brave-tests</module>
     <module>context</module>


### PR DESCRIPTION
- added a separate pom with licenses etc. (central will require this info from any module) called `parent-pom` (didn't have an idea for a better name)
- the `brave-instrumentation` BOM doesn't use the `parent`, but the  `parent-pom`, that's why it doesn't inherit any concrete library versions such as spring etc.

IMO what's missing is a `brave-all-bom` that contains all brave projects with their versions