### PR TITLE
Adds B3SinglePropagation for the "b3" header

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
@@ -1,5 +1,6 @@
 package brave.propagation;
 
+import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.test.propagation.PropagationTest;
 import java.util.Map;
@@ -83,5 +84,18 @@ public class B3PropagationTest extends PropagationTest<String> {
 
     assertThat(result.sampled())
         .isTrue();
+  }
+
+  @Test public void extractTraceContext_singleHeaderFormat() {
+    MapEntry mapEntry = new MapEntry();
+
+    map.put("b3", "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7");
+
+    TraceContext result = propagation().extractor(mapEntry).extract(map).context();
+
+    assertThat(result.traceIdString())
+        .isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+    assertThat(HexCodec.toLowerHex(result.spanId()))
+        .isEqualTo("00f067aa0ba902b7");
   }
 }

--- a/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
@@ -1,0 +1,93 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import brave.test.propagation.PropagationTest;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class B3SinglePropagationTest extends PropagationTest<String> {
+  @Override protected Propagation<String> propagation() {
+    return Propagation.B3_SINGLE_STRING;
+  }
+
+  @Override protected void inject(Map<String, String> map, @Nullable String traceId,
+      @Nullable String parentId, @Nullable String spanId, @Nullable Boolean sampled,
+      @Nullable Boolean debug) {
+    StringBuilder builder = new StringBuilder();
+    if (traceId == null) {
+      if (sampled != null) {
+        builder.append(sampled ? '1' : '0');
+        if (debug != null) builder.append(debug ? "-1" : "-0");
+      } else if (Boolean.TRUE.equals(debug)) {
+        builder.append("1-1");
+      }
+    } else {
+      builder.append(traceId).append('-').append(spanId);
+      if (sampled != null) builder.append(sampled ? "-1" : "-0");
+      if (parentId != null) builder.append('-').append(parentId);
+      if (debug != null) builder.append(debug ? "-1" : "-0");
+    }
+    if (builder.length() != 0) map.put("b3", builder.toString());
+  }
+
+  @Override protected void inject(Map<String, String> carrier, SamplingFlags flags) {
+    if (flags.debug()) {
+      carrier.put("b3", "1-1");
+    } else if (flags.sampled() != null) {
+      carrier.put("b3", flags.sampled() ? "1" : "0");
+    }
+  }
+
+  @Test public void extractTraceContext_sampledFalse() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("b3", "0");
+
+    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test public void extractTraceContext_sampledFalseUpperCase() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("B3", "0");
+
+    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test public void extractTraceContext_malformed() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("b3", "not-a-tumor");
+
+    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void extractTraceContext_malformed_uuid() {
+    MapEntry mapEntry = new MapEntry();
+    map.put("b3", "b970dafd-0d95-40aa-95d8-1d8725aebe40");
+
+    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+
+    assertThat(result)
+        .isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test public void extractTraceContext_debug_with_ids() {
+    MapEntry mapEntry = new MapEntry();
+
+    map.put("b3", "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1-1");
+
+    TraceContext result = propagation().extractor(mapEntry).extract(map).context();
+
+    assertThat(result.debug())
+        .isTrue();
+  }
+}

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -1,13 +1,13 @@
 package brave.propagation;
 
 import brave.propagation.B3SinglePropagation.B3SingleExtractor;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static brave.internal.HexCodec.toLowerHex;
 import static brave.propagation.B3SinglePropagation.LOWER_NAME;
 import static brave.propagation.B3SinglePropagation.UPPER_NAME;
+import static java.util.Arrays.asList;
 
 /**
  * Implements <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
@@ -61,7 +61,7 @@ public final class B3Propagation<K> implements Propagation<K> {
     this.sampledKey = keyFactory.create(SAMPLED_NAME);
     this.debugKey = keyFactory.create(FLAGS_NAME);
     this.fields = Collections.unmodifiableList(
-        Arrays.asList(traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey)
+        asList(lowerKey, upperKey, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey)
     );
   }
 

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -1,10 +1,13 @@
 package brave.propagation;
 
+import brave.propagation.B3SinglePropagation.B3SingleExtractor;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static brave.internal.HexCodec.toLowerHex;
+import static brave.propagation.B3SinglePropagation.LOWER_NAME;
+import static brave.propagation.B3SinglePropagation.UPPER_NAME;
 
 /**
  * Implements <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
@@ -46,6 +49,8 @@ public final class B3Propagation<K> implements Propagation<K> {
    * "1" implies sampled and is a request to override collection-tier sampling policy.
    */
   static final String FLAGS_NAME = "X-B3-Flags";
+  final K lowerKey; // only for extraction
+  final K upperKey; // only for extraction
   final K traceIdKey;
   final K spanIdKey;
   final K parentSpanIdKey;
@@ -54,6 +59,8 @@ public final class B3Propagation<K> implements Propagation<K> {
   final List<K> fields;
 
   B3Propagation(KeyFactory<K> keyFactory) {
+    this.lowerKey = keyFactory.create(LOWER_NAME);
+    this.upperKey = keyFactory.create(UPPER_NAME);
     this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
     this.spanIdKey = keyFactory.create(SPAN_ID_NAME);
     this.parentSpanIdKey = keyFactory.create(PARENT_SPAN_ID_NAME);
@@ -104,15 +111,23 @@ public final class B3Propagation<K> implements Propagation<K> {
 
   static final class B3Extractor<C, K> implements TraceContext.Extractor<C> {
     final B3Propagation<K> propagation;
+    final B3SingleExtractor<C, K> singleExtractor;
     final Getter<C, K> getter;
 
     B3Extractor(B3Propagation<K> propagation, Getter<C, K> getter) {
       this.propagation = propagation;
+      this.singleExtractor =
+          new B3SingleExtractor<>(propagation.lowerKey, propagation.upperKey, getter);
       this.getter = getter;
     }
 
     @Override public TraceContextOrSamplingFlags extract(C carrier) {
       if (carrier == null) throw new NullPointerException("carrier == null");
+
+      // try to extract single-header format
+      TraceContextOrSamplingFlags extracted = singleExtractor.extract(carrier);
+      if (extracted != TraceContextOrSamplingFlags.EMPTY) return extracted;
+
       // Start by looking at the sampled state as this is used regardless
       // Official sampled value is 1, though some old instrumentation send true
       String sampled = getter.get(carrier, propagation.sampledKey);

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -120,7 +120,7 @@ public final class B3Propagation<K> implements Propagation<K> {
 
       // try to extract single-header format
       TraceContextOrSamplingFlags extracted = singleExtractor.extract(carrier);
-      if (extracted != TraceContextOrSamplingFlags.EMPTY) return extracted;
+      if (!extracted.equals(TraceContextOrSamplingFlags.EMPTY)) return extracted;
 
       // Start by looking at the sampled state as this is used regardless
       // Official sampled value is 1, though some old instrumentation send true

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -49,13 +49,7 @@ public final class B3Propagation<K> implements Propagation<K> {
    * "1" implies sampled and is a request to override collection-tier sampling policy.
    */
   static final String FLAGS_NAME = "X-B3-Flags";
-  final K lowerKey; // only for extraction
-  final K upperKey; // only for extraction
-  final K traceIdKey;
-  final K spanIdKey;
-  final K parentSpanIdKey;
-  final K sampledKey;
-  final K debugKey;
+  final K lowerKey, upperKey, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey;
   final List<K> fields;
 
   B3Propagation(KeyFactory<K> keyFactory) {

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -1,0 +1,168 @@
+package brave.propagation;
+
+import brave.internal.Nullable;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
+import static brave.internal.HexCodec.writeHexLong;
+import static brave.internal.TraceContexts.FLAG_DEBUG;
+import static brave.internal.TraceContexts.FLAG_SAMPLED;
+import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
+import static java.util.logging.Level.FINE;
+
+/** Implements the progation format described in {@link B3SinglePropagation}. */
+final class B3SingleFormat {
+  static final Logger logger = Logger.getLogger(B3SingleFormat.class.getName());
+  static final int FORMAT_MAX_LENGTH = 32 + 1 + 16 + 2 + 16 + 2; // traceid128-spanid-1-parentid-1
+
+  static String writeB3SingleFormat(TraceContext context) {
+    char[] result = getCharBuffer();
+    int pos = 0;
+    long traceIdHigh = context.traceIdHigh();
+    if (traceIdHigh != 0L) {
+      writeHexLong(result, pos, traceIdHigh);
+      pos += 16;
+    }
+    writeHexLong(result, pos, context.traceId());
+    pos += 16;
+    result[pos++] = '-';
+    writeHexLong(result, pos, context.spanId());
+    pos += 16;
+
+    Boolean sampled = context.sampled();
+    if (sampled != null) {
+      result[pos++] = '-';
+      result[pos++] = (sampled == Boolean.TRUE) ? '1' : '0';
+    }
+
+    long b3Id = context.parentIdAsLong();
+    if (b3Id != 0) {
+      result[pos++] = '-';
+      writeHexLong(result, pos, b3Id);
+      pos += 16;
+    }
+
+    if (context.debug()) {
+      result[pos++] = '-';
+      result[pos++] = '1';
+    }
+    return new String(result, 0, pos);
+  }
+
+  static @Nullable TraceContextOrSamplingFlags maybeB3SingleFormat(String b3) {
+    int length = b3.length();
+    if (length == 1) {
+      int flags = parseSampledFlag(b3, 0);
+      if (flags == 0) return null;
+      return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
+    } else if (length == 3) {
+      int flags = parseSampledFlag(b3, 0);
+      if (flags == 0) return null;
+      flags = parseDebugFlag(b3, 2, flags);
+      if (flags == 0) return null;
+      return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
+    }
+
+    // At this point we minimally expect a traceId-spanId pair
+    if (length < 16 + 1 + 16 /* traceid64-spanid */) {
+      logger.fine("Invalid input: truncated");
+      return null;
+    } else if (length > FORMAT_MAX_LENGTH) {
+      logger.fine("Invalid input: too long");
+      return null;
+    }
+
+    int pos = 0;
+    long traceIdHigh, traceId;
+    if (b3.charAt(32) == '-') {
+      traceIdHigh = lenientLowerHexToUnsignedLong(b3, 0, 16);
+      traceId = lenientLowerHexToUnsignedLong(b3, 16, 32);
+      pos += 33; // traceid128-
+    } else {
+      traceIdHigh = 0L;
+      traceId = lenientLowerHexToUnsignedLong(b3, 0, 16);
+      pos += 17; // traceid64-
+    }
+
+    if (traceIdHigh == 0L && traceId == 0L) {
+      logger.fine("Invalid input: expected a 16 or 32 lower hex trace ID at offset 0");
+      return null;
+    }
+
+    long spanId = lenientLowerHexToUnsignedLong(b3, pos, pos + 16);
+    if (spanId == 0L) {
+      logger.log(FINE, "Invalid input: expected a 16 lower hex span ID at offset {0}", pos);
+      return null;
+    }
+    pos += 17; // spanid-
+
+    int flags = 0;
+    if (length == pos + 1 || (length > pos + 2 && b3.charAt(pos + 1) == '-')) {
+      flags = parseSampledFlag(b3, pos++);
+      if (flags == 0) return null;
+      pos++; // skip the dash
+    }
+
+    long parentId = 0L;
+    if (length >= pos + 17) {
+      parentId = lenientLowerHexToUnsignedLong(b3, pos, pos + 16);
+      if (parentId == 0L) {
+        logger.log(FINE, "Invalid input: expected a 16 lower hex parent ID at offset {0}", pos);
+        return null;
+      }
+      pos += 17;
+    }
+
+    if (length == pos + 1) {
+      flags = parseDebugFlag(b3, pos, flags);
+      if (flags == 0) return null;
+    }
+
+    return TraceContextOrSamplingFlags.create(new TraceContext(
+        flags,
+        traceIdHigh,
+        traceId,
+        parentId,
+        spanId,
+        Collections.emptyList()
+    ));
+  }
+
+
+  static int parseSampledFlag(String b3, int pos) {
+    int flags;
+    char sampledChar = b3.charAt(pos);
+    if (sampledChar == '1') {
+      flags = FLAG_SAMPLED_SET | FLAG_SAMPLED;
+    } else if (sampledChar == '0') {
+      flags = FLAG_SAMPLED_SET;
+    } else {
+      logger.log(FINE, "Invalid input: expected 0 or 1 for sampled at offset {0}", pos);
+      flags = 0;
+    }
+    return flags;
+  }
+
+  static int parseDebugFlag(String b3, int pos, int flags) {
+    char lastChar = b3.charAt(pos);
+    if (lastChar == '1') {
+      flags = FLAG_DEBUG | FLAG_SAMPLED_SET | FLAG_SAMPLED;
+    } else if (lastChar != '0') { // redundant to say debug false, but whatev
+      logger.log(FINE, "Invalid input: expected 1 for debug at offset {0}", pos);
+      flags = 0;
+    }
+    return flags;
+  }
+
+  static final ThreadLocal<char[]> CHAR_BUFFER = new ThreadLocal<>();
+
+  static char[] getCharBuffer() {
+    char[] charBuffer = CHAR_BUFFER.get();
+    if (charBuffer == null) {
+      charBuffer = new char[FORMAT_MAX_LENGTH];
+      CHAR_BUFFER.set(charBuffer);
+    }
+    return charBuffer;
+  }
+}

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -33,7 +33,7 @@ final class B3SingleFormat {
     Boolean sampled = context.sampled();
     if (sampled != null) {
       result[pos++] = '-';
-      result[pos++] = (sampled == Boolean.TRUE) ? '1' : '0';
+      result[pos++] = sampled ? '1' : '0';
     }
 
     long b3Id = context.parentIdAsLong();

--- a/brave/src/main/java/brave/propagation/B3SinglePropagation.java
+++ b/brave/src/main/java/brave/propagation/B3SinglePropagation.java
@@ -48,8 +48,7 @@ public final class B3SinglePropagation<K> implements Propagation<K> {
   static final String LOWER_NAME = "b3";
   static final String UPPER_NAME = "B3";
 
-  final K lowerKey;
-  final K upperKey;
+  final K lowerKey, upperKey;
   final List<K> fields;
 
   B3SinglePropagation(KeyFactory<K> keyFactory) {
@@ -87,8 +86,7 @@ public final class B3SinglePropagation<K> implements Propagation<K> {
   }
 
   static final class B3SingleExtractor<C, K> implements TraceContext.Extractor<C> {
-    final K lowerKey;
-    final K upperKey;
+    final K lowerKey, upperKey;
     final Getter<C, K> getter;
 
     B3SingleExtractor(K lowerKey, K upperKey, Getter<C, K> getter) {

--- a/brave/src/main/java/brave/propagation/B3SinglePropagation.java
+++ b/brave/src/main/java/brave/propagation/B3SinglePropagation.java
@@ -1,0 +1,113 @@
+package brave.propagation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This format corresponds to the propagation key "b3" (or "B3"), which delimits fields in the
+ * following manner.
+ *
+ * <pre>{@code
+ * b3: {x-b3-traceid}-{x-b3-spanid}-{x-b3-sampled}-{x-b3-parentspanid}-{x-b3-flags}
+ * }</pre>
+ *
+ * <p>For example, a sampled root span would look like:
+ * {@code 4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1}
+ *
+ * <p>Like normal B3, it is valid to omit trace identifiers in order to only propagate a sampling
+ * decision. For example, the following are valid downstream hints:
+ * <ul>
+ * <li>sampled - {@code b3: 1}</li>
+ * <li>unsampled - {@code b3: 0}</li>
+ * <li>debug - {@code b3: 1-1}</li>
+ * </ul>
+ * Note: {@code b3: 0-1} isn't supported as it doesn't make sense. Debug boosts ordinary sampling
+ * decision to also affect the collector tier. {@code b3: 0-1} would be like saying, don't sample,
+ * except at the collector tier, which is impossible as if you don't sample locally the data will
+ * never arrive at a collector.
+ *
+ * <p>See <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
+ */
+public final class B3SinglePropagation<K> implements Propagation<K> {
+
+  public static final Factory FACTORY = new Factory() {
+    @Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+      return new B3SinglePropagation<>(keyFactory);
+    }
+
+    @Override public boolean supportsJoin() {
+      return true;
+    }
+
+    @Override public String toString() {
+      return "B3SinglePropagationFactory";
+    }
+  };
+
+  static final String LOWER_NAME = "b3";
+  static final String UPPER_NAME = "B3";
+
+  final K lowerKey;
+  final K upperKey;
+  final List<K> fields;
+
+  B3SinglePropagation(KeyFactory<K> keyFactory) {
+    this.lowerKey = keyFactory.create(LOWER_NAME);
+    this.upperKey = keyFactory.create(UPPER_NAME);
+    this.fields = Collections.unmodifiableList(Arrays.asList(lowerKey, upperKey));
+  }
+
+  @Override public List<K> keys() {
+    return fields;
+  }
+
+  @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+    if (setter == null) throw new NullPointerException("setter == null");
+    return new B3SingleInjector<>(this, setter);
+  }
+
+  static final class B3SingleInjector<C, K> implements TraceContext.Injector<C> {
+    final B3SinglePropagation<K> propagation;
+    final Setter<C, K> setter;
+
+    B3SingleInjector(B3SinglePropagation<K> propagation, Setter<C, K> setter) {
+      this.propagation = propagation;
+      this.setter = setter;
+    }
+
+    @Override public void inject(TraceContext traceContext, C carrier) {
+      setter.put(carrier, propagation.lowerKey, B3SingleFormat.writeB3SingleFormat(traceContext));
+    }
+  }
+
+  @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+    if (getter == null) throw new NullPointerException("getter == null");
+    return new B3SingleExtractor<>(lowerKey, upperKey, getter);
+  }
+
+  static final class B3SingleExtractor<C, K> implements TraceContext.Extractor<C> {
+    final K lowerKey;
+    final K upperKey;
+    final Getter<C, K> getter;
+
+    B3SingleExtractor(K lowerKey, K upperKey, Getter<C, K> getter) {
+      this.lowerKey = lowerKey;
+      this.upperKey = upperKey;
+      this.getter = getter;
+    }
+
+    @Override public TraceContextOrSamplingFlags extract(C carrier) {
+      if (carrier == null) throw new NullPointerException("carrier == null");
+      String b3 = getter.get(carrier, lowerKey);
+      // In case someone accidentally propagated the wrong case format
+      if (b3 == null) b3 = getter.get(carrier, upperKey);
+      if (b3 == null) return TraceContextOrSamplingFlags.EMPTY;
+
+      TraceContextOrSamplingFlags extracted = B3SingleFormat.maybeB3SingleFormat(b3);
+      // if null, the trace context is malformed so return empty
+      if (extracted == null) return TraceContextOrSamplingFlags.EMPTY;
+      return extracted;
+    }
+  }
+}

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -19,6 +19,8 @@ import java.util.List;
  */
 public interface Propagation<K> {
   Propagation<String> B3_STRING = B3Propagation.FACTORY.create(Propagation.KeyFactory.STRING);
+  Propagation<String> B3_SINGLE_STRING =
+      B3SinglePropagation.FACTORY.create(Propagation.KeyFactory.STRING);
 
   abstract class Factory {
     /**

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -30,11 +30,6 @@ public class SamplingFlags {
     };
   }
 
-  public SamplingFlags build() {
-    return flags == 0 ? EMPTY : SamplingFlags.debug(flags) ? DEBUG
-        : (flags & FLAG_SAMPLED) == FLAG_SAMPLED ? SAMPLED : NOT_SAMPLED;
-  }
-
   final int flags; // bit field for sampled and debug
 
   SamplingFlags(int flags) {
@@ -108,8 +103,7 @@ public class SamplingFlags {
     }
 
     public SamplingFlags build() {
-      return flags == 0 ? EMPTY : SamplingFlags.debug(flags) ? DEBUG
-          : (flags & FLAG_SAMPLED) == FLAG_SAMPLED ? SAMPLED : NOT_SAMPLED;
+      return toSamplingFlags(flags);
     }
   }
 
@@ -124,5 +118,10 @@ public class SamplingFlags {
       flags &= ~FLAG_DEBUG;
     }
     return flags;
+  }
+
+  static SamplingFlags toSamplingFlags(int flags) {
+    return flags == 0 ? EMPTY : SamplingFlags.debug(flags) ? DEBUG
+        : (flags & FLAG_SAMPLED) == FLAG_SAMPLED ? SAMPLED : NOT_SAMPLED;
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
@@ -1,0 +1,89 @@
+package brave.propagation;
+
+import brave.internal.HexCodec;
+import brave.propagation.TraceContext.Extractor;
+import brave.propagation.TraceContext.Injector;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class B3SinglePropagationBenchmarks {
+  static final Propagation<String> b3 = Propagation.B3_SINGLE_STRING;
+  static final Injector<Map<String, String>> b3Injector = b3.injector(Map::put);
+  static final Extractor<Map<String, String>> b3Extractor = b3.extractor(Map::get);
+
+  static final TraceContext context = TraceContext.newBuilder()
+      .traceIdHigh(HexCodec.lowerHexToUnsignedLong("67891233abcdef01"))
+      .traceId(HexCodec.lowerHexToUnsignedLong("2345678912345678"))
+      .spanId(HexCodec.lowerHexToUnsignedLong("463ac35c9f6413ad"))
+      .sampled(true)
+      .build();
+
+  static final Map<String, String> incoming = new LinkedHashMap<String, String>() {
+    {
+      b3Injector.inject(context, this);
+    }
+  };
+
+  static final Map<String, String> incomingNotSampled = new LinkedHashMap<String, String>() {
+    {
+      put("b3", "0"); // unsampled
+    }
+  };
+
+  static final Map<String, String> incomingMalformed = new LinkedHashMap<String, String>() {
+    {
+      put("b3", "b970dafd-0d95-40aa-95d8-1d8725aebe40"); // not ok
+    }
+  };
+
+  static final Map<String, String> nothingIncoming = Collections.emptyMap();
+
+  @Benchmark public void inject() {
+    Map<String, String> carrier = new LinkedHashMap<>();
+    b3Injector.inject(context, carrier);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract() {
+    return b3Extractor.extract(incoming);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_nothing() {
+    return b3Extractor.extract(nothingIncoming);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_unsampled() {
+    return b3Extractor.extract(incomingNotSampled);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_malformed() {
+    return b3Extractor.extract(incomingMalformed);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + B3SinglePropagationBenchmarks.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
This will be used for JMS and other propagation formats such as w3c
tracestate entry. It is notably more efficient than multi-header.

Example header: `b3: 4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1`

To aid in migration, this teaches the normal B3 to attempt to extract
single header variants as well.

See https://github.com/openzipkin/b3-propagation/issues/21