### PR TITLE
Defaults to create dependency links for messaging spans

### DIFF
--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -5,7 +5,14 @@ Add decorators for Kafka producer and consumer to enable tracing.
 * `TracingConsumer` completes a consumer span on `poll`, resuming a trace in headers if present.
 
 ## Setup
-To use the producer simply wrap it like this : 
+First, setup the generic Kafka component like this:
+```java
+kafkaTracing = KafkaTracing.newBuilder(tracing)
+                           .remoteServiceName("my-broker")
+                           .build();
+```
+
+To use the producer simply wrap it like this :
 ```java
 Producer<K, V> stringProducer = new KafkaProducer<>(settings);
 TracingProducer<K, V> tracingProducer = kafkaTracing.producer(producer);

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
@@ -32,13 +32,16 @@ public final class SpringRabbitTracing {
 
   public static final class Builder {
     final Tracing tracing;
-    String remoteServiceName;
+    String remoteServiceName = "rabbitmq";
 
     Builder(Tracing tracing) {
       this.tracing = tracing;
     }
 
-    /** The remote service name that describes the broker in the dependency graph. No default */
+    /**
+     * The remote service name that describes the broker in the dependency graph. Defaults to
+     * "rabbitmq"
+     */
     public Builder remoteServiceName(String remoteServiceName) {
       this.remoteServiceName = remoteServiceName;
       return this;


### PR DESCRIPTION
This adds default service names for kafka and rabbitmq spans so that
dependency links are created by default. Set to null to disable this.