### PR TITLE
 Deprecates Tracer.newTrace(SamplingFlags) for Tracer.withSampler

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -406,7 +406,7 @@ public class Tracer {
    */
   public SpanCustomizer currentSpanCustomizer() {
     TraceContext currentContext = currentTraceContext.get();
-    return currentContext != null
+    return currentContext != null && Boolean.TRUE.equals(currentContext.sampled())
         ? RealSpanCustomizer.create(currentContext, recorder) : NoopSpanCustomizer.INSTANCE;
   }
 

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -2,6 +2,7 @@ package brave;
 
 import brave.internal.Nullable;
 import brave.internal.Platform;
+import brave.internal.recorder.Recorder;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
@@ -43,6 +44,14 @@ public abstract class Tracing implements Closeable {
 
   /** This supports edge cases like GRPC Metadata propagation which doesn't use String keys. */
   abstract public Propagation.Factory propagationFactory();
+
+  /**
+   * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether
+   * the overhead of tracing will occur and/or if a trace will be reported to Zipkin.
+   *
+   * @see Tracer#withSampler(Sampler)
+   */
+  abstract public Sampler sampler();
 
   /**
    * This supports in-process propagation, typically across thread boundaries. This includes
@@ -225,6 +234,8 @@ public abstract class Tracing implements Closeable {
     /**
      * Sampler is responsible for deciding if a particular trace should be "sampled", i.e. whether
      * the overhead of tracing will occur and/or if a trace will be reported to Zipkin.
+     *
+     * @see Tracer#withSampler(Sampler) for temporary overrides
      */
     public Builder sampler(Sampler sampler) {
       if (sampler == null) throw new NullPointerException("sampler == null");
@@ -303,16 +314,29 @@ public abstract class Tracing implements Closeable {
     final Propagation.Factory propagationFactory;
     final Propagation<String> stringPropagation;
     final CurrentTraceContext currentTraceContext;
+    final Sampler sampler;
     final Clock clock;
     final ErrorParser errorParser;
 
     Default(Builder builder) {
       this.clock = builder.clock;
       this.errorParser = builder.errorParser;
-      this.tracer = new Tracer(builder, clock, noop, errorParser);
       this.propagationFactory = builder.propagationFactory;
       this.stringPropagation = builder.propagationFactory.create(Propagation.KeyFactory.STRING);
       this.currentTraceContext = builder.currentTraceContext;
+      this.sampler = builder.sampler;
+      this.tracer = new Tracer(
+          builder.clock,
+          builder.propagationFactory,
+          builder.reporter,
+          new Recorder(builder.endpoint, clock, builder.reporter, noop),
+          builder.sampler,
+          builder.errorParser,
+          builder.currentTraceContext,
+          builder.traceId128Bit || propagationFactory.requires128BitTraceId(),
+          builder.supportsJoin && propagationFactory.supportsJoin(),
+          noop
+      );
       maybeSetCurrent();
     }
 
@@ -326,6 +350,10 @@ public abstract class Tracing implements Closeable {
 
     @Override public Propagation.Factory propagationFactory() {
       return propagationFactory;
+    }
+
+    @Override public Sampler sampler() {
+      return sampler;
     }
 
     @Override public CurrentTraceContext currentTraceContext() {

--- a/brave/src/test/java/brave/sampler/DeclarativeSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/DeclarativeSamplerTest.java
@@ -11,49 +11,68 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeclarativeSamplerTest {
 
-  DeclarativeSampler<Traced> sampler =
+  DeclarativeSampler<Traced> declarativeSampler =
       DeclarativeSampler.create(t -> t.enabled() ? t.sampleRate() : null);
 
   @Before public void clear() {
-    sampler.methodsToSamplers.clear();
+    declarativeSampler.methodsToSamplers.clear();
   }
 
   @Test public void honorsSampleRate() {
-    assertThat(sampler.sample(traced(1.0f, true)))
+    assertThat(declarativeSampler.sample(traced(1.0f, true)))
         .isEqualTo(SamplingFlags.SAMPLED);
 
-    assertThat(sampler.sample(traced(0.0f, true)))
+    assertThat(declarativeSampler.sample(traced(0.0f, true)))
         .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
 
   @Test public void acceptsFallback() {
-    assertThat(sampler.sample(traced(1.0f, false)))
+    assertThat(declarativeSampler.sample(traced(1.0f, false)))
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
+  @Test public void toSampler() {
+    assertThat(declarativeSampler.toSampler(traced(1.0f, true)).isSampled(0L))
+        .isTrue();
+
+    assertThat(declarativeSampler.toSampler(traced(0.0f, true)).isSampled(0L))
+        .isFalse();
+
+    // check not enabled is false
+    assertThat(declarativeSampler.toSampler(traced(1.0f, false)).isSampled(0L))
+        .isFalse();
+  }
+
+  @Test public void toSampler_fallback() {
+    Sampler withFallback = declarativeSampler.toSampler(traced(1.0f, false), Sampler.ALWAYS_SAMPLE);
+
+    assertThat(withFallback.isSampled(0L))
+        .isTrue();
+  }
+
   @Test public void samplerLoadsLazy() {
-    assertThat(sampler.methodsToSamplers)
+    assertThat(declarativeSampler.methodsToSamplers)
         .isEmpty();
 
-    sampler.sample(traced(1.0f, true));
+    declarativeSampler.sample(traced(1.0f, true));
 
-    assertThat(sampler.methodsToSamplers)
+    assertThat(declarativeSampler.methodsToSamplers)
         .hasSize(1);
 
-    sampler.sample(traced(0.0f, true));
+    declarativeSampler.sample(traced(0.0f, true));
 
-    assertThat(sampler.methodsToSamplers)
+    assertThat(declarativeSampler.methodsToSamplers)
         .hasSize(2);
   }
 
   @Test public void cardinalityIsPerAnnotationNotInvocation() {
     Traced traced = traced(1.0f, true);
 
-    sampler.sample(traced);
-    sampler.sample(traced);
-    sampler.sample(traced);
+    declarativeSampler.sample(traced);
+    declarativeSampler.sample(traced);
+    declarativeSampler.sample(traced);
 
-    assertThat(sampler.methodsToSamplers)
+    assertThat(declarativeSampler.methodsToSamplers)
         .hasSize(1);
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -9,7 +9,6 @@ import brave.http.HttpRuleSampler;
 import brave.http.HttpTracing;
 import brave.internal.HexCodec;
 import brave.propagation.ExtraFieldPropagation;
-import brave.propagation.SamplingFlags;
 import brave.sampler.Sampler;
 import java.util.Arrays;
 import okhttp3.mockwebserver.MockResponse;
@@ -106,10 +105,10 @@ public abstract class ITHttpClient<C> extends ITHttp {
   }
 
   @Test public void propagatesExtra_unsampledTrace() throws Exception {
-    Tracer tracer = httpTracing.tracing().tracer();
+    Tracer tracer = httpTracing.tracing().tracer().withSampler(Sampler.NEVER_SAMPLE);
     server.enqueue(new MockResponse());
 
-    brave.Span parent = tracer.newTrace(SamplingFlags.NOT_SAMPLED).name("test").start();
+    brave.Span parent = tracer.nextSpan().name("test").start();
     try (SpanInScope ws = tracer.withSpanInScope(parent)) {
       ExtraFieldPropagation.set(parent.context(), EXTRA_KEY, "joey");
       get(client, "/foo");

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -4,8 +4,8 @@ import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.internal.Nullable;
-import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
+import brave.sampler.Sampler;
 import zipkin2.Endpoint;
 
 /**
@@ -40,7 +40,8 @@ public final class HttpClientHandler<Req, Resp>
   }
 
   final Tracer tracer;
-  final HttpSampler sampler;
+  final Sampler sampler;
+  final HttpSampler httpSampler;
   final String serverName;
   final boolean serverNameSet;
 
@@ -51,7 +52,8 @@ public final class HttpClientHandler<Req, Resp>
         httpTracing.clientParser()
     );
     this.tracer = httpTracing.tracing().tracer();
-    this.sampler = httpTracing.clientSampler();
+    this.sampler = httpTracing.tracing().sampler();
+    this.httpSampler = httpTracing.clientSampler();
     this.serverName = httpTracing.serverName();
     this.serverNameSet = !serverName.equals("");
   }
@@ -111,13 +113,8 @@ public final class HttpClientHandler<Req, Resp>
    * @since 4.4
    */
   public Span nextSpan(Req request) {
-    TraceContext parent = currentTraceContext.get();
-    if (parent != null) return tracer.newChild(parent); // inherit the sampling decision
-
-    // If there was no parent, we are making a new trace. Try to sample the request.
-    Boolean sampled = sampler.trySample(adapter, request);
-    if (sampled == null) return tracer.newTrace(); // defer sampling decision to trace ID
-    return tracer.newTrace(sampled ? SamplingFlags.SAMPLED : SamplingFlags.NOT_SAMPLED);
+    Sampler override = httpSampler.toSampler(adapter, request, sampler);
+    return tracer.withSampler(override).nextSpan();
   }
 
   /**

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -14,6 +14,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.when;
 public class HttpClientHandlerTest {
   List<Span> spans = new ArrayList<>();
   HttpTracing httpTracing;
-  @Mock HttpSampler sampler;
+  HttpSampler sampler = HttpSampler.TRACE_ID;
   @Mock HttpClientAdapter<Object, Object> adapter;
   @Mock TraceContext.Injector<Object> injector;
   Object request = new Object();
@@ -30,7 +31,11 @@ public class HttpClientHandlerTest {
   @Before public void init() {
     httpTracing = HttpTracing.newBuilder(
         Tracing.newBuilder().spanReporter(spans::add).build()
-    ).clientSampler(sampler).build();
+    ).clientSampler(new HttpSampler() {
+      @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
+        return sampler.trySample(adapter, request);
+      }
+    }).build();
     handler = HttpClientHandler.create(httpTracing, adapter);
 
     when(adapter.method(request)).thenReturn("GET");
@@ -41,9 +46,6 @@ public class HttpClientHandlerTest {
   }
 
   @Test public void handleSend_defaultsToMakeNewTrace() {
-    // request sampler abstains (trace ID sampler will say true)
-    when(sampler.trySample(adapter, request)).thenReturn(null);
-
     assertThat(handler.handleSend(injector, request))
         .extracting(s -> s.isNoop(), s -> s.context().parentId())
         .containsExactly(false, null);
@@ -59,6 +61,7 @@ public class HttpClientHandlerTest {
   }
 
   @Test public void handleSend_makesRequestBasedSamplingDecision() {
+    sampler = mock(HttpSampler.class);
     // request sampler says false eventhough trace ID sampler would have said true
     when(sampler.trySample(adapter, request)).thenReturn(false);
 
@@ -82,8 +85,6 @@ public class HttpClientHandlerTest {
   @Test public void handleSend_addsClientAddressWhenOnlyServiceName() {
     httpTracing = httpTracing.clientOf("remote-service");
 
-    // request sampler abstains (trace ID sampler will say true)
-    when(sampler.trySample(adapter, request)).thenReturn(null);
     HttpClientHandler.create(httpTracing, adapter).handleSend(injector, request).finish();
 
     assertThat(spans)
@@ -96,6 +97,6 @@ public class HttpClientHandlerTest {
 
     assertThat(spans)
         .extracting(Span::remoteServiceName)
-        .isEmpty();
+        .containsNull();
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -7,7 +7,6 @@ import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.propagation.TraceIdContext;
-import brave.sampler.Sampler;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.github.charithe.kafka.KafkaJunitRule;
 import java.util.ArrayList;
@@ -261,7 +260,6 @@ public class ITKafkaTracing {
             return new TraceIdOnlyPropagation<>(keyFactory);
           }
         })
-        .sampler(Sampler.ALWAYS_SAMPLE)
         .build());
     producerTracing = KafkaTracing.create(Tracing.newBuilder()
         .spanReporter(producerSpans::add)
@@ -270,7 +268,6 @@ public class ITKafkaTracing {
             return new TraceIdOnlyPropagation<>(keyFactory);
           }
         })
-        .sampler(Sampler.ALWAYS_SAMPLE)
         .build());
 
     producer = createTracingProducer();

--- a/instrumentation/spring-rabbit/README.md
+++ b/instrumentation/spring-rabbit/README.md
@@ -10,7 +10,6 @@ To use this instrumentation, first define the common tracing configuration, e.g:
 public Tracing tracing() {
   return Tracing.newBuilder()
       .localServiceName("spring-amqp-producer")
-      .sampler(Sampler.ALWAYS_SAMPLE)
       .build();
 }
 

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
@@ -1,7 +1,6 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.sampler.Sampler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -216,7 +215,6 @@ public class ITSpringRabbitTracing {
     public Tracing tracing(BlockingQueue<Span> producerSpans) {
       return Tracing.newBuilder()
           .localServiceName("spring-amqp-producer")
-          .sampler(Sampler.ALWAYS_SAMPLE)
           .spanReporter(producerSpans::add)
           .build();
     }
@@ -273,7 +271,6 @@ public class ITSpringRabbitTracing {
     public Tracing tracing(BlockingQueue<Span> consumerSpans) {
       return Tracing.newBuilder()
           .localServiceName("spring-amqp-consumer")
-          .sampler(Sampler.ALWAYS_SAMPLE)
           .spanReporter(consumerSpans::add)
           .build();
     }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -1,7 +1,6 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.sampler.Sampler;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -15,7 +14,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class SpringRabbitTracingTest {
   SpringRabbitTracing tracing = SpringRabbitTracing.create(Tracing.newBuilder()
-      .sampler(Sampler.ALWAYS_SAMPLE)
       .spanReporter(Reporter.NOOP)
       .build());
 

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
@@ -1,7 +1,6 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.sampler.Sampler;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +21,6 @@ public class TracingMessagePostProcessorTest {
   @Before public void setupTracing() {
     reportedSpans.clear();
     Tracing tracing = Tracing.newBuilder()
-        .sampler(Sampler.ALWAYS_SAMPLE)
         .spanReporter(reportedSpans::add)
         .build();
     tracingMessagePostProcessor = new TracingMessagePostProcessor(tracing, "my-exchange");

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
@@ -1,7 +1,6 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.sampler.Sampler;
 import java.util.ArrayList;
 import java.util.List;
 import org.aopalliance.intercept.MethodInvocation;
@@ -32,7 +31,6 @@ public class TracingRabbitListenerAdviceTest {
   @Before public void setupTracing() {
     reportedSpans.clear();
     Tracing tracing = Tracing.newBuilder()
-        .sampler(Sampler.ALWAYS_SAMPLE)
         .spanReporter(reportedSpans::add)
         .build();
     tracingRabbitListenerAdvice = new TracingRabbitListenerAdvice(tracing, "my-service");


### PR DESCRIPTION
Before, we had an edge-case api for parameterized sampling:
`Tracer.newTrace(SamplingFlags)`. This deprecates that for a general
purpose api that allows you to temporarily override the underlying
trace ID sampler. This puts it in practice with an AspectJ example and
refactors http client sampling to use it. By establishing a common
pattern, future samplers, such as RPC ones will easily fit in. Moreover,
scoped spans do not need special sampling considerations.

Ex.
```java
// scope a tracer so that it always reports data
Tracer tracer = tracing.tracer().withSampler(Sampler.ALWAYS_SAMPLE);
```