### PR TITLE
Reverts to maven-invoker 2.0.0 as extraArtifacts is broken in 3.0.0

### DIFF
--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -88,8 +88,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
+        <!-- extraArtifacts broke in 3.0.0 https://issues.apache.org/jira/browse/MINVOKER-227 -->
+        <version>2.0.0</version>
         <configuration>
           <extraArtifacts>
             <extraArtifact>io.grpc:grpc-all:1.2.0:jar</extraArtifact>

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,6 @@
                 </configuration>
             </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.0.1</version>
           <configuration>
@@ -430,7 +429,6 @@
           </configuration>
           <executions>
             <execution>
-              <id>integration-test</id>
               <goals>
                 <goal>install</goal>
                 <goal>run</goal>


### PR DESCRIPTION
This causes quite a large redundant download on each build

We are hit by https://issues.apache.org/jira/browse/MINVOKER-227