### PR TITLE
Tests and documents SparkJava as compatible with servlet deployment

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -12,7 +12,6 @@ import brave.sampler.Sampler;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -82,8 +81,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class ITHttp {
   public static final String EXTRA_KEY = "user-id";
   static final String CONTEXT_LEAK = "context.leak";
-
-  @Rule public MockWebServer server = new MockWebServer();
 
   /**
    * When testing servers or asynchronous clients, spans are reported on a worker thread. In order

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -13,10 +13,12 @@ import brave.propagation.SamplingFlags;
 import brave.sampler.Sampler;
 import java.util.Arrays;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
@@ -25,6 +27,8 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITHttpClient<C> extends ITHttp {
+  @Rule public MockWebServer server = new MockWebServer();
+
   protected C client;
 
   @Before public void setup() {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
@@ -5,14 +5,19 @@ import org.junit.After;
 
 /** Starts a jetty server which runs a servlet container */
 public abstract class ITServletContainer extends ITHttpServer {
-  ServletContainer container = new ServletContainer() {
-    @Override public void init(ServletContextHandler handler) {
-      ITServletContainer.this.init(handler);
-    }
-  };
+  ServletContainer container;
+
+  protected ServletContainer newServletContainer() {
+    return new ServletContainer() {
+      @Override public void init(ServletContextHandler handler) {
+        ITServletContainer.this.init(handler);
+      }
+    };
+  }
 
   /** recreates the server so that it uses the supplied trace configuration */
   @Override protected final void init() {
+    container = newServletContainer();
     container.init();
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ServletContainer.java
@@ -13,11 +13,7 @@ public abstract class ServletContainer {
   /** recreates the server so that it uses the supplied trace configuration */
   public final void init() {
     stop();
-    SocketConnector connector = new SocketConnector();
-    connector.setMaxIdleTime(1000 * 60 * 60);
-    connector.setPort(port);
-    server = new Server();
-    server.setConnectors(new Connector[] {connector});
+    server = newServer(port);
 
     ServletContextHandler context = new ServletContextHandler();
     context.setContextPath("/");
@@ -27,10 +23,23 @@ public abstract class ServletContainer {
 
     try {
       server.start();
-      port = server.getConnectors()[0].getLocalPort();
+      port = getLocalPort(server);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to start server.", e);
     }
+  }
+
+  protected int getLocalPort(Server server) {
+    return server.getConnectors()[0].getLocalPort();
+  }
+
+  protected Server newServer(int port) {
+    Server result = new Server();
+    SocketConnector connector = new SocketConnector();
+    connector.setMaxIdleTime(1000 * 60 * 60);
+    connector.setPort(port);
+    result.setConnectors(new Connector[] {connector});
+    return result;
   }
 
   public final String url(String path) {

--- a/instrumentation/sparkjava/README.md
+++ b/instrumentation/sparkjava/README.md
@@ -17,3 +17,11 @@ Spark.afterAfter(sparkTracing.afterAfter());
 // any routes you add are now traced, such as the below
 Spark.get("/foo", (req, res) -> "bar");
 ```
+
+## Non-embedded mode
+SparkJava can run with embedded Jetty or as a [Servlet Filter](http://sparkjava.com/documentation#other-web-server).
+Servlet filter deployment allows you to run SparkJava in a war file, or
+anything that provides a servlet layer (such as Spring Boot). When using
+the filter approach, use our [TracingFilter](../servlet), not
+`SparkTracing` types.
+

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
@@ -32,6 +34,13 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- sparkjava provides its own jetty -->
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -46,6 +55,13 @@
               <Automatic-Module-Name>brave.sparkjava</Automatic-Module-Name>
             </manifestEntries>
           </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Prevent problems due to Spark's static initialization -->
+        <configuration>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
       <plugin>

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
@@ -1,0 +1,47 @@
+package brave.sparkjava;
+
+import brave.servlet.TracingFilter;
+import brave.test.http.ITServletContainer;
+import brave.test.http.ServletContainer;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration.Dynamic;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import spark.servlet.SparkFilter;
+
+public class ITTracingFilter extends ITServletContainer {
+  /** Override to support Jetty 9.x */
+  @Override protected ServletContainer newServletContainer() {
+    return new ServletContainer() {
+      @Override protected Server newServer(int port) {
+        Server result = new Server();
+        ServerConnector connector = new ServerConnector(result);
+        connector.setPort(port);
+        connector.setIdleTimeout(1000 * 60 * 60);
+        result.setConnectors(new Connector[] {connector});
+        return result;
+      }
+
+      @Override protected int getLocalPort(Server server) {
+        return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+      }
+
+      @Override public void init(ServletContextHandler handler) {
+        ITTracingFilter.this.init(handler);
+      }
+    };
+  }
+
+  @Override public void init(ServletContextHandler handler) {
+    handler.getServletContext()
+        .addFilter("tracingFilter", TracingFilter.create(httpTracing))
+        .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+
+    Dynamic sparkFilter = handler.getServletContext().addFilter("sparkFilter", new SparkFilter());
+    sparkFilter.setInitParameter("applicationClass", TestApplication.class.getName());
+    sparkFilter.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+  }
+}

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/TestApplication.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/TestApplication.java
@@ -1,0 +1,34 @@
+package brave.sparkjava;
+
+import brave.Tracing;
+import brave.propagation.ExtraFieldPropagation;
+import java.util.concurrent.atomic.AtomicBoolean;
+import spark.Spark;
+import spark.servlet.SparkApplication;
+
+import static brave.test.http.ITHttp.EXTRA_KEY;
+
+public class TestApplication implements SparkApplication {
+  @Override public void init() {
+    Spark.options("/", (req, res) -> "");
+    Spark.get("/foo", (req, res) -> "bar");
+    Spark.get("/extra", (req, res) -> ExtraFieldPropagation.get(EXTRA_KEY));
+    Spark.get("/badrequest", (req, res) -> {
+      res.status(400);
+      return res;
+    });
+    Spark.get("/child", (req, res) -> {
+      Tracing.currentTracer().nextSpan().name("child").start().finish();
+      return "happy";
+    });
+    Spark.get("/exception", (req, res) -> {
+      throw new Exception();
+    });
+
+    // TODO: we need matchUri: https://github.com/perwendel/spark/issues/959
+    //Spark.get("/items/:itemId", (request, response) -> request.params(":itemId"));
+    //Spark.path("/nested", () ->
+    //    Spark.get("/items/:itemId", (request, response) -> request.params(":itemId"))
+    //);
+  }
+}


### PR DESCRIPTION
There are a number of examples on the web where SparkJava runs in a war
file or in a Spring Boot application. This documents to use the normal
`TracingFilter` in this case.

Note: sometime in the future, we may add a span customizing feature
which could publish SparkJava's route information to the servlet layer.