### PR TITLE
Exposes Tracer.currentSpanCustomizer() and Span.customizer() for safety

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -484,7 +484,7 @@ operation.
 is generally a safe object to expose to third-party code to add tags.
 
 `Tracer.currentSpan()` should be reserved for framework code that cannot
-reference the span explicitly which to close or abandon an operation.
+reference the span it wants to finish, flush or abandon explicitly.
 
 `Tracer.nextSpan()` uses the "current span" to determine a parent. This
 creates a child of whatever is in-flight.

--- a/brave/src/main/java/brave/CurrentSpanCustomizer.java
+++ b/brave/src/main/java/brave/CurrentSpanCustomizer.java
@@ -20,37 +20,21 @@ public final class CurrentSpanCustomizer implements SpanCustomizer {
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer name(String name) {
-    Span currentSpan = tracer.currentSpan();
-    if (currentSpan != null) {
-      currentSpan.name(name);
-    }
-    return this;
+    return tracer.currentSpanCustomizer().name(name);
   }
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer tag(String key, String value) {
-    Span currentSpan = tracer.currentSpan();
-    if (currentSpan != null) {
-      currentSpan.tag(key, value);
-    }
-    return this;
+    return tracer.currentSpanCustomizer().tag(key, value);
   }
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer annotate(String value) {
-    Span currentSpan = tracer.currentSpan();
-    if (currentSpan != null) {
-      currentSpan.annotate(value);
-    }
-    return this;
+    return tracer.currentSpanCustomizer().annotate(value);
   }
 
   /** {@inheritDoc} */
   @Override public SpanCustomizer annotate(long timestamp, String value) {
-    Span currentSpan = tracer.currentSpan();
-    if (currentSpan != null) {
-      currentSpan.annotate(timestamp, value);
-    }
-    return this;
+    return tracer.currentSpanCustomizer().annotate(timestamp, value);
   }
 }

--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -11,6 +11,10 @@ abstract class NoopSpan extends Span {
     return new AutoValue_NoopSpan(context);
   }
 
+  @Override public SpanCustomizer customizer() {
+    return NoopSpanCustomizer.INSTANCE;
+  }
+
   @Override public boolean isNoop() {
     return true;
   }

--- a/brave/src/main/java/brave/NoopSpanCustomizer.java
+++ b/brave/src/main/java/brave/NoopSpanCustomizer.java
@@ -1,7 +1,11 @@
 package brave;
 
+/**
+ * Performs no operations as the span represented by this is not sampled to report to the tracing
+ * system.
+ */
 // Preferred to a constant NOOP in SpanCustomizer as the latter ends up in a hierachy including Span
