### PR TITLE
Adds CurrentTraceContext.maybeScope for conditional scoping

### DIFF
--- a/brave/src/test/java/brave/internal/HexCodecTest.java
+++ b/brave/src/test/java/brave/internal/HexCodecTest.java
@@ -1,7 +1,10 @@
 package brave.internal;
 
+import brave.propagation.TraceContext;
 import org.junit.Test;
 
+import static brave.internal.HexCodec.lowerHexEqualsTraceId;
+import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
 import static brave.internal.HexCodec.lowerHexToUnsignedLong;
 import static brave.internal.HexCodec.toLowerHex;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,5 +75,48 @@ public class HexCodecTest {
   @Test public void toLowerHex_whenHigh_32Chars() {
     assertThat(toLowerHex(1234L, 5678L))
         .hasToString("00000000000004d2000000000000162e");
+  }
+
+  @Test public void lowerHexEqualsUnsignedLong_minValue() {
+    assertThat(lowerHexEqualsUnsignedLong("7fffffffffffffff", Long.MAX_VALUE))
+        .isTrue();
+  }
+
+  @Test public void lowerHexEqualsUnsignedLong_midValue() {
+    assertThat(lowerHexEqualsUnsignedLong("00000000cafebabe", 3405691582L))
+        .isTrue();
+  }
+
+  @Test public void lowerHexEqualsUnsignedLong_whenNotHigh_16Chars() {
+    TraceContext context = TraceContext.newBuilder()
+        .traceId(12345678L)
+        .spanId(1L)
+        .build();
+    assertThat(lowerHexEqualsTraceId("0000000000bc614e", context))
+        .isTrue();
+    assertThat(lowerHexEqualsTraceId("00000000000000000000000000bc614e", context))
+        .isTrue();
+  }
+
+  @Test public void lowerHexEqualsUnsignedLong_paddedTraceIdOk() {
+    TraceContext context = TraceContext.newBuilder()
+        .traceId(12345678L)
+        .spanId(1L)
+        .build();
+    assertThat(lowerHexEqualsTraceId("00000000000000000000000000bc614e", context))
+        .isTrue();
+  }
+
+  @Test public void lowerHexEqualsUnsignedLong_whenHigh_32Chars() {
+    TraceContext context = TraceContext.newBuilder()
+        .traceIdHigh(1234L)
+        .traceId(5678L)
+        .spanId(1L)
+        .build();
+
+    assertThat(lowerHexEqualsTraceId("000000000000162e", context))
+        .isFalse();
+    assertThat(lowerHexEqualsTraceId("00000000000004d2000000000000162e", context))
+        .isTrue();
   }
 }

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -6,6 +6,9 @@ import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import org.slf4j.MDC;
 
