### PR TITLE
Adds Jersey Server span customizing event listener

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -10,7 +10,7 @@ Here's a brief overview of what's packaged here:
 * [httpasyncclient](httpasyncclient/README.md) - Tracing decorator for [Apache HttpClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+
 * [httpclient](httpclient/README.md) - Tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+
 * [jaxrs2](jaxrs2/README.md) - Tracing filters and a feature to automatically configure them
-* [jersey-server](jersey-server/README.md) - Tracing application event listener for [Jersey Server](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
+* [jersey-server](jersey-server/README.md) - Tracing and span customizing application event listeners for [Jersey Server](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
 * [kafka-clients](kafka-clients/README.md) - Tracing decorators for Kafka 0.11+ producers and consumers.
 * [mysql](mysql/README.md) - Tracing MySQL statement interceptor
 * [mysql6](mysql6/README.md) - Tracing MySQL v6 statement interceptor

--- a/instrumentation/jersey-server/README.md
+++ b/instrumentation/jersey-server/README.md
@@ -1,5 +1,18 @@
 # brave-instrumentation-jersey-server
-This module contains an application event listener for [Jersey Server 2.x](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
+This module contains application event listeners for [Jersey Server 2.x](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
+
+These instrumentation is an alternative to the [jaxrs2](../jaxrs2) container
+instrumentation. Do *not* use both.
+
+`TracingApplicationEventListener` extracts trace state from incoming
+requests. Then, it reports Zipkin how long each request takes, along
+with relevant tags like the http url and the resource.
+
+`SpanCustomizingApplicationEventListener` layers over [servlet](../servlet),
+adding resource tags and route information to servlet-originated spans.
+
+When in a servlet environment, use `SpanCustomizingApplicationEventListener`.
+When not, use `TracingApplicationEventListener`. Don't use both!
 
 `TracingApplicationEventListener` extracts trace state from incoming
 requests. Then, it reports Zipkin how long each request takes, along
@@ -8,6 +21,8 @@ with relevant tags like the http url.
 To enable tracing, you need to register the `TracingApplicationEventListener`.
 
 ## Configuration
+
+### Normal configuration (`TracingApplicationEventListener`)
 
 The `TracingApplicationEventListener` requires an instance of
 `HttpTracing` to operate. With that in mind, use [standard means](https://jersey.github.io/apidocs/2.26/jersey/org/glassfish/jersey/server/monitoring/ApplicationEventListener.html)
@@ -27,9 +42,29 @@ public class MyApplication extends Application {
 }
 ```
 
-The tracing listener should be the only server instrumentation you use.
-For example, do *not* use brave-instrumentation-jaxrs2 also, as this will
-result in duplicate data.
+### Servlet-based configuration (`SpanCustomizingApplicationEventListener`)
+
+When using `jersey-container-servlet`, setup [servlet tracing](../servlet),
+an register `SpanCustomizingContainerFilter`.
+
+```java
+public class MyApplication extends Application {
+  public Set<Object> getSingletons() {
+    HttpTracing httpTracing = // configure me!
+    return new LinkedHashSet<>(Arrays.asList(
+      SpanCustomizingApplicationEventListener.create(),
+      new MyResource()
+    ));
+  }
+```
 
 
+## Customizing Span data based on resources
+`EventParser` decides which resource-specific (data beyond normal
+http tags) end up on the span. You can override this to change what's
+parsed, or use `NOOP` to disable controller-specific data.
 
+Ex. If you want less tags, you can disable the JAX-RS resource ones.
+```java
+SpanCustomizingApplicationEventListener.create(EventParser.NOOP);
+```

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -24,12 +24,16 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-servlet</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/EventParser.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/EventParser.java
@@ -1,0 +1,44 @@
+package brave.jersey.server;
+
+import brave.SpanCustomizer;
+import brave.http.HttpTracing;
+import org.glassfish.jersey.server.model.Invocable;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+/**
+ * Jersey specific type used to customize traced requests based on the JAX-RS resource.
+ *
+ * <p>Note: This should not duplicate data added by {@link HttpTracing}. For example, this should
+ * not add the tag "http.url".
+ */
+// named event parser, not request event parser, in case we want to later support application event.
+public class EventParser {
+  /** Adds no data to the request */
+  public static final EventParser NOOP = new EventParser() {
+    @Override protected void requestMatched(RequestEvent event, SpanCustomizer customizer) {
+    }
+  };
+
+  /** Simple class name that processed the request. ex BookResource */
+  public static final String RESOURCE_CLASS = "jaxrs.resource.class";
+  /** Method name that processed the request. ex listOfBooks */
+  public static final String RESOURCE_METHOD = "jaxrs.resource.method";
+
+  /**
+   * Invoked prior to request invocation during {@link RequestEventListener#onEvent(RequestEvent)}
+   * where the event type is {@link RequestEvent.Type#REQUEST_MATCHED}
+   *
+   * <p>Adds the tags {@link #RESOURCE_CLASS} and {@link #RESOURCE_METHOD}. Override or use {@link #NOOP}
+   * to change this behavior.
+   */
+  protected void requestMatched(RequestEvent event, SpanCustomizer customizer) {
+    Invocable i =
+        event.getContainerRequest().getUriInfo().getMatchedResourceMethod().getInvocable();
+    customizer.tag(RESOURCE_CLASS, i.getHandler().getHandlerClass().getSimpleName());
+    customizer.tag(RESOURCE_METHOD, i.getHandlingMethod().getName());
+  }
+
+  public EventParser() { // intentionally public for @Inject to work without explicit binding
+  }
+}

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
@@ -1,0 +1,94 @@
+package brave.jersey.server;
+
+import brave.SpanCustomizer;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.ext.Provider;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.internal.routing.RoutingContext;
+import org.glassfish.jersey.server.monitoring.ApplicationEvent;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+import org.glassfish.jersey.uri.UriTemplate;
+
+import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.REQUEST_MATCHED;
+
+/**
+ * Adds application-tier data to an existing http span via {@link EventParser}.
+ * This also sets the request property "http.route" so that it can be used in naming the http span.
+ *
+ * <p>Use this instead of {@link TracingApplicationEventListener} when you start traces at the
+ * servlet level via {@code brave.servlet.TracingFilter}.
+ */
+@Provider
+public class SpanCustomizingApplicationEventListener
+    implements ApplicationEventListener, RequestEventListener {
+  public static SpanCustomizingApplicationEventListener create() {
+    return new SpanCustomizingApplicationEventListener(new EventParser());
+  }
+
+  public static SpanCustomizingApplicationEventListener create(EventParser parser) {
+    return new SpanCustomizingApplicationEventListener(parser);
+  }
+
+  final EventParser parser;
+
+  @Inject SpanCustomizingApplicationEventListener(EventParser parser) {
+    this.parser = parser;
+  }
+
+  @Override public void onEvent(ApplicationEvent event) {
+    // only onRequest is used
+  }
+
+  @Override public RequestEventListener onRequest(RequestEvent requestEvent) {
+    if (requestEvent.getType() == RequestEvent.Type.START) return this;
+    return null;
+  }
+
+  @Override public void onEvent(RequestEvent event) {
+    // Note: until REQUEST_MATCHED, we don't know metadata such as if the request is async or not
+    if (event.getType() != REQUEST_MATCHED) return;
+    ContainerRequest request = event.getContainerRequest();
+    SpanCustomizer span = (SpanCustomizer) request.getProperty(SpanCustomizer.class.getName());
+    if (span == null) return;
+    request.setProperty("http.route", route(event.getContainerRequest()));
+    parser.requestMatched(event, span);
+  }
+
+  /**
+   * This returns the matched template as defined by a base URL and path expressions.
+   *
+   * <p>Matched templates are pairs of (resource path, method path) added with
+   * {@link RoutingContext#pushTemplates(UriTemplate, UriTemplate)}.
+   * This code skips redundant slashes from either source caused by Path("/") or Path("").
+   */
+  static String route(ContainerRequest request) {
+    ExtendedUriInfo uriInfo = request.getUriInfo();
+    List<UriTemplate> templates = uriInfo.getMatchedTemplates();
+    int templateCount = templates.size();
+    if (templateCount == 0) return "";
+    assert templateCount % 2 == 0 : "expected matched templates to be resource/method pairs";
+    StringBuilder builder = null; // don't allocate unless you need it!
+    String basePath = uriInfo.getBaseUri().getPath();
+    String result = null;
+    if (!"/".equals(basePath)) { // skip empty base paths
+      result = basePath;
+    }
+    for (int i = templateCount - 1; i >= 0; i--) {
+      String template = templates.get(i).getTemplate();
+      if ("/".equals(template)) continue; // skip allocation
+      if (builder != null) {
+        builder.append(template);
+      } else if (result != null) {
+        builder = new StringBuilder(result).append(template);
+        result = null;
+      } else {
+        result = template;
+      }
+    }
+    return result != null ? result : builder != null ? builder.toString() : "";
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/InjectionTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/InjectionTest.java
@@ -1,0 +1,64 @@
+package brave.jersey.server;
+
+import brave.Tracing;
+import brave.http.HttpTracing;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** This ensures all filters can be injected, supplied with only {@linkplain HttpTracing}. */
+public class InjectionTest {
+
+  Injector injector = Guice.createInjector(new AbstractModule() {
+    @Override protected void configure() {
+      bind(HttpTracing.class).toInstance(HttpTracing.create(Tracing.newBuilder().build()));
+    }
+  });
+
+  @After public void close() {
+    Tracing.current().close();
+  }
+
+  @Test public void spanCustomizingApplicationEventListener() {
+    SpanCustomizingApplicationEventListener filter =
+        injector.getInstance(SpanCustomizingApplicationEventListener.class);
+
+    assertThat(filter.parser.getClass())
+        .isSameAs(EventParser.class);
+  }
+
+  @Test public void spanCustomizingApplicationEventListener_resource() {
+    SpanCustomizingApplicationEventListener filter =
+        injector.createChildInjector(new AbstractModule() {
+          @Override protected void configure() {
+            bind(EventParser.class).toInstance(EventParser.NOOP);
+          }
+        }).getInstance(SpanCustomizingApplicationEventListener.class);
+
+    assertThat(filter.parser)
+        .isSameAs(EventParser.NOOP);
+  }
+
+  @Test public void tracingApplicationEventListener() {
+    TracingApplicationEventListener filter =
+        injector.getInstance(TracingApplicationEventListener.class);
+
+    assertThat(filter.parser.getClass())
+        .isSameAs(EventParser.class);
+  }
+
+  @Test public void tracingApplicationEventListener_resource() {
+    TracingApplicationEventListener filter = injector.createChildInjector(new AbstractModule() {
+      @Override protected void configure() {
+        bind(EventParser.class).toInstance(EventParser.NOOP);
+      }
+    }).getInstance(TracingApplicationEventListener.class);
+
+    assertThat(filter.parser)
+        .isSameAs(EventParser.NOOP);
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/SpanCustomizingApplicationEventListenerTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/SpanCustomizingApplicationEventListenerTest.java
@@ -1,0 +1,91 @@
+package brave.jersey.server;
+
+import java.net.URI;
+import java.util.Arrays;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.uri.PathTemplate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpanCustomizingApplicationEventListenerTest {
+  @Mock ContainerRequest request;
+
+  @Test public void route() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/items/{itemId}")
+    ));
+
+    assertThat(SpanCustomizingApplicationEventListener.route(request))
+        .isEqualTo("/items/{itemId}");
+  }
+
+  /** not sure it is even possible for a template to match "/" "/".. */
+  @Test public void route_invalid() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/")
+    ));
+
+    assertThat(SpanCustomizingApplicationEventListener.route(request))
+        .isEmpty();
+  }
+
+  @Test public void route_basePath() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/base"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/items/{itemId}")
+    ));
+
+    assertThat(SpanCustomizingApplicationEventListener.route(request))
+        .isEqualTo("/base/items/{itemId}");
+  }
+
+  @Test public void route_nested() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/"),
+        new PathTemplate("/items/{itemId}"),
+        new PathTemplate("/"),
+        new PathTemplate("/nested")
+    ));
+
+    assertThat(SpanCustomizingApplicationEventListener.route(request))
+        .isEqualTo("/nested/items/{itemId}");
+  }
+
+  /** when the path expression is on the type not on the method */
+  @Test public void route_nested_reverse() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/items/{itemId}"),
+        new PathTemplate("/"),
+        new PathTemplate("/nested"),
+        new PathTemplate("/")
+    ));
+
+    assertThat(SpanCustomizingApplicationEventListener.route(request))
+        .isEqualTo("/nested/items/{itemId}");
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
@@ -1,0 +1,100 @@
+package brave.jersey.server;
+
+import brave.Tracer;
+import brave.http.HttpTracing;
+import brave.propagation.ExtraFieldPropagation;
+import java.io.IOException;
+import javax.ws.rs.GET;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.ManagedAsync;
+
+import static brave.test.http.ITHttp.EXTRA_KEY;
+
+@Path("")
+public class TestResource {
+  final Tracer tracer;
+
+  TestResource(HttpTracing httpTracing) {
+    this.tracer = httpTracing.tracing().tracer();
+  }
+
+  @OPTIONS
+  @Path("")
+  public Response root() {
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path("foo")
+  public Response foo() {
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path("extra")
+  public Response extra() {
+    return Response.ok(ExtraFieldPropagation.get(EXTRA_KEY)).build();
+  }
+
+  @GET
+  @Path("badrequest")
+  public Response badrequest() {
+    return Response.status(400).build();
+  }
+
+  @GET
+  @Path("child")
+  public Response child() {
+    tracer.nextSpan().name("child").start().finish();
+    return Response.status(200).build();
+  }
+
+  @GET
+  @Path("async")
+  public void async(@Suspended AsyncResponse response) {
+    new Thread(() -> response.resume("foo")).start();
+  }
+
+  @GET
+  @Path("managedAsync")
+  @ManagedAsync
+  public void managedAsync(@Suspended AsyncResponse response) {
+    response.resume("foo");
+  }
+
+  @GET
+  @Path("exception")
+  public Response disconnect() throws IOException {
+    throw new IOException();
+  }
+
+  @GET
+  @Path("items/{itemId}")
+  public String item(@PathParam("itemId") String itemId) {
+    return itemId;
+  }
+
+  @GET
+  @Path("exceptionAsync")
+  public void disconnectAsync(@Suspended AsyncResponse response) {
+    new Thread(() -> response.resume(new IOException())).start();
+  }
+
+  public static class NestedResource {
+    @GET
+    @Path("items/{itemId}")
+    public String item(@PathParam("itemId") String itemId) {
+      return itemId;
+    }
+  }
+
+  @Path("nested")
+  public NestedResource nestedResource() {
+    return new NestedResource();
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
@@ -2,11 +2,9 @@ package brave.jersey.server;
 
 import brave.jersey.server.TracingApplicationEventListener.Adapter;
 import java.net.URI;
-import java.util.Arrays;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.ExtendedUriInfo;
-import org.glassfish.jersey.uri.PathTemplate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -39,78 +37,10 @@ public class TracingApplicationEventListenerAdapterTest {
 
   @Test public void route() {
     when(response.getRequestContext()).thenReturn(request);
-    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
-    when(request.getUriInfo()).thenReturn(uriInfo);
-    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
-    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
-        new PathTemplate("/"),
-        new PathTemplate("/items/{itemId}")
-    ));
+    when(request.getProperty("http.route")).thenReturn("/items/{itemId}");
 
     assertThat(adapter.route(response))
         .isEqualTo("/items/{itemId}");
-  }
-
-  /** not sure it is even possible for a template to match "/" "/".. */
-  @Test public void route_invalid() {
-    when(response.getRequestContext()).thenReturn(request);
-    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
-    when(request.getUriInfo()).thenReturn(uriInfo);
-    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
-    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
-        new PathTemplate("/"),
-        new PathTemplate("/")
-    ));
-
-    assertThat(adapter.route(response))
-        .isEmpty();
-  }
-
-  @Test public void route_basePath() {
-    when(response.getRequestContext()).thenReturn(request);
-    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
-    when(request.getUriInfo()).thenReturn(uriInfo);
-    when(uriInfo.getBaseUri()).thenReturn(URI.create("/base"));
-    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
-        new PathTemplate("/"),
-        new PathTemplate("/items/{itemId}")
-    ));
-
-    assertThat(adapter.route(response))
-        .isEqualTo("/base/items/{itemId}");
-  }
-
-  @Test public void route_nested() {
-    when(response.getRequestContext()).thenReturn(request);
-    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
-    when(request.getUriInfo()).thenReturn(uriInfo);
-    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
-    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
-        new PathTemplate("/"),
-        new PathTemplate("/items/{itemId}"),
-        new PathTemplate("/"),
-        new PathTemplate("/nested")
-    ));
-
-    assertThat(adapter.route(response))
-        .isEqualTo("/nested/items/{itemId}");
-  }
-
-  /** when the path expression is on the type not on the method */
-  @Test public void route_nested_reverse() {
-    when(response.getRequestContext()).thenReturn(request);
-    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
-    when(request.getUriInfo()).thenReturn(uriInfo);
-    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
-    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
-        new PathTemplate("/items/{itemId}"),
-        new PathTemplate("/"),
-        new PathTemplate("/nested"),
-        new PathTemplate("/")
-    ));
-
-    assertThat(adapter.route(response))
-        .isEqualTo("/nested/items/{itemId}");
   }
 
   @Test public void url_derivedFromExtendedUriInfo() {


### PR DESCRIPTION
This introduces `SpanCustomizingApplicationEventListener` which layers
over the servlet `TracingFilter` to add resource tags and routing
information.

The additional tags can be disabled by binding `EventParser.NOOP`