### PR TITLE
Adds missing names for Kafka spans

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -62,7 +62,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
           Span consumerSpanForTopic = consumerSpansForTopic.get(topic);
           if (consumerSpanForTopic == null) {
             consumerSpansForTopic.put(topic,
-                consumerSpanForTopic = tracing.tracer().nextSpan(extracted)
+                consumerSpanForTopic = tracing.tracer().nextSpan(extracted).name("poll")
                     .kind(Span.Kind.CONSUMER)
                     .tag(KafkaTags.KAFKA_TOPIC_TAG, topic)
                     .start());
@@ -70,7 +70,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
           // no need to remove propagation headers as we failed to extract anything
           injector.inject(consumerSpanForTopic.context(), record.headers());
         } else { // we extracted request-scoped data, so cannot share a consumer span.
-          Span span = tracing.tracer().nextSpan(extracted).kind(Span.Kind.CONSUMER)
+          Span span = tracing.tracer().nextSpan(extracted).name("poll").kind(Span.Kind.CONSUMER)
               .tag(KafkaTags.KAFKA_TOPIC_TAG, topic)
               .start();
           span.finish();  // span won't be shared by other records

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
@@ -69,7 +69,7 @@ final class TracingProducer<K, V> implements Producer<K, V> {
       if (record.key() instanceof String && !"".equals(record.key())) {
         span.tag(KafkaTags.KAFKA_KEY_TAG, record.key().toString());
       }
-      span.tag(KafkaTags.KAFKA_TOPIC_TAG, record.topic()).kind(Kind.PRODUCER).start();
+      span.tag(KafkaTags.KAFKA_TOPIC_TAG, record.topic()).name("send").kind(Kind.PRODUCER).start();
     }
     try (Tracer.SpanInScope ws = tracing.tracer().withSpanInScope(span)) {
       return delegate.send(record, new TracingCallback(span, callback));

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
@@ -37,6 +37,11 @@ public class TracingConsumerTest extends BaseTracingTest {
     // offset changed
     assertThat(consumer.position(topicPartition)).isEqualTo(2L);
 
+    // name is correct
+    assertThat(spans)
+        .extracting(Span::name)
+        .containsExactly("poll");
+
     // kind is correct
     assertThat(spans)
         .extracting(Span::kind)


### PR DESCRIPTION
Somehow we forgot to add span names based on the operations before!