### PR TITLE
Adds Java 9 module names with manifest entries

### DIFF
--- a/brave-tests/pom.xml
+++ b/brave-tests/pom.xml
@@ -34,6 +34,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.test</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
         <executions>

--- a/brave-tests/src/main/java/brave/test/propagation/CurrentTraceContextTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/CurrentTraceContextTest.java
@@ -1,6 +1,8 @@
-package brave.propagation;
+package brave.test.propagation;
 
 import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -17,8 +19,8 @@ public abstract class CurrentTraceContextTest {
   protected abstract CurrentTraceContext newCurrentTraceContext();
 
   protected final CurrentTraceContext currentTraceContext;
-  final TraceContext context;
-  final TraceContext context2;
+  protected final TraceContext context;
+  protected final TraceContext context2;
 
   protected CurrentTraceContextTest() {
     currentTraceContext = newCurrentTraceContext();

--- a/brave-tests/src/main/java/brave/test/propagation/PropagationSetterTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/PropagationSetterTest.java
@@ -1,5 +1,6 @@
-package brave.propagation;
+package brave.test.propagation;
 
+import brave.propagation.Propagation;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
@@ -1,7 +1,11 @@
-package brave.propagation;
+package brave.test.propagation;
 
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
+import brave.propagation.Propagation;
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -10,18 +14,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class PropagationTest<K> {
 
-  abstract Propagation<K> propagation();
+  protected abstract Propagation<K> propagation();
 
-  abstract void inject(Map<K, String> map, @Nullable String traceId, @Nullable String parentId,
-      @Nullable String spanId, @Nullable Boolean sampled, @Nullable Boolean debug);
+  protected abstract void inject(Map<K, String> map, @Nullable String traceId,
+      @Nullable String parentId, @Nullable String spanId, @Nullable Boolean sampled,
+      @Nullable Boolean debug);
 
   /**
    * There's currently no standard API to just inject sampling flags, as IDs are intended to be
    * propagated.
    */
-  abstract void inject(Map<K, String> carrier, SamplingFlags samplingFlags);
+  protected abstract void inject(Map<K, String> carrier, SamplingFlags samplingFlags);
 
-  Map<K, String> map = new LinkedHashMap<>();
+  protected Map<K, String> map = new LinkedHashMap<>();
   MapEntry<K> mapEntry = new MapEntry<>();
 
   TraceContext rootSpan = TraceContext.newBuilder()
@@ -112,9 +117,11 @@ public abstract class PropagationTest<K> {
     assertThat(map).isEqualTo(injected);
   }
 
-  static class MapEntry<K> implements
+  protected static class MapEntry<K> implements
       Propagation.Getter<Map<K, String>, K>,
       Propagation.Setter<Map<K, String>, K> {
+    public MapEntry(){
+    }
 
     @Override public void put(Map<K, String> carrier, K key, String value) {
       carrier.put(key, value);

--- a/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
@@ -1,17 +1,18 @@
 package brave.propagation;
 
 import brave.internal.Nullable;
+import brave.test.propagation.PropagationTest;
 import java.util.Map;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class B3PropagationTest extends PropagationTest<String> {
-  @Override Propagation<String> propagation() {
+  @Override protected Propagation<String> propagation() {
     return Propagation.B3_STRING;
   }
 
-  @Override void inject(Map<String, String> map, @Nullable String traceId,
+  @Override protected void inject(Map<String, String> map, @Nullable String traceId,
       @Nullable String parentId, @Nullable String spanId, @Nullable Boolean sampled,
       @Nullable Boolean debug) {
     if (traceId != null) map.put("X-B3-TraceId", traceId);
@@ -21,7 +22,7 @@ public class B3PropagationTest extends PropagationTest<String> {
     if (debug != null) map.put("X-B3-Flags", debug ? "1" : "0");
   }
 
-  @Override void inject(Map<String, String> carrier, SamplingFlags flags) {
+  @Override protected void inject(Map<String, String> carrier, SamplingFlags flags) {
     if (flags.debug()) {
       carrier.put("X-B3-Flags", "1");
     } else if (flags.sampled() != null) {
@@ -52,7 +53,7 @@ public class B3PropagationTest extends PropagationTest<String> {
   @Test public void extractTraceContext_malformed() {
     MapEntry mapEntry = new MapEntry();
     map.put("X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124"); // ok
-    map.put("X-B3-SpanId",  "48485a3953bb6124"); // ok
+    map.put("X-B3-SpanId", "48485a3953bb6124"); // ok
     map.put("X-B3-ParentSpanId", "-"); // not ok
 
     SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();

--- a/brave-tests/src/test/java/brave/propagation/DefaultCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/DefaultCurrentTraceContextTest.java
@@ -1,5 +1,6 @@
 package brave.propagation;
 
+import brave.test.propagation.CurrentTraceContextTest;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
@@ -1,5 +1,6 @@
 package brave.propagation;
 
+import brave.test.propagation.CurrentTraceContextTest;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/brave-tests/src/test/java/brave/propagation/URLConnectionSetterTest.java
+++ b/brave-tests/src/test/java/brave/propagation/URLConnectionSetterTest.java
@@ -1,5 +1,6 @@
 package brave.propagation;
 
+import brave.test.propagation.PropagationSetterTest;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLConnection;

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -128,6 +128,9 @@
             <configuration>
               <archive>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave</Automatic-Module-Name>
+                </manifestEntries>
               </archive>
             </configuration>
             <goals>

--- a/context/log4j12/pom.xml
+++ b/context/log4j12/pom.xml
@@ -23,6 +23,20 @@
         <version>1.2.17</version>
         <scope>provided</scope>
     </dependency>
-
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.context.log4j12</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
@@ -3,7 +3,7 @@ package brave.context.log4j12;
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.CurrentTraceContextTest;
+import brave.test.propagation.CurrentTraceContextTest;
 import brave.propagation.TraceContext;
 import org.apache.log4j.MDC;
 import org.junit.ComparisonFailure;

--- a/context/log4j2/pom.xml
+++ b/context/log4j2/pom.xml
@@ -24,4 +24,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.context.log4j2</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -3,7 +3,7 @@ package brave.context.log4j2;
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.CurrentTraceContextTest;
+import brave.test.propagation.CurrentTraceContextTest;
 import brave.propagation.TraceContext;
 import org.apache.logging.log4j.ThreadContext;
 

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -30,4 +30,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.context.slf4j</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -3,7 +3,7 @@ package brave.context.slf4j;
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.CurrentTraceContextTest;
+import brave.test.propagation.CurrentTraceContextTest;
 import brave.propagation.TraceContext;
 import org.slf4j.MDC;
 

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -17,18 +17,7 @@
     <spring.version>${spring4.version}</spring.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-bom</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
+  <!-- can't import brave-bom due to build-support/go-offline.sh -->
   <dependencies>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
@@ -51,15 +40,18 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-httpclient</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-httpasyncclient</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -69,6 +61,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-spring-web</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -78,6 +71,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-okhttp3</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
@@ -87,6 +81,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-jaxrs2</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>net.ltgt.jaxrs</groupId>
@@ -97,11 +92,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-servlet</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-spring-webmvc</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -111,6 +108,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-sparkjava</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sparkjava</groupId>
@@ -121,6 +119,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-jersey-server</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
@@ -131,6 +130,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-netty-codec-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -166,6 +166,7 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-propagation-aws</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -28,4 +28,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.dubbo.rpc</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -56,6 +56,16 @@
     </extensions>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.grpc</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>

--- a/instrumentation/grpc/src/test/java/brave/grpc/MetadataSetterTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/MetadataSetterTest.java
@@ -1,7 +1,7 @@
 package brave.grpc;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import io.grpc.Metadata;
 import java.util.Collections;
 

--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -40,8 +40,19 @@
     </dependency>
   </dependencies>
 
+
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.test.http</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -1,6 +1,7 @@
-package brave.http;
+package brave.test.http;
 
 import brave.Tracing;
+import brave.http.HttpTracing;
 import brave.internal.HexCodec;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -1,4 +1,4 @@
-package brave.http;
+package brave.test.http;
 
 import brave.Tracer;
 import brave.Tracer.SpanInScope;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -1,8 +1,12 @@
-package brave.http;
+package brave.test.http;
 
 import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
+import brave.http.HttpAdapter;
+import brave.http.HttpClientParser;
+import brave.http.HttpRuleSampler;
+import brave.http.HttpTracing;
 import brave.internal.HexCodec;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.SamplingFlags;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -1,6 +1,10 @@
-package brave.http;
+package brave.test.http;
 
 import brave.SpanCustomizer;
+import brave.http.HttpAdapter;
+import brave.http.HttpRuleSampler;
+import brave.http.HttpServerParser;
+import brave.http.HttpTracing;
 import brave.propagation.ExtraFieldPropagation;
 import brave.sampler.Sampler;
 import java.io.IOException;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -1,6 +1,7 @@
-package brave.http;
+package brave.test.http;
 
 import brave.Tracer;
+import brave.http.HttpTracing;
 import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.util.EnumSet;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
@@ -1,4 +1,4 @@
-package brave.http;
+package brave.test.http;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
@@ -1,4 +1,4 @@
-package brave.http;
+package brave.test.http;
 
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.After;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ServletContainer.java
@@ -1,4 +1,4 @@
-package brave.http;
+package brave.test.http;
 
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
@@ -9,6 +11,12 @@
 
   <artifactId>brave-instrumentation-http</artifactId>
   <name>Brave Instrumentation: Http Adapters</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -29,9 +37,18 @@
     </dependency>
   </dependencies>
 
-  <properties>
-    <main.basedir>${project.basedir}/../..</main.basedir>
-    <main.java.version>1.6</main.java.version>
-    <main.signature.artifact>java16</main.signature.artifact>
-  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.http</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -36,4 +36,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.httpasyncclient</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpMessageSetterTest.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpMessageSetterTest.java
@@ -1,7 +1,7 @@
 package brave.httpasyncclient;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.http.HttpMessage;

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -1,6 +1,6 @@
 package brave.httpasyncclient;
 
-import brave.http.ITHttpAsyncClient;
+import brave.test.http.ITHttpAsyncClient;
 import java.io.IOException;
 import java.net.URI;
 import okhttp3.mockwebserver.MockResponse;

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -43,4 +43,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.httpclient</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/HttpRequestWrapperSetterTest.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/HttpRequestWrapperSetterTest.java
@@ -1,7 +1,7 @@
 package brave.httpclient;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.http.client.methods.HttpRequestWrapper;

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -1,6 +1,6 @@
 package brave.httpclient;
 
-import brave.http.ITHttpClient;
+import brave.test.http.ITHttpClient;
 import java.io.IOException;
 import java.net.URI;
 import okhttp3.mockwebserver.MockResponse;

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -69,8 +69,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.jaxrs2</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Client.java
@@ -1,6 +1,6 @@
 package brave.jaxrs2;
 
-import brave.http.ITHttpAsyncClient;
+import brave.test.http.ITHttpAsyncClient;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingFeature_Container.java
@@ -4,7 +4,7 @@ import brave.Tracer;
 import brave.http.HttpAdapter;
 import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
-import brave.http.ITServletContainer;
+import brave.test.http.ITServletContainer;
 import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.lang.reflect.Method;

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/MultivaluedMapSetterTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/MultivaluedMapSetterTest.java
@@ -1,7 +1,7 @@
 package brave.jaxrs2;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import javax.ws.rs.core.AbstractMultivaluedMap;

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/ITDeclarativeSampling.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/features/sampling/ITDeclarativeSampling.java
@@ -4,7 +4,7 @@ import brave.Tracing;
 import brave.http.HttpAdapter;
 import brave.http.HttpSampler;
 import brave.http.HttpTracing;
-import brave.http.ServletContainer;
+import brave.test.http.ServletContainer;
 import brave.jaxrs2.TracingBootstrap;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -48,6 +48,21 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.jersey.server</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>jigsaw</id>

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -2,7 +2,7 @@ package brave.jersey.server;
 
 import brave.Tracer;
 import brave.http.HttpTracing;
-import brave.http.ITServletContainer;
+import brave.test.http.ITServletContainer;
 import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import javax.ws.rs.GET;

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -50,6 +50,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.kafka.clients</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
         <executions>

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/HeadersSetterTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/HeadersSetterTest.java
@@ -1,7 +1,7 @@
 package brave.kafka.clients;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.kafka.common.header.Headers;

--- a/instrumentation/mysql/pom.xml
+++ b/instrumentation/mysql/pom.xml
@@ -24,4 +24,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.mysql</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/mysql6/pom.xml
+++ b/instrumentation/mysql6/pom.xml
@@ -22,4 +22,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.mysql6</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/netty-codec-http/pom.xml
+++ b/instrumentation/netty-codec-http/pom.xml
@@ -33,4 +33,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.netty.http</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
@@ -1,6 +1,6 @@
 package brave.netty.http;
 
-import brave.http.ITHttpServer;
+import brave.test.http.ITHttpServer;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/TestHandler.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/TestHandler.java
@@ -15,7 +15,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import java.io.IOException;
 
-import static brave.http.ITHttp.EXTRA_KEY;
+import static brave.test.http.ITHttp.EXTRA_KEY;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -36,4 +36,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.okhttp3</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -1,7 +1,7 @@
 package brave.okhttp3;
 
 import brave.Tracer;
-import brave.http.ITHttpAsyncClient;
+import brave.test.http.ITHttpAsyncClient;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -1,6 +1,6 @@
 package brave.okhttp3;
 
-import brave.http.ITHttpAsyncClient;
+import brave.test.http.ITHttpAsyncClient;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/RequestBuilderSetterTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/RequestBuilderSetterTest.java
@@ -1,7 +1,7 @@
 package brave.okhttp3;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import okhttp3.Request;
 
 import static brave.okhttp3.TracingInterceptor.SETTER;

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -38,4 +38,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.p6spy</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -36,8 +36,19 @@
     </dependency>
   </dependencies>
 
+
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.servlet</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>

--- a/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
+++ b/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
@@ -1,8 +1,8 @@
 package brave.servlet25;
 
-import brave.http.ITServlet25Container;
 import brave.servlet.TracingFilter;
 import javax.servlet.Filter;
+import brave.test.http.ITServlet25Container;
 
 public class ITTracingFilter extends ITServlet25Container {
 

--- a/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
@@ -1,6 +1,6 @@
 package brave.servlet;
 
-import brave.http.ITServlet3Container;
+import brave.test.http.ITServlet3Container;
 import javax.servlet.Filter;
 
 public class ITTracingFilter extends ITServlet3Container {

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -35,8 +35,19 @@
     </dependency>
   </dependencies>
 
+
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.sparkjava</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -1,6 +1,6 @@
 package brave.sparkjava;
 
-import brave.http.ITHttpServer;
+import brave.test.http.ITHttpServer;
 import brave.propagation.ExtraFieldPropagation;
 import okhttp3.Response;
 import org.junit.After;

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -1,55 +1,75 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<groupId>io.zipkin.brave</groupId>
-		<artifactId>brave-instrumentation-parent</artifactId>
-		<version>4.17.1-SNAPSHOT</version>
-	</parent>
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>4.17.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-	<artifactId>brave-instrumentation-spring-rabbit</artifactId>
-	<name>Brave Instrumentation: Spring RabbitMQ</name>
+  <artifactId>brave-instrumentation-spring-rabbit</artifactId>
+  <name>Brave Instrumentation: Spring RabbitMQ</name>
 
-	<properties>
-		<main.basedir>${project.basedir}/../..</main.basedir>
-		<main.java.version>1.6</main.java.version>
-		<main.signature.artifact>java16</main.signature.artifact>
-		<spring-rabbit.version>1.7.6.RELEASE</spring-rabbit.version>
-	</properties>
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+    <spring-rabbit.version>1.7.6.RELEASE</spring-rabbit.version>
+  </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.amqp</groupId>
-			<artifactId>spring-rabbit</artifactId>
-			<version>${spring-rabbit.version}</version>
-			<scope>provided</scope>
-		</dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit</artifactId>
+      <version>${spring-rabbit.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<!-- spring-aop is required for the consumer side instrumentation point -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aop</artifactId>
-			<version>${spring4.version}</version>
-			<scope>provided</scope>
-		</dependency>
+    <!-- spring-aop is required for the consumer side instrumentation point -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <version>${spring4.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>brave-tests</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-			<version>${spring4.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.amqp</groupId>
-			<artifactId>spring-rabbit-junit</artifactId>
-			<version>${spring-rabbit.version}</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring4.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit-junit</artifactId>
+      <version>${spring-rabbit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.spring.rabbit</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -61,6 +61,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.spring.web</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
       </plugin>

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -1,7 +1,7 @@
 package brave.spring.web3;
 
-import brave.http.ITHttpClient;
 import brave.spring.web.TracingClientHttpRequestInterceptor;
+import brave.test.http.ITHttpClient;
 import java.util.Arrays;
 import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/HttpHeadersSetterTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/HttpHeadersSetterTest.java
@@ -1,7 +1,7 @@
 package brave.spring.web;
 
 import brave.propagation.Propagation;
-import brave.propagation.PropagationSetterTest;
+import brave.test.propagation.PropagationSetterTest;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.http.HttpHeaders;

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -1,6 +1,6 @@
 package brave.spring.web;
 
-import brave.http.ITHttpAsyncClient;
+import brave.test.http.ITHttpAsyncClient;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -1,6 +1,6 @@
 package brave.spring.web;
 
-import brave.http.ITHttpClient;
+import brave.test.http.ITHttpClient;
 import java.util.Arrays;
 import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -42,6 +42,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.spring.webmvc</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
       </plugin>

--- a/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc25/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc25/ITTracingHandlerInterceptor.java
@@ -2,8 +2,8 @@ package brave.spring.webmvc25;
 
 import brave.Tracer;
 import brave.http.HttpTracing;
-import brave.http.ITServletContainer;
 import brave.spring.webmvc.TracingHandlerInterceptor;
+import brave.test.http.ITServletContainer;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.servlet.ServletContextHandler;

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingAsyncHandlerInterceptor.java
@@ -2,7 +2,7 @@ package brave.spring.webmvc;
 
 import brave.Tracer;
 import brave.http.HttpTracing;
-import brave.http.ITServletContainer;
+import brave.test.http.ITServletContainer;
 import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.util.concurrent.Callable;

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITTracingHandlerInterceptor.java
@@ -2,7 +2,7 @@ package brave.spring.webmvc;
 
 import brave.Tracer;
 import brave.http.HttpTracing;
-import brave.http.ITServletContainer;
+import brave.test.http.ITServletContainer;
 import brave.propagation.ExtraFieldPropagation;
 import java.io.IOException;
 import java.util.concurrent.Callable;

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -44,6 +44,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.vertx.web</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
         <executions>

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -3,7 +3,7 @@ package brave.vertx.web;
 import brave.SpanCustomizer;
 import brave.http.HttpAdapter;
 import brave.http.HttpServerParser;
-import brave.http.ITHttpServer;
+import brave.test.http.ITHttpServer;
 import brave.propagation.ExtraFieldPropagation;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;

--- a/propagation/aws/pom.xml
+++ b/propagation/aws/pom.xml
@@ -15,4 +15,19 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
   </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.propagation.aws</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -49,4 +49,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.spring.beans</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -17,18 +17,6 @@
     <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-bom</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -37,10 +25,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-reporter-spring-beans</artifactId>
+      <version>${zipkin-reporter.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
This is the easy way out of getting module names stable and mapped to
our entrypoint packages. I've only done this for the highly re-used
jars.

See square/okhttp#3743
thx @yschimke