### PR TITLE
Adds SpringRabbitTracing.Builder.remoteServiceName

### DIFF
--- a/instrumentation/spring-rabbit/README.md
+++ b/instrumentation/spring-rabbit/README.md
@@ -16,7 +16,9 @@ public Tracing tracing() {
 
 @Bean
 public SpringRabbitTracing springRabbitTracing(Tracing tracing) {
-  return SpringRabbitTracing.create(tracing);
+  return SpringRabbitTracing.newBuilder(tracing)
+                            .remoteServiceName("my-mq-service")
+                            .build();
 }
 ```
 

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
@@ -3,12 +3,14 @@ package brave.spring.rabbit;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
+import brave.internal.Nullable;
 import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext.Injector;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import zipkin2.Endpoint;
 
 /**
  * MessagePostProcessor to be used with the {@link RabbitTemplate#setBeforePublishPostProcessors
@@ -29,14 +31,21 @@ final class TracingMessagePostProcessor implements MessagePostProcessor {
 
   final Injector<MessageProperties> injector;
   final Tracer tracer;
+  @Nullable final String remoteServiceName;
 
-  TracingMessagePostProcessor(Tracing tracing) {
+  TracingMessagePostProcessor(Tracing tracing, @Nullable String remoteServiceName) {
     this.injector = tracing.propagation().injector(SETTER);
     this.tracer = tracing.tracer();
+    this.remoteServiceName = remoteServiceName;
   }
 
   @Override public Message postProcessMessage(Message message) {
-    Span span = tracer.nextSpan().kind(Span.Kind.PRODUCER).start();
+    Span span = tracer.nextSpan().kind(Span.Kind.PRODUCER).name("publish").start();
+    if (!span.isNoop()) {
+      if (remoteServiceName != null) {
+        span.remoteEndpoint(Endpoint.newBuilder().serviceName(remoteServiceName).build());
+      }
+    }
     injector.inject(span.context(), message.getMessageProperties());
     span.finish();
     return message;

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
@@ -95,7 +95,7 @@ public class ITSpringRabbitTracing {
         .flatExtracting(s -> s.tags().entrySet())
         .containsOnly(
             entry("rabbit.exchange", "test-exchange"),
-            entry("rabbit.routing.key", "test.binding"),
+            entry("rabbit.routing_key", "test.binding"),
             entry("rabbit.queue", "test-queue")
         );
 
@@ -105,7 +105,8 @@ public class ITSpringRabbitTracing {
         .isEmpty();
   }
 
-  @Test public void rabbit_listener_method_name_used_as_span_name() throws Exception {
+  // We will revisit this eventually, but these names mostly match the method names
+  @Test public void method_names_as_span_names() throws Exception {
     testFixture.produceMessage();
     testFixture.awaitMessageConsumed();
 
@@ -113,7 +114,7 @@ public class ITSpringRabbitTracing {
 
     assertThat(testFixture.consumerSpans)
         .extracting(Span::name)
-        .containsExactly("test-queue", "on-message");
+        .containsExactly("next-message", "on-message");
   }
 
   @Configuration

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
@@ -19,18 +19,16 @@ public class TracingMessagePostProcessorTest {
   List<Span> reportedSpans = new ArrayList<>();
   TracingMessagePostProcessor tracingMessagePostProcessor;
 
-  @Before
-  public void setupTracing() {
+  @Before public void setupTracing() {
     reportedSpans.clear();
     Tracing tracing = Tracing.newBuilder()
         .sampler(Sampler.ALWAYS_SAMPLE)
         .spanReporter(reportedSpans::add)
         .build();
-    tracingMessagePostProcessor = new TracingMessagePostProcessor(tracing);
+    tracingMessagePostProcessor = new TracingMessagePostProcessor(tracing, "my-exchange");
   }
 
-  @Test
-  public void should_add_b3_headers_to_message() throws Exception {
+  @Test public void should_add_b3_headers_to_message() {
     Message message = MessageBuilder.withBody(new byte[] {}).build();
     Message postProcessMessage = tracingMessagePostProcessor.postProcessMessage(message);
 
@@ -40,11 +38,18 @@ public class TracingMessagePostProcessorTest {
     assertThat(headerKeys).containsAll(expectedHeaders);
   }
 
-  @Test
-  public void should_report_span() throws Exception {
+  @Test public void should_report_span() {
     Message message = MessageBuilder.withBody(new byte[] {}).build();
     tracingMessagePostProcessor.postProcessMessage(message);
 
     assertThat(reportedSpans).hasSize(1);
+  }
+
+  @Test public void should_set_remote_service() {
+    Message message = MessageBuilder.withBody(new byte[] {}).build();
+    tracingMessagePostProcessor.postProcessMessage(message);
+
+    assertThat(reportedSpans.get(0).remoteServiceName())
+        .isEqualTo("my-exchange");
   }
 }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
@@ -35,7 +35,7 @@ public class TracingRabbitListenerAdviceTest {
         .sampler(Sampler.ALWAYS_SAMPLE)
         .spanReporter(reportedSpans::add)
         .build();
-    tracingRabbitListenerAdvice = new TracingRabbitListenerAdvice(tracing);
+    tracingRabbitListenerAdvice = new TracingRabbitListenerAdvice(tracing, "my-service");
 
     methodInvocation = mock(MethodInvocation.class);
   }
@@ -47,6 +47,15 @@ public class TracingRabbitListenerAdviceTest {
     assertThat(reportedSpans)
         .extracting(Span::kind)
         .containsExactly(CONSUMER, null);
+  }
+
+  @Test public void consumer_has_service_name() throws Throwable {
+    Message message = MessageBuilder.withBody(new byte[] {}).build();
+    onMessageConsumed(message);
+
+    assertThat(reportedSpans)
+        .extracting(Span::remoteServiceName)
+        .containsExactly("my-service", null);
   }
 
   @Test public void continues_parent_trace() throws Throwable {


### PR DESCRIPTION
`SpringRabbitTracing.Builder.remoteServiceName` allows you to set the
name the broker will have in the service graph. Usually you'll want a
service-scoped name like a cluster or similar.

This also adjusts the span names to always be operation names like other
instrumentation.