### PR TITLE
Register remote endpoint in TracingStatementInterceptor if cannot parse IP

### DIFF
--- a/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
@@ -82,7 +82,7 @@ public class TracingStatementInterceptor implements StatementInterceptor {
         }
       }
       Endpoint.Builder builder = Endpoint.newBuilder().serviceName(remoteServiceName).port(port);
-      if (!builder.parseIp(getHost(connection))) return;
+      builder.parseIp(getHost(connection));
       span.remoteEndpoint(builder.build());
     } catch (Exception e) {
       // remote address is optional

--- a/instrumentation/mysql6/src/test/java/brave/mysql6/TracingStatementInterceptorTest.java
+++ b/instrumentation/mysql6/src/test/java/brave/mysql6/TracingStatementInterceptorTest.java
@@ -68,7 +68,8 @@ public class TracingStatementInterceptorTest {
     setupAndReturnPropertiesForHost("localhost");
 
     TracingStatementInterceptor.parseServerAddress(connection, span);
-    verifyNoMoreInteractions(span);
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("mysql")
+        .port(5555).build());
   }
 
   @Test public void parseServerAddress_doesntCrash() throws SQLException {

--- a/instrumentation/mysql8/src/main/java/brave/mysql8/TracingQueryInterceptor.java
+++ b/instrumentation/mysql8/src/main/java/brave/mysql8/TracingQueryInterceptor.java
@@ -97,7 +97,7 @@ public class TracingQueryInterceptor implements QueryInterceptor {
         }
       }
       Endpoint.Builder builder = Endpoint.newBuilder().serviceName(remoteServiceName).port(port);
-      if (!builder.parseIp(getHost(connection))) return;
+      builder.parseIp(getHost(connection));
       span.remoteEndpoint(builder.build());
     } catch (Exception e) {
       // remote address is optional

--- a/instrumentation/mysql8/src/test/java/brave/mysql8/TracingQueryInterceptorTest.java
+++ b/instrumentation/mysql8/src/test/java/brave/mysql8/TracingQueryInterceptorTest.java
@@ -80,7 +80,8 @@ public class TracingQueryInterceptorTest {
     setupAndReturnPropertiesForHost("localhost");
 
     TracingQueryInterceptor.parseServerAddress(connection, span);
-    verifyNoMoreInteractions(span);
+    verify(span).remoteEndpoint(Endpoint.newBuilder().serviceName("mysql")
+        .port(5555).build());
   }
 
   @Test public void parseServerAddress_doesntCrash() throws SQLException {


### PR DESCRIPTION
Related issue: https://github.com/openzipkin/brave/issues/561

This change ports this fix https://github.com/openzipkin/brave/pull/700
to mysql connectors 6 and 8

As `Endpoint` can exist with ipv4 and ipv6 both equal to null it worth registering endpoint if `connection.getHost()` returns domain name instead of IP.