### PR TITLE
Adds ScopeDecorator and backports log correlation to use it

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
@@ -4,7 +4,7 @@ import brave.test.propagation.CurrentTraceContextTest;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DefaultCurrentTraceContextTest extends CurrentTraceContextTest {
+public class ThreadLocalCurrentTraceContextTest extends CurrentTraceContextTest {
 
   @Override protected CurrentTraceContext newCurrentTraceContext() {
     return CurrentTraceContext.Default.create();

--- a/brave/README.md
+++ b/brave/README.md
@@ -684,7 +684,7 @@ tracing = Tracing.newBuilder()
     .build();
 ```
 
-Besides logging, other tools are available. `StrictScopeCustomizer` can
+Besides logging, other tools are available. [StrictScopeDecorator](src/main/java/brave/propagation/StrictScopeDecorator.java) can
 help find out when code is not closing scopes properly. This can be
 useful when writing or diagnosing custom instrumentation.
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -512,7 +512,7 @@ needed to support the current span. It also exposes utilities which you
 can use to decorate executors.
 
 ```java
-CurrentTraceContext currentTraceContext = CurrentTraceContext.Default.create();
+CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.create();
 tracing = Tracing.newBuilder()
                  .currentTraceContext(currentTraceContext)
                  ...
@@ -666,6 +666,28 @@ class MyFilter extends Filter {
 }
 ```
 
+### Customizing in-process propagation (Ex. log correlation)
+
+The `CurrentTraceContext` makes a trace context visible, such that spans
+aren't accidentally added to the wrong trace. It also accepts hooks like
+log correlation.
+
+For example, if you use Log4J 2, you can copy trace IDs to your logging
+context with [our decorator](../context/log4j2/README.md):
+```java
+tracing = Tracing.newBuilder()
+    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+       .addScopeDecorator(ThreadContextScopeDecorator.create())
+       .build()
+    )
+    ...
+    .build();
+```
+
+Besides logging, other tools are available. `StrictScopeCustomizer` can
+help find out when code is not closing scopes properly. This can be
+useful when writing or diagnosing custom instrumentation.
+
 ## Disabling Tracing
 
 If you are in a situation where you need to turn off tracing at runtime,
@@ -687,7 +709,7 @@ When writing unit tests, there are a few tricks that will make bugs
 easier to find:
 
 * Report spans into a concurrent queue, so you can read them in tests
-* Use `StrictCurrentTraceContext` to reveal subtle propagation bugs
+* Use `StrictScopeDecorator` to reveal subtle thread-related propagation bugs
 * Unconditionally cleanup `Tracing.current()`, to prevent leaks
 
 Here's an example setup for your unit test fixture:
@@ -695,7 +717,10 @@ Here's an example setup for your unit test fixture:
 ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
 
 Tracing tracing = Tracing.newBuilder()
-                 .currentTraceContext(new StrictCurrentTraceContext())
+                 .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+                   .addScopeDecorator(StrictScopeDecorator.create())
+                   .build()
+                 )
                  .spanReporter(spans::add)
                  .build();
 

--- a/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
+++ b/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
@@ -15,6 +15,12 @@ import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
  */
 public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
 
+  /**
+   * When the input is not null "traceId", "parentId" and "spanId" correlation properties are saved
+   * off and replaced with those of the current span. When the input is null, these properties are
+   * removed. Either way, "traceId", "parentId" and "spanId" properties are restored on {@linkplain
+   * Scope#close()}.
+   */
   @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
     String previousTraceId = getIfString("traceId");
     String previousSpanId = getIfString("spanId");
@@ -39,6 +45,10 @@ public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
     return new CorrelationFieldCurrentTraceContextScope();
   }
 
+  /**
+   * Idempotently sets correlation properties to hex representation of trace identifiers in this
+   * context.
+   */
   void maybeReplaceTraceContext(
       TraceContext currentSpan,
       String previousTraceId,
@@ -60,10 +70,15 @@ public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
     if (!sameSpanId) put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
   }
 
+  /**
+   * Returns the correlation property of the specified name iff it is a string, or null otherwise.
+   */
   protected abstract @Nullable String getIfString(String key);
 
+  /** Replaces the correlation property of the specified name */
   protected abstract void put(String key, String value);
 
+  /** Removes the correlation property of the specified name */
   protected abstract void remove(String key);
 
   final void replace(String key, @Nullable String value) {

--- a/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
+++ b/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
@@ -22,9 +22,9 @@ public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
    * Scope#close()}.
    */
   @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
-    String previousTraceId = getIfString("traceId");
-    String previousSpanId = getIfString("spanId");
-    String previousParentId = getIfString("parentId");
+    String previousTraceId = get("traceId");
+    String previousSpanId = get("spanId");
+    String previousParentId = get("parentId");
 
     if (currentSpan != null) {
       maybeReplaceTraceContext(currentSpan, previousTraceId, previousParentId, previousSpanId);
@@ -73,7 +73,7 @@ public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
   /**
    * Returns the correlation property of the specified name iff it is a string, or null otherwise.
    */
-  protected abstract @Nullable String getIfString(String key);
+  protected abstract @Nullable String get(String key);
 
   /** Replaces the correlation property of the specified name */
   protected abstract void put(String key, String value);

--- a/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
+++ b/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
@@ -1,0 +1,76 @@
+package brave.internal.propagation;
+
+import brave.internal.HexCodec;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import brave.propagation.TraceContext;
+
+import static brave.internal.HexCodec.lowerHexEqualsTraceId;
+import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
+
+/**
+ * Adds correlation properties "traceId", "parentId" and "spanId" when a {@link
+ * brave.Tracer#currentSpan() span is current}.
+ */
+public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
+
+  @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
+    String previousTraceId = getIfString("traceId");
+    String previousSpanId = getIfString("spanId");
+    String previousParentId = getIfString("parentId");
+
+    if (currentSpan != null) {
+      maybeReplaceTraceContext(currentSpan, previousTraceId, previousParentId, previousSpanId);
+    } else {
+      remove("traceId");
+      remove("parentId");
+      remove("spanId");
+    }
+
+    class CorrelationFieldCurrentTraceContextScope implements Scope {
+      @Override public void close() {
+        scope.close();
+        replace("traceId", previousTraceId);
+        replace("parentId", previousParentId);
+        replace("spanId", previousSpanId);
+      }
+    }
+    return new CorrelationFieldCurrentTraceContextScope();
+  }
+
+  void maybeReplaceTraceContext(
+      TraceContext currentSpan,
+      String previousTraceId,
+      @Nullable String previousParentId,
+      String previousSpanId
+  ) {
+    boolean sameTraceId = lowerHexEqualsTraceId(previousTraceId, currentSpan);
+    if (!sameTraceId) put("traceId", currentSpan.traceIdString());
+
+    long parentId = currentSpan.parentIdAsLong();
+    if (parentId == 0L) {
+      remove("parentId");
+    } else {
+      boolean sameParentId = lowerHexEqualsUnsignedLong(previousParentId, parentId);
+      if (!sameParentId) put("parentId", HexCodec.toLowerHex(parentId));
+    }
+
+    boolean sameSpanId = lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId());
+    if (!sameSpanId) put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+  }
+
+  protected abstract @Nullable String getIfString(String key);
+
+  protected abstract void put(String key, String value);
+
+  protected abstract void remove(String key);
+
+  final void replace(String key, @Nullable String value) {
+    if (value != null) {
+      put(key, value);
+    } else {
+      remove(key);
+    }
+  }
+}

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -4,6 +4,8 @@ import brave.Tracer;
 import brave.Tracing;
 import brave.internal.Nullable;
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -21,6 +23,17 @@ import java.util.concurrent.ExecutorService;
  * com.google.inject.servlet.RequestScoper and com.github.kristofa.brave.CurrentSpan
  */
 public abstract class CurrentTraceContext {
+
+  public abstract static class Builder {
+    /**
+     * Use this to add features such as thread checks or log correlation fields when a scope is
+     * created or closed.
+     */
+    public abstract Builder scopeDecorators(List<ScopeDecorator> scopeDecorators);
+
+    public abstract CurrentTraceContext build();
+  }
+
   /** Returns the current span in scope or null if there isn't one. */
   public abstract @Nullable TraceContext get();
 
@@ -31,6 +44,29 @@ public abstract class CurrentTraceContext {
    * @param currentSpan span to place into scope or null to clear the scope
    */
   public abstract Scope newScope(@Nullable TraceContext currentSpan);
+
+  final List<ScopeDecorator> scopeDecorators;
+
+  public interface Factory {
+    CurrentTraceContext create(List<ScopeDecorator> scopeDecorators);
+  }
+
+  protected CurrentTraceContext() {
+    this(Collections.emptyList());
+  }
+
+  protected CurrentTraceContext(List<ScopeDecorator> scopeDecorators) {
+    this.scopeDecorators = scopeDecorators;
+  }
+
+  protected Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
+    int length = scopeDecorators.size();
+    if (length == 0) return scope;
+    for (int i = 0; i < length; i++) {
+      scope = scopeDecorators.get(i).decorateScope(currentSpan, scope);
+    }
+    return scope;
+  }
 
   /**
    * Like {@link #newScope(TraceContext)}, except returns {@link Scope#NOOP} if the given context is
@@ -84,6 +120,10 @@ public abstract class CurrentTraceContext {
     @Override void close();
   }
 
+  public interface ScopeDecorator {
+    Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope);
+  }
+
   /**
    * Default implementation which is backed by a static thread local.
    *
@@ -103,49 +143,30 @@ public abstract class CurrentTraceContext {
    * <p>If you want a different behavior, use a different subtype of {@link CurrentTraceContext},
    * possibly your own, or raise an issue and explain what your use case is.
    */
-  public static final class Default extends CurrentTraceContext {
-    static final ThreadLocal<TraceContext> DEFAULT = new ThreadLocal<>();
+  public static final class Default extends ThreadLocalCurrentTraceContext {
     // Inheritable as Brave 3's ThreadLocalServerClientAndLocalSpanState was inheritable
     static final InheritableThreadLocal<TraceContext> INHERITABLE = new InheritableThreadLocal<>();
 
-    final ThreadLocal<TraceContext> local;
-
     /** Uses a non-inheritable static thread local */
     public static CurrentTraceContext create() {
-      return new Default(DEFAULT);
+      return new ThreadLocalCurrentTraceContext(Collections.emptyList(), DEFAULT);
     }
 
     /**
-     * Uses an inheritable static thread local which allows arbitrary calls to {@link
-     * Thread#start()} to automatically inherit this context. This feature is available as it is was
-     * the default in Brave 3, because some users couldn't control threads in their applications.
+     * Uses an inheritable static thread local which allows arbitrary calls to {@link Thread#start()}
+     * to automatically inherit this context. This feature is available as it is was the default in
+     * Brave 3, because some users couldn't control threads in their applications.
      *
      * <p>This can be a problem in scenarios such as thread pool expansion, leading to data being
-     * recorded in the wrong span, or spans with the wrong parent. If you are impacted by this,
-     * switch to {@link #create()}.
+     * recorded in the wrong span, or spans with the wrong parent. If you are impacted by this, switch
+     * to {@link #create()}.
      */
     public static CurrentTraceContext inheritable() {
-      return new Default(INHERITABLE);
+      return new ThreadLocalCurrentTraceContext(Collections.emptyList(), INHERITABLE);
     }
 
     Default(ThreadLocal<TraceContext> local) {
-      if (local == null) throw new NullPointerException("local == null");
-      this.local = local;
-    }
-
-    @Override public TraceContext get() {
-      return local.get();
-    }
-
-    @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-      final TraceContext previous = local.get();
-      local.set(currentSpan);
-      class DefaultCurrentTraceContextScope implements Scope {
-        @Override public void close() {
-          local.set(previous);
-        }
-      }
-      return new DefaultCurrentTraceContextScope();
+      super(Collections.emptyList(), local);
     }
   }
 

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -61,7 +61,7 @@ public abstract class CurrentTraceContext {
   }
 
   protected CurrentTraceContext(Builder<?> builder) {
-    this.scopeDecorators = (List<ScopeDecorator>) builder.scopeDecorators.clone();
+    this.scopeDecorators = new ArrayList<>(builder.scopeDecorators);
   }
 
   /**
@@ -86,7 +86,6 @@ public abstract class CurrentTraceContext {
    */
   protected Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
     int length = scopeDecorators.size();
-    if (length == 0) return scope;
     for (int i = 0; i < length; i++) {
       scope = scopeDecorators.get(i).decorateScope(currentSpan, scope);
     }

--- a/brave/src/main/java/brave/propagation/StrictCurrentScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentScopeDecorator.java
@@ -1,0 +1,38 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext.Scope;
+
+/** Useful when developing instrumentation as state is enforced more strictly. */
+public final class StrictCurrentScopeDecorator implements CurrentTraceContext.ScopeDecorator {
+
+  /** Identifies problems by throwing assertion errors when a scope is closed on a different thread. */
+  @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
+    return new StrictScope(scope, new Error(String.format("Thread %s opened scope for %s here:",
+        Thread.currentThread().getName(), currentSpan)));
+  }
+
+  class StrictScope implements Scope {
+    final Scope delegate;
+    final Throwable caller;
+    final long threadId = Thread.currentThread().getId();
+
+    StrictScope(Scope delegate, Throwable caller) {
+      this.delegate = delegate;
+      this.caller = caller;
+    }
+
+    @Override public void close() {
+      if (Thread.currentThread().getId() != threadId) {
+        throw new IllegalStateException(
+            "scope closed in a different thread: " + Thread.currentThread().getName(),
+            caller);
+      }
+      delegate.close();
+    }
+
+    @Override public String toString() {
+      return caller.toString();
+    }
+  }
+}

--- a/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
@@ -10,8 +10,8 @@ package brave.propagation;
  */
 @Deprecated
 public final class StrictCurrentTraceContext extends ThreadLocalCurrentTraceContext {
-  static final Builder SCOPE_DECORATING_BUILDER = ThreadLocalCurrentTraceContext.newBuilder()
-      .addScopeDecorator(new StrictScopeDecorator());
+  static final CurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+      ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(new StrictScopeDecorator());
 
   public StrictCurrentTraceContext() { // Preserve historical public ctor
     // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work

--- a/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
@@ -1,19 +1,21 @@
 package brave.propagation;
 
-import java.util.Collections;
-
 /**
  * Useful when developing instrumentation as state is enforced more strictly.
  *
  * <p>For example, it is instance scoped as opposed to static scoped, not inheritable and throws an
  * exception if a scope is closed on a different thread that it was opened on.
  *
- * @see ThreadLocalCurrentTraceContext
+ * @deprecated use {@linkplain StrictScopeDecorator}. This will be removed in Brave v6.
  */
+@Deprecated
 public final class StrictCurrentTraceContext extends ThreadLocalCurrentTraceContext {
-  public StrictCurrentTraceContext() {
+  static final Builder SCOPE_DECORATING_BUILDER = ThreadLocalCurrentTraceContext.newBuilder()
+      .addScopeDecorator(new StrictScopeDecorator());
+
+  public StrictCurrentTraceContext() { // Preserve historical public ctor
     // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
     // intentionally not static to make explicit when instrumentation need per thread semantics
-    super(Collections.singletonList(new StrictCurrentScopeDecorator()), new ThreadLocal<>());
+    super(SCOPE_DECORATING_BUILDER, new ThreadLocal<>());
   }
 }

--- a/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
@@ -1,6 +1,6 @@
 package brave.propagation;
 
-import brave.internal.Nullable;
+import java.util.Collections;
 
 /**
  * Useful when developing instrumentation as state is enforced more strictly.
@@ -8,46 +8,12 @@ import brave.internal.Nullable;
  * <p>For example, it is instance scoped as opposed to static scoped, not inheritable and throws an
  * exception if a scope is closed on a different thread that it was opened on.
  *
- * @see CurrentTraceContext.Default
+ * @see ThreadLocalCurrentTraceContext
  */
-public final class StrictCurrentTraceContext extends CurrentTraceContext {
-  // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
-  // intentionally not static to make explicit when instrumentation need per thread semantics
-  final ThreadLocal<TraceContext> local = new ThreadLocal<>();
-
-  @Override public TraceContext get() {
-    return local.get();
-  }
-
-  /** Identifies problems by throwing assertion errors when a scope is closed on a different thread. */
-  @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-    TraceContext previous = local.get();
-    local.set(currentSpan);
-    return new StrictScope(previous, new Error(String.format("Thread %s opened scope for %s here:",
-        Thread.currentThread().getName(), currentSpan)));
-  }
-
-  class StrictScope implements Scope {
-    final TraceContext previous;
-    final Throwable caller;
-    final long threadId = Thread.currentThread().getId();
-
-    StrictScope(TraceContext previous, Throwable caller) {
-      this.previous = previous;
-      this.caller = caller;
-    }
-
-    @Override public void close() {
-      if (Thread.currentThread().getId() != threadId) {
-        throw new IllegalStateException(
-            "scope closed in a different thread: " + Thread.currentThread().getName(),
-            caller);
-      }
-      local.set(previous);
-    }
-
-    @Override public String toString() {
-      return caller.toString();
-    }
+public final class StrictCurrentTraceContext extends ThreadLocalCurrentTraceContext {
+  public StrictCurrentTraceContext() {
+    // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
+    // intentionally not static to make explicit when instrumentation need per thread semantics
+    super(Collections.singletonList(new StrictCurrentScopeDecorator()), new ThreadLocal<>());
   }
 }

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -2,9 +2,25 @@ package brave.propagation;
 
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
 
-/** Useful when developing instrumentation as state is enforced more strictly. */
-public final class StrictCurrentScopeDecorator implements CurrentTraceContext.ScopeDecorator {
+/**
+ * Useful when developing instrumentation as state is enforced more strictly.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * tracing = Tracing.newBuilder()
+ *                  .spanReporter(...)
+ *                  .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+ *                    .addScopeDecorator(StrictScopeDecorator.create())
+ *                    .build()
+ *                  ).build();
+ * }</pre>
+ */
+public final class StrictScopeDecorator implements ScopeDecorator {
+  public static ScopeDecorator create() {
+    return new StrictScopeDecorator();
+  }
 
   /** Identifies problems by throwing assertion errors when a scope is closed on a different thread. */
   @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
@@ -34,5 +50,8 @@ public final class StrictCurrentScopeDecorator implements CurrentTraceContext.Sc
     @Override public String toString() {
       return caller.toString();
     }
+  }
+
+  StrictScopeDecorator() {
   }
 }

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -29,11 +29,11 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
     return new Builder().build();
   }
 
-  public static Builder newBuilder() {
+  public static CurrentTraceContext.Builder newBuilder() {
     return new Builder();
   }
 
-  public static final class Builder extends CurrentTraceContext.Builder<Builder> {
+  static final class Builder extends CurrentTraceContext.Builder<Builder> {
 
     @Override public CurrentTraceContext build() {
       return new ThreadLocalCurrentTraceContext(this, DEFAULT);
@@ -47,7 +47,10 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
 
   final ThreadLocal<TraceContext> local;
 
-  ThreadLocalCurrentTraceContext(Builder builder, ThreadLocal<TraceContext> local) {
+  ThreadLocalCurrentTraceContext(
+      CurrentTraceContext.Builder builder,
+      ThreadLocal<TraceContext> local
+  ) {
     super(builder);
     if (local == null) throw new NullPointerException("local == null");
     this.local = local;

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -1,0 +1,78 @@
+package brave.propagation;
+
+import brave.Tracing;
+import brave.internal.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default implementation which is backed by a static thread local.
+ *
+ * <p>A static thread local ensures we have one context per thread, as opposed to one per thread-
+ * tracer. This means all tracer instances will be able to see any tracer's contexts.
+ *
+ * <p>The trade-off of this (instance-based reference) vs the reverse: trace contexts are not
+ * separated by tracer by default. For example, to make a trace invisible to another tracer, you
+ * have to use a non-default implementation.
+ *
+ * <p>Sometimes people make different instances of the tracer just to change configuration like
+ * the local service name. If we used a thread-instance approach, none of these would be able to see
+ * eachother's scopes. This would break {@link Tracing#currentTracer()} scope visibility in a way
+ * few would want to debug. It might be phrased as "MySQL always starts a new trace and I don't know
+ * why."
+ *
+ * <p>If you want a different behavior, use a different subtype of {@link CurrentTraceContext},
+ * possibly your own, or raise an issue and explain what your use case is.
+ */
+public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not final for backport
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends CurrentTraceContext.Builder {
+    List<ScopeDecorator> scopeDecorators = Collections.emptyList();
+
+    @Override public Builder scopeDecorators(List<ScopeDecorator> scopeDecorators) {
+      if (scopeDecorators == null) throw new NullPointerException("scopeDecorators == null");
+      this.scopeDecorators = scopeDecorators;
+      return this;
+    }
+
+    @Override public CurrentTraceContext build() {
+      return new ThreadLocalCurrentTraceContext(scopeDecorators, DEFAULT);
+    }
+
+    Builder() {
+    }
+  }
+
+  static final ThreadLocal<TraceContext> DEFAULT = new ThreadLocal<>();
+
+  final ThreadLocal<TraceContext> local;
+
+  ThreadLocalCurrentTraceContext(
+      List<ScopeDecorator> scopeDecorators,
+      ThreadLocal<TraceContext> local
+  ) {
+    super(scopeDecorators);
+    if (local == null) throw new NullPointerException("local == null");
+    this.local = local;
+  }
+
+  @Override public TraceContext get() {
+    return local.get();
+  }
+
+  @Override public Scope newScope(@Nullable TraceContext currentSpan) {
+    final TraceContext previous = local.get();
+    local.set(currentSpan);
+    class DefaultCurrentTraceContextScope implements Scope {
+      @Override public void close() {
+        local.set(previous);
+      }
+    }
+    Scope result = new DefaultCurrentTraceContextScope();
+    return decorateScope(currentSpan, result);
+  }
+}

--- a/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
@@ -1,6 +1,6 @@
 package brave;
 
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
@@ -14,13 +14,13 @@ public class CurrentSpanCustomizerTest {
 
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
   CurrentSpanCustomizer spanCustomizer = CurrentSpanCustomizer.create(tracing);
   Span span = tracing.tracer().newTrace();
 
-  @After public void close(){
+  @After public void close() {
     Tracing.current().close();
   }
 

--- a/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 public class CurrentSpanCustomizerTest {
 
-  List<zipkin2.Span> spans = new ArrayList();
+  List<zipkin2.Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
       .currentTraceContext(new StrictCurrentTraceContext())
       .spanReporter(spans::add)

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
@@ -1,7 +1,8 @@
 package brave;
 
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -24,7 +25,9 @@ public class CurrentTraceContextExecutorServiceTest {
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
 
   // override default so that it isn't inheritable
-  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
+      .addScopeDecorator(StrictScopeDecorator.create())
+      .build();
   ExecutorService executor = currentTraceContext.executorService(wrappedExecutor);
 
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(1).build();

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
@@ -1,7 +1,8 @@
 package brave;
 
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -18,7 +19,9 @@ public class CurrentTraceContextExecutorTest {
   // Ensures one at-a-time, but also on a different thread
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
   // override default so that it isn't inheritable
-  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
+      .addScopeDecorator(StrictScopeDecorator.create())
+      .build();
 
   Executor executor = currentTraceContext.executor(wrappedExecutor);
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(1).build();

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -1,8 +1,7 @@
 package brave;
 
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
-import java.net.InetSocketAddress;
 import org.junit.After;
 import org.junit.Test;
 
@@ -10,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class NoopSpanTest {
   Tracer tracer = Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE)
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .clock(() -> {
         throw new AssertionError();
       })
@@ -20,7 +19,7 @@ public class NoopSpanTest {
       .build().tracer();
   Span span = tracer.newTrace();
 
-  @After public void close(){
+  @After public void close() {
     Tracing.current().close();
   }
 

--- a/brave/src/test/java/brave/RealSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/RealSpanCustomizerTest.java
@@ -1,6 +1,6 @@
 package brave;
 
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.entry;
 public class RealSpanCustomizerTest {
   List<zipkin2.Span> spans = new ArrayList();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
   Span span = tracing.tracer().newTrace();

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -1,6 +1,6 @@
 package brave;
 
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.entry;
 public class RealSpanTest {
   List<zipkin2.Span> spans = new ArrayList();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
   Span span = tracing.tracer().newTrace();

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -5,7 +5,7 @@ import brave.propagation.B3Propagation;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import brave.propagation.SamplingFlags;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.propagation.TraceIdContext;
@@ -51,7 +51,7 @@ public class TracerTest {
           return propagationFactory.decorate(context);
         }
       })
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .localServiceName("my-service")
       .build().tracer();
 

--- a/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
+++ b/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
@@ -2,7 +2,8 @@ package brave.features.advanced;
 
 import brave.Clock;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CustomScopedClockTracingTest {
   List<Span> spans = new ArrayList();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
 

--- a/brave/src/test/java/brave/features/async/OneWaySpanTest.java
+++ b/brave/src/test/java/brave/features/async/OneWaySpanTest.java
@@ -2,7 +2,8 @@ package brave.features.async;
 
 import brave.Span;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.Collections;
 import java.util.List;
@@ -35,12 +36,14 @@ public class OneWaySpanTest {
   /** Use different tracers for client and server as usually they are on different hosts. */
   Tracing clientTracing = Tracing.newBuilder()
       .localServiceName("client")
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
       .spanReporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
       .build();
   Tracing serverTracing = Tracing.newBuilder()
       .localServiceName("server")
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(s -> storage.spanConsumer().accept(Collections.singletonList(s)))
       .build();
 

--- a/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
+++ b/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
@@ -3,7 +3,7 @@ package brave.features.sampler;
 import brave.ScopedSpan;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.DeclarativeSampler;
 import brave.sampler.Sampler;
 import java.lang.annotation.Retention;
@@ -41,7 +41,7 @@ public class AspectJSamplerTest {
 
   @Before public void clear() {
     tracing.set(Tracing.newBuilder()
-        .currentTraceContext(new StrictCurrentTraceContext())
+        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
         .spanReporter(spans::add)
         .sampler(new Sampler() {
           @Override public boolean isSampled(long traceId) {

--- a/context/log4j12/README.md
+++ b/context/log4j12/README.md
@@ -2,12 +2,15 @@
 This adds trace and span IDs to the Log4J v1.2 Mapped Diagnostic Context so that you
 can search or aggregate logs accordingly.
 
-To enable this, configure `brave.Tracing` with `MDCCurrentTraceContext`
+To enable this, configure `brave.Tracing` with `MDCScopeDecorator`
 like so:
 
 ```java
 tracing = Tracing.newBuilder()
-    .currentTraceContext(MDCCurrentTraceContext.create())
+    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+       .addScopeDecorator(MDCScopeDecorator.create())
+       .build()
+    )
     ...
     .build();
 ```

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
@@ -2,15 +2,21 @@ package brave.context.log4j12;
 
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
-import java.util.Collections;
 import org.apache.log4j.MDC;
 
 /**
  * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ *
+ * @deprecated use {@linkplain MDCScopeDecorator}. This will be removed in Brave v6.
  */
+@Deprecated
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
+  static final ThreadLocalCurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+      ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(MDCScopeDecorator.create());
+
   public static MDCCurrentTraceContext create() {
     return create(CurrentTraceContext.Default.inheritable());
   }
@@ -23,7 +29,7 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
   final CurrentTraceContext delegate;
 
   MDCCurrentTraceContext(CurrentTraceContext delegate) {
-    super(Collections.singletonList(MDCScopeDecorator.INSTANCE));
+    super(SCOPE_DECORATING_BUILDER);
     this.delegate = delegate;
   }
 

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
@@ -14,7 +14,7 @@ import org.apache.log4j.MDC;
  */
 @Deprecated
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
-  static final ThreadLocalCurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+  static final CurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
       ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(MDCScopeDecorator.create());
 
   public static MDCCurrentTraceContext create() {

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
@@ -1,17 +1,14 @@
 package brave.context.log4j12;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
+import java.util.Collections;
 import org.apache.log4j.MDC;
 
-import static brave.internal.HexCodec.lowerHexEqualsTraceId;
-import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
-
 /**
- * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link brave.Tracer#currentSpan()
- * span is current}. These can be used in log correlation.
+ * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
+ * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
  */
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
   public static MDCCurrentTraceContext create() {
@@ -19,15 +16,14 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
   }
 
   public static MDCCurrentTraceContext create(CurrentTraceContext delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
     return new MDCCurrentTraceContext(delegate);
   }
 
   final CurrentTraceContext delegate;
 
   MDCCurrentTraceContext(CurrentTraceContext delegate) {
-    if (delegate == null) {
-      throw new NullPointerException("delegate == null");
-    }
+    super(Collections.singletonList(MDCScopeDecorator.INSTANCE));
     this.delegate = delegate;
   }
 
@@ -36,77 +32,7 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
   }
 
   @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-    return newScope(currentSpan, getIfString("traceId"), getIfString("spanId"));
-  }
-
-  @Override public Scope maybeScope(@Nullable TraceContext currentSpan) {
-    String previousTraceId = getIfString("traceId");
-    String previousSpanId = getIfString("spanId");
-    if (currentSpan == null) {
-      if (previousTraceId == null) return Scope.NOOP;
-      return newScope(null, previousTraceId, previousSpanId);
-    }
-    if (lowerHexEqualsTraceId(previousTraceId, currentSpan)
-        && lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId())) {
-      return Scope.NOOP;
-    }
-    return newScope(currentSpan, previousTraceId, previousSpanId);
-  }
-
-  // all input parameters are nullable
-  Scope newScope(TraceContext currentSpan, String previousTraceId, String previousSpanId) {
-    String previousParentId = getIfString("parentId");
-    if (currentSpan != null) {
-      maybeReplaceTraceContext(currentSpan, previousTraceId, previousParentId, previousSpanId);
-    } else {
-      MDC.remove("traceId");
-      MDC.remove("parentId");
-      MDC.remove("spanId");
-    }
-
     Scope scope = delegate.newScope(currentSpan);
-    class MDCCurrentTraceContextScope implements Scope {
-      @Override public void close() {
-        scope.close();
-        replace("traceId", previousTraceId);
-        replace("parentId", previousParentId);
-        replace("spanId", previousSpanId);
-      }
-    }
-    return new MDCCurrentTraceContextScope();
-  }
-
-  void maybeReplaceTraceContext(
-      TraceContext currentSpan,
-      String previousTraceId,
-      @Nullable String previousParentId,
-      String previousSpanId
-  ) {
-    boolean sameTraceId = lowerHexEqualsTraceId(previousTraceId, currentSpan);
-    if (!sameTraceId) MDC.put("traceId", currentSpan.traceIdString());
-
-    long parentId = currentSpan.parentIdAsLong();
-    if (parentId == 0L) {
-      MDC.remove("parentId");
-    } else {
-      boolean sameParentId = lowerHexEqualsUnsignedLong(previousParentId, parentId);
-      if (!sameParentId) MDC.put("parentId", HexCodec.toLowerHex(parentId));
-    }
-
-    boolean sameSpanId = lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId());
-    if (!sameSpanId) MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
-  }
-
-  static String getIfString(String key) {
-    Object result = MDC.get(key);
-    return result instanceof String ? (String) result : null;
-  }
-
-  static void replace(String key, @Nullable Object value) {
-    if (value != null) {
-      MDC.put(key, value);
-    } else {
-      MDC.remove(key);
-    }
+    return decorateScope(currentSpan, scope);
   }
 }

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
@@ -1,17 +1,27 @@
 package brave.context.log4j12;
 
 import brave.internal.propagation.CorrelationFieldScopeDecorator;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import org.apache.log4j.MDC;
 
 /**
  * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * tracing = Tracing.newBuilder()
+ *                  .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+ *                    .addScopeDecorator(MDCScopeDecorator.create())
+ *                    .build()
+ *                  )
+ *                  ...
+ *                  .build();
+ * }</pre>
  */
 public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
-  static final MDCScopeDecorator INSTANCE = new MDCScopeDecorator();
-
-  public static MDCScopeDecorator create() {
-    return INSTANCE;
+  public static ScopeDecorator create() {
+    return new MDCScopeDecorator();
   }
 
   @Override protected String getIfString(String key) {
@@ -25,5 +35,8 @@ public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
 
   @Override protected void remove(String key) {
     MDC.remove(key);
+  }
+
+  MDCScopeDecorator() {
   }
 }

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
@@ -24,7 +24,7 @@ public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
     return new MDCScopeDecorator();
   }
 
-  @Override protected String getIfString(String key) {
+  @Override protected String get(String key) {
     Object result = MDC.get(key);
     return result instanceof String ? (String) result : null;
   }

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
@@ -1,0 +1,29 @@
+package brave.context.log4j12;
+
+import brave.internal.propagation.CorrelationFieldScopeDecorator;
+import org.apache.log4j.MDC;
+
+/**
+ * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
+ * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ */
+public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
+  static final MDCScopeDecorator INSTANCE = new MDCScopeDecorator();
+
+  public static MDCScopeDecorator create() {
+    return INSTANCE;
+  }
+
+  @Override protected String getIfString(String key) {
+    Object result = MDC.get(key);
+    return result instanceof String ? (String) result : null;
+  }
+
+  @Override protected void put(String key, String value) {
+    MDC.put(key, value);
+  }
+
+  @Override protected void remove(String key) {
+    MDC.remove(key);
+  }
+}

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
@@ -1,0 +1,47 @@
+package brave.context.log4j12;
+
+import brave.internal.HexCodec;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.test.propagation.CurrentTraceContextTest;
+import org.apache.log4j.MDC;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
+
+  @Override protected CurrentTraceContext newCurrentTraceContext() {
+    return ThreadLocalCurrentTraceContext.newBuilder()
+        .addScopeDecorator(MDCScopeDecorator.create())
+        .build();
+  }
+
+  @Test(expected = ComparisonFailure.class) // Log4J 1.2.x MDC is inheritable by default
+  public void isnt_inheritable() throws Exception {
+    super.isnt_inheritable();
+  }
+
+  @Override protected void verifyImplicitContext(@Nullable TraceContext context) {
+    if (context != null) {
+      assertThat(MDC.get("traceId"))
+          .isEqualTo(context.traceIdString());
+      long parentId = context.parentIdAsLong();
+      assertThat(MDC.get("parentId"))
+          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+      assertThat(MDC.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+    } else {
+      assertThat(MDC.get("traceId"))
+          .isNull();
+      assertThat(MDC.get("parentId"))
+          .isNull();
+      assertThat(MDC.get("spanId"))
+          .isNull();
+    }
+  }
+}
+

--- a/context/log4j2/README.md
+++ b/context/log4j2/README.md
@@ -2,12 +2,15 @@
 This adds trace and span IDs to the Log4J 2 Thread Context so that you
 can search or aggregate logs accordingly.
 
-To enable this, configure `brave.Tracing` with `ThreadContextCurrentTraceContext`
+To enable this, configure `brave.Tracing` with `ThreadContextScopeDecorator`
 like so:
 
 ```java
 tracing = Tracing.newBuilder()
-    .currentTraceContext(ThreadContextCurrentTraceContext.create())
+    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+       .addScopeDecorator(ThreadContextScopeDecorator.create())
+       .build()
+    )
     ...
     .build();
 ```

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -14,7 +14,7 @@ import org.apache.logging.log4j.ThreadContext;
  */
 @Deprecated
 public final class ThreadContextCurrentTraceContext extends CurrentTraceContext {
-  static final ThreadLocalCurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+  static final CurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
       ThreadLocalCurrentTraceContext.newBuilder()
           .addScopeDecorator(ThreadContextScopeDecorator.create());
 

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -1,13 +1,10 @@
 package brave.context.log4j2;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
+import java.util.Collections;
 import org.apache.logging.log4j.ThreadContext;
-
-import static brave.internal.HexCodec.lowerHexEqualsTraceId;
-import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
 
 /**
  * Adds {@linkplain ThreadContext} properties "traceId", "parentId" and "spanId" when a {@link
@@ -19,13 +16,14 @@ public final class ThreadContextCurrentTraceContext extends CurrentTraceContext 
   }
 
   public static ThreadContextCurrentTraceContext create(CurrentTraceContext delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
     return new ThreadContextCurrentTraceContext(delegate);
   }
 
   final CurrentTraceContext delegate;
 
   ThreadContextCurrentTraceContext(CurrentTraceContext delegate) {
-    if (delegate == null) throw new NullPointerException("delegate == null");
+    super(Collections.singletonList(ThreadContextScopeDecorator.INSTANCE));
     this.delegate = delegate;
   }
 
@@ -34,72 +32,7 @@ public final class ThreadContextCurrentTraceContext extends CurrentTraceContext 
   }
 
   @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-    return newScope(currentSpan, ThreadContext.get("traceId"), ThreadContext.get("spanId"));
-  }
-
-  @Override public Scope maybeScope(@Nullable TraceContext currentSpan) {
-    String previousTraceId = ThreadContext.get("traceId");
-    String previousSpanId = ThreadContext.get("spanId");
-    if (currentSpan == null) {
-      if (previousTraceId == null) return Scope.NOOP;
-      return newScope(null, previousTraceId, previousSpanId);
-    }
-    if (lowerHexEqualsTraceId(previousTraceId, currentSpan)
-        && lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId())) {
-      return Scope.NOOP;
-    }
-    return newScope(currentSpan, previousTraceId, previousSpanId);
-  }
-
-  // all input parameters are nullable
-  Scope newScope(TraceContext currentSpan, String previousTraceId, String previousSpanId) {
-    String previousParentId = ThreadContext.get("parentId");
-    if (currentSpan != null) {
-      maybeReplaceTraceContext(currentSpan, previousTraceId, previousParentId, previousSpanId);
-    } else {
-      ThreadContext.remove("traceId");
-      ThreadContext.remove("parentId");
-      ThreadContext.remove("spanId");
-    }
-
     Scope scope = delegate.newScope(currentSpan);
-    class ThreadContextCurrentTraceContextScope implements Scope {
-      @Override public void close() {
-        scope.close();
-        replace("traceId", previousTraceId);
-        replace("parentId", previousParentId);
-        replace("spanId", previousSpanId);
-      }
-    }
-    return new ThreadContextCurrentTraceContextScope();
-  }
-
-  void maybeReplaceTraceContext(
-      TraceContext currentSpan,
-      String previousTraceId,
-      @Nullable String previousParentId,
-      String previousSpanId
-  ) {
-    boolean sameTraceId = lowerHexEqualsTraceId(previousTraceId, currentSpan);
-    if (!sameTraceId) ThreadContext.put("traceId", currentSpan.traceIdString());
-
-    long parentId = currentSpan.parentIdAsLong();
-    if (parentId == 0L) {
-      ThreadContext.remove("parentId");
-    } else {
-      boolean sameParentId = lowerHexEqualsUnsignedLong(previousParentId, parentId);
-      if (!sameParentId) ThreadContext.put("parentId", HexCodec.toLowerHex(parentId));
-    }
-
-    boolean sameSpanId = lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId());
-    if (!sameSpanId) ThreadContext.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
-  }
-
-  static void replace(String key, @Nullable String value) {
-    if (value != null) {
-      ThreadContext.put(key, value);
-    } else {
-      ThreadContext.remove(key);
-    }
+    return decorateScope(currentSpan, scope);
   }
 }

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextCurrentTraceContext.java
@@ -2,15 +2,22 @@ package brave.context.log4j2;
 
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
-import java.util.Collections;
 import org.apache.logging.log4j.ThreadContext;
 
 /**
  * Adds {@linkplain ThreadContext} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ *
+ * @deprecated use {@linkplain ThreadContextScopeDecorator}. This will be removed in Brave v6.
  */
+@Deprecated
 public final class ThreadContextCurrentTraceContext extends CurrentTraceContext {
+  static final ThreadLocalCurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+      ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(ThreadContextScopeDecorator.create());
+
   public static ThreadContextCurrentTraceContext create() {
     return create(CurrentTraceContext.Default.inheritable());
   }
@@ -23,7 +30,7 @@ public final class ThreadContextCurrentTraceContext extends CurrentTraceContext 
   final CurrentTraceContext delegate;
 
   ThreadContextCurrentTraceContext(CurrentTraceContext delegate) {
-    super(Collections.singletonList(ThreadContextScopeDecorator.INSTANCE));
+    super(SCOPE_DECORATING_BUILDER);
     this.delegate = delegate;
   }
 

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
@@ -25,7 +25,7 @@ public final class ThreadContextScopeDecorator extends CorrelationFieldScopeDeco
     return new ThreadContextScopeDecorator();
   }
 
-  @Override protected String getIfString(String key) {
+  @Override protected String get(String key) {
     return ThreadContext.get(key);
   }
 

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
@@ -1,0 +1,32 @@
+package brave.context.log4j2;
+
+import brave.propagation.CorrelationFieldScopeDecorator;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * Adds {@linkplain ThreadContext} properties "traceId", "parentId" and "spanId" when a {@link
+ * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ */
+public final class ThreadContextScopeDecorator extends CorrelationFieldScopeDecorator {
+  static final ThreadContextScopeDecorator INSTANCE = new ThreadContextScopeDecorator();
+
+  public static ScopeDecorator create() {
+    return INSTANCE;
+  }
+
+  @Override protected String getIfString(String key) {
+    return ThreadContext.get(key);
+  }
+
+  @Override protected void put(String key, String value) {
+    ThreadContext.put(key, value);
+  }
+
+  @Override protected void remove(String key) {
+    ThreadContext.remove(key);
+  }
+
+  ThreadContextScopeDecorator() {
+  }
+}

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
@@ -7,12 +7,22 @@ import org.apache.logging.log4j.ThreadContext;
 /**
  * Adds {@linkplain ThreadContext} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * tracing = Tracing.newBuilder()
+ *                  .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+ *                    .addScopeDecorator(ThreadContextScopeDecorator.create())
+ *                    .build()
+ *                  )
+ *                  ...
+ *                  .build();
+ * }</pre>
  */
 public final class ThreadContextScopeDecorator extends CorrelationFieldScopeDecorator {
-  static final ThreadContextScopeDecorator INSTANCE = new ThreadContextScopeDecorator();
 
   public static ScopeDecorator create() {
-    return INSTANCE;
+    return new ThreadContextScopeDecorator();
   }
 
   @Override protected String getIfString(String key) {

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
@@ -1,6 +1,6 @@
 package brave.context.log4j2;
 
-import brave.propagation.CorrelationFieldScopeDecorator;
+import brave.internal.propagation.CorrelationFieldScopeDecorator;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import org.apache.logging.log4j.ThreadContext;
 

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
@@ -1,0 +1,39 @@
+package brave.context.log4j2;
+
+import brave.internal.HexCodec;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.test.propagation.CurrentTraceContextTest;
+import org.apache.logging.log4j.ThreadContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadContextScopeDecoratorTest extends CurrentTraceContextTest {
+
+  @Override protected CurrentTraceContext newCurrentTraceContext() {
+    return ThreadLocalCurrentTraceContext.newBuilder()
+        .addScopeDecorator(ThreadContextScopeDecorator.create())
+        .build();
+  }
+
+  @Override protected void verifyImplicitContext(@Nullable TraceContext context) {
+    if (context != null) {
+      assertThat(ThreadContext.get("traceId"))
+          .isEqualTo(context.traceIdString());
+      long parentId = context.parentIdAsLong();
+      assertThat(ThreadContext.get("parentId"))
+          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+      assertThat(ThreadContext.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+    } else {
+      assertThat(ThreadContext.get("traceId"))
+          .isNull();
+      assertThat(ThreadContext.get("parentId"))
+          .isNull();
+      assertThat(ThreadContext.get("spanId"))
+          .isNull();
+    }
+  }
+}

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingTest.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingTest.java
@@ -1,8 +1,10 @@
 package brave.context.rxjava2;
 
 import brave.context.rxjava2.CurrentTraceContextAssemblyTracking.SavedHooks;
+import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import hu.akarnokd.rxjava2.debug.RxJavaAssemblyTracking;
 import io.reactivex.Completable;
@@ -47,7 +49,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class CurrentTraceContextAssemblyTrackingTest {
-  StrictCurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
+      .addScopeDecorator(StrictScopeDecorator.create())
+      .build();
   CurrentTraceContextAssemblyTracking contextTracking =
       CurrentTraceContextAssemblyTracking.create(currentTraceContext);
   TraceContext context1 = TraceContext.newBuilder().traceId(1L).spanId(1L).build();

--- a/context/slf4j/README.md
+++ b/context/slf4j/README.md
@@ -2,12 +2,15 @@
 This adds trace and span IDs to the SLF4J Mapped Diagnostic Context (MDC)
 so that you can search or aggregate logs accordingly.
 
-To enable this, configure `brave.Tracing` with `MDCCurrentTraceContext`
+To enable this, configure `brave.Tracing` with `MDCScopeDecorator`
 like so:
 
 ```java
 tracing = Tracing.newBuilder()
