### PR TITLE
Register remote endpoint in TracingStatementInterceptor if cannot parse IP

### DIFF
--- a/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
@@ -79,7 +79,7 @@ public class TracingStatementInterceptor implements StatementInterceptorV2 {
         }
       }
       Endpoint.Builder builder = Endpoint.newBuilder().serviceName(remoteServiceName).port(port);
-      if (!builder.parseIp(connection.getHost())) return;
+      builder.parseIp(connection.getHost());
       span.remoteEndpoint(builder.build());
     } catch (Exception e) {
       // remote address is optional

--- a/instrumentation/mysql/src/test/java/brave/mysql/TracingStatementInterceptorTest.java
+++ b/instrumentation/mysql/src/test/java/brave/mysql/TracingStatementInterceptorTest.java
@@ -64,7 +64,8 @@ public class TracingStatementInterceptorTest {
     setupAndReturnPropertiesForHost("localhost");
 
     TracingStatementInterceptor.parseServerAddress(connection, span);
-    verifyNoMoreInteractions(span);
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("mysql")
+            .port(5555).build());
   }
 
   @Test public void parseServerAddress_doesntCrash() throws SQLException {


### PR DESCRIPTION
As `Endpoint` can exist with ipv4 and ipv6 both equal to null it worth registering endpoint if `connection.getHost()` returns DNS name instead of IP.