### PR TITLE
Fixes issue #661 - debug trace not sampled

### DIFF
--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -61,7 +61,7 @@ public abstract class SamplingFlags {
     }
 
     @Override public Boolean sampled() {
-      return sampled;
+      return debug ? Boolean.TRUE : sampled;
     }
 
     @Override public boolean debug() {
@@ -81,6 +81,10 @@ public abstract class SamplingFlags {
   static final int FLAG_DEBUG = 1 << 3;
 
   static Boolean sampled(int flags) {
+
+    // FLAG_DEBUG implies sampled
+    if ((flags & FLAG_DEBUG) == FLAG_DEBUG) return true;
+
     return (flags & FLAG_SAMPLED_SET) == FLAG_SAMPLED_SET
         ? (flags & FLAG_SAMPLED) == FLAG_SAMPLED
         : null;

--- a/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
@@ -19,9 +19,8 @@ public class SamplingFlagsTest {
   }
 
   @Test public void debugImpliesSampled() {
-    SamplingFlags flags = new SamplingFlags.Builder().debug(true).build();
+    SamplingFlags flags = new SamplingFlags.SamplingFlagsImpl(null, true);
 
-    assertThat(flags).isSameAs(SamplingFlags.DEBUG);
     assertThat(flags.sampled()).isTrue();
     assertThat(flags.debug()).isTrue();
   }
@@ -40,5 +39,13 @@ public class SamplingFlagsTest {
     assertThat(flags).isSameAs(SamplingFlags.NOT_SAMPLED);
     assertThat(flags.sampled()).isFalse();
     assertThat(flags.debug()).isFalse();
+  }
+
+  @Test public void sampledFlags() {
+    assertThat(SamplingFlags.sampled(0)).isNull();
+    assertThat(SamplingFlags.sampled(SamplingFlags.FLAG_SAMPLED)).isNull();
+    assertThat(SamplingFlags.sampled(SamplingFlags.FLAG_SAMPLED_SET)).isFalse();
+    assertThat(SamplingFlags.sampled(SamplingFlags.FLAG_SAMPLED | SamplingFlags.FLAG_SAMPLED_SET)).isTrue();
+    assertThat(SamplingFlags.sampled(SamplingFlags.FLAG_DEBUG)).isTrue();
   }
 }


### PR DESCRIPTION
The test `SamplingFlagsTest#debugImpliesSampled` uses a Builder to construct a SamplingFlags object. The problem is that the Builder contains the logic that implicitly enables sampling, when the debug flag is set. But not all sampling-flags are created using that Builder!

The solution provided here is moving the logic back to the `.sampled()` method, for both:
1. `SamplingFlagsImpl.sampled()` and
2. the `static Boolean sampled(int flags)` used by `TraceContext` and `TraceIdContext`

This should resolve issue #661 