### PR TITLE
Add instrumentation for mysql-connector-java 8.x, the current GA vers…

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -14,6 +14,7 @@ Here's a brief overview of what's packaged here:
 * [kafka-clients](kafka-clients/README.md) - Tracing decorators for Kafka 0.11+ producers and consumers.
 * [mysql](mysql/README.md) - Tracing MySQL statement interceptor
 * [mysql6](mysql6/README.md) - Tracing MySQL v6 statement interceptor
+* [mysql8](mysql8/README.md) - Tracing MySQL v8 statement interceptor
 * [netty-codec-http](netty-codec-http/README.md) - Tracing handler for [Netty](http://netty.io/) 4.x http servers
 * [okhttp3](okhttp3/README.md) - Tracing decorators for [OkHttp](https://github.com/square/okhttp) 3.x
 * [p6spy](p6spy/README.md) - Tracing event listener for [P6Spy](https://github.com/p6spy/p6spy) (a proxy for calls to your JDBC driver)

--- a/instrumentation/mysql8/README.md
+++ b/instrumentation/mysql8/README.md
@@ -1,0 +1,18 @@
+# brave-instrumentation-mysql8
+
+This includes a mysql-connector-java 8+ query interceptor that will report to Zipkin
+how long each query takes, along with relevant tags like the query.
+
+To use it, append `?queryInterceptors=brave.mysql8.TracingQueryInterceptor`
+to the end of the connection url.
+
+It is also recommended to add the exception interceptor so errors are added to the span, e.g.,
+`?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor`
+
+By default the service name corresponding to your database uses the format
+`mysql-${database}`, but you can append another property `zipkinServiceName` to customise it.
+
+`?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor&zipkinServiceName=myDatabaseService`
+
+The current tracing component is used at runtime. Until you have
+instantiated `brave.Tracing`, no traces will appear.

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -12,6 +12,9 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+    <!-- mysql-connector-java 8+ requires Java 8 -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>5.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-mysql8</artifactId>
+  <name>Brave Instrumentation: MySQL8</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>8.0.11</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.mysql8</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/mysql8/src/main/java/brave/mysql8/TracingExceptionInterceptor.java
+++ b/instrumentation/mysql8/src/main/java/brave/mysql8/TracingExceptionInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package brave.mysql8;
+
+import brave.Span;
+import brave.propagation.ThreadLocalSpan;
+import com.mysql.cj.exceptions.ExceptionInterceptor;
+import com.mysql.cj.log.Log;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * A MySQL exception interceptor that will annotate spans with SQL error codes.
+ *
+ * <p>To use it, both TracingQueryInterceptor and TracingExceptionInterceptor must be added by
+ * appending <code>?queryInterceptors=brave.mysql8.TracingQueryInterceptor&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor</code>.
+ */
+public class TracingExceptionInterceptor implements ExceptionInterceptor {
+
+  @Override public ExceptionInterceptor init(Properties properties, Log log) {
+    String queryInterceptors = properties.getProperty("queryInterceptors");
+    if (queryInterceptors == null ||
+        !queryInterceptors.contains(TracingQueryInterceptor.class.getName())) {
+      throw new IllegalStateException(
+          "TracingQueryInterceptor must be enabled to use TracingExceptionInterceptor.");
+    }
+    return new TracingExceptionInterceptor();
+  }
+
+  @Override public void destroy() {
+    // Don't care
+  }
+
+  /**
+   * Uses {@link ThreadLocalSpan} as there's no attribute namespace shared between callbacks, but
+   * all callbacks happen on the same thread. The span will already have been created in
+   * {@link TracingQueryInterceptor}.
+   *
+   * <p>Uses {@link ThreadLocalSpan#CURRENT_TRACER} and this interceptor initializes before
+   * tracing.
+   */
+  @Override public Exception interceptException(Exception e) {
+    Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+    if (span == null || span.isNoop()) return null;
+
+    if (e instanceof SQLException) {
+      span.tag("error", Integer.toString(((SQLException) e).getErrorCode()));
+    }
+
+    span.finish();
+
+    return null;
+  }
+}

--- a/instrumentation/mysql8/src/main/java/brave/mysql8/TracingQueryInterceptor.java
+++ b/instrumentation/mysql8/src/main/java/brave/mysql8/TracingQueryInterceptor.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package brave.mysql8;
+
+import brave.Span;
+import brave.propagation.ThreadLocalSpan;
+import com.mysql.cj.MysqlConnection;
+import com.mysql.cj.Query;
+import com.mysql.cj.interceptors.QueryInterceptor;
+import com.mysql.cj.jdbc.JdbcConnection;
+import com.mysql.cj.log.Log;
+import com.mysql.cj.protocol.Resultset;
+import com.mysql.cj.protocol.ServerSession;
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.function.Supplier;
+import zipkin2.Endpoint;
+
+/**
+ * A MySQL query interceptor that will report to Zipkin how long each query takes.
+ *
+ * <p>To use it, append <code>?queryInterceptors=brave.mysql8.TracingQueryInterceptor</code>
+ * to the end of the connection url. It is also highly recommended to add
+ * <code>&exceptionInterceptors=brave.mysql8.TracingExceptionInterceptor</code> so errors are also
+ * included in spans.
+ */
+public class TracingQueryInterceptor implements QueryInterceptor {
+
+  /**
+   * Uses {@link ThreadLocalSpan} as there's no attribute namespace shared between callbacks, but
+   * all callbacks happen on the same thread.
+   *
+   * <p>Uses {@link ThreadLocalSpan#CURRENT_TRACER} and this interceptor initializes before
+   * tracing.
+   */
+  @Override
+  public <T extends Resultset> T preProcess(Supplier<String> sqlSupplier, Query interceptedQuery) {
+    // Gets the next span (and places it in scope) so code between here and postProcess can read it
+    Span span = ThreadLocalSpan.CURRENT_TRACER.next();
+    if (span == null || span.isNoop()) return null;
+
+    String sql = sqlSupplier.get();
+    int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
+    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+    span.tag("sql.query", sql);
+    parseServerAddress(connection, span);
+    span.start();
+    return null;
+  }
+
+  private MysqlConnection connection;
+  private boolean interceptingExceptions;
+
+  @Override
+  public <T extends Resultset> T postProcess(Supplier<String> sql, Query interceptedQuery,
+      T originalResultSet, ServerSession serverSession) {
+    if (interceptingExceptions && originalResultSet == null) {
+      // Error case, the span will be finished in TracingExceptionInterceptor.
+      return null;
+    }
+    Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+    if (span == null || span.isNoop()) return null;
+
+    span.finish();
+
+    return null;
+  }
+
+  /**
+   * MySQL exposes the host connecting to, but not the port. This attempts to get the port from the
+   * JDBC URL. Ex. 5555 from {@code jdbc:mysql://localhost:5555/database}, or 3306 if absent.
+   */
+  static void parseServerAddress(MysqlConnection connection, Span span) {
+    try {
+      URI url = URI.create(connection.getURL().substring(5)); // strip "jdbc:"
+      int port = url.getPort() == -1 ? 3306 : url.getPort();
+      String remoteServiceName = connection.getProperties().getProperty("zipkinServiceName");
+      if (remoteServiceName == null || "".equals(remoteServiceName)) {
+        String databaseName = getDatabaseName(connection);
+        if (databaseName != null && !databaseName.isEmpty()) {
+          remoteServiceName = "mysql-" + databaseName;
+        } else {
+          remoteServiceName = "mysql";
+        }
+      }
+      Endpoint.Builder builder = Endpoint.newBuilder().serviceName(remoteServiceName).port(port);
+      if (!builder.parseIp(getHost(connection))) return;
+      span.remoteEndpoint(builder.build());
+    } catch (Exception e) {
+      // remote address is optional
+    }
+  }
+
+  private static String getDatabaseName(MysqlConnection connection) throws SQLException {
+    if (connection instanceof JdbcConnection) {
+      return ((JdbcConnection) connection).getCatalog();
+    }
+    return "";
+  }
+
+  private static String getHost(MysqlConnection connection) {
+    if (connection instanceof JdbcConnection) {
+      return ((JdbcConnection) connection).getHost();
+    }
+    return "";
+  }
+
+  @Override
+  public boolean executeTopLevelOnly() {
+    return true;  // True means that we don't get notified about queries that other interceptors issue
+  }
+
+  @Override
+  public QueryInterceptor init(MysqlConnection mysqlConnection, Properties properties,
+      Log log) {
+    String exceptionInterceptors = properties.getProperty("exceptionInterceptors");
+    TracingQueryInterceptor interceptor = new TracingQueryInterceptor();
+    interceptor.connection = mysqlConnection;
+    interceptor.interceptingExceptions = exceptionInterceptors != null &&
+        exceptionInterceptors.contains(TracingExceptionInterceptor.class.getName());
+    if (!interceptor.interceptingExceptions) {
+      log.logWarn("TracingExceptionInterceptor not enabled. It is highly recommended to "
+          + "enable it for error logging to Zipkin.");
+    }
+    return interceptor;
+  }
+
+  @Override
+  public void destroy() {
+    // Don't care
+  }
+}

--- a/instrumentation/mysql8/src/test/java/brave/mysql8/ITTracingQueryInterceptor.java
+++ b/instrumentation/mysql8/src/test/java/brave/mysql8/ITTracingQueryInterceptor.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package brave.mysql8;
+
+import brave.ScopedSpan;
+import brave.Tracing;
+import brave.propagation.StrictCurrentTraceContext;
+import brave.sampler.Sampler;
+import com.mysql.cj.jdbc.MysqlDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(Parameterized.class)
+public class ITTracingQueryInterceptor {
+  static final String QUERY = "select 'hello world'";
+  static final String ERROR_QUERY = "select unknown_field FROM unknown_table";
+
+  @Parameterized.Parameters(name = "exceptions traced: {0}")
+  public static Iterable<Boolean> exceptionsTraced() {
+    return Arrays.asList(false, true);
+  }
+
+  @Parameterized.Parameter
+  public boolean exceptionsTraced;
+
+  /** JDBC is synchronous and we aren't using thread pools: everything happens on the main thread */
+  ArrayList<Span> spans = new ArrayList<>();
+
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+  Connection connection;
+
+  @Before public void init() throws SQLException {
+    StringBuilder url = new StringBuilder("jdbc:mysql://");
+    url.append(envOr("MYSQL_HOST", "127.0.0.1"));
+    url.append(":").append(envOr("MYSQL_TCP_PORT", 3306));
+    String db = envOr("MYSQL_DB", null);
+    if (db != null) url.append("/").append(db);
+    url.append("?queryInterceptors=").append(TracingQueryInterceptor.class.getName());
+    if (exceptionsTraced) {
+      url.append("&exceptionInterceptors=").append(TracingExceptionInterceptor.class.getName());
+    }
+    url.append("&zipkinServiceName=").append("myservice");
+    url.append("&serverTimezone=").append("UTC");
+
+    MysqlDataSource dataSource = new MysqlDataSource();
+    dataSource.setUrl(url.toString());
+
+    dataSource.setUser(System.getenv("MYSQL_USER"));
+    assumeTrue("Minimally, the environment variable MYSQL_USER must be set",
+        dataSource.getUser() != null);
+    dataSource.setPassword(envOr("MYSQL_PASS", ""));
+    connection = dataSource.getConnection();
+    spans.clear();
+  }
+
+  @After public void close() throws SQLException {
+    Tracing.current().close();
+    if (connection != null) connection.close();
+  }
+
+  @Test
+  public void makesChildOfCurrentSpan() throws Exception {
+    ScopedSpan parent = tracing.tracer().startScopedSpan("test");
+    try {
+      prepareExecuteSelect(QUERY);
+    } finally {
+      parent.finish();
+    }
+
+    assertThat(spans)
+        .hasSize(2);
+  }
+
+  @Test
+  public void reportsClientKindToZipkin() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .extracting(Span::kind)
+        .containsExactly(Span.Kind.CLIENT);
+  }
+
+  @Test
+  public void defaultSpanNameIsOperationName() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .extracting(Span::name)
+        .containsExactly("select");
+  }
+
+  /** This intercepts all SQL, not just queries. This ensures single-word statements work */
+  @Test
+  public void defaultSpanNameIsOperationName_oneWord() throws Exception {
+    connection.setAutoCommit(false);
+    connection.commit();
+
+    assertThat(spans)
+        .extracting(Span::name)
+        .contains("commit");
+  }
+
+  @Test
+  public void addsQueryTag() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .flatExtracting(s -> s.tags().entrySet())
+        .containsExactly(entry("sql.query", QUERY));
+  }
+
+  @Test
+  public void reportsServerAddress() throws Exception {
+    prepareExecuteSelect(QUERY);
+
+    assertThat(spans)
+        .extracting(Span::remoteServiceName)
+        .contains("myservice");
+  }
+
+  @Test
+  public void sqlError() throws Exception {
+    assertThatThrownBy(() -> prepareExecuteSelect(ERROR_QUERY)).isInstanceOf(SQLException.class);
+    assertThat(spans)
+        .isNotEmpty();
+
+    if (exceptionsTraced) {
+      assertThat(spans)
+          .anySatisfy(span -> assertThat(span.tags()).containsEntry("error", "1046"));
+    }
+  }
+
+  void prepareExecuteSelect(String query) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(query)) {
+      try (ResultSet resultSet = ps.executeQuery()) {
+        while (resultSet.next()) {
+          resultSet.getString(1);
+        }
+      }
+    }
+  }
+
+  Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+        .spanReporter(new Reporter<Span>() {
+          @Override public void report(Span span) {
+            spans.add(span);
+          }
+        })
+        .currentTraceContext(new StrictCurrentTraceContext())
+        .sampler(sampler);
+  }
+
+  static int envOr(String key, int fallback) {
+    return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : fallback;
+  }
+
+  static String envOr(String key, String fallback) {
+    return System.getenv(key) != null ? System.getenv(key) : fallback;
+  }
+}

