### PR TITLE
Blocks only up to 3 seconds for span reporting in ITs

### DIFF
--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -60,4 +60,13 @@ public abstract class ITTracingFilter {
         .setTracing(tracing);
     this.tracing = tracing;
   }
+
+  /** Call this to block until a span was reported */
+  Span takeSpan() throws InterruptedException {
+    Span result = spans.poll(3, TimeUnit.SECONDS);
+    assertThat(result)
+        .withFailMessage("Span was not reported")
+        .isNotNull();
+    return result;
+  }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
@@ -37,7 +37,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     assertThat(context.parentId()).isNull();
     assertThat(context.sampled()).isTrue();
 
-    spans.take();
+    takeSpan();
   }
 
   @Test public void makesChildOfCurrentSpan() throws Exception {
@@ -55,7 +55,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
         .isEqualTo(parent.context().spanId());
 
     // we report one in-process and one RPC client span
-    assertThat(Arrays.asList(spans.take(), spans.take()))
+    assertThat(Arrays.asList(takeSpan(), takeSpan()))
         .extracting(Span::kind)
         .containsOnly(null, Span.Kind.CLIENT);
   }
@@ -89,7 +89,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     }
 
     // Check we reported 2 in-process spans and 2 client spans
-    assertThat(Arrays.asList(spans.take(), spans.take(), spans.take(), spans.take()))
+    assertThat(Arrays.asList(takeSpan(), takeSpan(), takeSpan(), takeSpan()))
         .extracting(Span::kind)
         .containsOnly(null, Span.Kind.CLIENT);
   }
@@ -108,7 +108,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
   @Test public void reportsClientKindToZipkin() throws Exception {
     client.get().sayHello("jorge");
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.kind())
         .isEqualTo(Span.Kind.CLIENT);
   }
@@ -116,7 +116,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
   @Test public void defaultSpanNameIsMethodName() throws Exception {
     client.get().sayHello("jorge");
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.name())
         .isEqualTo("greeterservice/sayhello");
   }
@@ -130,7 +130,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     } catch (RpcException e) {
     }
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.tags().get("error"))
         .contains("RemotingException");
   }
@@ -140,7 +140,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     RpcContext.getContext().asyncCall(() -> client.get().sayHello("romeo"));
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.tags().get("error"))
         .contains("RemotingException");
   }
@@ -150,7 +150,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
       client.get().sayHello("romeo");
     });
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.duration())
         .isNull();
   }
@@ -167,7 +167,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     } catch (RpcException e) {
     }
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.tags().get("dubbo.error_code"))
         .isEqualTo("1");
     assertThat(span.tags().get("error"))

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
@@ -52,7 +52,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
     client.get().sayHello("jorge");
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.traceId()).isEqualTo(traceId);
     assertThat(span.parentId()).isEqualTo(parentId);
     assertThat(span.id()).isEqualTo(spanId);
@@ -73,7 +73,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
     client.get().sayHello("jorge");
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.traceId()).isEqualTo(traceId);
     assertThat(span.parentId()).isEqualTo(spanId);
     assertThat(span.id()).isNotEqualTo(spanId);
@@ -92,13 +92,13 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     assertThat(client.get().sayHello("jorge"))
         .isNotEmpty();
 
-    spans.take();
+    takeSpan();
   }
 
   @Test public void reportsServerKindToZipkin() throws Exception {
     client.get().sayHello("jorge");
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.kind())
         .isEqualTo(Span.Kind.SERVER);
   }
@@ -106,7 +106,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
   @Test public void defaultSpanNameIsMethodName() throws Exception {
     client.get().sayHello("jorge");
 
-    Span span = spans.take();
+    Span span = takeSpan();
     assertThat(span.name())
         .isEqualTo("genericservice/sayhello");
   }
@@ -117,7 +117,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
       failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
     } catch (IllegalArgumentException e) {
-      Span span = spans.take();
+      Span span = takeSpan();
       assertThat(span.tags()).containsExactly(
           entry("error", "IllegalArgumentException")
       );

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITCensusInterop.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITCensusInterop.java
@@ -115,7 +115,7 @@ public class ITCensusInterop {
     // this takes 5 seconds due to hard-coding in ExportComponentImpl
     SpanData clientSpan = testHandler.waitForExport(1).get(0);
 
-    Span serverSpan = spans.take();
+    Span serverSpan = takeSpan();
     assertThat(clientSpan.getContext().getTraceId().toLowerBase16())
         .isEqualTo(serverSpan.traceId());
     assertThat(clientSpan.getContext().getSpanId().toLowerBase16())
@@ -139,7 +139,7 @@ public class ITCensusInterop {
     // this takes 5 seconds due to hard-coding in ExportComponentImpl
     SpanData clientSpan = testHandler.waitForExport(1).get(0);
 
-    Span serverSpan = spans.take();
+    Span serverSpan = takeSpan();
     assertThat(clientSpan.getContext().getTraceId().toLowerBase16())
         .isEqualTo(serverSpan.traceId());
     assertThat(clientSpan.getContext().getSpanId().toLowerBase16())
@@ -157,7 +157,7 @@ public class ITCensusInterop {
     // this takes 5 seconds due to hard-coding in ExportComponentImpl
     SpanData serverSpan = testHandler.waitForExport(1).get(0);
 
-    Span clientSpan = spans.take();
+    Span clientSpan = takeSpan();
     assertThat(clientSpan.traceId())
         .isEqualTo(serverSpan.getContext().getTraceId().toLowerBase16());
     assertThat(clientSpan.id()).isEqualTo(serverSpan.getParentSpanId().toLowerBase16());
@@ -207,5 +207,14 @@ public class ITCensusInterop {
       server.awaitTermination(1, TimeUnit.SECONDS);
     }
     tracing.close();
+  }
+
+  /** Call this to block until a span was reported */
+  Span takeSpan() throws InterruptedException {
+    Span result = spans.poll(3, TimeUnit.SECONDS);
+    assertThat(result)
+        .withFailMessage("Span was not reported")
+        .isNotNull();
+    return result;
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -91,7 +91,10 @@ public abstract class ITHttp {
 
   /** Call this to block until a span was reported */
   protected Span takeSpan() throws InterruptedException {
-    Span result = spans.take();
+    Span result = spans.poll(3, TimeUnit.SECONDS);
+    assertThat(result)
+        .withFailMessage("Span was not reported")
+        .isNotNull();
     assertThat(result.annotations())
         .extracting(Annotation::value)
         .doesNotContain(CONTEXT_LEAK);


### PR DESCRIPTION
This makes sure tests won't hang for more than 3 seconds. If they take
longer, we'll see a stacktrace.