### PR TITLE
Adds more defense when reporting spans on ideal and orphaned paths

### DIFF
--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -130,6 +130,14 @@ public class TracerTest {
         .isEqualTo(HexCodec.toLowerHex(fromIncomingRequest.spanId()));
   }
 
+  @Test public void finish_doesntCrashOnBadReporter() {
+    tracer = Tracing.newBuilder().spanReporter(span -> {
+      throw new RuntimeException();
+    }).build().tracer();
+
+    tracer.newTrace().start().finish();
+  }
+
   @Test public void join_createsChildWhenUnsupportedByPropagation() {
     tracer = Tracing.newBuilder()
         .propagationFactory(new Propagation.Factory() {

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -106,7 +106,7 @@ public class TracingFactoryBeanTest {
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
-        .extracting("tracer.recorder.reporter")
+        .extracting("tracer.recorder.reporter.delegate")
         .containsExactly(Reporter.CONSOLE);
   }
 


### PR DESCRIPTION
This moves the crash-guard from only on orphaned spans to all spans.
This also ensures when an unrelated thread is flushing orphaned spans,
it only gets clock overhead once.