### PR TITLE
TracingFilter sets the "brave.Span" attribute and reads "http.route"

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -90,7 +90,7 @@ public abstract class ITHttp {
    * to read them on the main thread, we use a concurrent queue. As some implementations report
    * after a response is sent, we use a blocking queue to prevent race conditions in tests.
    */
-  BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+  protected BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
   /** Call this to block until a span was reported */
   protected Span takeSpan() throws InterruptedException {
@@ -131,7 +131,7 @@ public abstract class ITHttp {
     }
   };
 
-  Tracing.Builder tracingBuilder(Sampler sampler) {
+  protected Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
         .spanReporter(s -> {
           // make sure the context was cleared prior to finish.. no leaks!

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -316,7 +316,6 @@ public abstract class ITHttpServer extends ITHttp {
 
     // verify normal tags
     assertThat(span.tags())
-        .hasSize(2)
         .containsEntry("http.method", "OPTIONS")
         .containsEntry("http.path", "/");
 

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -4,53 +4,85 @@ This module contains a tracing filter for Servlet 2.5+ (including Async).
 reports Zipkin how long each request takes, along with relevant tags
 like the http url.
 
+## Configuration
 To enable tracing, you need to add the `TracingFilter`.
 
-Here's a Servlet 3+ example:
+### Servlet 3+
+When configuring, make sure this is set for all paths, all dispatcher
+types and matches after other filters. Otherwise, you may miss spans or
+leak unfinished asynchronous spans.
+
+Here's an example Servlet 3+ listener
 ```java
 public class TracingServletContextListener implements ServletContextListener {
+  Sender sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
+  AsyncReporter<Span> spanReporter = AsyncReporter.create(sender);
+  Tracing tracing = Tracing.newBuilder()
+        .localServiceName("my-service-name")
+        .spanReporter(spanReporter).build();
 
   @Override
   public void contextInitialized(ServletContextEvent servletContextEvent) {
-    Tracing tracing = Tracing.newBuilder().localServiceName("myservicename").build();
     servletContextEvent
         .getServletContext()
-        .addFilter("TracingFilter", TracingFilter.create(tracing))
+        .addFilter("tracingFilter", TracingFilter.create(tracing))
         .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
   }
 
   @Override
   public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    try {
+      tracing.close(); // disables Tracing.current()
+      spanReporter.close(); // stops reporting thread and flushes data
+      sender.close(); // closes any transport resources
+    } catch (IOException e) {
+      // do something real
+    }
   }
 }
 ```
 
+### Servlet 2.5
+
 In Servlet 2.5, there's no `ServletContextListener`. Besides using tools
-like Spring or Guice, you can make a decorating `javax.servlet.Filter`
+like Spring or Guice, you can make a delegating `javax.servlet.Filter`
 that configures tracing, and add that to your web.xml.
+```xml
+  <filter>
+    <filter-name>tracingFilter</filter-name>
+    <filter-class>com.myco.DelegatingTracingFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>tracingFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+```
+
+Here's an example implementation:
 ```java
-public class ServletContextTracingFilter implements Filter {
+public class DelegatingTracingFilter implements Filter {
+  Sender sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
+  AsyncReporter<Span> spanReporter = AsyncReporter.create(sender);
+  Tracing tracing = Tracing.newBuilder()
+        .localServiceName("my-service-name")
+        .spanReporter(spanReporter).build();
+  Filter delegate = TracingFilter.create(tracing);
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
-    Filter currentTracingFilter =
-        (Filter) request.getServletContext().getAttribute(TracingFilter.class.getName());
-    if (currentTracingFilter == null) {
-      chain.doFilter(request, response);
-    } else {
-      currentTracingFilter.doFilter(request, response, chain);
-    }
-  }
-
-  @Override
-  public void init(FilterConfig filterConfig) {
-    Tracing tracing = Tracing.newBuilder().localServiceName("myservicename").build();
-    Filter tracingFilter = TracingFilter.create(tracing);
-    filterConfig.getServletContext().setAttribute(TracingFilter.class.getName(), tracingFilter);
+    delegate.doFilter(request, response, chain);
   }
 
   @Override public void destroy() {
+    try {
+      tracing.close(); // disables Tracing.current()
+      spanReporter.close(); // stops reporting thread and flushes data
+      sender.close(); // closes any transport resources
+    } catch (IOException e) {
+      // do something real
+    }
   }
 }
 ```

--- a/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
+++ b/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
@@ -1,12 +1,20 @@
 package brave.servlet25;
 
-import brave.servlet.TracingFilter;
-import javax.servlet.Filter;
 import brave.test.http.ITServlet25Container;
+import brave.servlet.TracingFilter;
+import java.util.EnumSet;
+import javax.servlet.Filter;
+import org.eclipse.jetty.server.DispatcherType;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ITTracingFilter extends ITServlet25Container {
 
   @Override protected Filter newTracingFilter() {
     return TracingFilter.create(httpTracing);
+  }
+
+  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
+    handler.addFilter(new FilterHolder(filter), "/*", EnumSet.allOf(DispatcherType.class));
   }
 }

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
@@ -3,11 +3,25 @@ package brave.servlet;
 import brave.http.HttpServerAdapter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 import zipkin2.Endpoint;
 
 /** This can also parse the remote IP of the client. */
 // public for others like sparkjava to use
 public class HttpServletAdapter extends HttpServerAdapter<HttpServletRequest, HttpServletResponse> {
+
+  /**
+   * Looks for the {@link HttpServletRequest#setAttribute(String, Object) request attribute}
+   * "http.route". When present, returns a response wrapper that this adapter can use to parse it.
+   */
+  // not static so that this can be overridden by implementations as needed.
+  public HttpServletResponse adaptResponse(HttpServletRequest req, HttpServletResponse resp) {
+    String httpRoute = (String) req.getAttribute("http.route");
+    return httpRoute != null
+        ? new DecoratedHttpServletResponse(resp, req.getMethod(), httpRoute)
+        : resp;
+  }
+
   final ServletRuntime servlet = ServletRuntime.get();
 
   /**
@@ -42,7 +56,39 @@ public class HttpServletAdapter extends HttpServerAdapter<HttpServletRequest, Ht
     return request.getHeader(name);
   }
 
+  /**
+   * When applied to {@link #adaptResponse(HttpServletRequest, HttpServletResponse)}, returns the
+   * {@link HttpServletRequest#getMethod() request method}.
+   */
+  @Override public String methodFromResponse(HttpServletResponse response) {
+    if (response instanceof DecoratedHttpServletResponse) {
+      return ((DecoratedHttpServletResponse) response).method;
+    }
+    return null;
+  }
+
+  /**
+   * When applied to {@link #adaptResponse(HttpServletRequest, HttpServletResponse)}, returns the
+   * {@link HttpServletRequest#getAttribute(String) request attribute} "http.route".
+   */
+  @Override public String route(HttpServletResponse response) {
+    if (response instanceof DecoratedHttpServletResponse) {
+      return ((DecoratedHttpServletResponse) response).httpRoute;
+    }
+    return null;
+  }
+
   @Override public Integer statusCode(HttpServletResponse response) {
     return servlet.status(response);
+  }
+
+  static class DecoratedHttpServletResponse extends HttpServletResponseWrapper {
+    final String method, httpRoute;
+
+    DecoratedHttpServletResponse(HttpServletResponse response, String method, String httpRoute) {
+      super(response);
+      this.method = method;
+      this.httpRoute = httpRoute;
+    }
   }
 }

--- a/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
@@ -1,11 +1,21 @@
 package brave.servlet;
 
 import brave.test.http.ITServlet3Container;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ITTracingFilter extends ITServlet3Container {
 
   @Override protected Filter newTracingFilter() {
     return TracingFilter.create(httpTracing);
+  }
+
+  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
+    // isMatchAfter=true is required for async tests to pass!
+    handler.getServletContext()
+        .addFilter(filter.getClass().getSimpleName(), filter)
+        .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -143,22 +143,22 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>brave-instrumentation-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brave-instrumentation-http-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>brave-instrumentation-servlet</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>brave-tests</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>brave-http</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>brave-http-tests</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This sets up the baseline for integration over `TracingFilter` via
* Setting the "brave.Span" attribute to reduce dependence on current trace context
* Reading the "http.route" attribute possibly set downstream
* Better documentation and small fixes

This is the base layer needed for #635