### PR TITLE
Tests demonstrating assertion exceptions from TracingApplicationEventListener

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -7,11 +7,6 @@ import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
 import brave.propagation.ExtraFieldPropagation;
 import brave.sampler.Sampler;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -23,6 +18,12 @@ import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -383,6 +384,24 @@ public abstract class ITHttpServer extends ITHttp {
     Span span = takeSpan();
     assertThat(span.tags())
         .containsEntry("http.path", "/foo");
+  }
+
+  @Test
+  public void testMethodWithPathAnnotation() throws Exception {
+    assertThat(get("/example/nested").isSuccessful()).isTrue();
+
+    Span span = takeSpan();
+    assertThat(span.tags())
+        .containsEntry("http.path", "/example/nested");
+  }
+
+  @Test
+  public void testMethodWithoutPathAnnotation() throws Exception {
+    assertThat(get("/example").isSuccessful()).isTrue();
+
+    Span span = takeSpan();
+    assertThat(span.tags())
+        .containsEntry("http.path", "/example");
   }
 
   protected Response get(String path) throws Exception {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -36,6 +36,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
   @Override public void init(ServletContextHandler handler) {
     ResourceConfig config = new ResourceConfig();
     config.register(new TestResource(httpTracing));
+    config.register(new TestResourceNoPathOnMethod());
     config.register(TracingApplicationEventListener.create(httpTracing));
     handler.addServlet(new ServletHolder(new ServletContainer(config)), "/*");
   }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResourceNoPathOnMethod.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResourceNoPathOnMethod.java
@@ -1,0 +1,22 @@
+package brave.jersey.server;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * Resource that has a class level Path annotation, but no Path at the method level.
+ */
+@Path("/example")
+public class TestResourceNoPathOnMethod {
+    @GET
+    public Response example() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("nested")
+    public Response nested() {
+        return Response.ok().build();
+    }
+}


### PR DESCRIPTION
Adding tests demonstrating an assertion error thrown by TracingApplicationEventListener
for jax-rs resources that have a method with no @Path annotation.