### PR TITLE
Clarifies dubbo is 2.6+ and fixes test which tried to bind docker IP

### DIFF
--- a/instrumentation/dubbo-rpc/README.md
+++ b/instrumentation/dubbo-rpc/README.md
@@ -1,5 +1,5 @@
 # brave-instrumentation-dubbo-rpc
-This is a tracing filter for RPC providers and consumers in [Dubbo](http://dubbo.io/books/dubbo-dev-book-en/impls/filter.html)
+This is a tracing filter for RPC providers and consumers in [Dubbo 2.6+](http://dubbo.io/books/dubbo-dev-book-en/impls/filter.html)
 
 When used on a consumer, `TracingFilter` adds trace state as attachments
 to outgoing requests. When a provider, it extracts trace state from

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -13,7 +13,7 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
-    <dubbo.version>2.6.0</dubbo.version>
+    <dubbo.version>2.6.1</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
@@ -28,7 +28,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     client.setApplication(new ApplicationConfig("bean-consumer"));
     client.setFilter("tracing");
     client.setInterface(GreeterService.class);
-    client.setUrl("dubbo://127.0.0.1:" + server.port() + "?scope=remote&generic=bean");
+    client.setUrl("dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean");
   }
 
   @Test public void propagatesSpan() throws Exception {

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
@@ -34,7 +34,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     ReferenceConfig<GreeterService> ref = new ReferenceConfig<>();
     ref.setApplication(new ApplicationConfig("bean-consumer"));
     ref.setInterface(GreeterService.class);
-    ref.setUrl("dubbo://127.0.0.1:" + server.port() + "?scope=remote&generic=bean");
+    ref.setUrl("dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean");
     client = ref;
 
     setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());


### PR DESCRIPTION
We had feedback offline that our RPC tracing doesn't work well before
version 2.6. While we don't have details, safer to say that we only
work with 2.6+.

This also fixes a test hang, where Dubbo's IP detection can pick docker
bridge IP instead of link local.