### PR TITLE
Fixes where vert.x span ended prior to response headers

### DIFF
--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <vertx.version>3.4.2</vertx.version>
+    <vertx.version>3.5.1</vertx.version>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
   </properties>

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxWebTracing.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxWebTracing.java
@@ -15,10 +15,11 @@ public final class VertxWebTracing {
     return new VertxWebTracing(httpTracing);
   }
 
-  final Handler<RoutingContext> routingContextHandler;
+  final HttpTracing httpTracing;
 
   VertxWebTracing(HttpTracing httpTracing) {
-    routingContextHandler = new TracingRoutingContextHandler(httpTracing);
+    if (httpTracing == null) throw new NullPointerException("httpTracing == null");
+    this.httpTracing = httpTracing;
   }
 
   /**
@@ -34,6 +35,6 @@ public final class VertxWebTracing {
    * }</pre>
    */
   public Handler<RoutingContext> routingContextHandler() {
-    return routingContextHandler;
+    return new TracingRoutingContextHandler(httpTracing);
   }
 }


### PR DESCRIPTION
Before, we accidentally ended a span when the request ended, vs when
response headers were sent. This prevents that and also removes
unnecessary duplication of handler code which was blindly copied from
opentracing as opposed to tested to see if actually necessary.