### PR TITLE
Re-scopes Jersey resource method when async and backfills tests

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -135,7 +135,8 @@ public abstract class ITHttpServer extends ITHttp {
    */
   @Test
   public void async() throws Exception {
-    get("/async");
+    Response response = get("/async");
+    assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
     takeSpan();
   }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -68,7 +68,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
   class DelegatingFilter implements Filter {
 
-    @Override public void init(FilterConfig filterConfig) throws ServletException {
+    @Override public void init(FilterConfig filterConfig) {
     }
 
     @Override

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
@@ -1,5 +1,6 @@
 package brave.test.http;
 
+import brave.Tracing;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -16,56 +17,67 @@ import org.junit.Test;
 public abstract class ITServlet3Container extends ITServlet25Container {
   static ExecutorService executor = Executors.newCachedThreadPool();
 
-  @AfterClass public static void shutdownExecutor() {
+  @AfterClass
+  public static void shutdownExecutor() {
     executor.shutdownNow();
   }
 
   static class AsyncServlet extends HttpServlet {
-    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (Tracing.currentTracer().currentSpan() == null) {
+        throw new IllegalStateException("couldn't read current span!");
+      }
       AsyncContext ctx = req.startAsync();
       ctx.start(ctx::complete);
     }
   }
 
-  @Test public void forward() throws Exception {
+  @Test
+  public void forward() throws Exception {
     get("/forward");
 
     takeSpan();
   }
 
-  @Test public void forwardAsync() throws Exception {
+  @Test
+  public void forwardAsync() throws Exception {
     get("/forwardAsync");
 
     takeSpan();
   }
 
   static class ForwardServlet extends HttpServlet {
-    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
         throws ServletException, IOException {
       req.getServletContext().getRequestDispatcher("/foo").forward(req, resp);
     }
   }
 
   static class AsyncForwardServlet extends HttpServlet {
-    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
       AsyncContext asyncContext = req.startAsync(req, resp);
       executor.execute(() -> asyncContext.dispatch("/async"));
     }
   }
 
   static class ExceptionAsyncServlet extends HttpServlet {
-    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
       AsyncContext ctx = req.startAsync();
       ctx.setTimeout(1);
-      ctx.start(() -> {
-        try {
-          Thread.sleep(10L);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        } finally {
-          ctx.complete();
-        }
-      });
+      ctx.start(
+          () -> {
+            try {
+              Thread.sleep(10L);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } finally {
+              ctx.complete();
+            }
+          });
     }
   }
 

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -122,7 +122,6 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
      */
     @Override
     public void onEvent(RequestEvent event) {
-      System.err.println("event "+event.getType() +" "+Thread.currentThread());
       Tracer.SpanInScope maybeSpanInScope;
       switch (event.getType()) {
         // Note: until REQUEST_MATCHED, we don't know metadata such as if the request is async or not

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -107,6 +107,7 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     final Span span;
     // Invalidated when an asynchronous method is in use
     volatile Tracer.SpanInScope spanInScope;
+    volatile boolean async;
 
     TracingRequestEventListener(Span span, Tracer.SpanInScope spanInScope) {
       this.span = span;
@@ -121,25 +122,41 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
      */
     @Override
     public void onEvent(RequestEvent event) {
+      System.err.println("event "+event.getType() +" "+Thread.currentThread());
       Tracer.SpanInScope maybeSpanInScope;
       switch (event.getType()) {
         // Note: until REQUEST_MATCHED, we don't know metadata such as if the request is async or not
         case REQUEST_MATCHED:
           parser.requestMatched(event, span);
+          async = async(event);
           break;
         case REQUEST_FILTERED:
-          if ((maybeSpanInScope = spanInScope) == null) break;
           // Jersey-specific @ManagedAsync stays on the request thread until REQUEST_FILTERED
           // Normal async methods sometimes stay on a thread until RESOURCE_METHOD_FINISHED, but
-          // this is not reliable.
-          if (event.getUriInfo().getMatchedResourceMethod().isManagedAsyncDeclared()
-              || event.getUriInfo().getMatchedResourceMethod().isSuspendDeclared()) {
-            maybeSpanInScope.close();
-            spanInScope = null;
-          }
+          // this is not reliable. So, we eagerly close the scope from request filters, and re-apply
+          // it later when the resource method starts.
+          if (!async || (maybeSpanInScope = spanInScope) == null) break;
+          maybeSpanInScope.close();
+          spanInScope = null;
+          break;
+        case RESOURCE_METHOD_START:
+          // If we are async, we have to re-scope the span as the resource method invocation is
+          // is likely on a different thread than the request filtering.
+          if (!async || spanInScope != null) break;
+          spanInScope = tracer.withSpanInScope(span);
+          break;
+        case RESOURCE_METHOD_FINISHED:
+          // If we scoped above, we have to close that to avoid leaks.
+          if (!async || (maybeSpanInScope = spanInScope) == null) break;
+          maybeSpanInScope.close();
+          spanInScope = null;
           break;
         case FINISHED:
-          if ((maybeSpanInScope = spanInScope) != null) maybeSpanInScope.close();
+          // In async FINISHED can happen before RESOURCE_METHOD_FINISHED, and on different threads!
+          // Don't close the scope unless it is a synchronous method.
+          if (!async && (maybeSpanInScope = spanInScope) != null) {
+            maybeSpanInScope.close();
+          }
           String maybeHttpRoute = route(event.getContainerRequest());
           if (maybeHttpRoute != null) {
             event.getContainerRequest().setProperty("http.route", maybeHttpRoute);
@@ -149,5 +166,10 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
         default:
       }
     }
+  }
+
+  static boolean async(RequestEvent event) {
+    return event.getUriInfo().getMatchedResourceMethod().isManagedAsyncDeclared()
+        || event.getUriInfo().getMatchedResourceMethod().isSuspendDeclared();
   }
 }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -1,6 +1,7 @@
 package brave.jersey.server;
 
 import brave.test.http.ITServletContainer;
+import okhttp3.Response;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -28,7 +29,8 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
 
   /** Tests that the span propagates between under asynchronous callbacks managed by jersey. */
   @Test public void managedAsync() throws Exception {
-    get("/managedAsync");
+    Response response = get("/managedAsync");
+    assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
     takeSpan();
   }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
@@ -56,6 +56,10 @@ public class TestResource {
   @GET
   @Path("async")
   public void async(@Suspended AsyncResponse response) {
+    if (tracer.currentSpan() == null) {
+      response.resume(new IllegalStateException("couldn't read current span!"));
+      return;
+    }
     blockOnAsyncResult("foo", response);
   }
 
@@ -63,6 +67,10 @@ public class TestResource {
   @Path("managedAsync")
   @ManagedAsync
   public void managedAsync(@Suspended AsyncResponse response) {
+    if (tracer.currentSpan() == null) {
+      response.resume(new IllegalStateException("couldn't read current span!"));
+      return;
+    }
     response.resume("foo");
   }
 

--- a/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
@@ -4,18 +4,22 @@ import brave.test.http.ITServlet3Container;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ITTracingFilter extends ITServlet3Container {
 
-  @Override protected Filter newTracingFilter() {
+  @Override
+  protected Filter newTracingFilter() {
     return TracingFilter.create(httpTracing);
   }
 
-  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
+  @Override
+  protected void addFilter(ServletContextHandler handler, Filter filter) {
+    FilterRegistration.Dynamic filterRegistration =
+        handler.getServletContext().addFilter(filter.getClass().getSimpleName(), filter);
+    filterRegistration.setAsyncSupported(true);
     // isMatchAfter=true is required for async tests to pass!
-    handler.getServletContext()
-        .addFilter(filter.getClass().getSimpleName(), filter)
-        .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+    filterRegistration.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
   }
 }


### PR DESCRIPTION
Before, we didn't actually check we could read the span on the resource
methods, rather only the async callbacks. This fixes that.

Fixes #722