+import static brave.internal.HexCodec.lowerHexEqualsTraceId;
+import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
+
 /**
  * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
@@ -31,17 +34,31 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
   }
 
   @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-    final String previousTraceId = MDC.get("traceId");
-    final String previousParentId = MDC.get("parentId");
-    final String previousSpanId = MDC.get("spanId");
+    return newScope(currentSpan, MDC.get("traceId"), MDC.get("spanId"));
+  }
 
+  @Override public Scope maybeScope(@Nullable TraceContext currentSpan) {
+    String previousTraceId = MDC.get("traceId");
+    String previousSpanId = MDC.get("spanId");
+    if (currentSpan == null) {
+      if (previousTraceId == null) return Scope.NOOP;
+      return newScope(null, previousTraceId, previousSpanId);
+    }
+    if (lowerHexEqualsTraceId(previousTraceId, currentSpan)
+        && lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId())) {
+      return Scope.NOOP;
+    }
+    return newScope(currentSpan, previousTraceId, previousSpanId);
+  }
+
+  // all input parameters are nullable
+  Scope newScope(TraceContext currentSpan, String previousTraceId, String previousSpanId) {
+    String previousParentId = MDC.get("parentId");
     if (currentSpan != null) {
-      MDC.put("traceId", currentSpan.traceIdString());
-      long parentId = currentSpan.parentIdAsLong();
-      replace("parentId", parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
-      MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+      maybeReplaceTraceContext(currentSpan, previousTraceId, previousParentId, previousSpanId);
     } else {
       MDC.remove("traceId");
+      MDC.remove("parentId");
       MDC.remove("spanId");
     }
 
@@ -55,6 +72,27 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
       }
     }
     return new MDCCurrentTraceContextScope();
+  }
+
+  void maybeReplaceTraceContext(
+      TraceContext currentSpan,
+      String previousTraceId,
+      @Nullable String previousParentId,
+      String previousSpanId
+  ) {
+    boolean sameTraceId = lowerHexEqualsTraceId(previousTraceId, currentSpan);
+    if (!sameTraceId) MDC.put("traceId", currentSpan.traceIdString());
+
+    long parentId = currentSpan.parentIdAsLong();
+    if (parentId == 0L) {
+      MDC.remove("parentId");
+    } else {
+      boolean sameParentId = lowerHexEqualsUnsignedLong(previousParentId, parentId);
+      if (!sameParentId) MDC.put("parentId", HexCodec.toLowerHex(parentId));
+    }
+
+    boolean sameSpanId = lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId());
+    if (!sameSpanId) MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
   }
 
   static void replace(String key, @Nullable String value) {

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/CurrentTraceContextBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/CurrentTraceContextBenchmarks.java
@@ -87,6 +87,36 @@ public class CurrentTraceContextBenchmarks {
     }
   }
 
+  @Benchmark public void maybeScope_default() {
+    try (CurrentTraceContext.Scope ws = base.maybeScope(contextWithParent)) {
+    }
+  }
+
+  @Benchmark public void maybeScope_log4j2() {
+    try (CurrentTraceContext.Scope ws = log4j2.maybeScope(contextWithParent)) {
+    }
+  }
+
+  @Benchmark public void maybeScope_redundant_default() {
+    try (CurrentTraceContext.Scope ws = base.maybeScope(context)) {
+    }
+  }
+
+  @Benchmark public void maybeScope_redundant_log4j2() {
+    try (CurrentTraceContext.Scope ws = log4j2.maybeScope(context)) {
+    }
+  }
+
+  @Benchmark public void maybeScope_clear_default() {
+    try (CurrentTraceContext.Scope ws = base.maybeScope(null)) {
+    }
+  }
+
+  @Benchmark public void maybeScope_clear_log4j2() {
+    try (CurrentTraceContext.Scope ws = log4j2.maybeScope(null)) {
+    }
+  }
+
   // Convenience main entry-point
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -78,10 +78,7 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
       HttpHost host = HttpClientContext.adapt(context).getTargetHost();
 
       TraceContext parent = (TraceContext) context.getAttribute(TraceContext.class.getName());
-      Span span;
-      try (Scope scope = currentTraceContext.newScope(parent)) {
-        span = handler.handleSend(injector, request, HttpRequestWrapper.wrap(request, host));
-      }
+      Span span = handler.handleSend(injector, request, HttpRequestWrapper.wrap(request, host));
 
       context.setAttribute(Span.class.getName(), span);
       context.setAttribute(Scope.class.getName(), currentTraceContext.newScope(span.context()));

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -4,6 +4,7 @@ import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import java.io.IOException;
 import okhttp3.Call;
@@ -57,7 +58,8 @@ public final class TracingCallFactory implements Call.Factory {
     }
 
     @Override public Response intercept(Chain chain) throws IOException {
-      try (CurrentTraceContext.Scope ws = currentTraceContext.newScope(previous)) {
+      // using maybeScope as when there's no backlog situation the span may already be in scope
+      try (Scope ws = currentTraceContext.maybeScope(previous)) {
         return chain.proceed(chain.request());
       }
     }


### PR DESCRIPTION
Reactive programming can imply hundreds or thousands of stages in the
same operation. Scoping a trace context, particularly when MDC or extra
fields are in use can result in a large amount of redundant overhead.
For example, MDC scoping implies marshaling IDs as hex strings. Extra
field propagation can affect map state. This can add up to measurable
and avoidable cost.

This adds `CurrentTraceContext.maybeScope` for use when instrumenting
things like executors and scheduler hooks. This also special-cases the
more common instrumentation points, such as SLF4J to cost less.

See #396