### PR TITLE
Re-adds TraceContext.shared to partition joined span data

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -166,7 +166,7 @@ public class Tracer {
     if (context.sampled() == null) { // then the caller didn't contribute data
       context = context.toBuilder().sampled(sampler.isSampled(context.traceId())).build();
     } else if (context.sampled()) { // we are recording and contributing to the same span ID
-      recorder.setShared(context);
+      context = context.toBuilder().shared(true).build();
     }
     return toSpan(context);
   }
@@ -225,7 +225,7 @@ public class Tracer {
       } else {
         builder = newContextBuilder(parent, sampler);
       }
-      return toSpan(builder.build());
+      return toSpan(builder.shared(false).build());
     }
     TraceIdContext traceIdContext = extracted.traceIdContext();
     if (extracted.traceIdContext() != null) {

--- a/brave/src/main/java/brave/internal/recorder/MutableSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/MutableSpan.java
@@ -20,15 +20,12 @@ final class MutableSpan {
         .traceId(context.traceIdString())
         .parentId(parentId != 0L ? HexCodec.toLowerHex(parentId) : null)
         .id(HexCodec.toLowerHex(context.spanId()))
-        .debug(context.debug() ? true : null);
+        .debug(context.debug() ? true : null)
+        .shared(context.shared() ? true : null);
   }
 
   void start() {
     start(clock.currentTimeMicroseconds());
-  }
-
-  synchronized void setShared() {
-    span.shared(true);
   }
 
   synchronized void start(long timestamp) {

--- a/brave/src/main/java/brave/internal/recorder/Recorder.java
+++ b/brave/src/main/java/brave/internal/recorder/Recorder.java
@@ -2,7 +2,6 @@ package brave.internal.recorder;
 
 import brave.Clock;
 import brave.Span;
-import brave.Tracer;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,18 +34,6 @@ public final class Recorder {
   public Clock clock(TraceContext context) {
     if (noop.get()) return clock;
     return spanMap.getOrCreate(context).clock;
-  }
-
-  /**
-   * Indicates we are contributing to a span started by another tracer (ex on a different host).
-   * Defaults to false.
-   *
-   * @see Tracer#joinSpan(TraceContext)
-   * @see zipkin2.Span#shared()
-   */
-  public void setShared(TraceContext context) {
-    if (noop.get()) return;
-    spanMap.getOrCreate(context).setShared();
   }
 
   /** @see brave.Span#start() */

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -22,11 +22,6 @@ public class SamplingFlags {
   /**
    * Should we sample this request or not? True means sample, false means don't, null means we defer
    * decision to someone further down in the stack.
-   *
-   * <p>Note: this is a uniform decision for the entire trace. Advanced sampling patterns can
-   * overlay this via {@link Propagation.Factory#isNoop(TraceContext)}. For example, a noop context
-   * usually implies sampled is false or unset. However, you can collect data anyway, locally for
-   * metrics, or to an aggregation stream.
    */
   @Nullable public final Boolean sampled() {
     return sampled(flags);

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -69,6 +69,7 @@ public class OpenTracingAdapterTest {
         .isEqualTo(TraceContext.newBuilder()
             .traceId(1L)
             .spanId(2L)
+            .shared(true)
             .sampled(true).build());
   }
 

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanTest.java
@@ -131,9 +131,8 @@ public class MutableSpanTest {
 
   // This prevents the server timestamp from overwriting the client one on the collector
   @Test public void reportsSharedStatus() {
-    MutableSpan span = new MutableSpan(() -> 0L, context);
+    MutableSpan span = new MutableSpan(() -> 0L, context.toBuilder().shared(true).build());
 
-    span.setShared();
     span.start(1L);
     span.kind(SERVER);
     span.finish(2L);

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -22,6 +22,19 @@ public class TraceContextTest {
         .isNotEqualTo(TraceContext.newBuilder().traceId(333L).spanId(1L).build().hashCode());
   }
 
+  /**
+   * Shared context is different than an unshared one, notably this keeps client/server loopback
+   * separate.
+   */
+  @Test public void compareUnequalIds_onShared() {
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(3L).build();
+
+    assertThat(context)
+        .isNotEqualTo(context.toBuilder().shared(true).build());
+    assertThat(context.hashCode())
+        .isNotEqualTo(context.toBuilder().shared(true).build().hashCode());
+  }
+
   @Test public void compareEqualIds() {
     TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(444L).build();
 


### PR DESCRIPTION
When loopback RPC requests occur, data can overlap, resulting in missing
spans data depending on whether the client or server completes first.

This fixes the situation by restoring the `TraceContext.shared` flag and
adding new tests that show what this supports.

This reverts commit 6d3322279de8d68b2c6cd83b7f8990bd316d2201.