-    .currentTraceContext(MDCCurrentTraceContext.create())
+    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+       .addScopeDecorator(MDCScopeDecorator.create())
+       .build()
+    )
     ...
     .build();
 ```

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -1,13 +1,10 @@
 package brave.context.slf4j;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
+import java.util.Collections;
 import org.slf4j.MDC;
-
-import static brave.internal.HexCodec.lowerHexEqualsTraceId;
-import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
 
 /**
  * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
@@ -19,13 +16,14 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
   }
 
   public static MDCCurrentTraceContext create(CurrentTraceContext delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
     return new MDCCurrentTraceContext(delegate);
   }
 
   final CurrentTraceContext delegate;
 
   MDCCurrentTraceContext(CurrentTraceContext delegate) {
-    if (delegate == null) throw new NullPointerException("delegate == null");
+    super(Collections.singletonList(MDCScopeDecorator.INSTANCE));
     this.delegate = delegate;
   }
 
@@ -33,73 +31,8 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
     return delegate.get();
   }
 
-  @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-    return newScope(currentSpan, MDC.get("traceId"), MDC.get("spanId"));
-  }
-
-  @Override public Scope maybeScope(@Nullable TraceContext currentSpan) {
-    String previousTraceId = MDC.get("traceId");
-    String previousSpanId = MDC.get("spanId");
-    if (currentSpan == null) {
-      if (previousTraceId == null) return Scope.NOOP;
-      return newScope(null, previousTraceId, previousSpanId);
-    }
-    if (lowerHexEqualsTraceId(previousTraceId, currentSpan)
-        && lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId())) {
-      return Scope.NOOP;
-    }
-    return newScope(currentSpan, previousTraceId, previousSpanId);
-  }
-
-  // all input parameters are nullable
-  Scope newScope(TraceContext currentSpan, String previousTraceId, String previousSpanId) {
-    String previousParentId = MDC.get("parentId");
-    if (currentSpan != null) {
-      maybeReplaceTraceContext(currentSpan, previousTraceId, previousParentId, previousSpanId);
-    } else {
-      MDC.remove("traceId");
-      MDC.remove("parentId");
-      MDC.remove("spanId");
-    }
-
-    Scope scope = delegate.newScope(currentSpan);
-    class MDCCurrentTraceContextScope implements Scope {
-      @Override public void close() {
-        scope.close();
-        replace("traceId", previousTraceId);
-        replace("parentId", previousParentId);
-        replace("spanId", previousSpanId);
-      }
-    }
-    return new MDCCurrentTraceContextScope();
-  }
-
-  void maybeReplaceTraceContext(
-      TraceContext currentSpan,
-      String previousTraceId,
-      @Nullable String previousParentId,
-      String previousSpanId
-  ) {
-    boolean sameTraceId = lowerHexEqualsTraceId(previousTraceId, currentSpan);
-    if (!sameTraceId) MDC.put("traceId", currentSpan.traceIdString());
-
-    long parentId = currentSpan.parentIdAsLong();
-    if (parentId == 0L) {
-      MDC.remove("parentId");
-    } else {
-      boolean sameParentId = lowerHexEqualsUnsignedLong(previousParentId, parentId);
-      if (!sameParentId) MDC.put("parentId", HexCodec.toLowerHex(parentId));
-    }
-
-    boolean sameSpanId = lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId());
-    if (!sameSpanId) MDC.put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
-  }
-
-  static void replace(String key, @Nullable String value) {
-    if (value != null) {
-      MDC.put(key, value);
-    } else {
-      MDC.remove(key);
-    }
+  @Override public CurrentTraceContext.Scope newScope(@Nullable TraceContext currentSpan) {
+    CurrentTraceContext.Scope scope = delegate.newScope(currentSpan);
+    return decorateScope(currentSpan, scope);
   }
 }

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -14,7 +14,7 @@ import org.slf4j.MDC;
  */
 @Deprecated
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
-  static final ThreadLocalCurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+  static final CurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
       ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(MDCScopeDecorator.create());
 
   public static MDCCurrentTraceContext create() {

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCCurrentTraceContext.java
@@ -2,15 +2,21 @@ package brave.context.slf4j;
 
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
-import java.util.Collections;
 import org.slf4j.MDC;
 
 /**
  * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ *
+ * @deprecated use {@linkplain MDCScopeDecorator}. This will be removed in Brave v6.
  */
+@Deprecated
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
+  static final ThreadLocalCurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
+      ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(MDCScopeDecorator.create());
+
   public static MDCCurrentTraceContext create() {
     return create(CurrentTraceContext.Default.inheritable());
   }
@@ -23,7 +29,7 @@ public final class MDCCurrentTraceContext extends CurrentTraceContext {
   final CurrentTraceContext delegate;
 
   MDCCurrentTraceContext(CurrentTraceContext delegate) {
-    super(Collections.singletonList(MDCScopeDecorator.INSTANCE));
+    super(SCOPE_DECORATING_BUILDER);
     this.delegate = delegate;
   }
 

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
@@ -1,17 +1,27 @@
 package brave.context.slf4j;
 
 import brave.internal.propagation.CorrelationFieldScopeDecorator;
+import brave.propagation.CurrentTraceContext;
 import org.slf4j.MDC;
 
 /**
  * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
  * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * tracing = Tracing.newBuilder()
+ *                  .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+ *                    .addScopeDecorator(MDCScopeDecorator.create())
+ *                    .build()
+ *                  )
+ *                  ...
+ *                  .build();
+ * }</pre>
  */
 public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
-  static final MDCScopeDecorator INSTANCE = new MDCScopeDecorator();
-
-  public static MDCScopeDecorator create() {
-    return INSTANCE;
+  public static CurrentTraceContext.ScopeDecorator create() {
+    return new MDCScopeDecorator();
   }
 
   @Override protected String getIfString(String key) {
@@ -24,5 +34,8 @@ public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
 
   @Override protected void remove(String key) {
     MDC.remove(key);
+  }
+
+  MDCScopeDecorator() {
   }
 }

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
@@ -24,7 +24,7 @@ public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
     return new MDCScopeDecorator();
   }
 
-  @Override protected String getIfString(String key) {
+  @Override protected String get(String key) {
     return MDC.get(key);
   }
 

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
@@ -1,0 +1,28 @@
+package brave.context.slf4j;
+
+import brave.internal.propagation.CorrelationFieldScopeDecorator;
+import org.slf4j.MDC;
+
+/**
+ * Adds {@linkplain MDC} properties "traceId", "parentId" and "spanId" when a {@link
+ * brave.Tracer#currentSpan() span is current}. These can be used in log correlation.
+ */
+public final class MDCScopeDecorator extends CorrelationFieldScopeDecorator {
+  static final MDCScopeDecorator INSTANCE = new MDCScopeDecorator();
+
+  public static MDCScopeDecorator create() {
+    return INSTANCE;
+  }
+
+  @Override protected String getIfString(String key) {
+    return MDC.get(key);
+  }
+
+  @Override protected void put(String key, String value) {
+    MDC.put(key, value);
+  }
+
+  @Override protected void remove(String key) {
+    MDC.remove(key);
+  }
+}

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
@@ -1,0 +1,39 @@
+package brave.context.slf4j;
+
+import brave.internal.HexCodec;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.test.propagation.CurrentTraceContextTest;
+import org.slf4j.MDC;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
+
+  @Override protected CurrentTraceContext newCurrentTraceContext() {
+    return ThreadLocalCurrentTraceContext.newBuilder()
+        .addScopeDecorator(MDCScopeDecorator.create())
+        .build();
+  }
+
+  protected void verifyImplicitContext(@Nullable TraceContext context) {
+    if (context != null) {
+      assertThat(MDC.get("traceId"))
+          .isEqualTo(context.traceIdString());
+      long parentId = context.parentIdAsLong();
+      assertThat(MDC.get("parentId"))
+          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+      assertThat(MDC.get("spanId"))
+          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+    } else {
+      assertThat(MDC.get("traceId"))
+          .isNull();
+      assertThat(MDC.get("parentId"))
+          .isNull();
+      assertThat(MDC.get("spanId"))
+          .isNull();
+    }
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -1,7 +1,8 @@
 package brave.dubbo.rpc;
 
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
 import com.alibaba.dubbo.config.ReferenceConfig;
@@ -50,7 +51,9 @@ public abstract class ITTracingFilter {
   Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
         .spanReporter(spans::add)
-        .currentTraceContext(new StrictCurrentTraceContext())
+        .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+            .addScopeDecorator(StrictScopeDecorator.create())
+            .build())
         .sampler(sampler);
   }
 

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
@@ -4,8 +4,9 @@ import brave.ScopedSpan;
 import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.Tracing;
-import brave.context.log4j2.ThreadContextCurrentTraceContext;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.context.log4j2.ThreadContextScopeDecorator;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.Sampler;
@@ -343,7 +344,10 @@ public class ITTracingClientInterceptor {
     return Tracing.newBuilder()
         .spanReporter(spans::add)
         .currentTraceContext( // connect to log4j
-            ThreadContextCurrentTraceContext.create(new StrictCurrentTraceContext()))
+            ThreadLocalCurrentTraceContext.newBuilder()
+                .addScopeDecorator(StrictScopeDecorator.create())
+                .addScopeDecorator(ThreadContextScopeDecorator.create())
+                .build())
         .sampler(sampler);
   }
 

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
@@ -2,9 +2,10 @@ package brave.grpc;
 
 import brave.SpanCustomizer;
 import brave.Tracing;
-import brave.context.log4j2.ThreadContextCurrentTraceContext;
+import brave.context.log4j2.ThreadContextScopeDecorator;
 import brave.internal.Nullable;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import io.grpc.CallOptions;
@@ -43,7 +44,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import zipkin2.Annotation;
 import zipkin2.Span;
 
 import static brave.grpc.GreeterImpl.HELLO_REQUEST;
@@ -311,7 +311,10 @@ public class ITTracingServerInterceptor {
     return Tracing.newBuilder()
         .spanReporter(spans::add)
         .currentTraceContext( // connect to log4j
-            ThreadContextCurrentTraceContext.create(new StrictCurrentTraceContext()))
+            ThreadLocalCurrentTraceContext.newBuilder()
+                .addScopeDecorator(StrictScopeDecorator.create())
+                .addScopeDecorator(ThreadContextScopeDecorator.create())
+                .build())
         .sampler(sampler);
   }
 

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -2,7 +2,8 @@ package brave.http;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +34,9 @@ public class HttpClientHandlerTest {
   @Before public void init() {
     httpTracing = HttpTracing.newBuilder(
         Tracing.newBuilder()
-            .currentTraceContext(new StrictCurrentTraceContext())
+            .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+                .addScopeDecorator(StrictScopeDecorator.create())
+                .build())
             .spanReporter(spans::add)
             .build()
     ).clientSampler(new HttpSampler() {

--- a/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
@@ -3,7 +3,7 @@ package brave.http;
 import brave.Span;
 import brave.SpanCustomizer;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpHandlerTest {
-  CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.create();
   TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(10L).build();
   @Mock HttpAdapter<Object, Object> adapter;
   @Mock brave.Span span;

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -4,7 +4,7 @@ import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
 import brave.propagation.SamplingFlags;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.ArrayList;
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import zipkin2.Endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
@@ -39,7 +38,7 @@ public class HttpServerHandlerTest {
   @Before public void init() {
     HttpTracing httpTracing = HttpTracing.newBuilder(
         Tracing.newBuilder()
-            .currentTraceContext(new StrictCurrentTraceContext())
+            .currentTraceContext(ThreadLocalCurrentTraceContext.create())
             .spanReporter(spans::add)
             .build()
     ).serverSampler(sampler).build();
@@ -83,7 +82,7 @@ public class HttpServerHandlerTest {
   @Test public void handleReceive_reusesTraceId() {
     HttpTracing httpTracing = HttpTracing.create(
         Tracing.newBuilder()
-            .currentTraceContext(new StrictCurrentTraceContext())
+            .currentTraceContext(ThreadLocalCurrentTraceContext.create())
             .supportsJoin(false)
             .spanReporter(spans::add)
             .build()

--- a/instrumentation/http/src/test/java/brave/http/features/RequestSamplingTest.java
+++ b/instrumentation/http/src/test/java/brave/http/features/RequestSamplingTest.java
@@ -4,7 +4,8 @@ import brave.Tracing;
 import brave.http.HttpAdapter;
 import brave.http.HttpSampler;
 import brave.http.HttpTracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import okhttp3.Call;
@@ -30,7 +31,9 @@ public class RequestSamplingTest {
   ConcurrentLinkedDeque<zipkin2.Span> spans = new ConcurrentLinkedDeque<>();
   Tracing tracing = Tracing.newBuilder()
       .localServiceName("server")
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
       .spanReporter(spans::push)
       .build();
   HttpTracing httpTracing = HttpTracing.newBuilder(tracing)

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/InjectionTest.java
@@ -2,7 +2,7 @@ package brave.jaxrs2;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** This ensures all filters can be injected, supplied with only {@linkplain HttpTracing}. */
 public class InjectionTest {
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(Reporter.NOOP)
       .build();
 

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/InjectionTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/InjectionTest.java
@@ -2,7 +2,7 @@ package brave.jersey.server;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** This ensures all filters can be injected, supplied with only {@linkplain HttpTracing}. */
 public class InjectionTest {
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(Reporter.NOOP)
       .build();
 

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerInjectionTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerInjectionTest.java
@@ -2,7 +2,7 @@ package brave.jersey.server;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TracingApplicationEventListenerInjectionTest {
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(Reporter.NOOP)
       .build();
 

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
@@ -1,7 +1,7 @@
 package brave.kafka.clients;
 
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.google.common.base.Charsets;
 import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
@@ -29,12 +29,12 @@ abstract class BaseTracingTest {
 
   ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
   KafkaTracing kafkaTracing = KafkaTracing.create(tracing);
 
-  @After public void tearDown() throws Exception {
+  @After public void tearDown() {
     tracing.close();
   }
 

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -4,7 +4,8 @@ import brave.Tracing;
 import brave.internal.HexCodec;
 import brave.propagation.Propagation;
 import brave.propagation.SamplingFlags;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.propagation.TraceIdContext;
@@ -55,12 +56,16 @@ public class ITKafkaTracing {
 
   KafkaTracing consumerTracing = KafkaTracing.create(Tracing.newBuilder()
       .localServiceName("consumer")
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
       .spanReporter(consumerSpans::add)
       .build());
   KafkaTracing producerTracing = KafkaTracing.create(Tracing.newBuilder()
       .localServiceName("producer")
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
       .spanReporter(producerSpans::add)
       .build());
 

--- a/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/test/java/brave/mysql/ITTracingStatementInterceptor.java
@@ -2,7 +2,7 @@ package brave.mysql;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
 import java.sql.Connection;
@@ -126,7 +126,7 @@ public class ITTracingStatementInterceptor {
   Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
         .spanReporter(spans::add)
-        .currentTraceContext(new StrictCurrentTraceContext())
+        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
         .sampler(sampler);
   }
 

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/ITTracingStatementInterceptor.java
@@ -2,7 +2,7 @@ package brave.mysql6;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import com.mysql.cj.jdbc.MysqlDataSource;
 import java.sql.Connection;
@@ -14,7 +14,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Span;
-import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -127,12 +126,8 @@ public class ITTracingStatementInterceptor {
 
   Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
-        .spanReporter(new Reporter<Span>() {
-          @Override public void report(Span span) {
-            spans.add(span);
-          }
-        })
-        .currentTraceContext(new StrictCurrentTraceContext())
+        .spanReporter(spans::add)
+        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
         .sampler(sampler);
   }
 

--- a/instrumentation/mysql8/src/test/java/brave/mysql8/ITTracingQueryInterceptor.java
+++ b/instrumentation/mysql8/src/test/java/brave/mysql8/ITTracingQueryInterceptor.java
@@ -16,7 +16,7 @@ package brave.mysql8;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import com.mysql.cj.jdbc.MysqlDataSource;
 import java.sql.Connection;
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import zipkin2.Span;
-import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -170,12 +169,8 @@ public class ITTracingQueryInterceptor {
 
   Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
-        .spanReporter(new Reporter<Span>() {
-          @Override public void report(Span span) {
-            spans.add(span);
-          }
-        })
-        .currentTraceContext(new StrictCurrentTraceContext())
+        .spanReporter(spans::add)
+        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
         .sampler(sampler);
   }
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/TracingInterceptorTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/TracingInterceptorTest.java
@@ -2,7 +2,7 @@ package brave.okhttp3;
 
 import brave.Span;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import okhttp3.Interceptor;
 import org.junit.After;
 import org.junit.Test;
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TracingInterceptorTest {
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(Reporter.NOOP)
       .build();
   @Mock Interceptor.Chain chain;
@@ -32,7 +32,7 @@ public class TracingInterceptorTest {
     verifyNoMoreInteractions(span);
   }
 
-  @After public void close(){
+  @After public void close() {
     tracing.close();
   }
 }

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -2,7 +2,7 @@ package brave.p6spy;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -107,7 +107,7 @@ public class ITTracingP6Factory {
   static Tracing.Builder tracingBuilder(Sampler sampler, ArrayList<Span> spans) {
     return Tracing.newBuilder()
         .spanReporter(spans::add)
-        .currentTraceContext(new StrictCurrentTraceContext())
+        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
         .sampler(sampler);
   }
 }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
@@ -1,7 +1,8 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -221,7 +222,9 @@ public class ITSpringRabbitTracing {
     @Bean
     public Tracing tracing(BlockingQueue<Span> producerSpans) {
       return Tracing.newBuilder()
-          .currentTraceContext(new StrictCurrentTraceContext())
+          .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+              .addScopeDecorator(StrictScopeDecorator.create())
+              .build())
           .localServiceName("spring-amqp-producer")
           .spanReporter(producerSpans::add)
           .build();
@@ -279,7 +282,9 @@ public class ITSpringRabbitTracing {
     public Tracing tracing(BlockingQueue<Span> consumerSpans) {
       return Tracing.newBuilder()
           .localServiceName("spring-amqp-consumer")
-          .currentTraceContext(new StrictCurrentTraceContext())
+          .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+              .addScopeDecorator(StrictScopeDecorator.create())
+              .build())
           .spanReporter(consumerSpans::add)
           .build();
     }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -1,7 +1,7 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class SpringRabbitTracingTest {
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(Reporter.NOOP)
       .build();
   SpringRabbitTracing rabbitTracing = SpringRabbitTracing.create(tracing);

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
@@ -1,7 +1,7 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TracingMessagePostProcessorTest {
   List<Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
   TracingMessagePostProcessor tracingMessagePostProcessor =

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
@@ -1,7 +1,7 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import org.aopalliance.intercept.MethodInvocation;
@@ -27,10 +27,11 @@ public class TracingRabbitListenerAdviceTest {
 
   List<Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(new StrictCurrentTraceContext())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
-  TracingRabbitListenerAdvice tracingRabbitListenerAdvice = new TracingRabbitListenerAdvice(tracing, "my-service");
+  TracingRabbitListenerAdvice tracingRabbitListenerAdvice =
+      new TracingRabbitListenerAdvice(tracing, "my-service");
   MethodInvocation methodInvocation = mock(MethodInvocation.class);
 
   @After public void close() {

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptorAutowireTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptorAutowireTest.java
@@ -2,23 +2,18 @@ package brave.spring.web;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictCurrentTraceContext;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
-import zipkin2.reporter.Reporter;
 
 public class TracingAsyncClientHttpRequestInterceptorAutowireTest {
 
   @Configuration static class HttpTracingConfiguration {
     @Bean HttpTracing httpTracing() {
-      return HttpTracing.create(Tracing.newBuilder()
-          .currentTraceContext(new StrictCurrentTraceContext())
-          .spanReporter(Reporter.NOOP)
-          .build());
+      return HttpTracing.create(Tracing.newBuilder().build());
     }
   }
 

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/TracingClientHttpRequestInterceptorAutowireTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/TracingClientHttpRequestInterceptorAutowireTest.java
@@ -2,23 +2,18 @@ package brave.spring.web;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictCurrentTraceContext;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
-import zipkin2.reporter.Reporter;
 
 public class TracingClientHttpRequestInterceptorAutowireTest {
 
   @Configuration static class HttpTracingConfiguration {
     @Bean HttpTracing httpTracing() {
-      return HttpTracing.create(Tracing.newBuilder()
-          .currentTraceContext(new StrictCurrentTraceContext())
-          .spanReporter(Reporter.NOOP)
-          .build());
+      return HttpTracing.create(Tracing.newBuilder().build());
     }
   }
 

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -24,7 +24,11 @@ Here are some example beans using the factories in this module:
       </bean>
     </property>
     <property name="currentTraceContext">
-      <bean class="brave.context.slf4j.MDCCurrentTraceContext" factory-method="create"/>
+      <bean class="brave.spring.beans.CurrentTraceContextFactoryBean">
+        <property name="scopeDecorators">
+          <bean class="brave.context.slf4j.MDCScopeDecorator" factory-method="create"/>
+        </property>
+      </bean>
     </property>
   </bean>
 

--- a/spring-beans/src/main/java/brave/spring/beans/CurrentTraceContextFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/CurrentTraceContextFactoryBean.java
@@ -1,0 +1,35 @@
+package brave.spring.beans;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import java.util.List;
+import org.springframework.beans.factory.FactoryBean;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class CurrentTraceContextFactoryBean implements FactoryBean {
+
+  List<ScopeDecorator> scopeDecorators;
+
+  @Override public CurrentTraceContext getObject() {
+    ThreadLocalCurrentTraceContext.Builder builder = ThreadLocalCurrentTraceContext.newBuilder();
+    if (scopeDecorators != null) {
+      for (ScopeDecorator scopeDecorator : scopeDecorators) {
+        builder.addScopeDecorator(scopeDecorator);
+      }
+    }
+    return builder.build();
+  }
+
+  @Override public Class<? extends CurrentTraceContext> getObjectType() {
+    return CurrentTraceContext.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setScopeDecorators(List<ScopeDecorator> scopeDecorators) {
+    this.scopeDecorators = scopeDecorators;
+  }
+}

--- a/spring-beans/src/main/java/brave/spring/beans/CurrentTraceContextFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/CurrentTraceContextFactoryBean.java
@@ -12,7 +12,7 @@ public class CurrentTraceContextFactoryBean implements FactoryBean {
   List<ScopeDecorator> scopeDecorators;
 
   @Override public CurrentTraceContext getObject() {
-    ThreadLocalCurrentTraceContext.Builder builder = ThreadLocalCurrentTraceContext.newBuilder();
+    CurrentTraceContext.Builder builder = ThreadLocalCurrentTraceContext.newBuilder();
     if (scopeDecorators != null) {
       for (ScopeDecorator scopeDecorator : scopeDecorators) {
         builder.addScopeDecorator(scopeDecorator);

--- a/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
@@ -1,0 +1,31 @@
+package brave.spring.beans;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CurrentTraceContextFactoryBeanTest {
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void scopeDecorators() {
+    context = new XmlBeans(""
+        + "<bean id=\"currentTraceContext\" class=\"brave.spring.beans.CurrentTraceContextFactoryBean\">\n"
+        + "  <property name=\"scopeDecorators\">\n"
+        + "    <bean class=\"brave.propagation.StrictScopeDecorator\" factory-method=\"create\"/>\n"
+        + "  </property>"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("currentTraceContext", CurrentTraceContext.class))
+        .extracting("scopeDecorators")
+        .allSatisfy(l -> assertThat(((List) l).get(0)).isInstanceOf(StrictScopeDecorator.class));
+  }
+}

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -4,7 +4,7 @@ import brave.Clock;
 import brave.ErrorParser;
 import brave.Tracing;
 import brave.propagation.ExtraFieldPropagation;
-import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import org.junit.After;
 import org.junit.Test;
@@ -156,14 +156,14 @@ public class TracingFactoryBeanTest {
     context = new XmlBeans(""
         + "<bean id=\"tracing\" class=\"brave.spring.beans.TracingFactoryBean\">\n"
         + "  <property name=\"currentTraceContext\">\n"
-        + "    <bean class=\"brave.propagation.StrictCurrentTraceContext\"/>\n"
+        + "    <bean class=\"brave.spring.beans.CurrentTraceContextFactoryBean\"/>\n"
         + "  </property>\n"
         + "</bean>"
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
         .extracting("tracer.currentTraceContext")
-        .allMatch(o -> o instanceof StrictCurrentTraceContext);
+        .allMatch(o -> o instanceof ThreadLocalCurrentTraceContext);
   }
 
   @Test public void propagationFactory() {


### PR DESCRIPTION
This is based on some work in Fukuoka where @anuraaga noticed we can stop some of the subclassing we do now

### Customizing in-process propagation (Ex. log correlation)

The `CurrentTraceContext` makes a trace context visible, such that spans
aren't accidentally added to the wrong trace. It also accepts hooks like
log correlation.

For example, if you use Log4J 2, you can copy trace IDs to your logging
context with [our decorator](https://github.com/openzipkin/brave/tree/master/context/log4j2):
```java
tracing = Tracing.newBuilder()
    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
       .addScopeDecorator(ThreadContextScopeDecorator.create())
       .build()
    )
    ...
    .build();
```

Besides logging, other tools are available. `StrictScopeDecorator` can
help find out when code is not closing scopes properly. This can be
useful when writing or diagnosing custom instrumentation.

See #682