### PR TITLE
Optimizes internal trace context related code, especially extra

### DIFF
--- a/brave/src/main/java/brave/RealScopedSpan.java
+++ b/brave/src/main/java/brave/RealScopedSpan.java
@@ -61,8 +61,8 @@ final class RealScopedSpan extends ScopedSpan {
   @Override public void finish() {
     scope.close();
     if (!pendingSpans.remove(context)) return; // don't double-report
-    spanReporter.report(context, state);
     state.finishTimestamp(clock.currentTimeMicroseconds());
+    spanReporter.report(context, state);
   }
 
   @Override public boolean equals(Object o) {

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -70,7 +70,7 @@ public abstract class Tracing implements Closeable {
    * @param context references a potentially unstarted span you'd like a clock correlated with
    */
   public final Clock clock(TraceContext context) {
-    return tracer().pendingSpans.getOrCreate(context).clock();
+    return tracer().pendingSpans.getOrCreate(context, false).clock();
   }
 
   abstract public ErrorParser errorParser();

--- a/brave/src/main/java/brave/internal/InternalPropagation.java
+++ b/brave/src/main/java/brave/internal/InternalPropagation.java
@@ -1,0 +1,27 @@
+package brave.internal;
+
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import java.util.List;
+
+/**
+ * Escalate internal APIs in {@code brave.propagation} so they can be used from outside packages.
+ * The only implementation is in {@link SamplingFlags}.
+ *
+ * <p>Inspired by {@code okhttp3.internal.Internal}.
+ */
+public abstract class InternalPropagation {
+
+  public static InternalPropagation instance;
+
+  public abstract int flags(SamplingFlags flags);
+
+  public abstract TraceContext newTraceContext(
+      int flags,
+      long traceIdHigh,
+      long traceId,
+      long parentId,
+      long spanId,
+      List<Object> extra
+  );
+}

--- a/brave/src/main/java/brave/internal/Lists.java
+++ b/brave/src/main/java/brave/internal/Lists.java
@@ -1,0 +1,57 @@
+package brave.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class Lists {
+
+  static List<Object> ensureMutable(List<Object> list) {
+    if (list instanceof ArrayList) return list;
+    int size = list.size();
+    ArrayList<Object> mutable = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      mutable.add(list.get(i));
+    }
+    return mutable;
+  }
+
+  public static List<Object> ensureImmutable(List<Object> extra) {
+    if (isImmutable(extra)) return extra;
+    // Faster to make a copy than check the type to see if it is already a singleton list
+    if (extra.size() == 1) return Collections.singletonList(extra.get(0));
+    return Collections.unmodifiableList(new ArrayList<>(extra));
+  }
+
+  static boolean isImmutable(List<Object> extra) {
+    if (extra == Collections.EMPTY_LIST) return true;
+    // avoid copying datastructure by trusting certain names.
+    String simpleName = extra.getClass().getSimpleName();
+    if (simpleName.equals("SingletonList")
+        || simpleName.startsWith("Unmodifiable")
+        || simpleName.contains("Immutable")) {
+      return true;
+    }
+    return false;
+  }
+
+  public static List<Object> concatImmutableLists(List<Object> left, List<Object> right) {
+    int leftSize = left.size();
+    if (leftSize == 0) return right;
+    int rightSize = right.size();
+    if (rightSize == 0) return left;
+
+    // now we know we have to concat
+    ArrayList<Object> mutable = new ArrayList<>();
+    for (int i = 0; i < leftSize; i++) {
+      mutable.add(left.get(i));
+    }
+    for (int i = 0; i < rightSize; i++) {
+      mutable.add(right.get(i));
+    }
+    return Collections.unmodifiableList(mutable);
+  }
+
+  Lists() {
+  }
+}

--- a/brave/src/main/java/brave/internal/MapPropagationFields.java
+++ b/brave/src/main/java/brave/internal/MapPropagationFields.java
@@ -34,7 +34,9 @@ public class MapPropagationFields extends PropagationFields {
       if (values == null) {
         values = new LinkedHashMap<>();
         values.put(name, value);
-      } else if (!value.equals(values.get(name))) {
+      } else if (value.equals(values.get(name))) {
+        return;
+      } else {
         // this is the copy-on-write part
         values = new LinkedHashMap<>(values);
         values.put(name, value);
@@ -69,5 +71,16 @@ public class MapPropagationFields extends PropagationFields {
     }
     if (values == null) return Collections.emptyMap();
     return values;
+  }
+
+  @Override public int hashCode() { // for unit tests
+    return values == null ? 0 : values.hashCode();
+  }
+
+  @Override public boolean equals(Object o) { // for unit tests
+    if (o == this) return true;
+    if (!(o instanceof MapPropagationFields)) return false;
+    MapPropagationFields that = (MapPropagationFields) o;
+    return values == null ? that.values == null : values.equals(that.values);
   }
 }

--- a/brave/src/main/java/brave/internal/PredefinedPropagationFields.java
+++ b/brave/src/main/java/brave/internal/PredefinedPropagationFields.java
@@ -50,8 +50,9 @@ public class PredefinedPropagationFields extends PropagationFields {
       if (elements == null) {
         elements = new String[fieldNames.length];
         elements[index] = value;
-      } else if (!value.equals(elements[index])) {
-        // this is the copy-on-write part
+      } else if (value.equals(elements[index])) {
+        return;
+      } else { // this is the copy-on-write part
         elements = Arrays.copyOf(elements, elements.length);
         elements[index] = value;
       }
@@ -103,5 +104,16 @@ public class PredefinedPropagationFields extends PropagationFields {
       if (fieldNames[i].equals(name)) return i;
     }
     return -1;
+  }
+
+  @Override public int hashCode() { // for unit tests
+    return values == null ? 0 : Arrays.hashCode(values);
+  }
+
+  @Override public boolean equals(Object o) { // for unit tests
+    if (o == this) return true;
+    if (!(o instanceof PredefinedPropagationFields)) return false;
+    PredefinedPropagationFields that = (PredefinedPropagationFields) o;
+    return values == null ? that.values == null : Arrays.equals(values, that.values);
   }
 }

--- a/brave/src/main/java/brave/internal/PropagationFieldsFactory.java
+++ b/brave/src/main/java/brave/internal/PropagationFieldsFactory.java
@@ -2,9 +2,10 @@ package brave.internal;
 
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-import static java.util.Collections.unmodifiableList;
+import static brave.internal.Lists.ensureMutable;
 
 public abstract class PropagationFieldsFactory<P extends PropagationFields> {
   protected abstract Class<P> type();
@@ -14,41 +15,87 @@ public abstract class PropagationFieldsFactory<P extends PropagationFields> {
   protected abstract P create(P parent);
 
   public final TraceContext decorate(TraceContext context) {
-    // If there's an implicit context while extracting only fields fields, we will have two extras!
-    List<Object> extras = context.extra();
-    int thisExtraIndex = -1, parentExtraIndex = -1;
-    for (int i = 0, length = extras.size(); i < length; i++) {
-      if (extras.get(i).getClass() == type()) {
-        P fields = (P) context.extra().get(i);
-        // If this fields is unassociated (due to remote extraction),
-        // or it is the same span ID, re-use the instance.
-        if (fields.tryAssociate(context)) {
-          thisExtraIndex = i;
-        } else {
-          parentExtraIndex = i;
-        }
+    long traceId = context.traceId(), spanId = context.spanId();
+    Class<P> type = type();
+
+    List<Object> extraFields = context.extra();
+    int extraSize = extraFields.size();
+    if (extraSize == 0) {
+      extraFields = Collections.singletonList(createExtraAndClaim(traceId, spanId));
+      return contextWithExtra(context, extraFields);
+    }
+
+    Object extra = extraFields.get(0);
+    P consolidatedFields = null;
+
+    // if the first item is a fields object, try to claim or copy its fields
+    if (type.isInstance(extra)) {
+      P existing = (P) extra;
+      if (existing.tryToClaim(traceId, spanId)) {
+        consolidatedFields = existing;
+      } else { // otherwise we need to consolidate the fields
+        consolidatedFields = createExtraAndClaim(traceId, spanId);
+        consolidatedFields.putAllIfAbsent(existing);
       }
     }
 
-    if (thisExtraIndex != -1 && parentExtraIndex == -1) return context;
-
-    // otherwise, we are creating a new instance
-    List<Object> copyOfExtra =
-        extras.isEmpty() ? new ArrayList<>() : new ArrayList<>(context.extra());
-    P fields;
-    if (thisExtraIndex == -1 && parentExtraIndex != -1) { // clone then parent (for copy-on-write)
-      fields = create((P) copyOfExtra.get(parentExtraIndex));
-      copyOfExtra.set(parentExtraIndex, fields);
-    } else if (thisExtraIndex != -1) { // merge with the parent
-      fields = ((P) copyOfExtra.get(thisExtraIndex));
-      P parent = (P) copyOfExtra.remove(parentExtraIndex); // ensures only one fields
-      fields.putAllIfAbsent(parent); // extracted wins vs parent
-    } else { // no fields were extracted and the parent also had no fields. create a new copy
-      fields = create();
-      copyOfExtra.add(fields);
+    // If we had only one extra, there are a few options:
+    // * we claimed an existing fields object successfully
+    // * we copied existing fields into a new fields object claimed by this ID
+    // * the existing extra was not a fields object, so we need to make a new list
+    if (extraSize == 1) {
+      if (consolidatedFields != null) {
+        if (consolidatedFields == extra) return context;
+        // otherwise we copied the fields of an existing object
+        return contextWithExtra(context, Collections.singletonList(consolidatedFields));
+      }
+      // we need to make new list to hold the unrelated extra element and our fields
+      extraFields = new ArrayList<>(2);
+      extraFields.add(extra);
+      extraFields.add(createExtraAndClaim(traceId, spanId));
+      return contextWithExtra(context, Collections.unmodifiableList(extraFields));
     }
-    TraceContext resultContext = context.toBuilder().extra(unmodifiableList(copyOfExtra)).build();
-    fields.tryAssociate(resultContext); // associate this with the new context
-    return resultContext;
+
+    // If we get here, we have at least one extra, but don't yet know if we need to create
+    // a new list. For example, if there is an unassociated fields object we may be able to
+    // avoid creating a new list.
+    for (int i = 1; i < extraSize; i++) {
+      extra = extraFields.get(i);
+      if (!type.isInstance(extra)) continue;
+      P existing = (P) extra;
+      if (consolidatedFields == null) {
+        if (existing.tryToClaim(traceId, spanId)) {
+          consolidatedFields = existing;
+          continue;
+        }
+        consolidatedFields = createExtraAndClaim(traceId, spanId);
+        consolidatedFields.putAllIfAbsent(existing);
+        extraFields = ensureMutable(extraFields);
+        extraFields.set(i, consolidatedFields);
+      } else {
+        consolidatedFields.putAllIfAbsent(existing);
+        extraFields = ensureMutable(extraFields);
+        extraFields.remove(i); // drop the previous fields item as we consolidated it
+        extraSize--;
+        i--;
+      }
+    }
+    if (consolidatedFields == null) {
+      consolidatedFields = createExtraAndClaim(traceId, spanId);
+      extraFields = ensureMutable(extraFields);
+      extraFields.add(consolidatedFields);
+    }
+    if (extraFields == context.extra()) return context;
+    return contextWithExtra(context, Collections.unmodifiableList(extraFields));
+  }
+
+  P createExtraAndClaim(long traceId, long spanId) {
+    P consolidatedFields = create();
+    consolidatedFields.tryToClaim(traceId, spanId);
+    return consolidatedFields;
+  }
+
+  protected TraceContext contextWithExtra(TraceContext context, List<Object> extra) {
+    return TraceContexts.contextWithExtra(context, extra);
   }
 }

--- a/brave/src/main/java/brave/internal/TraceContexts.java
+++ b/brave/src/main/java/brave/internal/TraceContexts.java
@@ -1,0 +1,46 @@
+package brave.internal;
+
+import brave.propagation.TraceContext;
+import java.util.List;
+
+public final class TraceContexts {
+  public static final int FLAG_SAMPLED = 1 << 1;
+  public static final int FLAG_SAMPLED_SET = 1 << 2;
+  public static final int FLAG_DEBUG = 1 << 3;
+  public static final int FLAG_SHARED = 1 << 4;
+
+  public static TraceContext contextWithFlags(TraceContext context, int flags) {
+    return InternalPropagation.instance.newTraceContext(
+        flags,
+        context.traceIdHigh(),
+        context.traceId(),
+        context.parentIdAsLong(),
+        context.spanId(),
+        context.extra()
+    );
+  }
+
+  public static TraceContext contextWithExtra(TraceContext context, List<Object> extra) {
+    return InternalPropagation.instance.newTraceContext(
+        InternalPropagation.instance.flags(context),
+        context.traceIdHigh(),
+        context.traceId(),
+        context.parentIdAsLong(),
+        context.spanId(),
+        Lists.ensureImmutable(extra)
+    );
+  }
+
+  public static int sampled(boolean sampled, int flags) {
+    if (sampled) {
+      flags |= FLAG_SAMPLED | FLAG_SAMPLED_SET;
+    } else {
+      flags |= FLAG_SAMPLED_SET;
+      flags &= ~FLAG_SAMPLED;
+    }
+    return flags;
+  }
+
+  TraceContexts() {
+  }
+}

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -123,18 +123,16 @@ public final class B3Propagation<K> implements Propagation<K> {
 
       String traceIdString = getter.get(carrier, propagation.traceIdKey);
       // It is ok to go without a trace ID, if sampling or debug is set
-      if (traceIdString == null) {
-        return TraceContextOrSamplingFlags.create(
-            debug ? SamplingFlags.DEBUG : SamplingFlags.Builder.build(sampledV)
-        );
-      }
+      if (traceIdString == null) return TraceContextOrSamplingFlags.create(sampledV, debug);
 
       // Try to parse the trace IDs into the context
       TraceContext.Builder result = TraceContext.newBuilder();
       if (result.parseTraceId(traceIdString, propagation.traceIdKey)
           && result.parseSpanId(getter, carrier, propagation.spanIdKey)
           && result.parseParentId(getter, carrier, propagation.parentSpanIdKey)) {
-        return TraceContextOrSamplingFlags.create(result.sampled(sampledV).debug(debug).build());
+        if (sampledV != null) result.sampled(sampledV.booleanValue());
+        if (debug) result.debug(true);
+        return TraceContextOrSamplingFlags.create(result.build());
       }
       return TraceContextOrSamplingFlags.EMPTY; // trace context is malformed so return empty
     }

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -24,16 +24,20 @@ import java.util.concurrent.ExecutorService;
  * com.google.inject.servlet.RequestScoper and com.github.kristofa.brave.CurrentSpan
  */
 public abstract class CurrentTraceContext {
+  static {
+    // ensure a reference to InternalPropagation exists
+    SamplingFlags.DEBUG.toString();
+  }
 
   /** Implementations of this allow standardized configuration, for example scope decoration. */
-  public abstract static class Builder<B extends Builder<B>> {
+  public abstract static class Builder {
     ArrayList<ScopeDecorator> scopeDecorators = new ArrayList<>();
 
     /** Implementations call decorators in order to add features like log correlation to a scope. */
-    public B addScopeDecorator(ScopeDecorator scopeDecorator) {
+    public Builder addScopeDecorator(ScopeDecorator scopeDecorator) {
       if (scopeDecorator == null) throw new NullPointerException("scopeDecorator == null");
       this.scopeDecorators.add(scopeDecorator);
-      return (B) this;
+      return this;
     }
 
     public abstract CurrentTraceContext build();
@@ -52,15 +56,11 @@ public abstract class CurrentTraceContext {
 
   final List<ScopeDecorator> scopeDecorators;
 
-  public interface Factory {
-    CurrentTraceContext create(List<ScopeDecorator> scopeDecorators);
-  }
-
   protected CurrentTraceContext() {
     this.scopeDecorators = Collections.emptyList();
   }
 
-  protected CurrentTraceContext(Builder<?> builder) {
+  protected CurrentTraceContext(Builder builder) {
     this.scopeDecorators = new ArrayList<>(builder.scopeDecorators);
   }
 

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -47,11 +47,13 @@ public interface Propagation<K> {
      * Decorates the input such that it can propagate extra data, such as a timestamp or a carrier
      * for extra fields.
      *
-     * <p>Implementations should be idempotent, returning the same instance where needed.
-     * Implementations are responsible for data scoping, if relevant. For example, if only global
-     * configuration is present, it could suffice to simply ensure that data is present. If data
-     * is span-scoped, an implementation might compare the context to its last span ID, copying on
-     * write or otherwise to ensure writes to one context don't affect another.
+     * <p>Implementations are responsible for data scoping, if relevant. For example, if only
+     * global configuration is present, it could suffice to simply ensure that data is present. If
+     * data is span-scoped, an implementation might compare the context to its last span ID, copying
+     * on write or otherwise to ensure writes to one context don't affect another.
+     *
+     * <p>Implementations should be idempotent, returning the same instance instead of re-applying
+     * change.
      *
      * @see TraceContext#extra()
      */

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -28,7 +28,7 @@ public final class StrictScopeDecorator implements ScopeDecorator {
         Thread.currentThread().getName(), currentSpan)));
   }
 
-  class StrictScope implements Scope {
+  static final class StrictScope implements Scope {
     final Scope delegate;
     final Throwable caller;
     final long threadId = Thread.currentThread().getId();

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -33,7 +33,7 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
     return new Builder();
   }
 
-  static final class Builder extends CurrentTraceContext.Builder<Builder> {
+  static final class Builder extends CurrentTraceContext.Builder{
 
     @Override public CurrentTraceContext build() {
       return new ThreadLocalCurrentTraceContext(this, DEFAULT);

--- a/brave/src/main/java/brave/propagation/ThreadLocalSpan.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalSpan.java
@@ -113,8 +113,8 @@ public class ThreadLocalSpan {
   }
 
   /**
-   * Returns the {@link Tracer#nextSpan(TraceContextOrSamplingFlags)} or null if {@link #CURRENT_TRACER}
-   * and tracing isn't available.
+   * Returns the {@link Tracer#nextSpan(TraceContextOrSamplingFlags)} or null if {@link
+   * #CURRENT_TRACER} and tracing isn't available.
    */
   @Nullable public Span next(TraceContextOrSamplingFlags extracted) {
     Tracer tracer = tracer();
@@ -142,8 +142,9 @@ public class ThreadLocalSpan {
    * Returns the span set in scope via {@link #next()} or null if there was none.
    *
    * <p>When assertions are on, this will throw an assertion error if the span returned was not the
-   * one currently in context. This could happen if someone called {@link Tracer#withSpanInScope(Span)}
-   * or {@link CurrentTraceContext#newScope(TraceContext)} outside a try/finally block.
+   * one currently in context. This could happen if someone called {@link
+   * Tracer#withSpanInScope(Span)} or {@link CurrentTraceContext#newScope(TraceContext)} outside a
+   * try/finally block.
    */
   @Nullable public Span remove() {
     Tracer tracer = tracer();

--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -1,11 +1,11 @@
 package brave.propagation;
 
 import brave.internal.Nullable;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import brave.internal.TraceContexts;
 
-import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 import static brave.internal.HexCodec.writeHexLong;
+import static brave.internal.TraceContexts.FLAG_SAMPLED;
+import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
 
 /**
  * Contains inbound trace ID and sampling flags, used when users control the root trace ID, but not
@@ -13,8 +13,6 @@ import static brave.internal.HexCodec.writeHexLong;
  */
 //@Immutable
 public final class TraceIdContext extends SamplingFlags {
-  static final Logger LOG = Logger.getLogger(TraceIdContext.class.getName());
-
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -30,7 +28,11 @@ public final class TraceIdContext extends SamplingFlags {
   }
 
   public Builder toBuilder() {
-    return new Builder(this);
+    Builder result = new Builder();
+    result.flags = flags;
+    result.traceIdHigh = traceIdHigh;
+    result.traceId = traceId;
+    return result;
   }
 
   /** Returns {@code $traceId} */
@@ -47,12 +49,9 @@ public final class TraceIdContext extends SamplingFlags {
     return new String(result);
   }
 
-  public static final class Builder extends InternalBuilder {
-    Builder(TraceIdContext context) { // no external implementations
-      traceIdHigh = context.traceIdHigh;
-      traceId = context.traceId;
-      flags = context.flags;
-    }
+  public static final class Builder {
+    long traceIdHigh, traceId;
+    int flags;
 
     /** @see TraceIdContext#traceIdHigh() */
     public Builder traceIdHigh(long traceIdHigh) {
@@ -67,30 +66,29 @@ public final class TraceIdContext extends SamplingFlags {
     }
 
     /** @see TraceIdContext#sampled() */
-    @Override public Builder sampled(boolean sampled) {
-      super.sampled(sampled);
+    public Builder sampled(boolean sampled) {
+      flags = TraceContexts.sampled(sampled, flags);
       return this;
     }
 
     /** @see TraceIdContext#sampled() */
-    @Override public Builder sampled(@Nullable Boolean sampled) {
-      super.sampled(sampled);
-      return this;
+    public Builder sampled(@Nullable Boolean sampled) {
+      if (sampled == null) {
+        flags &= ~(FLAG_SAMPLED_SET | FLAG_SAMPLED);
+        return this;
+      }
+      return sampled(sampled.booleanValue());
     }
 
     /** @see TraceIdContext#debug() */
-    @Override public Builder debug(boolean debug) {
-      super.debug(debug);
+    public Builder debug(boolean debug) {
+      flags = SamplingFlags.debug(debug, flags);
       return this;
     }
 
     public final TraceIdContext build() {
       if (traceId == 0L) throw new IllegalStateException("Missing: traceId");
-      return new TraceIdContext(this);
-    }
-
-    @Override Logger logger() {
-      return LOG;
+      return new TraceIdContext(flags, traceIdHigh, traceId);
     }
 
     Builder() { // no external implementations
@@ -99,10 +97,10 @@ public final class TraceIdContext extends SamplingFlags {
 
   final long traceIdHigh, traceId;
 
-  TraceIdContext(Builder builder) { // no external implementations
-    super(builder.flags);
-    traceIdHigh = builder.traceIdHigh;
-    traceId = builder.traceId;
+  TraceIdContext(int flags, long traceIdHigh, long traceId) { // no external implementations
+    super(flags);
+    this.traceIdHigh = traceIdHigh;
+    this.traceId = traceId;
   }
 
   /** Only includes mandatory fields {@link #traceIdHigh()} and {@link #traceId()} */
@@ -121,108 +119,5 @@ public final class TraceIdContext extends SamplingFlags {
     h *= 1000003;
     h ^= (int) ((traceId >>> 32) ^ traceId);
     return h;
-  }
-
-  static abstract class InternalBuilder {
-    abstract Logger logger();
-
-    long traceIdHigh, traceId;
-    int flags = 0; // bit field for sampled and debug
-
-    /**
-     * Returns true when {@link TraceContext#traceId()} and potentially also {@link TraceContext#traceIdHigh()}
-     * were parsed from the input. This assumes the input is valid, an up to 32 character lower-hex
-     * string.
-     *
-     * <p>Returns boolean, not this, for conditional, exception free parsing:
-     *
-     * <p>Example use:
-     * <pre>{@code
-     * // Attempt to parse the trace ID or break out if unsuccessful for any reason
-     * String traceIdString = getter.get(carrier, key);
-     * if (!builder.parseTraceId(traceIdString, propagation.traceIdKey)) {
-     *   return TraceContextOrSamplingFlags.EMPTY;
-     * }
-     * }</pre>
-     *
-     * @param traceIdString the 1-32 character lowerhex string
-     * @param key the name of the propagation field representing the trace ID; only using in logging
-     * @return false if the input is null or malformed
-     */
-    // temporarily package protected until we figure out if this is reusable enough to expose
-    final boolean parseTraceId(String traceIdString, Object key) {
-      if (isNull(key, traceIdString)) return false;
-      int length = traceIdString.length();
-      if (invalidIdLength(key, length, 32)) return false;
-
-      // left-most characters, if any, are the high bits
-      int traceIdIndex = Math.max(0, length - 16);
-      if (traceIdIndex > 0) {
-        traceIdHigh = lenientLowerHexToUnsignedLong(traceIdString, 0, traceIdIndex);
-        if (traceIdHigh == 0) {
-          maybeLogNotLowerHex(key, traceIdString);
-          return false;
-        }
-      }
-
-      // right-most up to 16 characters are the low bits
-      traceId = lenientLowerHexToUnsignedLong(traceIdString, traceIdIndex, length);
-      if (traceId == 0) {
-        maybeLogNotLowerHex(key, traceIdString);
-        return false;
-      }
-      return true;
-    }
-
-    boolean invalidIdLength(Object key, int length, int max) {
-      if (length > 1 && length <= max) return false;
-      Logger log = logger();
-      if (log.isLoggable(Level.FINE)) {
-        log.fine(key + " should be a 1 to " + max + " character lower-hex string with no prefix");
-      }
-      return true;
-    }
-
-    boolean isNull(Object key, String maybeNull) {
-      if (maybeNull != null) return false;
-      Logger log = logger();
-      if (log.isLoggable(Level.FINE)) log.fine(key + " was null");
-      return true;
-    }
-
-    void maybeLogNotLowerHex(Object key, String notLowerHex) {
-      Logger log = logger();
-      if (log.isLoggable(Level.FINE)) {
-        log.fine(key + ": " + notLowerHex + " is not a lower-hex string");
-      }
-    }
-
-    InternalBuilder sampled(boolean sampled) {
-      flags |= FLAG_SAMPLED_SET;
-      if (sampled) {
-        flags |= FLAG_SAMPLED;
-      } else {
-        flags &= ~FLAG_SAMPLED;
-      }
-      return this;
-    }
-
-    InternalBuilder sampled(@Nullable Boolean sampled) {
-      if (sampled != null) return sampled((boolean) sampled);
-      flags &= ~FLAG_SAMPLED_SET;
-      return this;
-    }
-
-    /** Ensures sampled is set when debug is */
-    InternalBuilder debug(boolean debug) {
-      if (debug) {
-        flags |= FLAG_DEBUG;
-        flags |= FLAG_SAMPLED_SET;
-        flags |= FLAG_SAMPLED;
-      } else {
-        flags &= ~FLAG_DEBUG;
-      }
-      return this;
-    }
   }
 }

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -613,4 +613,18 @@ public class TracerTest {
 
     assertThat(ExtraFieldPropagation.get(scoped.context(), "service")).isEqualTo("napkin");
   }
+
+  @Test public void startScopedSpan() {
+    ScopedSpan scoped = tracer.startScopedSpan("foo");
+    try {
+      assertThat(tracer.currentTraceContext.get()).isSameAs(scoped.context());
+    } finally {
+      scoped.finish();
+    }
+
+    assertThat(spans.get(0).name())
+        .isEqualTo("foo");
+    assertThat(spans.get(0).durationAsLong())
+        .isPositive();
+  }
 }

--- a/brave/src/test/java/brave/internal/ListsTest.java
+++ b/brave/src/test/java/brave/internal/ListsTest.java
@@ -1,0 +1,81 @@
+package brave.internal;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListsTest {
+
+  @Test public void ensureMutable_leavesArrayList() {
+    List<Object> list = new ArrayList<>();
+
+    assertThat(Lists.ensureMutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureMutable_copiesImmutable() {
+    List<Object> list = Collections.unmodifiableList(Arrays.asList("foo", "bar"));
+
+    assertThat(Lists.ensureMutable(list))
+        .isInstanceOf(ArrayList.class)
+        .containsExactlyElementsOf(list);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void ensureImmutable_returnsImmutableEmptyList() {
+    Lists.ensureImmutable(new ArrayList<>()).add("foo");
+  }
+
+  @Test public void ensureImmutable_convertsToSingletonList() {
+    List<Object> list = new ArrayList<>();
+    list.add("foo");
+    assertThat(Lists.ensureImmutable(list).getClass().getSimpleName())
+        .isEqualTo("SingletonList");
+  }
+
+  @Test public void ensureImmutable_returnsEmptyList() {
+    List<Object> list = Collections.emptyList();
+    assertThat(Lists.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureImmutable_doesntCopySingletonList() {
+    List<Object> list = Collections.singletonList("foo");
+    assertThat(Lists.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureImmutable_doesntCopyUnmodifiableList() {
+    List<Object> list = Collections.unmodifiableList(Arrays.asList("foo"));
+    assertThat(Lists.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void ensureImmutable_doesntCopyImmutableList() {
+    List<Object> list = ImmutableList.of("foo");
+    assertThat(Lists.ensureImmutable(list))
+        .isSameAs(list);
+  }
+
+  @Test public void concatImmutableLists_choosesNonEmpty() {
+    List<Object> list = ImmutableList.of("foo");
+    assertThat(Lists.concatImmutableLists(list, Collections.emptyList()))
+        .isSameAs(list);
+    assertThat(Lists.concatImmutableLists(Collections.emptyList(), list))
+        .isSameAs(list);
+  }
+
+  @Test public void concatImmutableLists_concatenates() {
+    List<Object> list1 = ImmutableList.of("foo");
+    List<Object> list2 = ImmutableList.of("bar", "baz");
+
+    assertThat(Lists.concatImmutableLists(list1, list2))
+        .hasSameClassAs(Collections.unmodifiableList(list1))
+        .containsExactly("foo", "bar", "baz");
+  }
+}

--- a/brave/src/test/java/brave/internal/MapPropagationFieldsTest.java
+++ b/brave/src/test/java/brave/internal/MapPropagationFieldsTest.java
@@ -1,5 +1,6 @@
 package brave.internal;
 
+import java.util.Map;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +30,21 @@ public class MapPropagationFieldsTest extends PropagationFieldsFactoryTest {
 
     assertThat(fields.values)
         .containsEntry("balloon-color", "red");
+  }
+
+  @Test public void put_idempotent() {
+    MapPropagationFields fields = (MapPropagationFields) factory.create();
+
+    fields.put("balloon-color", "red");
+    Map<String, String> fieldsMap = fields.values;
+
+    fields.put("balloon-color", "red");
+    assertThat(fields.values)
+        .isSameAs(fieldsMap);
+
+    fields.put("balloon-color", "blue");
+    assertThat(fields.values)
+        .isNotSameAs(fieldsMap);
   }
 
   @Test public void unmodifiable() {

--- a/brave/src/test/java/brave/internal/PredefinedPropagationFieldsTest.java
+++ b/brave/src/test/java/brave/internal/PredefinedPropagationFieldsTest.java
@@ -22,7 +22,7 @@ public class PredefinedPropagationFieldsTest extends PropagationFieldsFactoryTes
   }
 
   @Test public void put_ignore_if_not_defined() {
-    PropagationFields.put(context, "balloon-color", "red");
+    PropagationFields.put(context, "balloon-color", "red", factory.type());
 
     assertThat(((PropagationFields) context.extra().get(0)).toMap())
         .isEmpty();
@@ -35,6 +35,21 @@ public class PredefinedPropagationFieldsTest extends PropagationFieldsFactoryTes
 
     assertThat(fields)
         .isEqualToComparingFieldByField(factory.create());
+  }
+
+  @Test public void put_idempotent() {
+    PredefinedPropagationFields fields = (PredefinedPropagationFields) factory.create();
+
+    fields.put("foo", "red");
+    String[] fieldsArray = fields.values;
+
+    fields.put("foo", "red");
+    assertThat(fields.values)
+        .isSameAs(fieldsArray);
+
+    fields.put("foo", "blue");
+    assertThat(fields.values)
+        .isNotSameAs(fieldsArray);
   }
 
   @Test public void get_ignore_if_not_defined_index() {

--- a/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
+++ b/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
@@ -8,8 +8,11 @@ import brave.propagation.Propagation;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
+import java.util.List;
 import org.junit.Test;
 
+import static brave.internal.TraceContexts.contextWithExtra;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -31,7 +34,7 @@ public abstract class PropagationFieldsFactoryTest {
     }
   };
 
-  TraceContext context = factory.decorate(TraceContext.newBuilder()
+  TraceContext context = propagationFactory.decorate(TraceContext.newBuilder()
       .traceId(1L)
       .spanId(2L)
       .sampled(true)
@@ -41,27 +44,27 @@ public abstract class PropagationFieldsFactoryTest {
     try (Tracing tracing = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
 
       TraceContext context1 = tracing.tracer().nextSpan().context();
-      PropagationFields.put(context1, FIELD1, "1");
+      PropagationFields.put(context1, FIELD1, "1", factory.type());
       TraceContext context2 = tracing.tracer().newChild(context1).context();
 
       // Instances are not the same
-      assertThat(PropagationFields.find(context1.extra()))
-          .isNotSameAs(PropagationFields.find(context2.extra()));
+      assertThat(context1.findExtra(factory.type()))
+          .isNotSameAs(context2.findExtra(factory.type()));
 
       // But have the same values
-      assertThat(PropagationFields.find(context1.extra()).toMap())
-          .isEqualTo(PropagationFields.find(context2.extra()).toMap());
-      assertThat(PropagationFields.get(context1, FIELD1))
-          .isEqualTo(PropagationFields.get(context2, FIELD1))
+      assertThat(context1.<PropagationFields>findExtra(factory.type()).toMap())
+          .isEqualTo(context2.<PropagationFields>findExtra(factory.type()).toMap());
+      assertThat(PropagationFields.get(context1, FIELD1, factory.type()))
+          .isEqualTo(PropagationFields.get(context2, FIELD1, factory.type()))
           .isEqualTo("1");
 
-      PropagationFields.put(context1, FIELD1, "2");
-      PropagationFields.put(context2, FIELD1, "3");
+      PropagationFields.put(context1, FIELD1, "2", factory.type());
+      PropagationFields.put(context2, FIELD1, "3", factory.type());
 
       // Yet downstream changes don't affect eachother
-      assertThat(PropagationFields.get(context1, FIELD1))
+      assertThat(PropagationFields.get(context1, FIELD1, factory.type()))
           .isEqualTo("2");
-      assertThat(PropagationFields.get(context2, FIELD1))
+      assertThat(PropagationFields.get(context2, FIELD1, factory.type()))
           .isEqualTo("3");
     }
   }
@@ -70,7 +73,7 @@ public abstract class PropagationFieldsFactoryTest {
     try (Tracing tracing = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
 
       TraceContext context1 = tracing.tracer().nextSpan().context();
-      PropagationFields.put(context1, FIELD1, "1");
+      PropagationFields.put(context1, FIELD1, "1", factory.type());
 
       TraceContext context2 =
           tracing.tracer().toSpan(context1.toBuilder().sampled(false).build()).context();
@@ -92,7 +95,7 @@ public abstract class PropagationFieldsFactoryTest {
       assertThat(fields1.toMap()).isEqualTo(fields3.toMap());
 
       // inside the span, the same change is present, but the other span has the old values
-      PropagationFields.put(context1, FIELD1, "2");
+      PropagationFields.put(context1, FIELD1, "2", factory.type());
       assertThat(fields1).isEqualToComparingFieldByField(fields2);
       assertThat(fields3.get(FIELD1)).isEqualTo("1");
     }
@@ -111,7 +114,7 @@ public abstract class PropagationFieldsFactoryTest {
     try (Tracing tracing = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        PropagationFields.put(parent.context(), FIELD1, "1");
+        PropagationFields.put(parent.context(), FIELD1, "1", factory.type());
 
         PropagationFields extractedPropagationFields = factory.create();
         extractedPropagationFields.put(FIELD1, "2"); // extracted should win!
@@ -131,12 +134,43 @@ public abstract class PropagationFieldsFactoryTest {
             entry(FIELD1, "2"),
             entry(FIELD2, "a")
         );
-        assertThat(fields).extracting("context")
-            .containsExactly(context1);
+        assertThat(fields).extracting("traceId", "spanId")
+            .containsExactly(context1.traceId(), context1.spanId());
       } finally {
         parent.finish();
       }
     }
+  }
+
+  @Test public void decorate_empty() {
+    assertThat(factory.decorate(contextWithExtra(context, asList(1L))).extra())
+        .containsExactly(1L, factory.create());
+    assertThat(factory.decorate(contextWithExtra(context, asList(1L, 2L))).extra())
+        .containsExactly(1L, 2L, factory.create());
+    assertThat(factory.decorate(contextWithExtra(context, asList(factory.create()))).extra())
+        .containsExactly(factory.create());
+    assertThat(factory.decorate(contextWithExtra(context, asList(factory.create(), 1L))).extra())
+        .containsExactly(factory.create(), 1L);
+    assertThat(factory.decorate(contextWithExtra(context, asList(1L, factory.create()))).extra())
+        .containsExactly(1L, factory.create());
+
+    PropagationFields claimedBySelf = factory.create();
+    claimedBySelf.tryToClaim(context.traceId(), context.spanId());
+    assertThat(factory.decorate(contextWithExtra(context, asList(claimedBySelf))).extra())
+        .containsExactly(factory.create());
+    assertThat(factory.decorate(contextWithExtra(context, asList(claimedBySelf, 1L))).extra())
+        .containsExactly(factory.create(), 1L);
+    assertThat(factory.decorate(contextWithExtra(context, asList(1L, claimedBySelf))).extra())
+        .containsExactly(1L, factory.create());
+
+    PropagationFields claimedByOther = factory.create();
+    claimedBySelf.tryToClaim(99L, 99L);
+    assertThat(factory.decorate(contextWithExtra(context, asList(claimedByOther))).extra())
+        .containsExactly(factory.create());
+    assertThat(factory.decorate(contextWithExtra(context, asList(claimedByOther, 1L))).extra())
+        .containsExactly(factory.create(), 1L);
+    assertThat(factory.decorate(contextWithExtra(context, asList(1L, claimedByOther))).extra())
+        .containsExactly(1L, factory.create());
   }
 
   @Test public void nextSpanExtraWithImplicitParent_butNoImplicitExtraFields() {
@@ -159,8 +193,8 @@ public abstract class PropagationFieldsFactoryTest {
         PropagationFields fields = ((PropagationFields) context1.extra().get(0));
         assertThat(fields.toMap())
             .containsEntry(FIELD2, "a");
-        assertThat(fields).extracting("context")
-            .containsExactly(context1);
+        assertThat(fields).extracting("traceId", "spanId")
+            .containsExactly(context1.traceId(), context1.spanId());
       } finally {
         parent.finish();
       }
@@ -172,12 +206,13 @@ public abstract class PropagationFieldsFactoryTest {
 
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        PropagationFields.put(parent.context(), FIELD1, "1");
+        PropagationFields.put(parent.context(), FIELD1, "1", factory.type());
 
         TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
             .samplingFlags(SamplingFlags.EMPTY)
             .build();
 
+        // TODO didn't pass the reference from parent
         TraceContext context1 = tracing.tracer().nextSpan(extracted).context();
 
         assertThat(context1.extra()).hasSize(1); // didn't duplicate
@@ -185,8 +220,8 @@ public abstract class PropagationFieldsFactoryTest {
         PropagationFields fields = ((PropagationFields) context1.extra().get(0));
         assertThat(fields.toMap())
             .containsEntry(FIELD1, "1");
-        assertThat(fields).extracting("context")
-            .containsExactly(context1);
+        assertThat(fields).extracting("traceId", "spanId")
+            .containsExactly(context1.traceId(), context1.spanId());
       } finally {
         parent.finish();
       }
@@ -194,33 +229,40 @@ public abstract class PropagationFieldsFactoryTest {
   }
 
   @Test public void get() {
-    TraceContext context = factory.decorate(TraceContext.newBuilder().traceId(1).spanId(2).build());
-    PropagationFields.put(context, FIELD2, "a");
+    TraceContext context =
+        propagationFactory.decorate(TraceContext.newBuilder().traceId(1).spanId(2).build());
+    PropagationFields.put(context, FIELD2, "a", factory.type());
 
-    assertThat(PropagationFields.get(context, FIELD2))
+    assertThat(PropagationFields.get(context, FIELD2, factory.type()))
         .isEqualTo("a");
   }
 
   @Test public void get_null_if_not_set() {
-    assertThat(PropagationFields.get(context, FIELD2))
+    assertThat(PropagationFields.get(context, FIELD2, factory.type()))
         .isNull();
   }
 
   @Test public void get_ignore_if_not_defined() {
-    assertThat(PropagationFields.get(context, "balloon-color"))
+    assertThat(PropagationFields.get(context, "balloon-color", factory.type()))
         .isNull();
+  }
+
+  @Test public void idempotent() {
+    List<Object> originalExtra = context.extra();
+    assertThat(propagationFactory.decorate(context).extra())
+        .isSameAs(originalExtra);
   }
 
   @Test public void toSpan_selfLinksContext() {
     try (Tracing t = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
       ScopedSpan parent = t.tracer().startScopedSpan("parent");
       try {
-        PropagationFields.put(parent.context(), FIELD2, "a");
+        PropagationFields.put(parent.context(), FIELD2, "a", factory.type());
 
         PropagationFields fields = (PropagationFields) parent.context().extra().get(0);
 
-        assertThat(fields).extracting("context")
-            .containsExactly(parent.context());
+        assertThat(fields).extracting("traceId", "spanId")
+            .containsExactly(parent.context().traceId(), parent.context().spanId());
       } finally {
         parent.finish();
       }

--- a/brave/src/test/java/brave/internal/TraceContextsTest.java
+++ b/brave/src/test/java/brave/internal/TraceContextsTest.java
@@ -1,0 +1,58 @@
+package brave.internal;
+
+import brave.propagation.TraceContext;
+import java.util.Arrays;
+import org.junit.Test;
+
+import static brave.internal.TraceContexts.FLAG_SAMPLED;
+import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
+import static brave.internal.TraceContexts.contextWithExtra;
+import static brave.internal.TraceContexts.sampled;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceContextsTest {
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
+
+  @Test public void contextWithExtra_notEmpty() {
+    assertThat(contextWithExtra(context, Arrays.asList(1L)))
+        .extracting("extra")
+        .containsExactly(Arrays.asList(1L));
+  }
+
+  @Test public void contextWithExtra_empty() {
+    assertThat(contextWithExtra(context.toBuilder().extra(Arrays.asList(1L)).build(), emptyList()))
+        .extracting("extra")
+        .containsExactly(emptyList());
+  }
+
+  @Test public void get_sampled_true_object() {
+    assertThat(sampled(Boolean.TRUE, 0))
+        .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
+  }
+
+  @Test public void get_sampled_false_object() {
+    assertThat(sampled(Boolean.FALSE, FLAG_SAMPLED_SET | FLAG_SAMPLED))
+        .isEqualTo(FLAG_SAMPLED_SET);
+  }
+
+  @Test public void set_sampled_true_object() {
+    assertThat(sampled(Boolean.TRUE, 0))
+        .isEqualTo(FLAG_SAMPLED_SET + FLAG_SAMPLED);
+  }
+
+  @Test public void set_sampled_false_object() {
+    assertThat(sampled(Boolean.FALSE, FLAG_SAMPLED_SET | FLAG_SAMPLED))
+        .isEqualTo(FLAG_SAMPLED_SET);
+  }
+
+  @Test public void set_sampled_true() {
+    assertThat(sampled(true, 0))
+        .isEqualTo(FLAG_SAMPLED_SET + FLAG_SAMPLED);
+  }
+
+  @Test public void set_sampled_false() {
+    assertThat(sampled(false, FLAG_SAMPLED_SET | FLAG_SAMPLED))
+        .isEqualTo(FLAG_SAMPLED_SET);
+  }
+}

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -114,7 +114,7 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void inject_extra() {
-    PropagationFields fields = PropagationFields.find(context.extra());
+    PropagationFields fields = context.findExtra(ExtraFieldPropagation.Extra.class);
     fields.put("x-vcap-request-id", uuid);
 
     injector.inject(context, carrier);
@@ -123,7 +123,7 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void inject_two() {
-    PropagationFields fields = PropagationFields.find(context.extra());
+    PropagationFields fields = context.findExtra(ExtraFieldPropagation.Extra.class);
     fields.put("x-vcap-request-id", uuid);
     fields.put("x-amzn-trace-id", awsTraceId);
 
@@ -141,7 +141,7 @@ public class ExtraFieldPropagationTest {
         .build();
     initialize();
 
-    PropagationFields fields = PropagationFields.find(context.extra());
+    PropagationFields fields = context.findExtra(ExtraFieldPropagation.Extra.class);
     fields.put("x-vcap-request-id", uuid);
     fields.put("country-code", "FO");
 

--- a/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
@@ -1,16 +1,15 @@
 package brave.propagation;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
+import static brave.internal.TraceContexts.FLAG_DEBUG;
+import static brave.internal.TraceContexts.FLAG_SAMPLED;
+import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SamplingFlagsTest {
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void defaultIsEmpty() {
+  @Test public void builder_defaultIsEmpty() {
     SamplingFlags flags = new SamplingFlags.Builder().build();
 
     assertThat(flags).isSameAs(SamplingFlags.EMPTY);
@@ -18,7 +17,7 @@ public class SamplingFlagsTest {
     assertThat(flags.debug()).isFalse();
   }
 
-  @Test public void debugImpliesSampled() {
+  @Test public void builder_debugImpliesSampled() {
     SamplingFlags flags = new SamplingFlags.Builder().debug(true).build();
 
     assertThat(flags).isSameAs(SamplingFlags.DEBUG);
@@ -26,7 +25,7 @@ public class SamplingFlagsTest {
     assertThat(flags.debug()).isTrue();
   }
 
-  @Test public void sampled() {
+  @Test public void builder_sampled() {
     SamplingFlags flags = new SamplingFlags.Builder().sampled(true).build();
 
     assertThat(flags).isSameAs(SamplingFlags.SAMPLED);
@@ -34,7 +33,7 @@ public class SamplingFlagsTest {
     assertThat(flags.debug()).isFalse();
   }
 
-  @Test public void notSampled() {
+  @Test public void builder_notSampled() {
     SamplingFlags flags = new SamplingFlags.Builder().sampled(false).build();
 
     assertThat(flags).isSameAs(SamplingFlags.NOT_SAMPLED);
@@ -42,11 +41,23 @@ public class SamplingFlagsTest {
     assertThat(flags.debug()).isFalse();
   }
 
-  @Test public void nullSampled() {
+  @Test public void builder_nullSampled() {
     SamplingFlags flags = new SamplingFlags.Builder().sampled(true).sampled(null).build();
 
     assertThat(flags).isSameAs(SamplingFlags.EMPTY);
     assertThat(flags.sampled()).isNull();
     assertThat(flags.debug()).isFalse();
+  }
+
+  @Test public void debug_set_true() {
+    assertThat(SamplingFlags.debug(true, SamplingFlags.EMPTY.flags))
+        .isEqualTo(SamplingFlags.DEBUG.flags)
+        .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED | FLAG_DEBUG);
+  }
+
+  @Test public void sampled_flags() {
+    assertThat(SamplingFlags.debug(false, SamplingFlags.DEBUG.flags))
+        .isEqualTo(SamplingFlags.SAMPLED.flags)
+        .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
@@ -1,44 +1,171 @@
 package brave.propagation;
 
+import java.util.Collections;
 import org.junit.Test;
 
+import static brave.internal.TraceContexts.FLAG_SAMPLED;
+import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TraceContextOrSamplingFlagsTest {
+  TraceContext base = TraceContext.newBuilder().traceId(333L).spanId(1L).build();
+
+  @Test public void create_sampledNullDebugFalse() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(null, false);
+
+    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(flags.sampled()).isNull();
+    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.EMPTY);
+  }
+
+  @Test public void create_sampledNullDebugTrue() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(null, true);
+
+    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.DEBUG);
+    assertThat(flags.sampled()).isTrue();
+    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.DEBUG);
+  }
+
+  @Test public void create_sampledTrueDebugFalse() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(true, false);
+
+    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.SAMPLED);
+    assertThat(flags.sampled()).isTrue();
+    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.SAMPLED);
+  }
+
+  @Test public void create_sampledFalseDebugFalse() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(false, false);
+
+    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.NOT_SAMPLED);
+    assertThat(flags.sampled()).isFalse();
+    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.NOT_SAMPLED);
+  }
 
   @Test public void contextWhenIdsAreSet() {
-    TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).spanId(1L);
-    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder.build());
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.create(base);
 
-    assertThat(extracted.context())
-        .isEqualTo(builder.build());
-    assertThat(extracted.traceIdContext())
+    assertThat(toTest.context())
+        .isEqualTo(base);
+    assertThat(toTest.traceIdContext())
         .isNull();
-    assertThat(extracted.samplingFlags())
+    assertThat(toTest.samplingFlags())
         .isNull();
   }
 
   @Test public void contextWhenIdsAndSamplingAreSet() {
-    TraceContext.Builder builder = TraceContext.newBuilder().traceId(333L).spanId(1L).sampled(true);
-    TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(builder.build());
+    TraceContext.Builder builder = base.toBuilder().sampled(true);
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.create(builder.build());
 
-    assertThat(extracted.context())
+    assertThat(toTest.context())
         .isEqualTo(builder.build());
-    assertThat(extracted.traceIdContext())
+    assertThat(toTest.traceIdContext())
         .isNull();
-    assertThat(extracted.samplingFlags())
+    assertThat(toTest.samplingFlags())
         .isNull();
   }
 
-  @Test public void flags() {
-    TraceContextOrSamplingFlags extracted =
-        TraceContextOrSamplingFlags.create(SamplingFlags.SAMPLED);
+  @Test public void build_extra() {
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(base)
+        .addExtra(1L).build();
+    assertThat(toTest.extra()).isEmpty();
+    assertThat(toTest.context().extra()).containsExactly(1L);
 
-    assertThat(extracted.context())
+    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
+    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
+        .addExtra(1L).build();
+    assertThat(toTest.extra()).containsExactly(1L);
+
+    toTest = TraceContextOrSamplingFlags.newBuilder()
+        .samplingFlags(SamplingFlags.SAMPLED).addExtra(1L).build();
+    assertThat(toTest.extra()).containsExactly(1L);
+  }
+
+  @Test public void build_threeExtra() {
+    TraceContext context = base.toBuilder()
+        .extra(Collections.singletonList(1L)).build();
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(context)
+        .addExtra(2L).addExtra(3L).build();
+    assertThat(toTest.extra()).isEmpty();
+    assertThat(toTest.context().extra())
+        .containsExactly(1L, 2L, 3L);
+
+    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
+    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
+        .addExtra(1L).addExtra(2L).addExtra(3L).build();
+    assertThat(toTest.extra())
+        .containsExactly(1L, 2L, 3L);
+
+    toTest = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.SAMPLED)
+        .addExtra(1L).addExtra(2L).addExtra(3L).build();
+    assertThat(toTest.extra())
+        .containsExactly(1L, 2L, 3L);
+  }
+
+  @Test public void flags() {
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.create(SamplingFlags.SAMPLED);
+
+    assertThat(toTest.context())
         .isNull();
-    assertThat(extracted.traceIdContext())
+    assertThat(toTest.traceIdContext())
         .isNull();
-    assertThat(extracted.samplingFlags())
+    assertThat(toTest.samplingFlags())
         .isSameAs(SamplingFlags.SAMPLED);
+  }
+
+  @Test public void sampled_true() {
+    assertThat(TraceContextOrSamplingFlags.create(base).sampled(true).value.flags)
+        .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
+
+    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
+    assertThat(TraceContextOrSamplingFlags.create(idContext).sampled(true).value.flags)
+        .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
+
+    assertThat(TraceContextOrSamplingFlags.EMPTY.sampled(true).value.flags)
+        .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
+  }
+
+  @Test public void sampled_false() {
+    assertThat(TraceContextOrSamplingFlags.create(base).sampled(false).value.flags)
+        .isEqualTo(FLAG_SAMPLED_SET);
+
+    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
+    assertThat(TraceContextOrSamplingFlags.create(idContext).sampled(false).value.flags)
+        .isEqualTo(FLAG_SAMPLED_SET);
+
+    assertThat(TraceContextOrSamplingFlags.EMPTY.sampled(false).value.flags)
+        .isEqualTo(FLAG_SAMPLED_SET);
+  }
+
+  @Test public void sampled_true_noop() {
+    TraceContext context = base.toBuilder().sampled(true).build();
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(context)
+        .addExtra(1L).build();
+    assertThat(toTest.sampled(true)).isSameAs(toTest);
+
+    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).sampled(true).build();
+    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
+        .addExtra(1L).build();
+    assertThat(toTest.sampled(true)).isSameAs(toTest);
+
+    toTest = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.SAMPLED)
+        .addExtra(1L).build();
+    assertThat(toTest.sampled(true)).isSameAs(toTest);
+  }
+
+  @Test public void sampled_false_noop() {
+    TraceContext context = base.toBuilder().sampled(false).build();
+    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(context)
+        .addExtra(1L).build();
+    assertThat(toTest.sampled(false)).isSameAs(toTest);
+
+    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).sampled(false).build();
+    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
+        .addExtra(1L).build();
+    assertThat(toTest.sampled(false)).isSameAs(toTest);
+
+    toTest = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.NOT_SAMPLED)
+        .addExtra(1L).build();
+    assertThat(toTest.sampled(false)).isSameAs(toTest);
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceIdContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceIdContextTest.java
@@ -1,172 +1,80 @@
 package brave.propagation;
 
-import brave.internal.HexCodec;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TraceIdContextTest {
-  TraceIdContext context = TraceIdContext.newBuilder().traceId(333L).build();
+  TraceIdContext base = TraceIdContext.newBuilder().traceId(333L).build();
 
-  @Test public void compareUnequalIds() {
-    assertThat(context)
-        .isNotEqualTo(context.toBuilder().traceIdHigh(222L).build());
-  }
-
-  @Test public void compareEqualIds() {
-    assertThat(context)
-        .isEqualTo(TraceIdContext.newBuilder().traceId(333L).build());
-  }
-
-  @Test public void testToString_lo() {
-    assertThat(context.toString())
-        .isEqualTo("000000000000014d");
-  }
-
-  @Test public void testToString() {
-    assertThat(context.toBuilder().traceIdHigh(222L).build().toString())
-        .isEqualTo("00000000000000de000000000000014d");
-  }
-
-  @Test public void debugImpliesSampled() {
-    TraceIdContext primitives = context.toBuilder()
-        .debug(true)
-        .build();
-
-    TraceIdContext objects = context.toBuilder()
-        .sampled(Boolean.TRUE)
-        .debug(Boolean.TRUE)
-        .build();
-
-    assertThat(primitives)
-        .isEqualToComparingFieldByField(objects);
-  }
-
-  @Test public void canUsePrimitiveOverloads() {
-    TraceIdContext primitives = context.toBuilder()
+  @Test public void canUsePrimitiveOverloads_true() {
+    TraceIdContext primitives = base.toBuilder()
         .sampled(true)
         .debug(true)
         .build();
 
-    TraceIdContext objects = context.toBuilder()
+    TraceIdContext objects = base.toBuilder()
         .sampled(Boolean.TRUE)
         .debug(Boolean.TRUE)
         .build();
 
     assertThat(primitives)
         .isEqualToComparingFieldByField(objects);
-  }
-
-  @Test public void parseTraceId_128bit() {
-    String traceIdString = "463ac35c9f6413ad48485a3953bb6124";
-
-    TestBuilder builder = parseGoodTraceID(traceIdString);
-
-    assertThat(HexCodec.toLowerHex(builder.traceIdHigh))
-        .isEqualTo("463ac35c9f6413ad");
-    assertThat(HexCodec.toLowerHex(builder.traceId))
-        .isEqualTo("48485a3953bb6124");
-  }
-
-  @Test public void parseTraceId_64bit() {
-    String traceIdString = "48485a3953bb6124";
-
-    TestBuilder builder = parseGoodTraceID(traceIdString);
-
-    assertThat(builder.traceIdHigh).isZero();
-    assertThat(HexCodec.toLowerHex(builder.traceId))
-        .isEqualTo(traceIdString);
-  }
-
-  @Test public void parseTraceId_short128bit() {
-    String traceIdString = "3ac35c9f6413ad48485a3953bb6124";
-
-    TestBuilder builder = parseGoodTraceID(traceIdString);
-
-    assertThat(HexCodec.toLowerHex(builder.traceIdHigh))
-        .isEqualTo("003ac35c9f6413ad");
-    assertThat(HexCodec.toLowerHex(builder.traceId))
-        .isEqualTo("48485a3953bb6124");
-  }
-
-  @Test public void parseTraceId_short64bit() {
-    String traceIdString = "6124";
-
-    TestBuilder builder = parseGoodTraceID(traceIdString);
-
-    assertThat(builder.traceIdHigh).isZero();
-    assertThat(HexCodec.toLowerHex(builder.traceId))
-        .isEqualTo("000000000000" + traceIdString);
-  }
-
-  /**
-   * Trace ID is a required parameter, so it cannot be null empty malformed or other nonsense.
-   *
-   * <p>Notably, this shouldn't throw exception or allocate anything
-   */
-  @Test public void parseTraceId_malformedReturnsFalse() {
-    parseBadTraceId("463acL$c9f6413ad48485a3953bb6124");
-    parseBadTraceId("holy 💩");
-    parseBadTraceId("-");
-    parseBadTraceId("");
-    parseBadTraceId(null);
-
-    assertThat(messages).containsExactly(
-        "trace-id: 463acL$c9f6413ad48485a3953bb6124 is not a lower-hex string",
-        "trace-id: holy 💩 is not a lower-hex string",
-        "trace-id should be a 1 to 32 character lower-hex string with no prefix",
-        "trace-id should be a 1 to 32 character lower-hex string with no prefix",
-        "trace-id was null"
-    );
-  }
-
-  @Test public void parseTraceId_whenFineDisabledNoLogs() {
-    logger.setLevel(Level.INFO);
-
-    parseBadTraceId("463acL$c9f6413ad48485a3953bb6124");
-    parseBadTraceId("holy 💩");
-    parseBadTraceId("-");
-    parseBadTraceId("");
-    parseBadTraceId(null);
-
-    assertThat(messages).isEmpty();
-  }
-
-  TestBuilder parseGoodTraceID(String traceIdString) {
-    TestBuilder builder = new TestBuilder();
-    assertThat(builder.parseTraceId(traceIdString, "trace-id"))
+    assertThat(primitives.debug())
         .isTrue();
-    return builder;
+    assertThat(primitives.sampled())
+        .isTrue();
   }
 
-  void parseBadTraceId(String traceIdString) {
-    TestBuilder builder = new TestBuilder();
-    assertThat(builder.parseTraceId(traceIdString, "trace-id"))
+  @Test public void canUsePrimitiveOverloads_false() {
+    base = base.toBuilder().debug(true).build();
+
+    TraceIdContext primitives = base.toBuilder()
+        .sampled(false)
+        .debug(false)
+        .build();
+
+    TraceIdContext objects = base.toBuilder()
+        .sampled(Boolean.FALSE)
+        .debug(Boolean.FALSE)
+        .build();
+
+    assertThat(primitives)
+        .isEqualToComparingFieldByField(objects);
+    assertThat(primitives.debug())
         .isFalse();
-    assertThat(builder.traceIdHigh).isZero();
-    assertThat(builder.traceId).isZero();
+    assertThat(primitives.sampled())
+        .isFalse();
   }
 
-  List<String> messages = new ArrayList<>();
+  @Test public void canSetSampledNull() {
+    base = base.toBuilder().sampled(true).build();
 
-  Logger logger = new Logger("", null) {
-    {
-      setLevel(Level.ALL);
-    }
+    TraceIdContext objects = base.toBuilder().sampled(null).build();
 
-    @Override public void log(Level level, String msg) {
-      assertThat(level).isEqualTo(Level.FINE);
-      messages.add(msg);
-    }
-  };
+    assertThat(objects.debug())
+        .isFalse();
+    assertThat(objects.sampled())
+        .isNull();
+  }
 
-  class TestBuilder extends TraceIdContext.InternalBuilder {
-    @Override Logger logger() {
-      return logger;
-    }
+  @Test public void compareUnequalIds() {
+    assertThat(base)
+        .isNotEqualTo(base.toBuilder().traceIdHigh(222L).build());
+  }
+
+  @Test public void compareEqualIds() {
+    assertThat(base)
+        .isEqualTo(TraceIdContext.newBuilder().traceId(333L).build());
+  }
+
+  @Test public void testToString_lo() {
+    assertThat(base.toString())
+        .isEqualTo("000000000000014d");
+  }
+
+  @Test public void testToString() {
+    assertThat(base.toBuilder().traceIdHigh(222L).build().toString())
+        .isEqualTo("00000000000000de000000000000014d");
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/TracerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/TracerBenchmarks.java
@@ -175,7 +175,7 @@ public class TracerBenchmarks {
   public static void main(String[] args) throws Exception {
     Options opt = new OptionsBuilder()
         .addProfiler("gc")
-        .include(".*" + TracerBenchmarks.class.getSimpleName() + ".*")
+        .include(".*" + TracerBenchmarks.class.getSimpleName()+".*startScopedSpanWithParent_unsampled_extra")
         .build();
 
     new Runner(opt).run();

--- a/instrumentation/benchmarks/src/main/java/brave/grpc/GrpcPropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/grpc/GrpcPropagationBenchmarks.java
@@ -2,6 +2,7 @@ package brave.grpc;
 
 import brave.grpc.GrpcPropagation.Tags;
 import brave.internal.HexCodec;
+import brave.internal.PropagationFields;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
@@ -53,7 +54,7 @@ public class GrpcPropagationBenchmarks {
   static final Metadata nothingIncoming = new Metadata();
 
   static {
-    Tags.put(contextWithTags, "method", "helloworld.Greeter/SayHello");
+    PropagationFields.put(contextWithTags, "method", "helloworld.Greeter/SayHello", Tags.class);
     b3Injector.inject(context, incomingB3);
     bothInjector.inject(contextWithTags, incomingBoth);
     bothInjector.inject(context, incomingBothNoTags);

--- a/instrumentation/benchmarks/src/main/java/brave/grpc/TraceContextBinaryMarshallerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/grpc/TraceContextBinaryMarshallerBenchmarks.java
@@ -21,8 +21,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class TraceContextBinaryMarshallerBenchmarks {
-  static final TraceContextBinaryMarshaller marshaller = new TraceContextBinaryMarshaller();
-
   static final TraceContext context = TraceContext.newBuilder()
       .traceIdHigh(HexCodec.lowerHexToUnsignedLong("67891233abcdef01"))
       .traceId(HexCodec.lowerHexToUnsignedLong("2345678912345678"))
@@ -30,14 +28,14 @@ public class TraceContextBinaryMarshallerBenchmarks {
       .sampled(true)
       .build();
 
-  static final byte[] serialized = marshaller.toBytes(context);
+  static final byte[] serialized = TraceContextBinaryFormat.toBytes(context);
 
   @Benchmark public byte[] toBytes() {
-    return marshaller.toBytes(context);
+    return TraceContextBinaryFormat.toBytes(context);
   }
 
   @Benchmark public TraceContext parseBytes() {
-    return marshaller.parseBytes(serialized);
+    return TraceContextBinaryFormat.parseBytes(serialized, null);
   }
 
   // Convenience main entry-point

--- a/instrumentation/grpc/src/main/java/brave/grpc/TracingServerInterceptor.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TracingServerInterceptor.java
@@ -3,6 +3,7 @@ package brave.grpc;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
+import brave.grpc.GrpcPropagation.Tags;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -52,7 +53,7 @@ final class TracingServerInterceptor implements ServerInterceptor {
 
     // If grpc propagation is enabled, make sure we refresh the server method
     if (grpcPropagationFormatEnabled) {
-      GrpcPropagation.Tags tags = GrpcPropagation.findTags(span.context());
+      Tags tags = span.context().findExtra(Tags.class);
       if (tags != null) tags.put(RPC_METHOD, call.getMethodDescriptor().getFullMethodName());
     }
 

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITCensusInterop.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITCensusInterop.java
@@ -72,7 +72,7 @@ public class ITCensusInterop {
           tracing != null ? tracing.currentTraceContext().get() : null;
       Map<String, String> braveTags =
           currentTraceContext != null
-              ? GrpcPropagation.findTags(currentTraceContext).toMap()
+              ? currentTraceContext.findExtra(brave.grpc.GrpcPropagation.Tags.class).toMap()
               : Collections.emptyMap();
       for (Map.Entry<String, String> entry : braveTags.entrySet()) {
         spanCustomizer.tag(entry.getKey(), entry.getValue());

--- a/instrumentation/grpc/src/test/java/brave/grpc/TraceContextBinaryFormatTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TraceContextBinaryFormatTest.java
@@ -1,6 +1,8 @@
 package brave.grpc;
 
+import brave.grpc.GrpcPropagation.Tags;
 import brave.propagation.TraceContext;
+import java.util.Collections;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,12 +10,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests here are based on {@code io.opencensus.implcore.trace.propagation.BinaryFormatImplTest}
  */
-public class TraceContextBinaryMarshallerTest {
+public class TraceContextBinaryFormatTest {
   TraceContext context = TraceContext.newBuilder()
       .traceIdHigh(Long.MAX_VALUE).traceId(Long.MIN_VALUE)
       .spanId(-1)
       .sampled(true)
       .build();
+
   byte[] contextBytes = {
       0, // version
       0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0, // trace ID
@@ -21,103 +24,113 @@ public class TraceContextBinaryMarshallerTest {
       2, 1 // sampled
   };
 
-  TraceContextBinaryMarshaller binaryMarshaller = new TraceContextBinaryMarshaller();
-
   @Test public void roundtrip() {
-    byte[] serialized = binaryMarshaller.toBytes(context);
+    byte[] serialized = TraceContextBinaryFormat.toBytes(context);
     assertThat(serialized)
         .containsExactly(contextBytes);
 
-    assertThat(binaryMarshaller.parseBytes(serialized))
+    assertThat(TraceContextBinaryFormat.parseBytes(serialized, null))
         .isEqualTo(context);
   }
 
   @Test public void roundtrip_unsampled() {
     context = context.toBuilder().sampled(false).build();
 
-    byte[] serialized = binaryMarshaller.toBytes(context);
+    byte[] serialized = TraceContextBinaryFormat.toBytes(context);
     contextBytes[contextBytes.length - 1] = 0; // unsampled
     assertThat(serialized)
         .containsExactly(contextBytes);
 
-    assertThat(binaryMarshaller.parseBytes(serialized))
+    assertThat(TraceContextBinaryFormat.parseBytes(serialized, null))
+        .isEqualTo(context);
+  }
+
+  @Test public void roundtrip_tags() {
+    Tags tags = new Tags();
+    context = context.toBuilder().extra(Collections.singletonList(tags)).build();
+
+    byte[] serialized = TraceContextBinaryFormat.toBytes(context);
+    assertThat(serialized)
+        .containsExactly(contextBytes);
+
+    assertThat(TraceContextBinaryFormat.parseBytes(serialized, tags))
         .isEqualTo(context);
   }
 
   @Test public void parseBytes_empty_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[0]))
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[0], null))
         .isNull();
   }
 
   @Test public void parseBytes_unsupportedVersionId_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         1, // bad version
         0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0,
         1, -1, -1, -1, -1, -1, -1, -1, -1,
         2, 1
-    })).isNull();
+    }, null)).isNull();
   }
 
   @Test public void parseBytes_unsupportedFieldIdFirst_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         4, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0, // bad field number
         1, -1, -1, -1, -1, -1, -1, -1, -1,
         2, 1
-    })).isNull();
+    }, null)).isNull();
   }
 
   @Test public void parseBytes_unsupportedFieldIdSecond_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0,
         4, -1, -1, -1, -1, -1, -1, -1, -1, // bad field number
         2, 1
-    })).isNull();
+    }, null)).isNull();
   }
 
   @Test public void parseBytes_unsupportedFieldIdThird_toSampledNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0,
         1, -1, -1, -1, -1, -1, -1, -1, -1,
         4, 1 // bad field number
-    }).sampled()).isNull();
+    }, null).sampled()).isNull();
   }
 
   @Test public void parseBytes_64BitTraceId_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         0, 127, -1, -1, -1, -1, -1, -1, -1, // half a trace ID
         1, -1, -1, -1, -1, -1, -1, -1, -1,
         2, 1
-    })).isNull();
+    }, null)).isNull();
   }
 
   @Test public void parseBytes_32BitSpanId_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0,
         1, -1, -1, -1, -1, // half a span ID
         2, 1
-    })).isNull();
+    }, null)).isNull();
   }
 
   @Test public void parseBytes_truncatedTraceOptions_toNull() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0,
         1, -1, -1, -1, -1, -1, -1, -1, -1,
         2 // has field ID, but missing sampled bit
-    })).isNull();
+    }, null)).isNull();
   }
 
   @Test public void parseBytes_missingTraceOptions() {
-    assertThat(binaryMarshaller.parseBytes(new byte[] {
+    assertThat(TraceContextBinaryFormat.parseBytes(new byte[] {
         0,
         0, 127, -1, -1, -1, -1, -1, -1, -1, -128, 0, 0, 0, 0, 0, 0, 0,
         1, -1, -1, -1, -1, -1, -1, -1, -1,
         // no trace options field
-    })).isEqualTo(context);
+    }, null)).isEqualTo(context);
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -47,12 +47,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <h3>Debugging test failures</h3>
  *
  * <p>If a test hangs, likely {@link BlockingQueue#take()} is being called when a span wasn't
- * reported. An exception or bug could cause this (for example, the error handling route not
- * calling {@link brave.Span#finish()}).
+ * reported. An exception or bug could cause this (for example, the error handling route not calling
+ * {@link brave.Span#finish()}).
  *
- * <p>If a test fails on {@link After}, it can mean that your test created a span, but didn't {@link BlockingQueue#take()}
- * it off the queue. If you are testing something that creates a span, you may not want to verify
- * each one. In this case, at least take them similar to below:
+ * <p>If a test fails on {@link After}, it can mean that your test created a span, but didn't
+ * {@link
+ * BlockingQueue#take()} it off the queue. If you are testing something that creates a span, you may
+ * not want to verify each one. In this case, at least take them similar to below:
  *
  * <p><pre>{@code
  * for (int i = 0; i < 10; i++) takeSpan(); // we expected 10 spans
@@ -64,15 +65,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Testing such instrumentation could be easier, ex reporting into a list. Some other race-detecting
  * features may feel overkill in this case.
  *
- * <p>Consider though, this is a base class for all http instrumentation: servers (always report off
- * main thread) and asynchronous clients (often report off main). Also, even blocking clients can
- * execute their "on headers received" hook on a separate thread! Even if the http client you are
- * working on does everything on the same thread, a small change could invalidate that assumption.
- * If something written to work on one thread is suddenly working on two threads, tests can fail
- * "randomly", perhaps not until an unrelated change to JRE. When tests fail, they also make it
- * impossible to release new code until we disable the test or fix it. Bugs or race conditions
- * instrumentation can be very time consuming to solve. For example, they can appear as "flakes" in
- * CI servers such as Travis, which can be near impossible to debug.
+ * <p>Consider though, this is a base class for all http instrumentation: servers (always report
+ * off main thread) and asynchronous clients (often report off main). Also, even blocking clients
+ * can execute their "on headers received" hook on a separate thread! Even if the http client you
+ * are working on does everything on the same thread, a small change could invalidate that
+ * assumption. If something written to work on one thread is suddenly working on two threads, tests
+ * can fail "randomly", perhaps not until an unrelated change to JRE. When tests fail, they also
+ * make it impossible to release new code until we disable the test or fix it. Bugs or race
+ * conditions instrumentation can be very time consuming to solve. For example, they can appear as
+ * "flakes" in CI servers such as Travis, which can be near impossible to debug.
  *
  * <p>Bottom-line is that we accept that strict tests are harder up front, and not necessary for a
  * few types of blocking client instrumentation. However, the majority of http instrumentation have
@@ -88,7 +89,7 @@ public abstract class ITHttp {
    * to read them on the main thread, we use a concurrent queue. As some implementations report
    * after a response is sent, we use a blocking queue to prevent race conditions in tests.
    */
-  protected BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+  BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
   /** Call this to block until a span was reported */
   protected Span takeSpan() throws InterruptedException {
@@ -108,8 +109,8 @@ public abstract class ITHttp {
   protected HttpTracing httpTracing;
 
   /**
-   * This closes the current instance of tracing, to prevent it from being accidentally
-   * visible to other test classes which call {@link Tracing#current()}.
+   * This closes the current instance of tracing, to prevent it from being accidentally visible to
+   * other test classes which call {@link Tracing#current()}.
    */
   @After public void close() throws Exception {
     Tracing current = Tracing.current();

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -81,8 +81,10 @@ public final class HttpServerHandler<Req, Resp>
 
   /** Creates a potentially noop span representing this request */
   Span nextSpan(TraceContextOrSamplingFlags extracted, Req request) {
-    if (extracted.sampled() == null) { // Otherwise, try to make a new decision
-      extracted = extracted.sampled(sampler.trySample(adapter, request));
+    Boolean sampled = extracted.sampled();
+    // only recreate the context if the http sampler made a decision
+    if (sampled == null && (sampled = sampler.trySample(adapter, request)) != null) {
+      extracted = extracted.sampled(sampled.booleanValue());
     }
     return extracted.context() != null
         ? tracer.joinSpan(extracted.context())

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
@@ -88,8 +88,10 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
   /** Creates a potentially noop span representing this request */
   // copy/pasted from HttpServerHandler.nextSpan
   Span nextSpan(TraceContextOrSamplingFlags extracted, HttpRequest request) {
-    if (extracted.sampled() == null) { // Otherwise, try to make a new decision
-      extracted = extracted.sampled(sampler.trySample(adapter, request));
+    Boolean sampled = extracted.sampled();
+    // only recreate the context if the http sampler made a decision
+    if (sampled == null && (sampled = sampler.trySample(adapter, request)) != null) {
+      extracted = extracted.sampled(sampled.booleanValue());
     }
     return extracted.context() != null
         ? tracer.joinSpan(extracted.context())


### PR DESCRIPTION
After some trial and error with benchmarking, I found
`MutableTraceContext` is not enough a win unless we change api, which we
can't until Brave 6. Meanwhile, this optimizes as much as possible,
notably eliminating as many arraylist creations (from extra) as
possible.

Alternative to #755