### PR TITLE
Avoids dragons in javadoc by avoiding implicit lookups in servlet filter

### DIFF
--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -58,6 +58,13 @@
     </extensions>
     <plugins>
       <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Try to prevent flakes in circleci -->
+        <configuration>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
@@ -90,7 +90,7 @@ public final class TracingFilter implements Filter {
     } finally {
       scope.close();
       if (servlet.isAsync(httpRequest)) { // we don't have the actual response, handle later
-        servlet.handleAsync(handler, httpRequest, span);
+        servlet.handleAsync(handler, httpRequest, httpResponse, span);
       } else { // we have a synchronous response, so we can finish the span
         handler.handleSend(ADAPTER.adaptResponse(httpRequest, httpResponse), error, span);
       }


### PR DESCRIPTION
@felixbarny warned us about a subtle case noted in javadoc which can
result in null references.

Fixes #729