### PR TITLE
Adds instructions for integrating over TracingFilter

### DIFF
--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -86,3 +86,21 @@ public class DelegatingTracingFilter implements Filter {
   }
 }
 ```
+
+## Collaborating with `TracingFilter`
+
+`TracingFilter` sets the servlet attributes so that you can access span
+data without relying on implicit context:
+* `brave.SpanCustomizer` - add tags or rename the span without a tracer
+* `brave.propagation.TraceContext` - shows trace IDs and any extra data
+
+Ex: The following
+```java
+SpanCustomizer customizer = (SpanCustomizer) request.getAttribute(SpanCustomizer.class.getName());
+if (customizer != null) customizer.tag("platform", "XX");
+```
+
+`TracingFilter` also looks for the attribute "http.route". When present,
+this is available to normal parsing, for example a route-base span name.
+This feature allows frameworks like spring-webmvc to contribute
+controller information with less code duplication.

--- a/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
@@ -1,6 +1,7 @@
 package brave.servlet;
 
 import brave.Span;
+import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpServerHandler;
@@ -64,8 +65,11 @@ public final class TracingFilter implements Filter {
     request.setAttribute("TracingFilter", "true");
 
     Span span = handler.handleReceive(extractor, httpRequest);
-    // add the span to the request context for cheaper access by customizers
-    request.setAttribute(Span.class.getName(), span);
+
+    // Add attributes for explicit access to customization or span context
+    request.setAttribute(SpanCustomizer.class.getName(), span);
+    request.setAttribute(TraceContext.class.getName(), span.context());
+
     Throwable error = null;
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
       chain.doFilter(httpRequest, httpResponse); // any downstream filters see Tracer.currentSpan


### PR DESCRIPTION
This clarifies and also lowers access needed (for example, not exposing
brave.Span)