### PR TITLE
Adds RxJava v2 CurrentTraceContextAssemblyTracking

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -98,6 +98,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>brave-context-rxjava2</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-instrumentation-dubbo-rpc</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -163,6 +163,11 @@ public abstract class CurrentTraceContext {
   }
 
   /** Wraps the input so that it executes with the same context as now. */
+  // TODO: here and elsewhere consider a volatile reference. When the invocation context equals an
+  // existing wrapped context, it isn't necessarily the same as fields in context.extra may be
+  // different and equals does not consider extra. For example, if a new propagation field has been
+  // added, this should be considered. Doing so via a reference swap could be a lot cheaper than
+  // re-wrapping and achieve the same goal.
   public Runnable wrap(Runnable task) {
     final TraceContext invocationContext = get();
     class CurrentTraceContextRunnable implements Runnable {

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -20,6 +20,7 @@
     <module>slf4j</module>
     <module>log4j12</module>
     <module>log4j2</module>
+    <module>rxjava2</module>
   </modules>
 
   <dependencies>

--- a/context/rxjava2/README.md
+++ b/context/rxjava2/README.md
@@ -1,0 +1,30 @@
+# brave-context-rxjava2
+`CurrentTraceContextcontextTracking` prevents traces from breaking
+during RxJava operations by scoping them with trace context.
+
+The design of this library borrows heavily from https://github.com/akaita/RxJava2Debug and https://github.com/akarnokd/RxJava2Extensions
+
+To set this up, create `CurrentTraceContextcontextTracking` using the
+current trace context provided by your `Tracing` component.
+
+```java
+contextTracking = CurrentTraceContextcontextTracking.create(
+  tracing.currentTraceContext()
+);
+```
+
+After your application-specific changes to `RxJavaPlugins`, enable trace
+context tracking like so:
+
+```java
+contextTracking.enable();
+```
+
+Or, if you want to be able to restore any preceding hooks, enable like
+this:
+```java
+SavedHooks hooks = contextTracking.enableAndChain();
+
+// then, later you can restore like this
+hooks.restore();
+```

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-context-parent</artifactId>
+    <version>5.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-context-rxjava2</artifactId>
+  <name>Brave Context: RxJava 2</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.7</main.java.version>
+    <main.signature.artifact>java17</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>2.1.14</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>adapter-rxjava2</artifactId>
+      <version>2.4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava2-extensions</artifactId>
+      <version>0.19.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.context.rxjava2</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/CurrentTraceContextAssemblyTracking.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/CurrentTraceContextAssemblyTracking.java
@@ -1,0 +1,291 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.functions.Function;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+import java.util.concurrent.Callable;
+
+/**
+ * Prevents traces from breaking during RxJava operations by scoping them with trace context.
+ *
+ * <p>The design of this library borrows heavily from https://github.com/akaita/RxJava2Debug and
+ * https://github.com/akarnokd/RxJava2Extensions
+ */
+public final class CurrentTraceContextAssemblyTracking {
+
+  public interface SavedHooks {
+
+    /** Restores the previous set of hooks. */
+    void restore();
+  }
+
+  static volatile boolean enabled;
+
+  final CurrentTraceContext currentTraceContext;
+
+  CurrentTraceContextAssemblyTracking(CurrentTraceContext currentTraceContext) {
+    if (currentTraceContext == null) throw new NullPointerException("currentTraceContext == null");
+    this.currentTraceContext = currentTraceContext;
+  }
+
+  public static CurrentTraceContextAssemblyTracking create(CurrentTraceContext delegate) {
+    return new CurrentTraceContextAssemblyTracking(delegate);
+  }
+
+  /**
+   * Enable the protocol violation hooks.
+   *
+   * @see #enableAndChain()
+   * @see #disable()
+   */
+  public void enable() {
+    enable(false);
+  }
+
+  /**
+   * Enable the protocol violation hooks by chaining it before any existing hook.
+   *
+   * @return the SavedHooks instance that allows restoring the previous assembly hook handlers
+   *     overridden by this method
+   * @see #enable()
+   */
+  public SavedHooks enableAndChain() {
+    return enable(true);
+  }
+
+  @SuppressWarnings("rawtypes")
+  SavedHooks enable(boolean chain) {
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super Completable, ? extends Completable> saveC =
+        RxJavaPlugins.getOnCompletableAssembly();
+    Function<? super Completable, ? extends Completable> oldCompletable = saveC;
+    if (oldCompletable == null || !chain) {
+      oldCompletable = Functions.identity();
+    }
+    final Function<? super Completable, ? extends Completable> oldC = oldCompletable;
+
+    RxJavaPlugins.setOnCompletableAssembly(
+        new ConditionalOnCurrentTraceContextFunction<Completable>() {
+          @Override
+          Completable applyActual(Completable c, TraceContext ctx) {
+            if (!(c instanceof Callable)) {
+              return new TraceContextCompletable(c, currentTraceContext, ctx);
+            }
+            if (c instanceof ScalarCallable) {
+              return new TraceContextScalarCallableCompletable(c, currentTraceContext, ctx);
+            }
+            return new TraceContextCallableCompletable(c, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super Maybe, ? extends Maybe> saveM = RxJavaPlugins.getOnMaybeAssembly();
+    Function<? super Maybe, ? extends Maybe> oldMaybe = saveM;
+    if (oldMaybe == null || !chain) {
+      oldMaybe = Functions.identity();
+    }
+    final Function<? super Maybe, ? extends Maybe> oldM = oldMaybe;
+
+    RxJavaPlugins.setOnMaybeAssembly(
+        new ConditionalOnCurrentTraceContextFunction<Maybe>() {
+          @Override
+          Maybe applyActual(Maybe m, TraceContext ctx) {
+            if (!(m instanceof Callable)) {
+              return new TraceContextMaybe(m, currentTraceContext, ctx);
+            }
+            if (m instanceof ScalarCallable) {
+              return new TraceContextScalarCallableMaybe(m, currentTraceContext, ctx);
+            }
+            return new TraceContextCallableMaybe(m, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super Single, ? extends Single> saveS = RxJavaPlugins.getOnSingleAssembly();
+    Function<? super Single, ? extends Single> oldSingle = saveS;
+    if (oldSingle == null || !chain) {
+      oldSingle = Functions.identity();
+    }
+    final Function<? super Single, ? extends Single> oldS = oldSingle;
+
+    RxJavaPlugins.setOnSingleAssembly(
+        new ConditionalOnCurrentTraceContextFunction<Single>() {
+          @Override
+          Single applyActual(Single s, TraceContext ctx) {
+            if (!(s instanceof Callable)) {
+              return new TraceContextSingle(s, currentTraceContext, ctx);
+            }
+            if (s instanceof ScalarCallable) {
+              return new TraceContextScalarCallableSingle(s, currentTraceContext, ctx);
+            }
+            return new TraceContextCallableSingle(s, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super Observable, ? extends Observable> saveO =
+        RxJavaPlugins.getOnObservableAssembly();
+    Function<? super Observable, ? extends Observable> oldObservable = saveO;
+    if (oldObservable == null || !chain) {
+      oldObservable = Functions.identity();
+    }
+    final Function<? super Observable, ? extends Observable> oldO = oldObservable;
+
+    RxJavaPlugins.setOnObservableAssembly(
+        new ConditionalOnCurrentTraceContextFunction<Observable>() {
+          @Override
+          Observable applyActual(Observable o, TraceContext ctx) {
+            if (!(o instanceof Callable)) {
+              return new TraceContextObservable(o, currentTraceContext, ctx);
+            }
+            if (o instanceof ScalarCallable) {
+              return new TraceContextScalarCallableObservable(o, currentTraceContext, ctx);
+            }
+            return new TraceContextCallableObservable(o, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super Flowable, ? extends Flowable> saveF =
+        RxJavaPlugins.getOnFlowableAssembly();
+    Function<? super Flowable, ? extends Flowable> oldFlowable = saveF;
+    if (oldFlowable == null || !chain) {
+      oldFlowable = Functions.identity();
+    }
+    final Function<? super Flowable, ? extends Flowable> oldF = oldFlowable;
+
+    RxJavaPlugins.setOnFlowableAssembly(
+        new ConditionalOnCurrentTraceContextFunction<Flowable>() {
+          @Override
+          Flowable applyActual(Flowable f, TraceContext ctx) {
+            if (!(f instanceof Callable)) {
+              return new TraceContextFlowable(f, currentTraceContext, ctx);
+            }
+            if (f instanceof ScalarCallable) {
+              return new TraceContextScalarCallableFlowable(f, currentTraceContext, ctx);
+            }
+            return new TraceContextCallableFlowable(f, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super ConnectableFlowable, ? extends ConnectableFlowable> saveCF =
+        RxJavaPlugins.getOnConnectableFlowableAssembly();
+    Function<? super ConnectableFlowable, ? extends ConnectableFlowable> oldConnFlow = saveCF;
+    if (oldConnFlow == null || !chain) {
+      oldConnFlow = Functions.identity();
+    }
+    final Function<? super ConnectableFlowable, ? extends ConnectableFlowable> oldCF = oldConnFlow;
+
+    RxJavaPlugins.setOnConnectableFlowableAssembly(
+        new ConditionalOnCurrentTraceContextFunction<ConnectableFlowable>() {
+          @Override
+          ConnectableFlowable applyActual(ConnectableFlowable cf, TraceContext ctx) {
+            return new TraceContextConnectableFlowable(cf, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super ConnectableObservable, ? extends ConnectableObservable> saveCO =
+        RxJavaPlugins.getOnConnectableObservableAssembly();
+    Function<? super ConnectableObservable, ? extends ConnectableObservable> oldConnObs = saveCO;
+    if (oldConnObs == null || !chain) {
+      oldConnObs = Functions.identity();
+    }
+    final Function<? super ConnectableObservable, ? extends ConnectableObservable> oldCO =
+        oldConnObs;
+
+    RxJavaPlugins.setOnConnectableObservableAssembly(
+        new ConditionalOnCurrentTraceContextFunction<ConnectableObservable>() {
+          @Override
+          ConnectableObservable applyActual(ConnectableObservable co, TraceContext ctx) {
+            return new TraceContextConnectableObservable(co, currentTraceContext, ctx);
+          }
+        });
+
+    // ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    final Function<? super ParallelFlowable, ? extends ParallelFlowable> savePF =
+        RxJavaPlugins.getOnParallelAssembly();
+    Function<? super ParallelFlowable, ? extends ParallelFlowable> oldParFlow = savePF;
+    if (oldParFlow == null || !chain) {
+      oldParFlow = Functions.identity();
+    }
+    final Function<? super ParallelFlowable, ? extends ParallelFlowable> oldPF = oldParFlow;
+
+    RxJavaPlugins.setOnParallelAssembly(
+        new ConditionalOnCurrentTraceContextFunction<ParallelFlowable>() {
+          @Override
+          ParallelFlowable applyActual(ParallelFlowable pf, TraceContext ctx) {
+            return new TraceContextParallelFlowable(pf, currentTraceContext, ctx);
+          }
+        });
+
+    enabled = true;
+
+    return new SavedHooks() {
+      @Override
+      public void restore() {
+        RxJavaPlugins.setOnCompletableAssembly(saveC);
+        RxJavaPlugins.setOnSingleAssembly(saveS);
+        RxJavaPlugins.setOnMaybeAssembly(saveM);
+        RxJavaPlugins.setOnObservableAssembly(saveO);
+        RxJavaPlugins.setOnFlowableAssembly(saveF);
+
+        RxJavaPlugins.setOnConnectableObservableAssembly(saveCO);
+        RxJavaPlugins.setOnConnectableFlowableAssembly(saveCF);
+
+        RxJavaPlugins.setOnParallelAssembly(savePF);
+      }
+    };
+  }
+
+  /** Disables the validation hooks be resetting the assembly hooks to none. */
+  public static void disable() {
+    RxJavaPlugins.setOnCompletableAssembly(null);
+    RxJavaPlugins.setOnSingleAssembly(null);
+    RxJavaPlugins.setOnMaybeAssembly(null);
+    RxJavaPlugins.setOnObservableAssembly(null);
+    RxJavaPlugins.setOnFlowableAssembly(null);
+
+    RxJavaPlugins.setOnConnectableObservableAssembly(null);
+    RxJavaPlugins.setOnConnectableFlowableAssembly(null);
+
+    RxJavaPlugins.setOnParallelAssembly(null);
+    enabled = false;
+  }
+
+  /** Returns true if the validation hooks have been installed. */
+  public static boolean isEnabled() {
+    return enabled;
+  }
+
+  abstract class ConditionalOnCurrentTraceContextFunction<T> implements Function<T, T> {
+    @Override
+    public final T apply(T t) {
+      TraceContext ctx = currentTraceContext.get();
+      if (ctx == null) return t; // less overhead when there's no current trace
+      return applyActual(t, ctx);
+    }
+
+    abstract T applyActual(T t, TraceContext ctx);
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableCompletable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableCompletable.java
@@ -1,0 +1,40 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextCompletable.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
+import java.util.concurrent.Callable;
+
+final class TraceContextCallableCompletable<T> extends Completable implements Callable<T> {
+  final CompletableSource source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextCallableCompletable(
+      CompletableSource source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(CompletableObserver s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() throws Exception {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((Callable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableFlowable.java
@@ -1,0 +1,42 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import java.util.concurrent.Callable;
+import org.reactivestreams.Publisher;
+
+final class TraceContextCallableFlowable<T> extends Flowable<T> implements Callable<T> {
+  final Publisher<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextCallableFlowable(
+      Publisher<T> source, CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
+    try (CurrentTraceContext.Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      if (s instanceof ConditionalSubscriber) {
+        source.subscribe(
+            new TraceContextConditionalSubscriber<>(
+                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
+      } else {
+        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() throws Exception {
+    try (CurrentTraceContext.Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((Callable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableMaybe.java
@@ -1,0 +1,40 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextMaybe.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import java.util.concurrent.Callable;
+
+final class TraceContextCallableMaybe<T> extends Maybe<T> implements Callable<T> {
+  final MaybeSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextCallableMaybe(
+      MaybeSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(MaybeObserver<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() throws Exception {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((Callable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableObservable.java
@@ -1,0 +1,39 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextObservable.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import java.util.concurrent.Callable;
+
+final class TraceContextCallableObservable<T> extends Observable<T> implements Callable<T> {
+  final ObservableSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextCallableObservable(
+      ObservableSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(io.reactivex.Observer<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() throws Exception {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((Callable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableSingle.java
@@ -1,0 +1,40 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextSingle.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import java.util.concurrent.Callable;
+
+final class TraceContextCallableSingle<T> extends Single<T> implements Callable<T> {
+  final SingleSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextCallableSingle(
+      SingleSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(SingleObserver<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() throws Exception {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((Callable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletable.java
@@ -1,0 +1,81 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+final class TraceContextCompletable extends Completable {
+  final CompletableSource source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextCompletable(
+      CompletableSource source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(CompletableObserver s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  static final class Observer implements CompletableObserver, Disposable {
+    final CompletableObserver actual;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext assemblyContext;
+    Disposable d;
+
+    Observer(
+        CompletableObserver actual,
+        CurrentTraceContext currentTraceContext,
+        TraceContext assemblyContext) {
+      this.actual = actual;
+      this.currentTraceContext = currentTraceContext;
+      this.assemblyContext = assemblyContext;
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+      if (!DisposableHelper.validate(this.d, d)) return;
+      this.d = d;
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onSubscribe(this);
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onError(t);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onComplete();
+      }
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return d.isDisposed();
+    }
+
+    @Override
+    public void dispose() {
+      d.dispose();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConditionalSubscriber.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConditionalSubscriber.java
@@ -1,0 +1,65 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.subscribers.BasicFuseableConditionalSubscriber;
+
+final class TraceContextConditionalSubscriber<T> extends BasicFuseableConditionalSubscriber<T, T> {
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextConditionalSubscriber(
+      io.reactivex.internal.fuseable.ConditionalSubscriber actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    super(actual);
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  public boolean tryOnNext(T t) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return actual.tryOnNext(t);
+    }
+  }
+
+  @Override
+  public void onNext(T t) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      actual.onNext(t);
+    }
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      actual.onError(t);
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      actual.onComplete();
+    }
+  }
+
+  @Override
+  public int requestFusion(int mode) {
+    QueueSubscription<T> qs = this.qs;
+    if (qs != null) {
+      int m = qs.requestFusion(mode);
+      sourceMode = m;
+      return m;
+    }
+    return NONE;
+  }
+
+  @Override
+  public T poll() throws Exception {
+    return qs.poll();
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableFlowable.java
@@ -1,0 +1,44 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+
+final class TraceContextConnectableFlowable<T> extends ConnectableFlowable<T> {
+  final ConnectableFlowable<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextConnectableFlowable(
+      ConnectableFlowable<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      if (s instanceof ConditionalSubscriber) {
+        source.subscribe(
+            new TraceContextConditionalSubscriber<>(
+                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
+      } else {
+        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
+      }
+    }
+  }
+
+  @Override
+  public void connect(Consumer<? super Disposable> connection) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.connect(connection);
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableObservable.java
@@ -1,0 +1,38 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextObservable.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.observables.ConnectableObservable;
+
+final class TraceContextConnectableObservable<T> extends ConnectableObservable<T> {
+  final ConnectableObservable<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextConnectableObservable(
+      ConnectableObservable<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(io.reactivex.Observer s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<T>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @Override
+  public void connect(Consumer<? super Disposable> connection) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.connect(connection);
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextFlowable.java
@@ -1,0 +1,35 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+final class TraceContextFlowable<T> extends Flowable<T> {
+  final Publisher<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextFlowable(
+      Publisher<T> source, CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(Subscriber s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      if (s instanceof ConditionalSubscriber) {
+        source.subscribe(
+            new TraceContextConditionalSubscriber<>(
+                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
+      } else {
+        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
+      }
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybe.java
@@ -1,0 +1,88 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+final class TraceContextMaybe<T> extends Maybe<T> {
+  final MaybeSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextMaybe(
+      MaybeSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(MaybeObserver<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  static final class Observer<T> implements MaybeObserver<T>, Disposable {
+    final MaybeObserver<T> actual;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext assemblyContext;
+    Disposable d;
+
+    Observer(
+        MaybeObserver actual,
+        CurrentTraceContext currentTraceContext,
+        TraceContext assemblyContext) {
+      this.actual = actual;
+      this.currentTraceContext = currentTraceContext;
+      this.assemblyContext = assemblyContext;
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+      if (!DisposableHelper.validate(this.d, d)) return;
+      this.d = d;
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onSubscribe(this);
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onError(t);
+      }
+    }
+
+    @Override
+    public void onSuccess(T value) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onSuccess(value);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onComplete();
+      }
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return d.isDisposed();
+    }
+
+    @Override
+    public void dispose() {
+      d.dispose();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
@@ -1,0 +1,82 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.internal.fuseable.QueueDisposable;
+import io.reactivex.internal.observers.BasicFuseableObserver;
+
+final class TraceContextObservable<T> extends Observable<T> {
+  final ObservableSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextObservable(
+      ObservableSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(io.reactivex.Observer<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  static final class Observer<T> extends BasicFuseableObserver<T, T> {
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext assemblyContext;
+
+    Observer(
+        io.reactivex.Observer<T> actual,
+        CurrentTraceContext currentTraceContext,
+        TraceContext assemblyContext) {
+      super(actual);
+      this.currentTraceContext = currentTraceContext;
+      this.assemblyContext = assemblyContext;
+    }
+
+    @Override
+    public void onNext(T t) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onNext(t);
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onError(t);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onComplete();
+      }
+    }
+
+    @Override
+    public int requestFusion(int mode) {
+      QueueDisposable<T> qs = this.qs;
+      if (qs != null) {
+        int m = qs.requestFusion(mode);
+        sourceMode = m;
+        return m;
+      }
+      return NONE;
+    }
+
+    @Override
+    public T poll() throws Exception {
+      return qs.poll();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextParallelFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextParallelFlowable.java
@@ -1,0 +1,49 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.parallel.ParallelFlowable;
+import org.reactivestreams.Subscriber;
+
+final class TraceContextParallelFlowable<T> extends ParallelFlowable<T> {
+  final ParallelFlowable<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextParallelFlowable(
+      ParallelFlowable<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  public int parallelism() {
+    return source.parallelism();
+  }
+
+  @Override
+  public void subscribe(Subscriber<? super T>[] s) {
+    if (!validate(s)) return;
+    int n = s.length;
+    @SuppressWarnings("unchecked")
+    Subscriber<? super T>[] parents = new Subscriber[n];
+    for (int i = 0; i < n; i++) {
+      Subscriber<? super T> z = s[i];
+      if (z instanceof ConditionalSubscriber) {
+        parents[i] =
+            new TraceContextConditionalSubscriber<>(
+                (ConditionalSubscriber<? super T>) z, currentTraceContext, assemblyContext);
+      } else {
+        parents[i] = new TraceContextSubscriber<>(z, currentTraceContext, assemblyContext);
+      }
+    }
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(parents);
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableCompletable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableCompletable.java
@@ -1,0 +1,41 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextCompletable.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
+import io.reactivex.internal.fuseable.ScalarCallable;
+
+final class TraceContextScalarCallableCompletable<T> extends Completable
+    implements ScalarCallable<T> {
+  final CompletableSource source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextScalarCallableCompletable(
+      CompletableSource source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(CompletableObserver s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((ScalarCallable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableFlowable.java
@@ -1,0 +1,43 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import org.reactivestreams.Publisher;
+
+final class TraceContextScalarCallableFlowable<T> extends Flowable<T> implements ScalarCallable<T> {
+  final Publisher<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextScalarCallableFlowable(
+      Publisher<T> source, CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      if (s instanceof ConditionalSubscriber) {
+        source.subscribe(
+            new TraceContextConditionalSubscriber<>(
+                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
+      } else {
+        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((ScalarCallable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableMaybe.java
@@ -1,0 +1,40 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextMaybe.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.internal.fuseable.ScalarCallable;
+
+final class TraceContextScalarCallableMaybe<T> extends Maybe<T> implements ScalarCallable<T> {
+  final MaybeSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextScalarCallableMaybe(
+      MaybeSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(MaybeObserver<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((ScalarCallable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableObservable.java
@@ -1,0 +1,40 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextObservable.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.internal.fuseable.ScalarCallable;
+
+final class TraceContextScalarCallableObservable<T> extends Observable<T>
+    implements ScalarCallable<T> {
+  final ObservableSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextScalarCallableObservable(
+      ObservableSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(io.reactivex.Observer<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((ScalarCallable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableSingle.java
@@ -1,0 +1,40 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.TraceContextSingle.Observer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.internal.fuseable.ScalarCallable;
+
+final class TraceContextScalarCallableSingle<T> extends Single<T> implements ScalarCallable<T> {
+  final SingleSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextScalarCallableSingle(
+      SingleSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(SingleObserver<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public T call() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      return ((ScalarCallable<T>) source).call();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingle.java
@@ -1,0 +1,81 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.internal.disposables.DisposableHelper;
+
+final class TraceContextSingle<T> extends Single<T> {
+  final SingleSource<T> source;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextSingle(
+      SingleSource<T> source,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    this.source = source;
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  protected void subscribeActual(SingleObserver<? super T> s) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+    }
+  }
+
+  static final class Observer<T> implements SingleObserver<T>, Disposable {
+    final SingleObserver<T> actual;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext assemblyContext;
+    Disposable d;
+
+    Observer(
+        SingleObserver actual,
+        CurrentTraceContext currentTraceContext,
+        TraceContext assemblyContext) {
+      this.actual = actual;
+      this.currentTraceContext = currentTraceContext;
+      this.assemblyContext = assemblyContext;
+    }
+
+    @Override
+    public void onSubscribe(Disposable d) {
+      if (!DisposableHelper.validate(this.d, d)) return;
+      this.d = d;
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onSubscribe(this);
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onError(t);
+      }
+    }
+
+    @Override
+    public void onSuccess(T value) {
+      try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+        actual.onSuccess(value);
+      }
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return d.isDisposed();
+    }
+
+    @Override
+    public void dispose() {
+      d.dispose();
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSubscriber.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSubscriber.java
@@ -1,0 +1,58 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.internal.subscribers.BasicFuseableSubscriber;
+
+final class TraceContextSubscriber<T> extends BasicFuseableSubscriber<T, T> {
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext assemblyContext;
+
+  TraceContextSubscriber(
+      org.reactivestreams.Subscriber actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext) {
+    super(actual);
+    this.currentTraceContext = currentTraceContext;
+    this.assemblyContext = assemblyContext;
+  }
+
+  @Override
+  public void onNext(T t) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      actual.onNext(t);
+    }
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      actual.onError(t);
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    try (Scope scope = currentTraceContext.maybeScope(assemblyContext)) {
+      actual.onComplete();
+    }
+  }
+
+  @Override
+  public int requestFusion(int mode) {
+    QueueSubscription<T> qs = this.qs;
+    if (qs != null) {
+      int m = qs.requestFusion(mode);
+      sourceMode = m;
+      return m;
+    }
+    return NONE;
+  }
+
+  @Override
+  public T poll() throws Exception {
+    return qs.poll();
+  }
+}

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingTest.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingTest.java
@@ -1,0 +1,1442 @@
+package brave.context.rxjava2;
+
+import brave.context.rxjava2.CurrentTraceContextAssemblyTracking.SavedHooks;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.TraceContext;
+import hu.akarnokd.rxjava2.debug.RxJavaAssemblyTracking;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.functions.Predicate;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import io.reactivex.internal.operators.completable.CompletableEmpty;
+import io.reactivex.internal.operators.completable.CompletableFromCallable;
+import io.reactivex.internal.operators.flowable.FlowableFromCallable;
+import io.reactivex.internal.operators.flowable.FlowablePublish;
+import io.reactivex.internal.operators.flowable.FlowableRange;
+import io.reactivex.internal.operators.maybe.MaybeFromCallable;
+import io.reactivex.internal.operators.maybe.MaybeJust;
+import io.reactivex.internal.operators.observable.ObservableFromCallable;
+import io.reactivex.internal.operators.observable.ObservablePublish;
+import io.reactivex.internal.operators.observable.ObservableRange;
+import io.reactivex.internal.operators.parallel.ParallelFromPublisher;
+import io.reactivex.internal.operators.single.SingleFromCallable;
+import io.reactivex.internal.operators.single.SingleJust;
+import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class CurrentTraceContextAssemblyTrackingTest {
+  StrictCurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  CurrentTraceContextAssemblyTracking contextTracking =
+      CurrentTraceContextAssemblyTracking.create(currentTraceContext);
+  TraceContext context1 = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
+  TraceContext context2 = context1.toBuilder().parentId(1L).spanId(2L).build();
+  Predicate<Integer> lessThanThreeInContext1 =
+      i -> {
+        assertContext1();
+        return i < 3;
+      };
+  Predicate<Integer> lessThanThreeInContext2 =
+      i -> {
+        assertContext2();
+        return i < 3;
+      };
+
+  @Before
+  public void setup() {
+    RxJavaPlugins.reset();
+    contextTracking.enable();
+  }
+
+  @After
+  public void tearDown() {
+    contextTracking.disable();
+  }
+
+  @Test
+  public void completable() {
+    Completable source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source = Completable.complete().doOnComplete(() -> assertContext1());
+      errorSource =
+          Completable.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult();
+  }
+
+  @Test
+  public void completable_subscribesUnderScope() {
+    Completable source = Completable.complete().doOnComplete(() -> assertContext2());
+    Completable errorSource =
+        Completable.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult();
+  }
+
+  @Test
+  public void completable_unwrappedWhenNotInScope() {
+    assertThat(Completable.complete()).isEqualTo(CompletableEmpty.INSTANCE);
+  }
+
+  @Test
+  public void flowable() {
+    Flowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Flowable.range(1, 3).doOnNext(i -> assertContext1()).doOnComplete(() -> assertContext1());
+      errorSource =
+          Flowable.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void flowable_subscribesUnderScope() {
+    Flowable<Integer> source =
+        Flowable.range(1, 3).doOnNext(i -> assertContext2()).doOnComplete(() -> assertContext2());
+    Flowable<Integer> errorSource =
+        Flowable.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void flowable_unwrappedWhenNotInScope() {
+    assertThat(Flowable.range(1, 3))
+        .isInstanceOf(FlowableRange.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void flowable_conditional() {
+    Flowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Flowable.range(1, 3)
+              .filter(lessThanThreeInContext1)
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1());
+      errorSource =
+          Flowable.<Integer>error(new IllegalStateException())
+              .filter(lessThanThreeInContext1)
+              .doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1, 2);
+  }
+
+  @Test
+  public void flowable_conditional_subscribesUnderScope() {
+    Flowable<Integer> source =
+        Flowable.range(1, 3)
+            .filter(lessThanThreeInContext2)
+            .doOnNext(i -> assertContext2())
+            .doOnComplete(() -> assertContext2());
+    Flowable<Integer> errorSource =
+        Flowable.<Integer>error(new IllegalStateException())
+            .filter(lessThanThreeInContext2)
+            .doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1, 2);
+  }
+
+  @Test
+  public void observable() {
+    Observable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Observable.range(1, 3)
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1());
+      errorSource =
+          Observable.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source, errorSource).assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void observable_subscribesUnderScope() {
+    Observable<Integer> source =
+        Observable.range(1, 3).doOnNext(i -> assertContext2()).doOnComplete(() -> assertContext2());
+    Observable<Integer> errorSource =
+        Observable.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source, errorSource).assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void observable_unwrappedWhenNotInScope() {
+    assertThat(Observable.range(1, 3))
+        .isInstanceOf(ObservableRange.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void single() {
+    Single<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source = Single.just(1).doOnSuccess(i -> assertContext1());
+      errorSource =
+          Single.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+  }
+
+  @Test
+  public void single_subscribesUnderScope() {
+    Single<Integer> source = Single.just(1).doOnSuccess(i -> assertContext2());
+    Single<Integer> errorSource =
+        Single.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+  }
+
+  @Test
+  public void single_unwrappedWhenNotInScope() {
+    assertThat(Single.just(1))
+        .isInstanceOf(SingleJust.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void maybe() {
+    Maybe<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source = Maybe.just(1).doOnSuccess(i -> assertContext1());
+      errorSource =
+          Maybe.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+  }
+
+  @Test
+  public void maybe_subscribesUnderScope() {
+    Maybe<Integer> source = Maybe.just(1).doOnSuccess(i -> assertContext2());
+    Maybe<Integer> errorSource =
+        Maybe.<Integer>error(new IllegalStateException()).doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+  }
+
+  @Test
+  public void maybe_unwrappedWhenNotInScope() {
+    assertThat(Maybe.just(1))
+        .isInstanceOf(MaybeJust.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void parallelFlowable() {
+    ParallelFlowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Flowable.range(1, 3)
+              .parallel()
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1());
+      errorSource =
+          Flowable.concat(
+                  Flowable.<Integer>error(new IllegalStateException()),
+                  Flowable.<Integer>error(new IllegalStateException()))
+              .parallel()
+              .doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source, errorSource).assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void parallelFlowable_subscribesUnderScope() {
+    ParallelFlowable<Integer> source =
+        Flowable.range(1, 3)
+            .parallel()
+            .doOnNext(i -> assertContext2())
+            .doOnComplete(() -> assertContext2());
+    ParallelFlowable<Integer> errorSource =
+        Flowable.concat(
+                Flowable.<Integer>error(new IllegalStateException()),
+                Flowable.<Integer>error(new IllegalStateException()))
+            .parallel()
+            .doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source, errorSource).assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void parallelFlowable_unwrappedWhenNotInScope() {
+    assertThat(Flowable.range(1, 3).parallel())
+        .isInstanceOf(ParallelFromPublisher.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void parallelFlowable_conditional() {
+    ParallelFlowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Flowable.range(1, 3)
+              .parallel()
+              .filter(lessThanThreeInContext1)
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1());
+      errorSource =
+          Flowable.concat(
+                  Flowable.<Integer>error(new IllegalStateException()),
+                  Flowable.<Integer>error(new IllegalStateException()))
+              .parallel()
+              .filter(lessThanThreeInContext1)
+              .doOnError(t -> assertContext1());
+    }
+
+    subscribesInScope1RunsInScope2(source, errorSource).assertResult(1, 2);
+  }
+
+  @Test
+  public void parallelFlowable_conditional_subscribesUnderScope() {
+    ParallelFlowable<Integer> source =
+        Flowable.range(1, 3)
+            .parallel()
+            .filter(lessThanThreeInContext2)
+            .doOnNext(i -> assertContext2())
+            .doOnComplete(() -> assertContext2());
+    ParallelFlowable<Integer> errorSource =
+        Flowable.concat(
+                Flowable.<Integer>error(new IllegalStateException()),
+                Flowable.<Integer>error(new IllegalStateException()))
+            .parallel()
+            .filter(lessThanThreeInContext2)
+            .doOnError(t -> assertContext2());
+
+    subscribesAndRunsInScope2(source, errorSource).assertResult(1, 2);
+  }
+
+  @Test
+  public void connectableFlowable() {
+    ConnectableFlowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Flowable.range(1, 3)
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1())
+              .publish();
+      errorSource =
+          Flowable.<Integer>error(new IllegalStateException())
+              .doOnError(t -> assertContext1())
+              .publish();
+    }
+
+    subscribesInScope1RunsInScope2(
+            source.autoConnect().toObservable(), errorSource.autoConnect().toObservable())
+        .assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void connectableFlowable_subscribesUnderScope() {
+    ConnectableFlowable<Integer> source =
+        Flowable.range(1, 3)
+            .doOnNext(i -> assertContext2())
+            .doOnComplete(() -> assertContext2())
+            .publish();
+    ConnectableFlowable<Integer> errorSource =
+        Flowable.<Integer>error(new IllegalStateException())
+            .doOnError(t -> assertContext2())
+            .publish();
+
+    subscribesAndRunsInScope2(
+            source.autoConnect().toObservable(), errorSource.autoConnect().toObservable())
+        .assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void connectableFlowable_unwrappedWhenNotInScope() {
+    assertThat(Flowable.range(1, 3).publish())
+        .isInstanceOf(FlowablePublish.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void connectableFlowable_conditional() {
+    ConnectableFlowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Flowable.range(1, 3)
+              .filter(lessThanThreeInContext1)
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1())
+              .publish();
+      errorSource =
+          Flowable.<Integer>error(new IllegalStateException())
+              .filter(lessThanThreeInContext1)
+              .doOnError(t -> assertContext1())
+              .publish();
+    }
+
+    subscribesInScope1RunsInScope2(
+            source.autoConnect().toObservable(), errorSource.autoConnect().toObservable())
+        .assertResult(1, 2);
+  }
+
+  @Test
+  public void connectableFlowable_conditional_subscribesUnderScope() {
+    ConnectableFlowable<Integer> source =
+        Flowable.range(1, 3)
+            .filter(lessThanThreeInContext2)
+            .doOnNext(i -> assertContext2())
+            .doOnComplete(() -> assertContext2())
+            .publish();
+    ConnectableFlowable<Integer> errorSource =
+        Flowable.<Integer>error(new IllegalStateException())
+            .filter(lessThanThreeInContext2)
+            .doOnError(t -> assertContext2())
+            .publish();
+
+    subscribesAndRunsInScope2(
+            source.autoConnect().toObservable(), errorSource.autoConnect().toObservable())
+        .assertResult(1, 2);
+  }
+
+  @Test
+  public void connectableObservable() {
+    ConnectableObservable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          Observable.range(1, 3)
+              .doOnNext(i -> assertContext1())
+              .doOnComplete(() -> assertContext1())
+              .publish();
+      errorSource =
+          Observable.<Integer>error(new IllegalStateException())
+              .doOnError(t -> assertContext1())
+              .publish();
+    }
+
+    subscribesInScope1RunsInScope2(source.autoConnect(), errorSource.autoConnect())
+        .assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void connectableObservable_subscribesUnderScope() {
+    ConnectableObservable<Integer> source =
+        Observable.range(1, 3)
+            .doOnNext(i -> assertContext2())
+            .doOnComplete(() -> assertContext2())
+            .publish();
+    ConnectableObservable<Integer> errorSource =
+        Observable.<Integer>error(new IllegalStateException())
+            .doOnError(t -> assertContext2())
+            .publish();
+
+    subscribesAndRunsInScope2(source.autoConnect(), errorSource.autoConnect())
+        .assertResult(1, 2, 3);
+  }
+
+  @Test
+  public void connectableObservable_unwrappedWhenNotInScope() {
+    assertThat(Observable.range(1, 3).publish())
+        .isInstanceOf(ObservablePublish.class); // is a final class so impossible we wrapped it
+  }
+
+  @Test
+  public void callable_completable() throws Exception {
+    Completable source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new CallableCompletable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new CallableCompletable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertComplete();
+    callUnderScope2((Callable<Integer>) source, (Callable<Integer>) errorSource);
+  }
+
+  @Test
+  public void callable_completable_subscribesUnderScope() throws Exception {
+    Completable source =
+        RxJavaPlugins.onAssembly(
+            new CallableCompletable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Completable errorSource =
+        RxJavaPlugins.onAssembly(
+            new CallableCompletable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertComplete();
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new CallableCompletable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void callable_flowable() throws Exception {
+    Flowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new CallableFlowable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new CallableFlowable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void callable_flowable_subscribesUnderScope() throws Exception {
+    Flowable<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new CallableFlowable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Flowable<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new CallableFlowable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new CallableFlowable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void callable_flowable_conditional() throws Exception {
+    Flowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+                  new CallableFlowable<Integer>() {
+                    @Override
+                    public Integer call() {
+                      assertContext1();
+                      return 1;
+                    }
+                  })
+              .filter(i -> i < 1);
+      errorSource =
+          RxJavaPlugins.onAssembly(
+                  new CallableFlowable<Integer>() {
+                    @Override
+                    public Integer call() {
+                      assertContext1();
+                      throw new IllegalStateException();
+                    }
+                  })
+              .filter(i -> i < 1);
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult();
+  }
+
+  @Test
+  public void callable_flowable_conditional_subscribesUnderScope() throws Exception {
+    Flowable<Integer> source =
+        RxJavaPlugins.onAssembly(
+                new CallableFlowable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertContext2();
+                    return 1;
+                  }
+                })
+            .filter(i -> i < 1);
+    Flowable<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+                new CallableFlowable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertContext2();
+                    throw new IllegalStateException();
+                  }
+                })
+            .filter(i -> i < 1);
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult();
+  }
+
+  @Test
+  public void callable_maybe() throws Exception {
+    Maybe<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new CallableMaybe<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new CallableMaybe<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void callable_maybe_subscribesUnderScope() throws Exception {
+    Maybe<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new CallableMaybe<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Maybe<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new CallableMaybe<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new CallableMaybe<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void callable_observable() throws Exception {
+    Observable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new CallableObservable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new CallableObservable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source, errorSource).assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void callable_observable_subscribesUnderScope() throws Exception {
+    Observable<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new CallableObservable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Observable<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new CallableObservable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source, errorSource).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new CallableObservable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void callable_single() throws Exception {
+    Single<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new CallableSingle<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new CallableSingle<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void callable_single_subscribesUnderScope() throws Exception {
+    Single<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new CallableSingle<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Single<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new CallableSingle<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new CallableSingle<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void scalarcallable_completable() throws Exception {
+    Completable source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableCompletable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableCompletable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult();
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void scalarcallable_completable_subscribesUnderScope() throws Exception {
+    Completable source =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableCompletable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Completable errorSource =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableCompletable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult();
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new ScalarCallableCompletable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void scalarcallable_flowable() throws Exception {
+    Flowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableFlowable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableFlowable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void scalarcallable_flowable_subscribesUnderScope() throws Exception {
+    Flowable<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableFlowable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Flowable<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableFlowable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new ScalarCallableFlowable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void scalarcallable_flowable_conditional() throws Exception {
+    Flowable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+                  new ScalarCallableFlowable<Integer>() {
+                    @Override
+                    public Integer call() {
+                      assertContext1();
+                      return 1;
+                    }
+                  })
+              .filter(i -> i < 1);
+      errorSource =
+          RxJavaPlugins.onAssembly(
+                  new ScalarCallableFlowable<Integer>() {
+                    @Override
+                    public Integer call() {
+                      assertContext1();
+                      throw new IllegalStateException();
+                    }
+                  })
+              .filter(i -> i < 1);
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult();
+  }
+
+  @Test
+  public void scalarcallable_flowable_conditional_subscribesUnderScope() throws Exception {
+    Flowable<Integer> source =
+        RxJavaPlugins.onAssembly(
+                new ScalarCallableFlowable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertContext2();
+                    return 1;
+                  }
+                })
+            .filter(i -> i < 1);
+    Flowable<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+                new ScalarCallableFlowable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertContext2();
+                    throw new IllegalStateException();
+                  }
+                })
+            .filter(i -> i < 1);
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult();
+  }
+
+  @Test
+  public void scalarcallable_maybe() throws Exception {
+    Maybe<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableMaybe<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableMaybe<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void scalarcallable_maybe_subscribesUnderScope() throws Exception {
+    Maybe<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableMaybe<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Maybe<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableMaybe<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new ScalarCallableMaybe<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void scalarcallable_observable() throws Exception {
+    Observable<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableObservable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableObservable<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source, errorSource).assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void scalarcallable_observable_subscribesUnderScope() throws Exception {
+    Observable<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableObservable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Observable<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableObservable<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source, errorSource).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new ScalarCallableObservable<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void scalarcallable_single() throws Exception {
+    Single<Integer> source, errorSource;
+    try (Scope scope = currentTraceContext.newScope(context1)) {
+      source =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableSingle<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  return 1;
+                }
+              });
+      errorSource =
+          RxJavaPlugins.onAssembly(
+              new ScalarCallableSingle<Integer>() {
+                @Override
+                public Integer call() {
+                  assertContext1();
+                  throw new IllegalStateException();
+                }
+              });
+    }
+
+    subscribesInScope1RunsInScope2(source.toObservable(), errorSource.toObservable())
+        .assertResult(1);
+    callUnderScope2((Callable) source, (Callable) errorSource);
+  }
+
+  @Test
+  public void scalarcallable_single_subscribesUnderScope() throws Exception {
+    Single<Integer> source =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableSingle<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                return 1;
+              }
+            });
+    Single<Integer> errorSource =
+        RxJavaPlugins.onAssembly(
+            new ScalarCallableSingle<Integer>() {
+              @Override
+              public Integer call() {
+                assertContext2();
+                throw new IllegalStateException();
+              }
+            });
+
+    subscribesAndRunsInScope2(source.toObservable(), errorSource.toObservable()).assertResult(1);
+
+    ((Callable)
+            RxJavaPlugins.onAssembly(
+                new ScalarCallableSingle<Integer>() {
+                  @Override
+                  public Integer call() {
+                    assertNoContext();
+                    return 1;
+                  }
+                }))
+        .call();
+  }
+
+  @Test
+  public void withAssemblyTracking() {
+    RxJavaAssemblyTracking.enable();
+    try {
+      Object o1 = RxJavaPlugins.getOnCompletableAssembly();
+      Object o2 = RxJavaPlugins.getOnSingleAssembly();
+      Object o3 = RxJavaPlugins.getOnMaybeAssembly();
+      Object o4 = RxJavaPlugins.getOnObservableAssembly();
+      Object o5 = RxJavaPlugins.getOnFlowableAssembly();
+      Object o6 = RxJavaPlugins.getOnConnectableFlowableAssembly();
+      Object o7 = RxJavaPlugins.getOnConnectableObservableAssembly();
+      Object o8 = RxJavaPlugins.getOnParallelAssembly();
+
+      SavedHooks h = contextTracking.enableAndChain();
+
+      h.restore();
+
+      Assert.assertSame(o1, RxJavaPlugins.getOnCompletableAssembly());
+      Assert.assertSame(o2, RxJavaPlugins.getOnSingleAssembly());
+      Assert.assertSame(o3, RxJavaPlugins.getOnMaybeAssembly());
+      Assert.assertSame(o4, RxJavaPlugins.getOnObservableAssembly());
+      Assert.assertSame(o5, RxJavaPlugins.getOnFlowableAssembly());
+      Assert.assertSame(o6, RxJavaPlugins.getOnConnectableFlowableAssembly());
+      Assert.assertSame(o7, RxJavaPlugins.getOnConnectableObservableAssembly());
+      Assert.assertSame(o8, RxJavaPlugins.getOnParallelAssembly());
+    } finally {
+      RxJavaAssemblyTracking.disable();
+    }
+  }
+
+  @Test
+  public void withAssemblyTrackingOverride() {
+    RxJavaAssemblyTracking.enable();
+    try {
+      contextTracking.enable();
+
+      CurrentTraceContextAssemblyTracking.disable();
+
+      Assert.assertNull(RxJavaPlugins.getOnCompletableAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnSingleAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnMaybeAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnObservableAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnFlowableAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnConnectableFlowableAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnConnectableObservableAssembly());
+      Assert.assertNull(RxJavaPlugins.getOnParallelAssembly());
+    } finally {
+      RxJavaAssemblyTracking.disable();
+    }
+  }
+
+  TestObserver<Integer> subscribesAndRunsInScope2(
+      Observable<Integer> source, Observable<Integer> errorSource) {
+    return runsInScope2(i -> assertContext2(), source, errorSource);
+  }
+
+  TestObserver<Integer> subscribesInScope1RunsInScope2(
+      Observable<Integer> source, Observable<Integer> errorSource) {
+    return runsInScope2(i -> assertContext1(), source, errorSource);
+  }
+
+  TestObserver<Integer> runsInScope2(
+      Consumer<Void> onSubscribeContext,
+      Observable<Integer> source,
+      Observable<Integer> errorSource) {
+    // Set another span between the time the source was created and subscribed.
+    try (Scope scope2 = currentTraceContext.newScope(context2)) {
+      // callbacks after test subscribes should be in the second context
+      errorSource
+          .doOnSubscribe(s -> onSubscribeContext.accept(null))
+          .doOnError(r -> assertContext2())
+          .test()
+          .assertFailure(IllegalStateException.class);
+
+      return source
+          .doOnSubscribe(s -> onSubscribeContext.accept(null))
+          .doOnComplete(() -> assertContext2())
+          .test();
+    }
+  }
+
+  TestSubscriber<Integer> subscribesAndRunsInScope2(
+      ParallelFlowable<Integer> source, ParallelFlowable<Integer> errorSource) {
+    return runsInScope2(i -> assertContext2(), source, errorSource);
+  }
+
+  TestSubscriber<Integer> subscribesInScope1RunsInScope2(
+      ParallelFlowable<Integer> source, ParallelFlowable<Integer> errorSource) {
+    return runsInScope2(i -> assertContext1(), source, errorSource);
+  }
+
+  TestSubscriber<Integer> runsInScope2(
+      Consumer<Void> onSubscribeContext,
+      ParallelFlowable<Integer> source,
+      ParallelFlowable<Integer> errorSource) {
+    // Set another span between the time the source was created and subscribed.
+    try (Scope scope2 = currentTraceContext.newScope(context2)) {
+      // callbacks after test subscribes should be in the second context
+      errorSource
+          .doOnSubscribe(s -> onSubscribeContext.accept(null))
+          .doOnError(r -> assertContext2())
+          .sequential()
+          .test()
+          .assertFailure(IllegalStateException.class);
+
+      return source
+          .doOnSubscribe(s -> onSubscribeContext.accept(null))
+          .doOnComplete(() -> assertContext2())
+          .sequential()
+          .test();
+    }
+  }
+
+  void assertNoContext() {
+    assertThat(currentTraceContext.get()).isNull();
+  }
+
+  void assertContext1() {
+    assertThat(currentTraceContext.get()).isEqualTo(context1);
+  }
+
+  void assertContext2() {
+    assertThat(currentTraceContext.get()).isEqualTo(context2);
+  }
+
+  <T> void callUnderScope2(Callable<T> source, Callable<T> errorSource) throws Exception {
+    // Set another span between the time the callable was created and invoked.
+    try (Scope scope2 = currentTraceContext.newScope(context2)) {
+      try {
+        errorSource.call();
+        failBecauseExceptionWasNotThrown(IllegalStateException.class);
+      } catch (IllegalStateException e) {
+      }
+
+      source.call();
+    }
+  }
+
+  abstract class CallableCompletable<T> extends Completable implements Callable<T> {
+    final CompletableFromCallable delegate = new CompletableFromCallable(this);
+
+    @Override
+    protected void subscribeActual(CompletableObserver s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class CallableFlowable<T> extends Flowable<T> implements Callable<T> {
+    final FlowableFromCallable<T> delegate = new FlowableFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class CallableMaybe<T> extends Maybe<T> implements Callable<T> {
+    final MaybeFromCallable<T> delegate = new MaybeFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class CallableObservable<T> extends Observable<T> implements Callable<T> {
+    final ObservableFromCallable<T> delegate = new ObservableFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class CallableSingle<T> extends Single<T> implements Callable<T> {
+    final SingleFromCallable<T> delegate = new SingleFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class ScalarCallableCompletable<T> extends Completable implements ScalarCallable<T> {
+    final CompletableFromCallable delegate = new CompletableFromCallable(this);
+
+    @Override
+    protected void subscribeActual(CompletableObserver s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class ScalarCallableFlowable<T> extends Flowable<T> implements ScalarCallable<T> {
+    final FlowableFromCallable<T> delegate = new FlowableFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(Subscriber<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class ScalarCallableMaybe<T> extends Maybe<T> implements ScalarCallable<T> {
+    final MaybeFromCallable<T> delegate = new MaybeFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class ScalarCallableObservable<T> extends Observable<T> implements ScalarCallable<T> {
+    final ObservableFromCallable<T> delegate = new ObservableFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(Observer<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+
+  abstract class ScalarCallableSingle<T> extends Single<T> implements ScalarCallable<T> {
+    final SingleFromCallable<T> delegate = new SingleFromCallable<>(this);
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> s) {
+      delegate.subscribe(s);
+    }
+  }
+}

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/features/ITRetrofitRxJava2.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/features/ITRetrofitRxJava2.java
@@ -1,0 +1,215 @@
+package brave.context.rxjava2.features;
+
+import brave.context.rxjava2.CurrentTraceContextAssemblyTracking;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.test.http.ITHttp;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.Single;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.subscribers.TestSubscriber;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.function.BiConsumer;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.http.GET;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** This tests that propagation isn't lost when passing through an untraced system. */
+public class ITRetrofitRxJava2 extends ITHttp {
+  TraceContext context1 = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
+  CurrentTraceContextAssemblyTracking contextTracking =
+      CurrentTraceContextAssemblyTracking.create(currentTraceContext);
+
+  @Rule public MockWebServer server = new MockWebServer();
+  CurrentTraceContextObserver currentTraceContextObserver = new CurrentTraceContextObserver();
+
+  @Before
+  public void setup() {
+    RxJavaPlugins.reset();
+    contextTracking.enable();
+  }
+
+  @After
+  public void tearDown() {
+    contextTracking.disable();
+  }
+
+  interface Service {
+    @GET("/")
+    Completable completable();
+
+    @GET("/")
+    Maybe<ResponseBody> maybe();
+
+    @GET("/")
+    Observable<ResponseBody> observable();
+
+    @GET("/")
+    Single<ResponseBody> single();
+
+    @GET("/")
+    Flowable<ResponseBody> flowable();
+  }
+
+  @Test
+  public void createAsync_completable_success() {
+    rxjava_createAsync_success(
+        (service, observer) -> {
+          try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context1)) {
+            service.completable().subscribe(observer);
+          }
+        });
+  }
+
+  @Test
+  public void createAsync_maybe_success() {
+    rxjava_createAsync_success(
+        (service, observer) -> {
+          try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context1)) {
+            service.maybe().subscribe(observer);
+          }
+        });
+  }
+
+  @Test
+  public void createAsync_observable_success() {
+    rxjava_createAsync_success(
+        (service, observer) -> {
+          try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context1)) {
+            service.observable().subscribe(observer);
+          }
+        });
+  }
+
+  @Test
+  public void createAsync_single_success() {
+    rxjava_createAsync_success(
+        (service, observer) -> {
+          try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context1)) {
+            service.single().subscribe(observer);
+          }
+        });
+  }
+
+  private void rxjava_createAsync_success(BiConsumer<Service, TestObserver<Object>> subscriber) {
+    TestObserver<Object> observer = new TestObserver<>(currentTraceContextObserver);
+
+    Service service = service(retrofit2716(RxJava2CallAdapterFactory.createAsync()));
+    subscriber.accept(service, observer);
+
+    // enqueue later
+    server.enqueue(new MockResponse());
+
+    observer.awaitTerminalEvent(1, SECONDS);
+    observer.assertComplete();
+    assertThat(currentTraceContextObserver.onComplete).isEqualTo(context1);
+  }
+
+  @Test
+  public void createAsync_flowable_success() {
+    rx_createAsync_success(
+        (service, subscriber) -> {
+          try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(context1)) {
+            service.flowable().subscribe(subscriber);
+          }
+        });
+  }
+
+  private void rx_createAsync_success(BiConsumer<Service, TestSubscriber<Object>> subscriber) {
+    TestSubscriber<Object> observer = new TestSubscriber<>(currentTraceContextObserver);
+
+    Service service = service(retrofit2716(RxJava2CallAdapterFactory.createAsync()));
+    subscriber.accept(service, observer);
+
+    // enqueue later
+    server.enqueue(new MockResponse());
+
+    observer.awaitTerminalEvent(1, SECONDS);
+    observer.assertComplete();
+    assertThat(currentTraceContextObserver.onComplete).isEqualTo(context1);
+  }
+
+  // TODO remove on retrofit 2.4.1 or 2.5.0
+  // https://github.com/square/retrofit/issues/2716
+  static CallAdapter.Factory retrofit2716(RxJava2CallAdapterFactory factory) {
+    return new CallAdapter.Factory() {
+      @Override
+      public CallAdapter<?, ?> get(Type type, Annotation[] annotations, Retrofit retrofit) {
+        CallAdapter<?, ?> delegate = factory.get(type, annotations, retrofit);
+        return new CallAdapter<Object, Object>() {
+          @Override
+          public Type responseType() {
+            return delegate.responseType();
+          }
+
+          @Override
+          public Object adapt(Call call) {
+            Object result = delegate.adapt(call);
+            if (result instanceof Observable) {
+              return RxJavaPlugins.onAssembly((Observable) result);
+            }
+            return result;
+          }
+        };
+      }
+    };
+  }
+
+  Service service(CallAdapter.Factory callAdapterFactory) {
+    return new Retrofit.Builder()
+        .baseUrl(server.url("/"))
+        .addCallAdapterFactory(callAdapterFactory)
+        .build()
+        .create(Service.class);
+  }
+
+  class CurrentTraceContextObserver implements Observer<Object>, Subscriber<Object> {
+    volatile TraceContext onSubscribe, onNext, onError, onComplete;
+
+    @Override
+    public void onSubscribe(Disposable d) {
+      onSubscribe = currentTraceContext.get();
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      onSubscribe = currentTraceContext.get();
+    }
+
+    @Override
+    public void onNext(Object object) {
+      onNext = currentTraceContext.get();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+      onError = currentTraceContext.get();
+    }
+
+    @Override
+    public void onComplete() {
+      onComplete = currentTraceContext.get();
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -524,7 +524,7 @@
         <plugin>
           <groupId>net.orfjackal.retrolambda</groupId>
           <artifactId>retrolambda-maven-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>2.5.3</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
`CurrentTraceContextAssemblyTracking` prevents traces from breaking
during RxJava operations by scoping them with trace context.

The design of this library borrows heavily from https://github.com/akaita/RxJava2Debug

To set this up, create `CurrentTraceContextAssemblyTracking` using the
current trace context provided by your `Tracing` component.

```java
assemblyTracking = CurrentTraceContextAssemblyTracking.create(
  tracing.currentTraceContext()
);
```

After your application-specific changes to `RxJavaPlugins`, enable trace
context tracking like so:

```java
assemblyTracking.enable();
```

Fixes #664