### PR TITLE
Implements GCP propagation

### DIFF
--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -161,7 +161,7 @@ public final class TraceIdContext extends SamplingFlags {
      * @return false if the input is null or malformed
      */
     // temporarily package protected until we figure out if this is reusable enough to expose
-    final boolean parseTraceId(String traceIdString, Object key) {
+    public final boolean parseTraceId(String traceIdString, Object key) {
       if (isNull(key, traceIdString)) return false;
       int length = traceIdString.length();
       if (invalidIdLength(key, length, 32)) return false;

--- a/propagation/brave-propagation-gcp/pom.xml
+++ b/propagation/brave-propagation-gcp/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>brave-propagation-parent</artifactId>
+        <groupId>io.zipkin.brave</groupId>
+        <version>5.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>brave-propagation-gcp</artifactId>
+    <name>Brave Propagation: Google Cloud Platform (GCP)</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>brave.propagation.gcp</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/propagation/brave-propagation-gcp/src/main/java/brave/propagation/gcp/CompositeExtractor.java
+++ b/propagation/brave-propagation-gcp/src/main/java/brave/propagation/gcp/CompositeExtractor.java
@@ -1,0 +1,26 @@
+package brave.propagation.gcp;
+
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+
+public class CompositeExtractor<C> implements TraceContext.Extractor<C> {
+
+	private TraceContext.Extractor<C>[] extractors;
+
+	public CompositeExtractor(TraceContext.Extractor<C>... extractors) {
+		this.extractors = extractors;
+	}
+
+	@Override
+	public TraceContextOrSamplingFlags extract(C carrier) {
+		TraceContextOrSamplingFlags context = TraceContextOrSamplingFlags.EMPTY;
+
+		int currentExtractor = 0;
+		while (context == TraceContextOrSamplingFlags.EMPTY
+				&& currentExtractor < extractors.length) {
+			context = extractors[currentExtractor++].extract(carrier);
+		}
+
+		return context;
+	}
+}

--- a/propagation/brave-propagation-gcp/src/main/java/brave/propagation/gcp/StackdriverTracePropagation.java
+++ b/propagation/brave-propagation-gcp/src/main/java/brave/propagation/gcp/StackdriverTracePropagation.java
@@ -1,0 +1,81 @@
+package brave.propagation.gcp;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class StackdriverTracePropagation<K> implements Propagation<K> {
+
+	public static final Propagation.Factory FACTORY = new Propagation.Factory() {
+		@Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+			return new StackdriverTracePropagation<>(keyFactory);
+		}
+
+		@Override public boolean supportsJoin() {
+			return true;
+		}
+
+		@Override public String toString() {
+			return "StackdriverTracePropagationFactory";
+		}
+	};
+
+	/**
+	 * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
+	 */
+	static final String TRACE_ID_NAME = "x-cloud-trace-context";
+
+	private Propagation<K> b3Propagation;
+	final K traceIdKey;
+	final List<K> fields;
+
+	StackdriverTracePropagation(KeyFactory<K> keyFactory) {
+		this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
+		this.fields = Collections.unmodifiableList(Collections.singletonList(traceIdKey));
+		this.b3Propagation = B3Propagation.FACTORY.create(keyFactory);
+	}
+
+	@Override public List<K> keys() {
+		return fields;
+	}
+
+	@Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+		return b3Propagation.injector(setter);
+	}
+
+	@Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+		if (getter == null) throw new NullPointerException("getter == null");
+		return new CompositeExtractor<>(
+				new XCloudTraceContextExtractor<>(this, getter),
+				b3Propagation.extractor(getter));
+	}
+
+	static final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<C> {
+		final StackdriverTracePropagation<K> propagation;
+		final Getter<C, K> getter;
+
+		XCloudTraceContextExtractor(StackdriverTracePropagation<K> propagation,
+									Getter<C, K> getter) {
+			this.propagation = propagation;
+			this.getter = getter;
+		}
+
+		@Override public TraceContextOrSamplingFlags extract(C carrier) {
+			if (carrier == null) throw new NullPointerException("carrier == null");
+
+			String traceIdString = getter.get(carrier, propagation.traceIdKey);
+
+			// Try to parse the trace IDs into the context
+			TraceContext.Builder result = TraceContext.newBuilder();
+			if (result.parseTraceId(traceIdString, propagation.traceIdKey)) {
+				return TraceContextOrSamplingFlags.create(result.build());
+			}
+			return TraceContextOrSamplingFlags.EMPTY;
+		}
+	}
+}
+

--- a/propagation/pom.xml
+++ b/propagation/pom.xml
@@ -18,6 +18,7 @@
 
   <modules>
     <module>aws</module>
+    <module>brave-propagation-gcp</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
This propagation re-uses B3Propagation's injector, while adding a new
CompositeExtractor concept that aims at extracting multiple trace IDs,
in order.

In this case, we're interested in extracting the trace ID from the
'x-cloud-trace-context' header, followed by 'X-B3-TraceId'.

Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/703