### PR TITLE
Re-enables errorprone on JDK 10+

### DIFF
--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -218,39 +218,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration combine.self="override">
+              <!-- instead of javac-with-errorprone -->
+              <compilerId>javac</compilerId>
+              <!-- scrub errorprone compiler args -->
+              <compilerArgs/>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <!-- disable errorprone on JMH source tree -->
-      <id>error-prone-off</id>
-      <activation>
-        <!-- error-prone isn't happy in jdk 10 yet https://github.com/google/error-prone/issues/860#issuecomment-396154710 -->
-        <jdk>[1.8,10)</jdk>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <compilerId>javac-with-errorprone</compilerId>
-                  <compilerArgs>
-                    <arg>-XepDisableAllChecks</arg>
-                  </compilerArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -15,6 +15,9 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
 
+    <!-- disable errorprone override warning as we do this intentionally to allow old clients -->
+    <errorprone.args>-Xep:MissingOverride:OFF</errorprone.args>
+
     <kafka.version>2.0.0</kafka.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
     <kafka-junit.version>4.1.2</kafka-junit.version>
@@ -84,37 +87,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <!-- disable errorprone override warning as we do this intentionally to allow old clients -->
-      <id>error-prone-off</id>
-      <activation>
-        <!-- error-prone isn't happy in jdk 10 yet https://github.com/google/error-prone/issues/860#issuecomment-396154710 -->
-        <jdk>[1.8,10)</jdk>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-compile</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>compile</goal>
-                </goals>
-                <configuration>
-                  <compilerId>javac-with-errorprone</compilerId>
-                  <compilerArgs>
-                    <arg>-Xep:MissingOverride:OFF</arg>
-                  </compilerArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
+    <!-- override to set exclusions per-project -->
+    <!-- error-prone doesn't like generated code -->
+    <errorprone.args>-XepDisableWarningsInGeneratedCode</errorprone.args>
+
     <!-- use the same values in bom/pom.xml -->
     <zipkin.version>2.10.4</zipkin.version>
     <zipkin-reporter.version>2.7.7</zipkin-reporter.version>
@@ -617,8 +621,7 @@
                   <compilerId>javac-with-errorprone</compilerId>
                   <forceJavacCompilerUse>true</forceJavacCompilerUse>
                   <compilerArgs>
-                    <!-- error-prone doesn't like generated code -->
-                    <arg>-XepDisableWarningsInGeneratedCode</arg>
+                    <arg>${errorprone.args}</arg>
                   </compilerArgs>
                 </configuration>
               </execution>
@@ -661,7 +664,7 @@
                   <forceJavacCompilerUse>true</forceJavacCompilerUse>
                   <compilerArgs>
                     <arg>-XDcompilePolicy=simple</arg>
-                    <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode</arg>
+                    <arg>-Xplugin:ErrorProne ${errorprone.args}</arg>
                   </compilerArgs>
                   <annotationProcessorPaths>
                     <processorPath>

--- a/pom.xml
+++ b/pom.xml
@@ -661,14 +661,12 @@
                   <forceJavacCompilerUse>true</forceJavacCompilerUse>
                   <compilerArgs>
                     <arg>-XDcompilePolicy=simple</arg>
-                    <arg>-Xplugin:ErrorProne</arg>
-                    <!-- TODO: why does this not work? -->
-                    <!--<arg>-XepDisableWarningsInGeneratedCode</arg>-->
+                    <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode</arg>
                   </compilerArgs>
                   <annotationProcessorPaths>
                     <processorPath>
                       <groupId>com.google.errorprone</groupId>
-                      <artifactId>error_prone_ant</artifactId>
+                      <artifactId>error_prone_core</artifactId>
                       <version>2.3.1</version>
                     </processorPath>
                   </annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -596,10 +596,9 @@
 
   <profiles>
     <profile>
-      <id>error-prone</id>
+      <id>error-prone-1.8</id>
       <activation>
-        <!-- error-prone isn't happy in jdk 10 yet https://github.com/google/error-prone/issues/860#issuecomment-396154710 -->
-        <jdk>[1.8,10)</jdk>
+        <jdk>1.8</jdk>
         <activeByDefault>false</activeByDefault>
       </activation>
       <build>
@@ -617,8 +616,8 @@
                 <configuration>
                   <compilerId>javac-with-errorprone</compilerId>
                   <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                  <!-- error-prone doesn't like generated code -->
                   <compilerArgs>
+                    <!-- error-prone doesn't like generated code -->
                     <arg>-XepDisableWarningsInGeneratedCode</arg>
                   </compilerArgs>
                 </configuration>
@@ -636,6 +635,46 @@
                 <version>2.3.1</version>
               </dependency>
             </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>error-prone-9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- only use errorprone on main source tree -->
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                  <compilerArgs>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>-Xplugin:ErrorProne</arg>
+                    <!-- TODO: why does this not work? -->
+                    <!--<arg>-XepDisableWarningsInGeneratedCode</arg>-->
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <processorPath>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_ant</artifactId>
+                      <version>2.3.1</version>
+                    </processorPath>
+                  </annotationProcessorPaths>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
This uses the commandline instructions here:
  http://errorprone.info/docs/installation

See https://github.com/google/error-prone/issues/860