### PR TITLE
Removes unnecessary assertion check in jersey

### DIFF
--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
@@ -70,7 +70,6 @@ public class SpanCustomizingApplicationEventListener
     List<UriTemplate> templates = uriInfo.getMatchedTemplates();
     int templateCount = templates.size();
     if (templateCount == 0) return "";
-    assert templateCount % 2 == 0 : "expected matched templates to be resource/method pairs";
     StringBuilder builder = null; // don't allocate unless you need it!
     String basePath = uriInfo.getBaseUri().getPath();
     String result = null;

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/SpanCustomizingApplicationEventListenerTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/SpanCustomizingApplicationEventListenerTest.java
@@ -31,6 +31,18 @@ public class SpanCustomizingApplicationEventListenerTest {
         .isEqualTo("/items/{itemId}");
   }
 
+  @Test public void route_noPath() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("/"));
+    when(uriInfo.getMatchedTemplates()).thenReturn(Arrays.asList(
+        new PathTemplate("/eggs")
+    ));
+
+    assertThat(SpanCustomizingApplicationEventListener.route(request))
+        .isEqualTo("/eggs");
+  }
+
   /** not sure it is even possible for a template to match "/" "/".. */
   @Test public void route_invalid() {
     ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
@@ -23,8 +23,7 @@ public class TestResource {
     this.tracer = httpTracing.tracing().tracer();
   }
 
-  @OPTIONS
-  @Path("")
+  @OPTIONS // intentionally leave out the @Path annotation
   public Response root() {
     return Response.ok().build();
   }


### PR DESCRIPTION
@gordz noticed we didn't actually need to ensure pairing of resource
/method `@Path` annotations.

Fixes #704