### PR TITLE
Ensures we don't copy immutable lists

### DIFF
--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -345,6 +345,13 @@ public final class TraceContext extends SamplingFlags {
 
   static List<Object> ensureImmutable(List<Object> extra) {
     if (extra == Collections.EMPTY_LIST) return extra;
+    // avoid copying datastructure by trusting certain names.
+    String simpleName = extra.getClass().getSimpleName();
+    if (simpleName.equals("SingletonList")
+        || simpleName.startsWith("Unmodifiable")
+        || simpleName.contains("Immutable")) {
+      return extra;
+    }
     // Faster to make a copy than check the type to see if it is already a singleton list
     if (extra.size() == 1) return Collections.singletonList(extra.get(0));
     return Collections.unmodifiableList(new ArrayList<>(extra));

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -1,7 +1,9 @@
 package brave.propagation;
 
 import brave.internal.HexCodec;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -78,13 +80,30 @@ public class TraceContextTest {
   @Test public void ensureImmutable_convertsToSingletonList() {
     List<Object> list = new ArrayList<>();
     list.add("foo");
-    TraceContext.ensureImmutable(list);
     assertThat(TraceContext.ensureImmutable(list).getClass().getSimpleName())
         .isEqualTo("SingletonList");
   }
 
   @Test public void ensureImmutable_returnsEmptyList() {
     List<Object> list = Collections.emptyList();
+    assertThat(TraceContext.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureImmutable_doesntCopySingletonList() {
+    List<Object> list = Collections.singletonList("foo");
+    assertThat(TraceContext.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureImmutable_doesntCopyUnmodifiableList() {
+    List<Object> list = Collections.unmodifiableList(Arrays.asList("foo"));
+    assertThat(TraceContext.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureImmutable_doesntCopyImmutableList() {
+    List<Object> list = ImmutableList.of("foo");
     assertThat(TraceContext.ensureImmutable(list))
         .isSameAs(list);
   }


### PR DESCRIPTION
This is important as TraceContext is immutable. It causes excess garbage when we have to do things like .toBuilder().XXX.build() such as marking shared status.