### PR TITLE
Removes bytecode so we can add more

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -34,18 +34,6 @@
       <!-- annotations are not runtime retention, so don't need a runtime dep -->
       <scope>provided</scope>
     </dependency>
-    <!-- for value types... don't worry. this dependency is compile only! -->
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <!-- generated code includes Generated annotations! -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <!-- to mock Platform calls -->
     <dependency>
       <groupId>org.powermock</groupId>

--- a/brave/src/main/java/brave/NoopScopedSpan.java
+++ b/brave/src/main/java/brave/NoopScopedSpan.java
@@ -40,4 +40,20 @@ final class NoopScopedSpan extends ScopedSpan {
   @Override public String toString() {
     return "NoopScopedSpan(" + context + ")";
   }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof NoopScopedSpan)) return false;
+    NoopScopedSpan that = (NoopScopedSpan) o;
+    return context.equals(that.context) && scope.equals(that.scope);
+  }
+
+  @Override public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= context.hashCode();
+    h *= 1000003;
+    h ^= scope.hashCode();
+    return h;
+  }
 }

--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -1,14 +1,14 @@
 package brave;
 
 import brave.propagation.TraceContext;
-import com.google.auto.value.AutoValue;
 import zipkin2.Endpoint;
 
-@AutoValue
-abstract class NoopSpan extends Span {
+final class NoopSpan extends Span {
 
-  static NoopSpan create(TraceContext context) {
-    return new AutoValue_NoopSpan(context);
+  final TraceContext context;
+
+  NoopSpan(TraceContext context) {
+    this.context = context;
   }
 
   @Override public SpanCustomizer customizer() {
@@ -17,6 +17,10 @@ abstract class NoopSpan extends Span {
 
   @Override public boolean isNoop() {
     return true;
+  }
+
+  @Override public TraceContext context() {
+    return context;
   }
 
   @Override public Span start() {
@@ -65,5 +69,19 @@ abstract class NoopSpan extends Span {
   }
 
   @Override public void flush() {
+  }
+
+  @Override public String toString() {
+    return "NoopSpan(" + context + ")";
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof NoopSpan)) return false;
+    return context.equals(((NoopSpan) o).context);
+  }
+
+  @Override public int hashCode() {
+    return context.hashCode();
   }
 }

--- a/brave/src/main/java/brave/RealScopedSpan.java
+++ b/brave/src/main/java/brave/RealScopedSpan.java
@@ -47,7 +47,19 @@ final class RealScopedSpan extends ScopedSpan {
     recorder.finish(context);
   }
 
-  @Override public String toString() {
-    return "RealScopedSpan(" + context + ")";
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof RealScopedSpan)) return false;
+    RealScopedSpan that = (RealScopedSpan) o;
+    return context.equals(that.context) && scope.equals(that.scope);
+  }
+
+  @Override public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= context.hashCode();
+    h *= 1000003;
+    h ^= scope.hashCode();
+    return h;
   }
 }

--- a/brave/src/main/java/brave/RealSpanCustomizer.java
+++ b/brave/src/main/java/brave/RealSpanCustomizer.java
@@ -2,36 +2,35 @@ package brave;
 
 import brave.internal.recorder.Recorder;
 import brave.propagation.TraceContext;
-import com.google.auto.value.AutoValue;
 
 /** This wraps the public api and guards access to a mutable span. */