-enum NoopSpanCustomizer implements SpanCustomizer {
+public enum NoopSpanCustomizer implements SpanCustomizer {
   INSTANCE;
 
   @Override public SpanCustomizer name(String name) {

--- a/brave/src/main/java/brave/NoopSpanCustomizer.java
+++ b/brave/src/main/java/brave/NoopSpanCustomizer.java
@@ -1,0 +1,22 @@
+package brave;
+
+// Preferred to a constant NOOP in SpanCustomizer as the latter ends up in a hierachy including Span
+enum NoopSpanCustomizer implements SpanCustomizer {
+  INSTANCE;
+
+  @Override public SpanCustomizer name(String name) {
+    return this;
+  }
+
+  @Override public SpanCustomizer tag(String key, String value) {
+    return this;
+  }
+
+  @Override public SpanCustomizer annotate(String value) {
+    return this;
+  }
+
+  @Override public SpanCustomizer annotate(long timestamp, String value) {
+    return this;
+  }
+}

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -12,7 +12,7 @@ abstract class RealSpan extends Span {
   abstract Recorder recorder();
 
   static RealSpan create(TraceContext context, Recorder recorder) {
-    return new AutoValue_RealSpan(context, recorder);
+    return new AutoValue_RealSpan(context, RealSpanCustomizer.create(context, recorder), recorder);
   }
 
   @Override public boolean isNoop() {

--- a/brave/src/main/java/brave/RealSpanCustomizer.java
+++ b/brave/src/main/java/brave/RealSpanCustomizer.java
@@ -1,0 +1,42 @@
+package brave;
+
+import brave.internal.recorder.Recorder;
+import brave.propagation.TraceContext;
+import com.google.auto.value.AutoValue;
+
+/** This wraps the public api and guards access to a mutable span. */
+@AutoValue
+abstract class RealSpanCustomizer implements SpanCustomizer {
+
+  abstract TraceContext context();
+  abstract Recorder recorder();
+
+  static RealSpanCustomizer create(TraceContext context, Recorder recorder) {
+    return new AutoValue_RealSpanCustomizer(context, recorder);
+  }
+
+  @Override public SpanCustomizer name(String name) {
+    recorder().name(context(), name);
+    return this;
+  }
+
+  @Override public SpanCustomizer annotate(String value) {
+    recorder().annotate(context(), value);
+    return this;
+  }
+
+  @Override public SpanCustomizer annotate(long timestamp, String value) {
+    recorder().annotate(context(), timestamp, value);
+    return this;
+  }
+
+  @Override public SpanCustomizer tag(String key, String value) {
+    recorder().tag(context(), key, value);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "RealSpanCustomizer(" + context() + ")";
+  }
+}

--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -54,6 +54,9 @@ public abstract class Span implements SpanCustomizer {
 
   public abstract TraceContext context();
 
+  /** Returns a customizer appropriate for the current span. Prefer this when invoking user code */
+  public abstract SpanCustomizer customizer();
+
   /**
    * Starts the span with an implicit timestamp.
    *

--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -20,6 +20,8 @@ import zipkin2.Endpoint;
 // Design note: this does not require a builder as the span is mutable anyway. Having a single
 // mutation interface is less code to maintain. Those looking to prepare a span before starting it
 // can simply call start when they are ready.
+// BRAVE5: do not inherit SpanCustomizer, rather just return it. This will prevent accidentally
+// leaking lifecycle methods
 public abstract class Span implements SpanCustomizer {
   public enum Kind {
     CLIENT,

--- a/brave/src/main/java/brave/SpanCustomizer.java
+++ b/brave/src/main/java/brave/SpanCustomizer.java
@@ -9,6 +9,16 @@ import zipkin.TraceKeys;
  *
  * <p>This type is safer to expose directly to users than {@link Span}, as it has no hooks that
  * can affect the span lifecycle.
+ *
+ * <p>While unnecessary when tagging constants, guard potentially expensive operations on the
+ * {@link NoopSpanCustomizer} type.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * if (!(customizer instanceof NoopSpanCustomizer)) {
+ *   customizer.tag("summary", computeSummary());
+ * }
+ * }</pre>
  */
 // Note: this is exposed to users. We cannot add methods to this until Java 8 is required or we do a
 // major version bump

--- a/brave/src/main/java/brave/SpanCustomizer.java
+++ b/brave/src/main/java/brave/SpanCustomizer.java
@@ -12,6 +12,7 @@ import zipkin.TraceKeys;
  */
 // Note: this is exposed to users. We cannot add methods to this until Java 8 is required or we do a
 // major version bump
+// BRAVE5: add isNoop to avoid instanceof checks
 public interface SpanCustomizer {
   /**
    * Sets the string name for the logical operation this span represents.

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -230,9 +230,9 @@ public abstract class Tracing implements Closeable {
     }
 
     /**
-     * Responsible for implementing {@link Tracer#currentSpan()} and {@link
-     * Tracer#withSpanInScope(Span)}. By default a simple thread-local is used. Override to support
-     * other mechanisms or to synchronize with other mechanisms such as SLF4J's MDC.
+     * Responsible for implementing {@link Tracer#currentSpanCustomizer()}, {@link Tracer#currentSpan()}
+     * and {@link Tracer#withSpanInScope(Span)}. By default a simple thread-local is used. Override
+     * to support other mechanisms or to synchronize with other mechanisms such as SLF4J's MDC.
      */
     public Builder currentTraceContext(CurrentTraceContext currentTraceContext) {
       if (currentTraceContext == null) throw new NullPointerException("currentTraceContext == null");

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -31,6 +31,10 @@ public class NoopSpanTest {
     assertThat(span.context().spanId()).isNotZero();
   }
 
+  @Test public void hasNoopCustomizer() {
+    assertThat(span.customizer()).isSameAs(NoopSpanCustomizer.INSTANCE);
+  }
+
   @Test public void doesNothing() {
     // Since our clock and spanReporter throw, we know this is doing nothing
     span.start();

--- a/brave/src/test/java/brave/RealSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/RealSpanCustomizerTest.java
@@ -1,0 +1,54 @@
+package brave;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.Annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class RealSpanCustomizerTest {
+  List<zipkin2.Span> spans = new ArrayList();
+  Tracer tracer = Tracing.newBuilder().spanReporter(spans::add).build().tracer();
+  Span span = tracer.newTrace();
+  SpanCustomizer spanCustomizer = span.customizer();
+
+  @After public void close() {
+    Tracing.current().close();
+  }
+
+  @Test public void name() {
+    spanCustomizer.name("foo");
+    span.flush();
+
+    assertThat(spans).extracting(zipkin2.Span::name)
+        .containsExactly("foo");
+  }
+
+  @Test public void annotate() {
+    spanCustomizer.annotate("foo");
+    span.flush();
+
+    assertThat(spans).flatExtracting(zipkin2.Span::annotations)
+        .extracting(Annotation::value)
+        .containsExactly("foo");
+  }
+
+  @Test public void annotate_timestamp() {
+    spanCustomizer.annotate(2, "foo");
+    span.flush();
+
+    assertThat(spans).flatExtracting(zipkin2.Span::annotations)
+        .containsExactly(Annotation.create(2L, "foo"));
+  }
+
+  @Test public void tag() {
+    spanCustomizer.tag("foo", "bar");
+    span.flush();
+
+    assertThat(spans).flatExtracting(s -> s.tags().entrySet())
+        .containsExactly(entry("foo", "bar"));
+  }
+}

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -26,6 +26,10 @@ public class RealSpanTest {
     assertThat(span.context().spanId()).isNotZero();
   }
 
+  @Test public void hasRealCustomizer() {
+    assertThat(span.customizer()).isInstanceOf(RealSpanCustomizer.class);
+  }
+
   @Test public void start() {
     span.start();
     span.flush();

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -270,6 +270,11 @@ public class TracerTest {
         .isInstanceOf(NoopSpan.class);
   }
 
+  @Test public void currentSpanCustomizer_defaultsToNoop() {
+    assertThat(tracer.currentSpanCustomizer())
+        .isSameAs(NoopSpanCustomizer.INSTANCE);
+  }
+
   @Test public void currentSpan_defaultsToNull() {
     assertThat(tracer.currentSpan()).isNull();
   }
@@ -378,6 +383,9 @@ public class TracerTest {
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(current)) {
       assertThat(tracer.currentSpan())
           .isEqualTo(current);
+      assertThat(tracer.currentSpanCustomizer())
+          .isNotEqualTo(current)
+          .isNotEqualTo(NoopSpanCustomizer.INSTANCE);
     }
 
     // context was cleared
@@ -441,6 +449,8 @@ public class TracerTest {
       try (Tracer.SpanInScope clearScope = tracer.withSpanInScope(null)) {
         assertThat(tracer.currentSpan())
             .isNull();
+        assertThat(tracer.currentSpanCustomizer())
+            .isEqualTo(NoopSpanCustomizer.INSTANCE);
       }
 
       // old parent reverted

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -83,7 +83,7 @@ public final class TracingFilter implements Filter {
     try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
       Result result = invoker.invoke(invocation);
       if (result.hasException()) {
-        onError(result.getException(), span);
+        onError(result.getException(), span.customizer());
       }
       isOneway = RpcUtils.isOneway(invoker.getUrl(), invocation);
       Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
@@ -93,7 +93,7 @@ public final class TracingFilter implements Filter {
       }
       return result;
     } catch (Error | RuntimeException e) {
-      onError(e, span);
+      onError(e, span.customizer());
       throw e;
     } finally {
       if (isOneway) {

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -18,7 +18,8 @@ import zipkin2.Endpoint;
  * Span span = handler.handleSend(injector, request);
  * Throwable error = null;
  * try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
- *   response = invoke(request); // any downstream code can see Tracer.currentSpan
+ *   // any downstream code can see Tracer.currentSpan() or use Tracer.currentSpanCustomizer()
+ *   response = invoke(request);
  * } catch (RuntimeException | Error e) {
  *   error = e;
  *   throw e;
@@ -103,7 +104,7 @@ public final class HttpClientHandler<Req, Resp> {
     // Ensure user-code can read the current trace context
     Tracer.SpanInScope ws = tracer.withSpanInScope(span);
     try {
-      parser.request(adapter, request, span);
+      parser.request(adapter, request, span.customizer());
     } finally {
       ws.close();
     }
@@ -143,7 +144,7 @@ public final class HttpClientHandler<Req, Resp> {
     if (span.isNoop()) return;
     Tracer.SpanInScope ws = tracer.withSpanInScope(span);
     try {
-      parser.response(adapter, response, error, span);
+      parser.response(adapter, response, error, span.customizer());
     } finally {
       ws.close();
       span.finish();

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -17,7 +17,8 @@ import zipkin2.Endpoint;
  * Span span = handler.handleReceive(extractor, request);
  * Throwable error = null;
  * try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
- *   response = invoke(request); // any downstream code can see Tracer.currentSpan
+ *   // any downstream code can see Tracer.currentSpan() or use Tracer.currentSpanCustomizer()
+ *   response = invoke(request);
  * } catch (RuntimeException | Error e) {
  *   error = e;
  *   throw e;
@@ -92,7 +93,7 @@ public final class HttpServerHandler<Req, Resp> {
     // Ensure user-code can read the current trace context
     Tracer.SpanInScope ws = tracer.withSpanInScope(span);
     try {
-      parser.request(adapter, request, span);
+      parser.request(adapter, request, span.customizer());
     } finally {
       ws.close();
     }
@@ -127,7 +128,7 @@ public final class HttpServerHandler<Req, Resp> {
     // Ensure user-code can read the current trace context
     Tracer.SpanInScope ws = tracer.withSpanInScope(span);
     try {
-      parser.response(adapter, response, error, span);
+      parser.response(adapter, response, error, span.customizer());
     } finally {
       ws.close();
       span.finish();

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -22,8 +22,8 @@ import static javax.ws.rs.RuntimeType.CLIENT;
 
 /**
  * This filter is set at highest priority which means it executes before other filters. The impact
- * is that other filters can see the span created here via {@link Tracer#currentSpan()}. Another
- * impact is that the span will not see modifications to the request made by downstream filters.
+ * is other filters can modify the span created here via {@link Tracer#currentSpanCustomizer()}.
+ * Another impact is the span will not see modifications to the request made by downstream filters.
  */
 // If tags for the request are added on response, they might include changes made by other filters..
 // However, the response callback isn't invoked on error, so this choice could be worse.

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -1,6 +1,7 @@
 package brave.kafka.clients;
 
 import brave.Span;
+import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
@@ -82,7 +83,7 @@ public final class KafkaTracing {
       return tracing.tracer().toSpan(extracted.context()); // avoid creating an unnecessary child
     }
     Span result = tracing.tracer().nextSpan(extracted);
-    if (!result.isNoop()) addTags(record, result);
+    if (!result.isNoop()) addTags(record, result.customizer());
     return result;
   }
 
@@ -103,7 +104,7 @@ public final class KafkaTracing {
   }
 
   /** When an upstream context was not present, lookup keys are unlikely added */
-  static void addTags(ConsumerRecord<?, ?> record, Span result) {
+  static void addTags(ConsumerRecord<?, ?> record, SpanCustomizer result) {
     if (record.key() instanceof String && !"".equals(record.key())) {
       result.tag(KafkaTags.KAFKA_KEY_TAG, record.key().toString());
     }

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
@@ -61,7 +61,7 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
     // Place the span in scope so that downstream code can read trace IDs
     try {
       if (!span.isNoop()) {
-        parser.request(adapter, request, span);
+        parser.request(adapter, request, span.customizer());
         maybeParseClientAddress(ctx.channel(), request, span);
         span.start();
       }
@@ -110,7 +110,7 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
     if (spanInScope == null) spanInScope = tracer.withSpanInScope(span);
     try {
       ctx.write(msg, prm);
-      parser.response(adapter, response, null, span);
+      parser.response(adapter, response, null, span.customizer());
     } finally {
       spanInScope.close(); // clear scope before reporting
       span.finish();

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -14,7 +14,7 @@ import okhttp3.Response;
 
 /**
  * This internally adds an interceptor which ensures whatever current span exists is available via
- * {@link Tracer#currentSpan()}
+ * {@link Tracer#currentSpanCustomizer()} and {@link Tracer#currentSpan()}
  */
 // NOTE: this is not an interceptor because the current span can get lost when there's a backlog.
 // This will be completely different after https://github.com/square/okhttp/issues/270

--- a/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
@@ -67,12 +67,13 @@ public final class TracingFilter implements Filter {
     Span span = handler.handleReceive(extractor, httpRequest);
 
     // Add attributes for explicit access to customization or span context
-    request.setAttribute(SpanCustomizer.class.getName(), span);
+    request.setAttribute(SpanCustomizer.class.getName(), span.customizer());
     request.setAttribute(TraceContext.class.getName(), span.context());
 
     Throwable error = null;
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-      chain.doFilter(httpRequest, httpResponse); // any downstream filters see Tracer.currentSpan
+      // any downstream code can see Tracer.currentSpan() or use Tracer.currentSpanCustomizer()
+      chain.doFilter(httpRequest, httpResponse);
     } catch (IOException | ServletException | RuntimeException | Error e) {
       error = e;
       throw e;


### PR DESCRIPTION
Eventhough we made a safe user type `SpanCustomizer`, we didn't provide
a safe alternative to `Tracer.currentSpan()`. This led to routine
leaking of `brave.Span` to users (even if they need to cast to discover
this). While we did have `CurrentSpanCustomizer`, that relied on current
context to work. Particularly the new servlet instrumentation uses
explicit references, which are cheaper.

This adds a couple utilities and uses them:
`Tracer.currentSpanCustomizer()` - safer than `currentSpan()`
`Span.customizer()` - safely masks lifecycle methods from parsers

These are safer as they don't have the ability to abend the span, and
have a chance of holding less state (ex NoopSpanCustomizer is constant).

Future work will introduce `UnsafeSpan`, which can rely on these methods
to ensure higher performance in single-threaded scenarios such as
synchronous calls.