--- a/instrumentation/mysql8/src/test/java/brave/mysql8/TracingQueryInterceptorTest.java
+++ b/instrumentation/mysql8/src/test/java/brave/mysql8/TracingQueryInterceptorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package brave.mysql8;
+
+import brave.Span;
+import com.mysql.cj.jdbc.DatabaseMetaData;
+import com.mysql.cj.jdbc.JdbcConnection;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import zipkin2.Endpoint;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracingQueryInterceptorTest {
+  @Mock
+  JdbcConnection connection;
+  @Mock
+  DatabaseMetaData metaData;
+
+  @Mock Span span;
+  String url = "jdbc:mysql://myhost:5555/mydatabase";
+
+  @Test public void parseServerAddress_ipFromHost_portFromUrl() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1");
+
+    TracingQueryInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("mysql")
+        .ip("127.0.0.1").port(5555).build());
+  }
+
+  @Test public void parseServerAddress_serviceNameFromDatabaseName() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1");
+    when(connection.getCatalog()).thenReturn("mydatabase");
+
+    TracingQueryInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("mysql-mydatabase")
+        .ip("127.0.0.1").port(5555).build());
+  }
+
+  @Test public void parseServerAddress_propertiesOverrideServiceName() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1").setProperty("zipkinServiceName", "foo");
+
+    TracingQueryInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("foo")
+        .ip("127.0.0.1").port(5555).build());
+  }
+
+  @Test public void parseServerAddress_emptyZipkinServiceNameIgnored() throws SQLException {
+    setupAndReturnPropertiesForHost("127.0.0.1").setProperty("zipkinServiceName", "");
+
+    TracingQueryInterceptor.parseServerAddress(connection, span);
+
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("mysql")
+        .ip("127.0.0.1").port(5555).build());
+  }
+
+  @Test public void parseServerAddress_doesntNsLookup() throws SQLException {
+    setupAndReturnPropertiesForHost("localhost");
+
+    TracingQueryInterceptor.parseServerAddress(connection, span);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void parseServerAddress_doesntCrash() throws SQLException {
+    when(connection.getMetaData()).thenThrow(new SQLException());
+
+    verifyNoMoreInteractions(span);
+  }
+
+  Properties setupAndReturnPropertiesForHost(String host) throws SQLException {
+    when(connection.getMetaData()).thenReturn(metaData);
+    when(connection.getURL()).thenReturn(url);
+    Properties properties = new Properties();
+    when(connection.getProperties()).thenReturn(properties);
+    when(connection.getHost()).thenReturn(host);
+    return properties;
+  }
+}

--- a/instrumentation/mysql8/src/test/resources/log4j2.properties
+++ b/instrumentation/mysql8/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -28,6 +28,7 @@
     <module>jersey-server</module>
     <module>mysql</module>
     <module>mysql6</module>
+    <module>mysql8</module>
     <module>okhttp3</module>
     <module>p6spy</module>
     <module>servlet</module>


### PR DESCRIPTION
…ion.

The new version separates query interception and exception interception. As it still does not provide any context for propagating information between these two, we just have to rely on the thread-local span's propagation, meaning for exception logging there is a dependency on having the query interceptor enabled explicitly. Annoying, but at least we can validate the presence of both interceptors.

The differences between mysql-connector-6 is 

- TracingExceptionInterceptor
- When exception interceptor is enabled, the query interceptor does not close the span since it runs before the exception interceptor. Admittedly, I'm not sure if this order is guaranteed in future versions...
- Just from trying it out, it seems the new `Supplier<String>` of queries returns even for prepared statements, so removed the previous workaround that used `PreparedStatement`.