### PR TITLE
Adds package-private HttpHandler to optimize current trace context code

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpHandler.java
@@ -1,0 +1,77 @@
+package brave.http;
+
+import brave.Span;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import zipkin2.Endpoint;
+
+abstract class HttpHandler<Req, Resp, A extends HttpAdapter<Req, Resp>> {
+
+  final CurrentTraceContext currentTraceContext;
+  final A adapter;
+  final HttpParser parser;
+
+  HttpHandler(CurrentTraceContext currentTraceContext, A adapter, HttpParser parser) {
+    this.currentTraceContext = currentTraceContext;
+    this.adapter = adapter;
+    this.parser = parser;
+  }
+
+  Span handleStart(Req request, Span span) {
+    if (span.isNoop()) return span;
+    Scope ws = maybeNewScope(span, currentTraceContext.get());
+    try {
+      parser.request(adapter, request, span.customizer());
+
+      Endpoint.Builder remoteEndpoint = Endpoint.newBuilder();
+      if (parseRemoteEndpoint(request, remoteEndpoint)) {
+        span.remoteEndpoint(remoteEndpoint.build());
+      }
+    } finally {
+      if (ws != null) ws.close();
+    }
+
+    // all of the above parsing happened before a timestamp on the span
+    return span.start();
+  }
+
+  /** Starts a trace scope unless the current is the same span */
+  Scope maybeNewScope(Span span, @Nullable TraceContext currentScope) {
+    TraceContext spanContext = span.context();
+    return spanContext.equals(currentScope) ? null : currentTraceContext.newScope(spanContext);
+  }
+
+  /** parses the remote endpoint while the current span is in scope (for logging for example) */
+  abstract boolean parseRemoteEndpoint(Req request, Endpoint.Builder remoteEndpoint);
+
+  void handleFinish(@Nullable Resp response, @Nullable Throwable error, Span span) {
+    if (span.isNoop()) return;
+    TraceContext currentScope = currentTraceContext.get();
+    try {
+      Scope ws = maybeNewScope(span, currentScope);
+      try {
+        parser.response(adapter, response, error, span.customizer());
+      } finally {
+        if (ws != null) ws.close(); // close the scope before finishing the span
+      }
+    } finally {
+      if (currentScope != null) {
+        finishInNullScope(span);
+      } else {
+        span.finish();
+      }
+    }
+  }
+
+  /** Clears the scope to prevent remote reporters from accidentally tracing */
+  void finishInNullScope(Span span) {
+    Scope ws = currentTraceContext.newScope(null);
+    try {
+      span.finish();
+    } finally {
+      ws.close();
+    }
+  }
+}

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -14,8 +14,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,9 +24,7 @@ public class HttpClientHandlerTest {
   @Mock HttpSampler sampler;
   @Mock HttpClientAdapter<Object, Object> adapter;
   @Mock TraceContext.Injector<Object> injector;
-  @Mock brave.Span span;
   Object request = new Object();
-  Object response = new Object();
   HttpClientHandler<Object, Object> handler;
 
   @Before public void init() {
@@ -101,32 +97,5 @@ public class HttpClientHandlerTest {
     assertThat(spans)
         .extracting(Span::remoteServiceName)
         .isEmpty();
-  }
-
-  @Test public void handleReceive_nothingOnNoop_success() {
-    when(span.isNoop()).thenReturn(true);
-
-    handler.handleReceive(response, null, span);
-
-    verify(span, never()).finish();
-  }
-
-  @Test public void handleReceive_nothingOnNoop_error() {
-    when(span.isNoop()).thenReturn(true);
-
-    handler.handleReceive(null, new RuntimeException("drat"), span);
-
-    verify(span, never()).finish();
-  }
-
-  @Test public void handleReceive_finishedEvenIfAdapterThrows() {
-    when(adapter.statusCodeAsInt(response)).thenThrow(new RuntimeException());
-
-    try {
-      handler.handleReceive(response, null, span);
-      failBecauseExceptionWasNotThrown(RuntimeException.class);
-    } catch (RuntimeException e) {
-      verify(span).finish();
-    }
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
@@ -1,0 +1,173 @@
+package brave.http;
+
+import brave.SpanCustomizer;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.TraceContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import zipkin2.Endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpHandlerTest {
+  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(10L).build();
+  @Mock HttpAdapter<Object, Object> adapter;
+  @Mock brave.Span span;
+  @Mock SpanCustomizer spanCustomizer;
+  Object request = new Object(), response = new Object();
+  HttpHandler<Object, Object, HttpAdapter<Object, Object>> handler;
+
+  @Before public void init() {
+    handler = new HttpHandler(currentTraceContext, adapter, new HttpParser()) {
+      @Override boolean parseRemoteEndpoint(Object request, Endpoint.Builder remoteEndpoint) {
+        return false;
+      }
+    };
+    when(span.context()).thenReturn(context);
+    when(span.customizer()).thenReturn(spanCustomizer);
+  }
+
+  @Test public void handleStart_nothingOnNoop_success() {
+    when(span.isNoop()).thenReturn(true);
+
+    handler.handleStart(request, span);
+
+    verify(span, never()).start();
+  }
+
+  @Test public void handleStart_parsesTagsWithCustomizer() {
+    when(adapter.method(request)).thenReturn("GET");
+    when(span.customizer()).thenReturn(spanCustomizer);
+
+    handler.handleStart(request, span);
+
+    verify(spanCustomizer).name("GET");
+    verify(spanCustomizer).tag("http.method", "GET");
+    verifyNoMoreInteractions(spanCustomizer);
+  }
+
+  @Test public void handleStart_parsesTagsInScope() {
+    handler = new HttpHandler(currentTraceContext, adapter, new HttpParser() {
+      @Override
+      public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
+        assertThat(currentTraceContext.get()).isNotNull();
+      }
+    }) {
+      @Override boolean parseRemoteEndpoint(Object request, Endpoint.Builder remoteEndpoint) {
+        return false;
+      }
+    };
+
+    handler.handleStart(request, span);
+  }
+
+  @Test public void handleStart_skipsRemoteEndpointWhenNotParsed() {
+    handler = new HttpHandler(currentTraceContext, adapter, new HttpParser()) {
+      @Override boolean parseRemoteEndpoint(Object request, Endpoint.Builder remoteEndpoint) {
+        return false;
+      }
+    };
+
+    handler.handleStart(request, span);
+
+    verify(span, never()).remoteEndpoint(any(Endpoint.class));
+  }
+
+  @Test public void handleStart_addsRemoteEndpointWhenParsed() {
+    handler = new HttpHandler(currentTraceContext, adapter, new HttpParser()) {
+      @Override boolean parseRemoteEndpoint(Object request, Endpoint.Builder remoteEndpoint) {
+        remoteEndpoint.serviceName("romeo");
+        return true;
+      }
+    };
+
+    handler.handleStart(request, span);
+
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("romeo").build());
+  }
+
+  @Test public void handleFinish_nothingOnNoop_success() {
+    when(span.isNoop()).thenReturn(true);
+
+    handler.handleFinish(response, null, span);
+
+    verify(span, never()).finish();
+  }
+
+  @Test public void handleFinish_nothingOnNoop_error() {
+    when(span.isNoop()).thenReturn(true);
+
+    handler.handleFinish(null, new RuntimeException("drat"), span);
+
+    verify(span, never()).finish();
+  }
+
+  @Test public void handleFinish_parsesTagsWithCustomizer() {
+    when(adapter.statusCodeAsInt(response)).thenReturn(404);
+    when(span.customizer()).thenReturn(spanCustomizer);
+
+    handler.handleFinish(response, null, span);
+
+    verify(spanCustomizer).tag("http.status_code", "404");
+    verify(spanCustomizer).tag("error", "404");
+    verifyNoMoreInteractions(spanCustomizer);
+  }
+
+  @Test public void handleFinish_parsesTagsInScope() {
+    handler = new HttpHandler(currentTraceContext, adapter, new HttpParser() {
+      @Override public <Resp> void response(HttpAdapter<?, Resp> adapter, Resp res, Throwable error,
+          SpanCustomizer customizer) {
+        assertThat(currentTraceContext.get()).isNotNull();
+      }
+    }) {
+      @Override boolean parseRemoteEndpoint(Object request, Endpoint.Builder remoteEndpoint) {
+        return false;
+      }
+    };
+
+    handler.handleFinish(response, null, span);
+  }
+
+  @Test public void handleFinish_finishesWhenSpanNotInScope() {
+    doAnswer(new Answer() {
+      @Override public Object answer(InvocationOnMock invocation) {
+        assertThat(currentTraceContext.get()).isNull();
+        return null;
+      }
+    }).when(span).finish();
+
+    handler.handleFinish(response, null, span);
+  }
+
+  @Test public void handleFinish_finishesWhenSpanNotInScope_clearingIfNecessary() {
+    try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(context)) {
+      handleFinish_finishesWhenSpanNotInScope();
+    }
+  }
+
+  @Test public void handleFinish_finishedEvenIfAdapterThrows() {
+    when(adapter.statusCodeAsInt(response)).thenThrow(new RuntimeException());
+
+    try {
+      handler.handleFinish(response, null, span);
+      failBecauseExceptionWasNotThrown(RuntimeException.class);
+    } catch (RuntimeException e) {
+      verify(span).finish();
+    }
+  }
+}

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -17,11 +17,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import zipkin2.Endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -31,9 +28,7 @@ public class HttpServerHandlerTest {
   @Mock HttpSampler sampler;
   @Mock HttpServerAdapter<Object, Object> adapter;
   @Mock TraceContext.Extractor<Object> extractor;
-  @Mock brave.Span span;
   Object request = new Object();
-  Object response = new Object();
   HttpServerHandler<Object, Object> handler;
 
   @Before public void init() {
@@ -128,32 +123,5 @@ public class HttpServerHandlerTest {
 
     assertThat(handler.handleReceive(extractor, request).isNoop())
         .isTrue();
-  }
-
-  @Test public void handleSend_nothingOnNoop_success() {
-    when(span.isNoop()).thenReturn(true);
-
-    handler.handleSend(response, null, span);
-
-    verify(span, never()).finish();
-  }
-
-  @Test public void handleSend_nothingOnNoop_error() {
-    when(span.isNoop()).thenReturn(true);
-
-    handler.handleSend(null, new RuntimeException("drat"), span);
-
-    verify(span, never()).finish();
-  }
-
-  @Test public void handleSend_finishedEvenIfAdapterThrows() {
-    when(adapter.statusCodeAsInt(response)).thenThrow(new RuntimeException());
-
-    try {
-      handler.handleSend(response, null, span);
-      failBecauseExceptionWasNotThrown(RuntimeException.class);
-    } catch (RuntimeException e) {
-      verify(span).finish();
-    }
   }
 }


### PR DESCRIPTION
Before, we assumed there was no span in scope when calling finish. This
could lead to redundant calls to scope a span (overhead), and also cause
a leak to get to the reporter layer. This centralizes code and tests to
eliminate these problems.

This is particularly important in the work going on for decoupled
context propagation, such as RxJava2 in #665. When others are scoping
spans we don't want to accidentally duplicate scope syncrhonization
overhead.