-@AutoValue
-abstract class RealSpanCustomizer implements SpanCustomizer {
+final class RealSpanCustomizer implements SpanCustomizer {
 
-  abstract TraceContext context();
-  abstract Recorder recorder();
+  final TraceContext context;
+  final Recorder recorder;
 
-  static RealSpanCustomizer create(TraceContext context, Recorder recorder) {
-    return new AutoValue_RealSpanCustomizer(context, recorder);
+  RealSpanCustomizer(TraceContext context, Recorder recorder) {
+    this.context = context;
+    this.recorder = recorder;
   }
 
   @Override public SpanCustomizer name(String name) {
-    recorder().name(context(), name);
+    recorder.name(context, name);
     return this;
   }
 
   @Override public SpanCustomizer annotate(String value) {
-    recorder().annotate(context(), value);
+    recorder.annotate(context, value);
     return this;
   }
 
   @Override public SpanCustomizer tag(String key, String value) {
-    recorder().tag(context(), key, value);
+    recorder.tag(context, key, value);
     return this;
   }
 
   @Override
   public String toString() {
-    return "RealSpanCustomizer(" + context() + ")";
+    return "RealSpanCustomizer(" + context + ")";
   }
 }

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -3,63 +3,55 @@ package brave.internal.recorder;
 import brave.Clock;
 import brave.Span;
 import brave.internal.HexCodec;
-import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import zipkin2.Endpoint;
 
 final class MutableSpan {
   final Clock clock;
   final zipkin2.Span.Builder span;
-  boolean finished;
   long timestamp;
 
   // Since this is not exposed, this class could be refactored later as needed to act in a pool
   // to reduce GC churn. This would involve calling span.clear and resetting the fields below.
-  MutableSpan(Clock clock, TraceContext context, Endpoint localEndpoint) {
+  MutableSpan(Clock clock, TraceContext context) {
     this.clock = clock;
     long parentId = context.parentIdAsLong();
     this.span = zipkin2.Span.newBuilder()
         .traceId(context.traceIdString())
         .parentId(parentId != 0L ? HexCodec.toLowerHex(parentId) : null)
         .id(HexCodec.toLowerHex(context.spanId()))
-        .debug(context.debug() ? true : null)
-        .localEndpoint(localEndpoint);
-    finished = false;
+        .debug(context.debug() ? true : null);
   }
 
-  MutableSpan start() {
-    return start(clock.currentTimeMicroseconds());
+  void start() {
+    start(clock.currentTimeMicroseconds());
   }
 
-  synchronized MutableSpan setShared() {
+  synchronized void setShared() {
     span.shared(true);
-    return this;
   }
 
-  synchronized MutableSpan start(long timestamp) {
+  synchronized void start(long timestamp) {
     span.timestamp(this.timestamp = timestamp);
-    return this;
   }
 
-  synchronized MutableSpan name(String name) {
+  synchronized void name(String name) {
     span.name(name);
-    return this;
   }
 
-  synchronized MutableSpan kind(Span.Kind kind) {
+  synchronized void kind(Span.Kind kind) {
     try {
       span.kind(zipkin2.Span.Kind.valueOf(kind.name()));
     } catch (IllegalArgumentException e) {
       // TODO: log
     }
-    return this;
   }
 
-  MutableSpan annotate(String value) {
-    return annotate(clock.currentTimeMicroseconds(), value);
+  void annotate(String value) {
+    annotate(clock.currentTimeMicroseconds(), value);
   }
 
-  synchronized MutableSpan annotate(long timestamp, String value) {
+  synchronized void annotate(long timestamp, String value) {
     if ("cs".equals(value)) {
       span.kind(zipkin2.Span.Kind.CLIENT).timestamp(this.timestamp = timestamp);
     } else if ("sr".equals(value)) {
@@ -73,31 +65,24 @@ final class MutableSpan {
     } else {
       span.addAnnotation(timestamp, value);
     }
-    return this;
   }
 
-  synchronized MutableSpan tag(String key, String value) {
+  synchronized void tag(String key, String value) {
     span.putTag(key, value);
-    return this;
   }
 
-  synchronized MutableSpan remoteEndpoint(Endpoint remoteEndpoint) {
+  synchronized void remoteEndpoint(Endpoint remoteEndpoint) {
     span.remoteEndpoint(remoteEndpoint);
-    return this;
   }
 
   /** Completes and reports the span */
-  synchronized MutableSpan finish(@Nullable Long finishTimestamp) {
-    if (finished) return this;
-    finished = true;
-
-    if (timestamp != 0 && finishTimestamp != null) {
+  synchronized void finish(long finishTimestamp) {
+    if (timestamp != 0L && finishTimestamp != 0L) {
       span.duration(Math.max(finishTimestamp - timestamp, 1));
     }
-    return this;
   }
 
-  synchronized zipkin2.Span toSpan() {
-    return span.build();
+  synchronized zipkin2.Span toSpan(Endpoint localEndpoint) {
+    return span.localEndpoint(localEndpoint).build();
   }
 }

--- a/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpanMap.java
@@ -63,7 +63,7 @@ final class MutableSpanMap extends ReferenceQueue<TraceContext> {
       clock = new TickClock(this.clock.currentTimeMicroseconds(), System.nanoTime());
     }
 
-    MutableSpan newSpan = new MutableSpan(clock, context, endpoint);
+    MutableSpan newSpan = new MutableSpan(clock, context);
     MutableSpan previousSpan = delegate.putIfAbsent(new RealKey(context, this), newSpan);
     if (previousSpan != null) return previousSpan; // lost race
     return newSpan;
@@ -93,7 +93,7 @@ final class MutableSpanMap extends ReferenceQueue<TraceContext> {
       if (value == null || noop.get()) continue;
       try {
         value.annotate(value.clock.currentTimeMicroseconds(), "brave.flush");
-        reporter.report(value.toSpan());
+        reporter.report(value.toSpan(endpoint));
       } catch (RuntimeException e) {
         // don't crash the caller if there was a problem reporting an unrelated span.
         if (context != null && logger.isLoggable(Level.FINE)) {

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -3,41 +3,80 @@ package brave.propagation;
 import brave.internal.Nullable;
 
 //@Immutable
-public abstract class SamplingFlags {
-  public static final SamplingFlags EMPTY = new SamplingFlagsImpl(null, false);
-  public static final SamplingFlags SAMPLED = new SamplingFlagsImpl(true, false);
-  public static final SamplingFlags NOT_SAMPLED = new SamplingFlagsImpl(false, false);
-  public static final SamplingFlags DEBUG = new SamplingFlagsImpl(true, true);
+public class SamplingFlags {
+  static final int FLAG_SAMPLED = 1 << 1;
+  static final int FLAG_SAMPLED_SET = 1 << 2;
+  static final int FLAG_DEBUG = 1 << 3;
+
+  public static final SamplingFlags EMPTY = new SamplingFlags(0);
+  public static final SamplingFlags NOT_SAMPLED = new SamplingFlags(FLAG_SAMPLED_SET);
+  public static final SamplingFlags SAMPLED = new SamplingFlags(NOT_SAMPLED.flags | FLAG_SAMPLED);
+  public static final SamplingFlags DEBUG = new SamplingFlags(SAMPLED.flags | FLAG_DEBUG);
+
+  final int flags; // bit field for sampled and debug
+
+  SamplingFlags(int flags) {
+    this.flags = flags;
+  }
 
   /**
    * Should we sample this request or not? True means sample, false means don't, null means we defer
    * decision to someone further down in the stack.
+   *
+   * <p>Note: this is a uniform decision for the entire trace. Advanced sampling patterns can
+   * overlay this via {@link Propagation.Factory#isNoop(TraceContext)}. For example, a noop context
+   * usually implies sampled is false or unset. However, you can collect data anyway, locally for
+   * metrics, or to an aggregation stream.
    */
-  @Nullable public abstract Boolean sampled();
+  @Nullable public final Boolean sampled() {
+    return sampled(flags);
+  }
 
   /**
    * True is a request to store this span even if it overrides sampling policy. Defaults to false.
    */
-  public abstract boolean debug();
+  public final boolean debug() {
+    return debug(flags);
+  }
+
+  @Override public String toString() {
+    return "SamplingFlags(sampled=" + sampled() + ", debug=" + debug() + ")";
+  }
 
   public static final class Builder {
-    Boolean sampled;
-    boolean debug = false;
+    int flags = 0; // bit field for sampled and debug
 
     public Builder() {
       // public constructor instead of static newBuilder which would clash with TraceContext's
     }
 
     public Builder sampled(@Nullable Boolean sampled) {
-      this.sampled = sampled;
+      if (sampled == null) {
+        flags &= ~FLAG_SAMPLED_SET;
+        flags &= ~FLAG_SAMPLED;
+        return this;
+      }
+      flags |= FLAG_SAMPLED_SET;
+      if (sampled) {
+        flags |= FLAG_SAMPLED;
+      } else {
+        flags &= ~FLAG_SAMPLED;
+      }
       return this;
     }
 
+    /** Ensures sampled is set when debug is */
     public Builder debug(boolean debug) {
-      this.debug = debug;
-      if (debug) sampled(true);
+      if (debug) {
+        flags |= FLAG_DEBUG;
+        flags |= FLAG_SAMPLED_SET;
+        flags |= FLAG_SAMPLED;
+      } else {
+        flags &= ~FLAG_DEBUG;
+      }
       return this;
     }
+
 
     /** Allows you to create flags from a boolean value without allocating a builder instance */
     public static SamplingFlags build(@Nullable Boolean sampled) {
@@ -46,47 +85,18 @@ public abstract class SamplingFlags {
     }
 
     public SamplingFlags build() {
-      if (debug) return DEBUG;
-      return build(sampled);
+      return flags == 0 ? EMPTY : SamplingFlags.debug(flags) ? DEBUG
+          : SamplingFlags.sampled(flags) ? SAMPLED : NOT_SAMPLED;
     }
   }
 
-  static final class SamplingFlagsImpl extends SamplingFlags {
-    final Boolean sampled;
-    final boolean debug;
-
-    SamplingFlagsImpl(Boolean sampled, boolean debug) {
-      this.sampled = sampled;
-      this.debug = debug;
-    }
-
-    @Override public Boolean sampled() {
-      return sampled;
-    }
-
-    @Override public boolean debug() {
-      return debug;
-    }
-
-    @Override public String toString() {
-      return "SamplingFlags(sampled=" + sampled + ", debug=" + debug + ")";
-    }
-  }
-
-  SamplingFlags() {
-  }
-
-  static final int FLAG_SAMPLED = 1 << 1;
-  static final int FLAG_SAMPLED_SET = 1 << 2;
-  static final int FLAG_DEBUG = 1 << 3;
-
-  static Boolean sampled(int flags) {
+  private static Boolean sampled(int flags) {
     return (flags & FLAG_SAMPLED_SET) == FLAG_SAMPLED_SET
         ? (flags & FLAG_SAMPLED) == FLAG_SAMPLED
         : null;
   }
 
-  static boolean debug(int flags) {
+  private static boolean debug(int flags) {
     return (flags & FLAG_DEBUG) == FLAG_DEBUG;
   }
 }

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -93,16 +93,6 @@ public final class TraceContext extends SamplingFlags {
     return parentId;
   }
 
-  /** {@inheritDoc} */
-  @Override @Nullable public Boolean sampled() {
-    return sampled(flags);
-  }
-
-  /** {@inheritDoc} */
-  @Override public boolean debug() {
-    return debug(flags);
-  }
-
   /**
    * Unique 8-byte identifier of this span within a trace.
    *
@@ -240,15 +230,14 @@ public final class TraceContext extends SamplingFlags {
   }
 
   final long traceIdHigh, traceId, parentId, spanId;
-  final int flags; // bit field for sampled and debug
   final List<Object> extra;
 
   TraceContext(Builder builder) { // no external implementations
+    super(builder.flags);
     traceIdHigh = builder.traceIdHigh;
     traceId = builder.traceId;
     parentId = builder.parentId;
     spanId = builder.spanId;
-    flags = builder.flags;
     extra = builder.extra;
   }
 

--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -29,16 +29,6 @@ public final class TraceIdContext extends SamplingFlags {
     return traceId;
   }
 
-  /** {@inheritDoc} */
-  @Override @Nullable public Boolean sampled() {
-    return sampled(flags);
-  }
-
-  /** {@inheritDoc} */
-  @Override public boolean debug() {
-    return debug(flags);
-  }
-
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -108,12 +98,11 @@ public final class TraceIdContext extends SamplingFlags {
   }
 
   final long traceIdHigh, traceId;
-  final int flags; // bit field for sampled and debug
 
   TraceIdContext(Builder builder) { // no external implementations
+    super(builder.flags);
     traceIdHigh = builder.traceIdHigh;
     traceId = builder.traceId;
-    flags = builder.flags;
   }
 
   /** Only includes mandatory fields {@link #traceIdHigh()} and {@link #traceId()} */

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanMapTest.java
@@ -25,8 +25,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({MutableSpanMap.class, MutableSpan.class})
 public class MutableSpanMapTest {
   Endpoint endpoint = Platform.get().endpoint();
-  List<zipkin2.Span> spans = new ArrayList();
-  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+  List<zipkin2.Span> spans = new ArrayList<>();
+  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
   MutableSpanMap map = new MutableSpanMap(endpoint, () -> 0L, spans::add, new AtomicBoolean(false));
 
   @Test
@@ -180,6 +180,10 @@ public class MutableSpanMapTest {
     // We also expect the spans to have been reported
     assertThat(spans).flatExtracting(Span::annotations).extracting(Annotation::value)
         .containsExactly("brave.flush", "brave.flush");
+
+    // We also expect the spans reported to have the endpoint of the tracer
+    assertThat(spans).extracting(Span::localEndpoint)
+        .containsExactly(endpoint, endpoint);
   }
 
   @Test

--- a/brave/src/test/java/brave/internal/recorder/RecorderTest.java
+++ b/brave/src/test/java/brave/internal/recorder/RecorderTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RecorderTest {
   Endpoint localEndpoint = Platform.get().endpoint();
   List<zipkin2.Span> spans = new ArrayList<>();
-  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
   Recorder recorder = new Recorder(localEndpoint, () -> 0L, spans::add, new AtomicBoolean(false));
 
   @Test public void finish_calculatesDuration() {

--- a/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
@@ -41,4 +41,12 @@ public class SamplingFlagsTest {
     assertThat(flags.sampled()).isFalse();
     assertThat(flags.debug()).isFalse();
   }
+
+  @Test public void nullSampled() {
+    SamplingFlags flags = new SamplingFlags.Builder().sampled(true).sampled(null).build();
+
+    assertThat(flags).isSameAs(SamplingFlags.EMPTY);
+    assertThat(flags.sampled()).isNull();
+    assertThat(flags.debug()).isFalse();
+  }
 }

--- a/brave/src/test/java/brave/sampler/DeclarativeSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/DeclarativeSamplerTest.java
@@ -1,7 +1,7 @@
 package brave.sampler;
 
 import brave.propagation.SamplingFlags;
-import com.google.auto.value.AutoAnnotation;
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.junit.Before;
@@ -82,8 +82,19 @@ public class DeclarativeSamplerTest {
     boolean enabled() default true;
   }
 
-  // note: Unlike normal java annotations, auto-annotation do value-based equals and hashCode
-  @AutoAnnotation static Traced traced(float sampleRate, boolean enabled) {
-    return new AutoAnnotation_DeclarativeSamplerTest_traced(sampleRate, enabled);
+  static Traced traced(float sampleRate, boolean enabled) {
+    return new Traced() {
+      @Override public Class<? extends Annotation> annotationType() {
+        return Traced.class;
+      }
+
+      @Override public float sampleRate() {
+        return sampleRate;
+      }
+
+      @Override public boolean enabled() {
+        return enabled;
+      }
+    };
   }
 }

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -24,12 +24,6 @@
       <version>${grpc.version}</version>
       <scope>provided</scope>
     </dependency>
-    <!-- generated code includes Generated annotations! -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -18,17 +18,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <!-- generated code includes Generated annotations! -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -31,6 +31,7 @@
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <scope>provided</scope>
+      <version>1.3.1</version>
     </dependency>
     <!-- For Inject -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
     <assertj.version>3.9.0</assertj.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <mockito.version>1.10.19</mockito.version>
-    <javax.annotation-api.version>1.3.1</javax.annotation-api.version>
     <!-- last version on jax-rs 2.0 per https://jersey.github.io/download.html -->
     <jersey.version>2.25.1</jersey.version>
     <jmh.version>1.20</jmh.version>
@@ -212,16 +211,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>1.5.3</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>${javax.annotation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This removes the auto-value dependency and related for inlining the few
cases where it was used. It also trims the class hierarchy of sampling
flags. Finally, it moves out the in-flight localEndpoint as it is
constant.

Besides fixing a few bugs, these changes reduced the size of the jar by
12KiB and scraps 2 dependencies.

```bash
du -k /Users/acole/.m2/repository/io/zipkin/brave/brave/5.1.2/brave-5.1.2.jar /Users/acole/.m2/repository/io/zipkin/brave/brave/5.1.3-SNAPSHOT/brave-5.1.3-SNAPSHOT.jar
116	/Users/acole/.m2/repository/io/zipkin/brave/brave/5.1.2/brave-5.1.2.jar
128	/Users/acole/.m2/repository/io/zipkin/brave/brave/5.1.3-SNAPSHOT/brave-5.1.3-SNAPSHOT.jar
```