### PR TITLE
Deprecates JAX-RS TracingContainerFilter in favor of layering on Servlet

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -9,7 +9,7 @@ Here's a brief overview of what's packaged here:
 * [grpc](grpc/README.md) - Tracing client and server interceptors for [grpc](github.com/grpc/grpc-java)
 * [httpasyncclient](httpasyncclient/README.md) - Tracing decorator for [Apache HttpClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+
 * [httpclient](httpclient/README.md) - Tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+
-* [jaxrs2](jaxrs2/README.md) - Tracing filters and a feature to automatically configure them
+* [jaxrs2](jaxrs2/README.md) - Client tracing filter and span customizing resource filter for JAX-RS 2.x
 * [jersey-server](jersey-server/README.md) - Tracing and span customizing application event listeners for [Jersey Server](https://jersey.github.io/documentation/latest/monitoring_tracing.html#d0e16007).
 * [kafka-clients](kafka-clients/README.md) - Tracing decorators for Kafka 0.11+ producers and consumers.
 * [mysql](mysql/README.md) - Tracing MySQL statement interceptor

--- a/instrumentation/jaxrs2/README.md
+++ b/instrumentation/jaxrs2/README.md
@@ -1,105 +1,58 @@
 # brave-instrumentation-jaxrs2
-This module contains JAX-RS 2.x compatible tracing filters and a feature
-to automatically configure them.
+This module contains JAX-RS 2.x compatible tracing filters.
 
 The `TracingClientFilter` adds trace headers to outgoing requests.
-`TracingContainerFilter` extracts trace state from incoming requests.
-Both report to Zipkin how long each request takes, along with relevant
-tags like the http url.
+`SpanCustomizingContainerFilter` layers over [servlet](../servlet),
+adding resource tags to servlet-originated spans.
 
-## Configuration
+If you are using Jersey, use our [jersey-server](../jersey-server)
+instrumentation instead of `SpanCustomizingContainerFilter` as it has
+more data.
 
-### Dependency Injection
-Tracing always needs an instance of type `brave.http.HttpTracing`
-configured. Make sure this is in place before proceeding.
+## Container Setup
+If not using [jersey-server](../jersey-server), setup [servlet tracing](../servlet),
+then add `SpanCustomizingContainerFilter`.
 
-Then, configure `TracingFeature`, which sets up filters automatically.
-
-For example, this is how configuration looks with Jersey 2.x:
-
-
-In your web.xml:
-
-```xml
-<init-param>
-    <param-name>jersey.config.server.provider.packages</param-name>
-    <param-value>my.existing.packages,brave.jaxrs2</param-value>
-</init-param>
-```
-
-### Manual
-
-For server side setup, an Application class could look like this:
-
+Ex.
 ```java
 public class MyApplication extends Application {
 
   public Set<Object> getSingletons() {
-    Tracing tracing = Tracing.newBuilder().build();
-    TracingFeature tracingFeature = TracingFeature.create(tracing);
-    return new LinkedHashSet<>(Arrays.asList(tracingFeature));
+    return new LinkedHashSet<>(Arrays.asList(
+      SpanCustomizingContainerFilter.create(),
+      .. your other things
+    ));
   }
 
 }
 ```
 
-For client side setup, you just have to register the BraveTracingFeature
+## Customizing Span data based on resources
+`ContainerParser` decides which resource-specific (data beyond normal
+http tags) end up on the span. You can override this to change what's
+parsed, or use `NOOP` to disable controller-specific data.
+
+Ex. If you want less tags, you can disable the JAX-RS resource ones.
+```java
+SpanCustomizingContainerFilter.create(ContainerParser.NOOP);
+```
+
+## Client Setup
+
+For client side setup, you just have to register the TracingClientFilter
 with your `WebTarget` before you make your request:
 
 ```java
 WebTarget target = target("/mytarget");
-target.register(TracingFeature.create(tracing));
-```
-
-## Customizing Span data based on Java Annotations
-JAX-RS resources are declared via annotations. You may want to consider
-the resource method when choosing name or tags.
-
-For example, the below adds the java method name as the span name:
-```java
-TracingFeature.create(httpTracing.toBuilder().serverParser(new HttpServerParser() {
-  @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
-    Method method = ((ContainerAdapter) adapter).resourceMethod(req);
-    return method.getName().toLowerCase();
-  }
-}).build());
-```
-
-## Exception handling
-`ContainerResponseFilter` has no means to handle uncaught exceptions.
-Unless you provide a catch-all exception mapper, requests that result in
-unhandled exceptions will leak until they are eventually flushed.
-
-Besides using framework-specific code, the only approach is to make a
-custom `ExceptionMapper`, similar to below, which ensures a request is
-sent back even when something unexpected happens.
-
-```java
-@Provider
-public static class CatchAllExceptions implements ExceptionMapper<Exception> {
-
-  @Override public Response toResponse(Exception e) {
-    if (e instanceof WebApplicationException) {
-      return ((WebApplicationException) e).getResponse();
-    }
-
-    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-        .entity("Internal error")
-        .type("text/plain")
-        .build();
-  }
-}
+target.register(TracingClientFilter.create(tracing));
 ```
 
 ### Async Tasks
-
 Different frameworks require different means to control the thread pool
-asynchronous tasks operate on. Here's an example of how to configure
-Jersey 2+ to ensure traces propagate even when requests are completed
-asynchronously.
+asynchronous tasks operate on.
 
+Here's an example setting up the executor used by Jersey:
 ```java
-
 @ClientAsyncExecutor
 class TracingExecutorServiceProvider implements ExecutorServiceProvider {
 
@@ -120,3 +73,16 @@ ClientConfig clientConfig = new ClientConfig();
 clientConfig.register(TracingFeature.create(httpTracing));
 clientConfig.register(new TracingExecutorServiceProvider(httpTracing.tracing(), executorService));
 ```
+
+## Why don't we use `ContainerResponseFilter`
+
+### `ContainerResponseFilter` doesn't handle errors
+`ContainerResponseFilter` has no means to handle uncaught exceptions.
+Unless you provide a catch-all exception mapper, requests that result in
+unhandled exceptions will leak until they are eventually flushed. This
+problem does not exist in servlet or Jersey-specific instrumentation.
+
+### Async Tasks can lose context
+Different frameworks require different means to control the thread pool
+asynchronous tasks operate on. This implies using servlet or framework-
+specific mechanisms.

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -51,6 +51,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
       <scope>test</scope>

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerAdapter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerAdapter.java
@@ -46,16 +46,22 @@ public final class ContainerAdapter
     return response.getStatus();
   }
 
+  /** @deprecated use {@link ContainerParser} instead */
+  @Deprecated
   @Nullable public final <Req> Method resourceMethod(Req request) {
     ResourceInfo resourceInfo = resourceInfo(request);
     return resourceInfo != null ? resourceInfo.getResourceMethod() : null;
   }
 
+  /** @deprecated use {@link ContainerParser} instead */
+  @Deprecated
   @Nullable public final <Req> Class<?> resourceClass(Req request) {
     ResourceInfo resourceInfo = resourceInfo(request);
     return resourceInfo != null ? resourceInfo.getResourceClass() : null;
   }
 
+  /** @deprecated use {@link ContainerParser} instead */
+  @Deprecated
   @Nullable public final <Req> ResourceInfo resourceInfo(Req request) {
     if (!(request instanceof ContainerRequestContext)) return null;
     return (ResourceInfo) ((ContainerRequestContext) request).getProperty(

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerParser.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/ContainerParser.java
@@ -1,0 +1,41 @@
+package brave.jaxrs2;
+
+import brave.SpanCustomizer;
+import brave.http.HttpTracing;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+
+/**
+ * JAX-RS specific type used to customize traced requests based on the JAX-RS resource.
+ *
+ * <p>Note: This should not duplicate data added by {@link HttpTracing}. For example, this should
+ * not add the tag "http.url".
+ */
+public class ContainerParser {
+  /** Adds no data to the request */
+  public static final ContainerParser NOOP = new ContainerParser() {
+    @Override protected void resourceInfo(ResourceInfo resourceInfo, SpanCustomizer customizer) {
+    }
+  };
+
+  /** Simple class name that processed the request. ex BookResource */
+  public static final String RESOURCE_CLASS = "jaxrs.resource.class";
+  /** Method name that processed the request. ex listOfBooks */
+  public static final String RESOURCE_METHOD = "jaxrs.resource.method";
+
+  /**
+   * Invoked prior to request invocation during {@link ContainerRequestFilter#filter(ContainerRequestContext)}
+   * where the resource info was injected from context.
+   *
+   * <p>Adds the tags {@link #RESOURCE_CLASS} and {@link #RESOURCE_METHOD}. Override or use {@link #NOOP}
+   * to change this behavior.
+   */
+  protected void resourceInfo(ResourceInfo resourceInfo, SpanCustomizer customizer) {
+    customizer.tag(RESOURCE_CLASS, resourceInfo.getResourceClass().getSimpleName());
+    customizer.tag(RESOURCE_METHOD, resourceInfo.getResourceMethod().getName());
+  }
+
+  public ContainerParser() { // intentionally public for @Inject to work without explicit binding
+  }
+}

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/SpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/SpanCustomizingContainerFilter.java
@@ -1,0 +1,49 @@
+package brave.jaxrs2;
+
+import brave.SpanCustomizer;
+import javax.inject.Inject;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+import static javax.ws.rs.RuntimeType.SERVER;
+
+/**
+ * Adds application-tier data to an existing http span via {@link ContainerParser}.
+ *
+ * <p>Use this instead of {@link TracingContainerFilter} when you are tracing at a lower level,
+ * like via {@code brave.servlet.TracingFilter}.
+ */
+// Currently not using PreMatching because we are attempting to detect if the method is async or not
+@Provider
+@ConstrainedTo(SERVER)
+public final class SpanCustomizingContainerFilter implements ContainerRequestFilter {
+
+  public static SpanCustomizingContainerFilter create() {
+    return create(new ContainerParser());
+  }
+
+  public static SpanCustomizingContainerFilter create(ContainerParser parser) {
+    return new SpanCustomizingContainerFilter(parser);
+  }
+
+  final ContainerParser parser;
+
+  @Inject SpanCustomizingContainerFilter(ContainerParser parser) {
+    this.parser = parser;
+  }
+
+  /** {@link PreMatching} cannot be used: pre-matching doesn't inject the resource info! */
+  @Context ResourceInfo resourceInfo;
+
+  @Override public void filter(ContainerRequestContext request) {
+    SpanCustomizer span = (SpanCustomizer) request.getProperty(SpanCustomizer.class.getName());
+    if (span != null && resourceInfo != null) {
+      parser.resourceInfo(resourceInfo, span);
+    }
+  }
+}

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingFeature.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingFeature.java
@@ -7,6 +7,12 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
+/**
+ * @deprecated because the container filter is unreliable with regards to errors.
+ * Integrate {@code brave.jersey.server.TracingApplicationEventListener} if using Jersey, or the
+ * normal {@code brave.servlet.TracingFilter} with {@link SpanCustomizingContainerFilter} if not.
+ */
+@Deprecated
 @Provider
 public final class TracingFeature implements Feature {
   public static Feature create(Tracing tracing) {
@@ -31,7 +37,7 @@ public final class TracingFeature implements Feature {
         context.register(new TracingClientFilter(httpTracing));
         break;
       case SERVER:
-        context.register(new TracingContainerFilter(httpTracing));
+        context.register(new TracingContainerFilter(httpTracing, new ContainerParser()));
     }
     return true;
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -1,0 +1,80 @@
+package brave.jaxrs2;
+
+import brave.CurrentSpanCustomizer;
+import brave.http.HttpTracing;
+import brave.servlet.TracingFilter;
+import brave.test.http.ITServletContainer;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.ws.rs.core.Application;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITSpanCustomizingContainerFilter extends ITServletContainer {
+
+  @Override @Test public void reportsClientAddress() {
+    throw new AssumptionViolatedException("ContainerRequestContext doesn't include remote address");
+  }
+
+  @Test public void tagsResource() throws Exception {
+    get("/foo");
+
+    Span span = takeSpan();
+    assertThat(span.tags())
+        .containsEntry("jaxrs.resource.class", "TestResource")
+        .containsEntry("jaxrs.resource.method", "foo");
+  }
+
+  @Override public void init(ServletContextHandler handler) {
+    // Adds application programmatically as opposed to using web.xml
+    handler.addServlet(new ServletHolder(new HttpServletDispatcher()), "/*");
+    handler.addEventListener(new TaggingBootstrap(httpTracing, new TestResource(httpTracing)));
+
+    addFilter(handler, TracingFilter.create(httpTracing));
+  }
+
+  void addFilter(ServletContextHandler handler, Filter filter) {
+    handler.addFilter(new FilterHolder(filter), "/*", EnumSet.allOf(DispatcherType.class));
+  }
+
+  static class TaggingBootstrap extends ResteasyBootstrap {
+
+    public TaggingBootstrap(HttpTracing httpTracing, Object resource) {
+      deployment = new ResteasyDeployment();
+      deployment.setApplication(new Application() {
+        @Override public Set<Object> getSingletons() {
+          return new LinkedHashSet<>(Arrays.asList(
+              resource,
+              SpanCustomizingContainerFilter.create()
+          ));
+        }
+      });
+    }
+
+    @Override public void contextInitialized(ServletContextEvent event) {
+      ServletContext servletContext = event.getServletContext();
+      ListenerBootstrap config = new ListenerBootstrap(servletContext);
+      servletContext.setAttribute(ResteasyDeployment.class.getName(), deployment);
+      deployment.getDefaultContextObjects().put(ResteasyConfiguration.class, config);
+      config.createDeployment();
+      deployment.start();
+    }
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
@@ -19,21 +19,53 @@ public class InjectionTest {
     }
   });
 
-  @After public void close(){
+  @After public void close() {
     Tracing.current().close();
   }
 
-  @Test public void tracingClientFilter() throws Exception {
+  @Test public void tracingClientFilter() {
     assertThat(injector.getInstance(TracingClientFilter.class))
         .isNotNull();
   }
 
-  @Test public void tracingContainerFilter() throws Exception {
-    assertThat(injector.getInstance(TracingContainerFilter.class))
-        .isNotNull();
+  @Test public void spanCustomizingContainerFilter() {
+    SpanCustomizingContainerFilter filter =
+        injector.getInstance(SpanCustomizingContainerFilter.class);
+
+    assertThat(filter.parser.getClass())
+        .isSameAs(ContainerParser.class);
   }
 
-  @Test public void tracingFeature() throws Exception {
+  @Test public void spanCustomizingContainerFilter_resource() {
+    SpanCustomizingContainerFilter filter = injector.createChildInjector(new AbstractModule() {
+      @Override protected void configure() {
+        bind(ContainerParser.class).toInstance(ContainerParser.NOOP);
+      }
+    }).getInstance(SpanCustomizingContainerFilter.class);
+
+    assertThat(filter.parser)
+        .isSameAs(ContainerParser.NOOP);
+  }
+
+  @Test public void tracingContainerFilter() {
+    TracingContainerFilter filter = injector.getInstance(TracingContainerFilter.class);
+
+    assertThat(filter.parser.getClass())
+        .isSameAs(ContainerParser.class);
+  }
+
+  @Test public void tracingContainerFilter_resource() {
+    TracingContainerFilter filter = injector.createChildInjector(new AbstractModule() {
+      @Override protected void configure() {
+        bind(ContainerParser.class).toInstance(ContainerParser.NOOP);
+      }
+    }).getInstance(TracingContainerFilter.class);
+
+    assertThat(filter.parser)
+        .isSameAs(ContainerParser.NOOP);
+  }
+
+  @Test public void tracingFeature() {
     assertThat(injector.getInstance(TracingFeature.class))
         .isNotNull();
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TestResource.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TestResource.java
@@ -1,0 +1,72 @@
+package brave.jaxrs2;
+
+import brave.Tracer;
+import brave.http.HttpTracing;
+import brave.propagation.ExtraFieldPropagation;
+import java.io.IOException;
+import javax.ws.rs.GET;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response;
+
+import static brave.test.http.ITHttp.EXTRA_KEY;
+
+@Path("")
+public class TestResource { // public for resteasy to inject
+  final Tracer tracer;
+
+  TestResource(HttpTracing httpTracing) {
+    this.tracer = httpTracing.tracing().tracer();
+  }
+
+  @OPTIONS
+  @Path("")
+  public Response root() {
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path("foo")
+  public Response foo() {
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path("extra")
+  public Response extra() {
+    return Response.ok(ExtraFieldPropagation.get(EXTRA_KEY)).build();
+  }
+
+  @GET
+  @Path("badrequest")
+  public Response badrequest() {
+    return Response.status(400).build();
+  }
+
+  @GET
+  @Path("child")
+  public Response child() {
+    tracer.nextSpan().name("child").start().finish();
+    return Response.status(200).build();
+  }
+
+  @GET
+  @Path("async")
+  public void async(@Suspended AsyncResponse response) throws IOException {
+    new Thread(() -> response.resume(Response.status(200).build())).start();
+  }
+
+  @GET
+  @Path("exception")
+  public Response disconnect() throws IOException {
+    throw new IOException();
+  }
+
+  @GET
+  @Path("exceptionAsync")
+  public void disconnectAsync(@Suspended AsyncResponse response) throws IOException {
+    new Thread(() -> response.resume(new IOException())).start();
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TracingContainerFilterTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TracingContainerFilterTest.java
@@ -25,12 +25,13 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TracingContainerFilterTest {
   Tracing tracing = Tracing.newBuilder().build();
-  TracingContainerFilter filter = new TracingContainerFilter(HttpTracing.create(tracing));
+  TracingContainerFilter filter =
+      new TracingContainerFilter(HttpTracing.create(tracing), ContainerParser.NOOP);
   @Mock ContainerRequestContext context;
   @Mock UriInfo uriInfo;
   @Mock ResourceInfo resourceInfo;
 
-  @After public void close(){
+  @After public void close() {
     Tracing.current().close();
   }
 


### PR DESCRIPTION
The `TracingContainerFilter` had a number of problems including error
handling and route information. This deprecates it and the
`TracingFeature` in favor of tracing at a lower level such as servlet or
Jersey. If there are no better choices for resource parsing the
`SpanCustomizingContainerFilter` can add tags correspondingly. These
can be modified or removed by providing `ContainerParser.NOOP`