### PR TITLE
Exposes B3SingleFormat after getting meticulous about parsing

### DIFF
--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -81,10 +81,10 @@ public final class B3SingleFormat {
   }
 
   /**
-   * Like {@link #writeB3SingleAsBytes(TraceContext)}, but for carriers with byte array or byte
-   * buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
+   * Like {@link #writeB3SingleFormatAsBytes(TraceContext)}, but for carriers with byte array or
+   * byte buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
-  public static byte[] writeB3SingleAsBytes(TraceContext context) {
+  public static byte[] writeB3SingleFormatAsBytes(TraceContext context) {
     char[] buffer = getCharBuffer();
     int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
     return asciiToNewByteArray(buffer, length);

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -2,6 +2,7 @@ package brave.propagation;
 
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.logging.Logger;
 
@@ -11,7 +12,31 @@ import static brave.internal.TraceContexts.FLAG_SAMPLED;
 import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
 import static java.util.logging.Level.FINE;
 
-/** Implements the propagation format described in {@link B3SinglePropagation}. */
+/**
+ * This format corresponds to the propagation key "b3" (or "B3"), which delimits fields in the
+ * following manner.
+ *
+ * <pre>{@code
+ * b3: {x-b3-traceid}-{x-b3-spanid}-{x-b3-sampled}-{x-b3-parentspanid}-{x-b3-flags}
+ * }</pre>
+ *
+ * <p>For example, a sampled root span would look like:
+ * {@code 4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1}
+ *
+ * <p>Like normal B3, it is valid to omit trace identifiers in order to only propagate a sampling
+ * decision. For example, the following are valid downstream hints:
+ * <ul>
+ * <li>sampled - {@code b3: 1}</li>
+ * <li>unsampled - {@code b3: 0}</li>
+ * <li>debug - {@code b3: 1-1}</li>
+ * </ul>
+ * Note: {@code b3: 0-1} isn't supported as it doesn't make sense. Debug boosts ordinary sampling
+ * decision to also affect the collector tier. {@code b3: 0-1} would be like saying, don't sample,
+ * except at the collector tier, which is impossible as if you don't sample locally the data will
+ * never arrive at a collector.
+ *
+ * <p>See <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
+ */
 public final class B3SingleFormat {
   static final Logger logger = Logger.getLogger(B3SingleFormat.class.getName());
   static final int FORMAT_MAX_LENGTH = 32 + 1 + 16 + 2 + 16 + 2; // traceid128-spanid-1-parentid-1
@@ -26,7 +51,19 @@ public final class B3SingleFormat {
    * use {@link #writeB3SingleFormat(TraceContext)} instead, as RPC servers often share a trace ID.
    */
   public static String writeB3SingleFormatWithoutParentId(TraceContext context) {
-    return writeB3SingleFormat(context, 0L);
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, 0L, buffer);
+    return new String(buffer, 0, length);
+  }
+
+  /**
+   * Like {@link #writeB3SingleFormatWithoutParentId(TraceContext)}, but for carriers with byte
+   * array or byte buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
+   */
+  public static byte[] writeB3SingleFormatWithoutParentIdAsBytes(TraceContext context) {
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, 0L, buffer);
+    return asciiToNewByteArray(buffer, length);
   }
 
   /**
@@ -38,11 +75,22 @@ public final class B3SingleFormat {
    * share trace IDs, prefer {@link #writeB3SingleFormatWithoutParentId(TraceContext)}.
    */
   public static String writeB3SingleFormat(TraceContext context) {
-    return writeB3SingleFormat(context, context.parentIdAsLong());
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
+    return new String(buffer, 0, length);
   }
 
-  static String writeB3SingleFormat(TraceContext context, long parentId) {
-    char[] result = getCharBuffer();
+  /**
+   * Like {@link #writeB3SingleAsBytes(TraceContext)}, but for carriers with byte array or byte
+   * buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
+   */
+  public static byte[] writeB3SingleAsBytes(TraceContext context) {
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
+    return asciiToNewByteArray(buffer, length);
+  }
+
+  static int writeB3SingleFormat(TraceContext context, long parentId, char[] result) {
     int pos = 0;
     long traceIdHigh = context.traceIdHigh();
     if (traceIdHigh != 0L) {
@@ -71,52 +119,53 @@ public final class B3SingleFormat {
       result[pos++] = '-';
       result[pos++] = '1';
     }
-    return new String(result, 0, pos);
+    return pos;
   }
 
-  @Nullable public static TraceContextOrSamplingFlags parseB3SingleFormat(String b3) {
-    int length = b3.length();
-    if (length == 1) { // assume just tracing flag. ex "b3: 1"
-      int flags = parseSampledFlag(b3, 0);
-      if (flags == 0) return null;
-      return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
-    } else if (length == 3) { // assume tracing + debug flag. ex "b3: 1-1"
-      int flags = parseSampledFlag(b3, 0);
-      if (flags == 0) return null;
-      flags = parseDebugFlag(b3, 2, flags);
-      if (flags == 0) return null;
-      return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
+  @Nullable
+  public static TraceContextOrSamplingFlags parseB3SingleFormat(CharSequence b3) {
+    return parseB3SingleFormat(b3, 0, b3.length());
+  }
+
+  /**
+   * @param beginIndex the start index, inclusive
+   * @param endIndex the end index, exclusive
+   */
+  @Nullable
+  public static TraceContextOrSamplingFlags parseB3SingleFormat(CharSequence b3, int beginIndex,
+      int endIndex) {
+    if (endIndex <= beginIndex + 3) { // possibly sampling flags
+      return decode(b3, beginIndex, endIndex);
     }
 
+    int pos = beginIndex;
     // At this point we minimally expect a traceId-spanId pair
-    if (length < 16 + 1 + 16 /* traceid64-spanid */) {
+    if (endIndex < 16 + 1 + 16 /* traceid64-spanid */) {
       logger.fine("Invalid input: truncated");
       return null;
-    } else if (length > FORMAT_MAX_LENGTH) {
+    } else if (endIndex > FORMAT_MAX_LENGTH) {
       logger.fine("Invalid input: too long");
       return null;
     }
 
-    int pos = 0;
     long traceIdHigh, traceId;
-    if (b3.charAt(32) == '-') {
-      traceIdHigh = tryParse16HexCharacters(b3, pos, length);
+    if (b3.charAt(pos + 32) == '-') {
+      traceIdHigh = tryParse16HexCharacters(b3, pos, endIndex);
       pos += 16; // upper 64 bits of the trace ID
-      traceId = tryParse16HexCharacters(b3, pos, length);
+      traceId = tryParse16HexCharacters(b3, pos, endIndex);
     } else {
       traceIdHigh = 0L;
-      traceId = tryParse16HexCharacters(b3, pos, length);
+      traceId = tryParse16HexCharacters(b3, pos, endIndex);
     }
     pos += 16; // traceId
-    if (!checkHyphen(b3, pos)) return null;
-    pos++; // consume the hyphen
+    if (!checkHyphen(b3, pos++)) return null;
 
     if (traceIdHigh == 0L && traceId == 0L) {
       logger.fine("Invalid input: expected a 16 or 32 lower hex trace ID at offset 0");
       return null;
     }
 
-    long spanId = tryParse16HexCharacters(b3, pos, length);
+    long spanId = tryParse16HexCharacters(b3, pos, endIndex);
     if (spanId == 0L) {
       logger.log(FINE, "Invalid input: expected a 16 lower hex span ID at offset {0}", pos);
       return null;
@@ -125,40 +174,38 @@ public final class B3SingleFormat {
 
     int flags = 0;
     long parentId = 0L;
-    if (length > pos) {
+    if (endIndex > pos) {
       // If we are at this point, we have more than just traceId-spanId.
       // If the sampling field is present, we'll have a delimiter 2 characters from now. Ex "-1"
       // If it is absent, but a parent ID is (which is strange), we'll have at least 17 characters.
       // Therefore, if we have less than two characters, the input is truncated.
-      if (length == pos + 1) {
+      if (endIndex == pos + 1) {
         logger.fine("Invalid input: truncated");
         return null;
       }
-      if (!checkHyphen(b3, pos)) return null;
-      pos++; // consume the hyphen
+      if (!checkHyphen(b3, pos++)) return null;
 
       // If our position is at the end of the string, or another delimiter is one character past our
       // position, try to read sampled status.
-      if (length == pos + 1 || delimiterFollowsPos(b3, pos, length)) {
+      if (endIndex == pos + 1 || delimiterFollowsPos(b3, pos, endIndex)) {
         flags = parseSampledFlag(b3, pos);
         if (flags == 0) return null;
         pos++; // consume the sampled status
       }
 
-      if (length > pos) {
+      if (endIndex > pos) {
         // If we are at this point, we have only two possible fields left, parent and/or debug
         // If the parent field is present, we'll have at least 17 characters. If it is absent, but debug
         // is present, we'll have we'll have a delimiter 2 characters from now. Ex "-1"
         // Therefore, if we have less than two characters, the input is truncated.
-        if (length == pos + 1) {
+        if (endIndex == pos + 1) {
           logger.fine("Invalid input: truncated");
           return null;
         }
 
-        if (length > pos + 2) {
-          if (!checkHyphen(b3, pos)) return null;
-          pos++; // consume the hyphen
-          parentId = tryParse16HexCharacters(b3, pos, length);
+        if (endIndex > pos + 2) {
+          if (!checkHyphen(b3, pos++)) return null;
+          parentId = tryParse16HexCharacters(b3, pos, endIndex);
           if (parentId == 0L) {
             logger.log(FINE, "Invalid input: expected a 16 lower hex parent ID at offset {0}", pos);
             return null;
@@ -167,7 +214,7 @@ public final class B3SingleFormat {
         }
 
         // the only option at this point is that we have a debug flag
-        if (length == pos + 2) {
+        if (endIndex == pos + 2) {
           if (!checkHyphen(b3, pos)) return null;
           pos++; // consume the hyphen
           flags = parseDebugFlag(b3, pos, flags);
@@ -186,23 +233,45 @@ public final class B3SingleFormat {
     ));
   }
 
-  static boolean checkHyphen(String b3, int pos) {
+  @Nullable
+  static TraceContextOrSamplingFlags decode(CharSequence b3, int beginIndex, int endIndex) {
+    int pos = beginIndex;
+    if (pos == endIndex) { // empty
+      logger.log(FINE, "Invalid input: expected 0 or 1 for sampled at offset {0}", pos);
+      return null;
+    }
+
+    int flags = parseSampledFlag(b3, pos++);
+    if (flags == 0) return null;
+    if (endIndex > pos) {
+      if (!checkHyphen(b3, pos++)) return null;
+      if (endIndex == pos) {
+        logger.fine("Invalid input: truncated");
+        return null;
+      }
+      flags = parseDebugFlag(b3, pos, flags);
+      if (flags == 0) return null;
+    }
+    return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
+  }
+
+  static boolean checkHyphen(CharSequence b3, int pos) {
     if (b3.charAt(pos) == '-') return true;
     logger.log(FINE, "Invalid input: expected a hyphen(-) delimiter offset {0}", pos);
     return false;
   }
 
-  static boolean delimiterFollowsPos(String b3, int pos, int length) {
-    return (length >= pos + 2) && b3.charAt(pos + 1) == '-';
+  static boolean delimiterFollowsPos(CharSequence b3, int pos, int end) {
+    return (end >= pos + 2) && b3.charAt(pos + 1) == '-';
   }
 
-  static long tryParse16HexCharacters(CharSequence lowerHex, int index, int length) {
+  static long tryParse16HexCharacters(CharSequence lowerHex, int index, int end) {
     int endIndex = index + 16;
-    if (endIndex > length) return 0L;
+    if (endIndex > end) return 0L;
     return HexCodec.lenientLowerHexToUnsignedLong(lowerHex, index, endIndex);
   }
 
-  static int parseSampledFlag(String b3, int pos) {
+  static int parseSampledFlag(CharSequence b3, int pos) {
     int flags;
     char sampledChar = b3.charAt(pos);
     if (sampledChar == '1') {
@@ -216,7 +285,7 @@ public final class B3SingleFormat {
     return flags;
   }
 
-  static int parseDebugFlag(String b3, int pos, int flags) {
+  static int parseDebugFlag(CharSequence b3, int pos, int flags) {
     char lastChar = b3.charAt(pos);
     if (lastChar == '1') {
       flags = FLAG_DEBUG | FLAG_SAMPLED_SET | FLAG_SAMPLED;
@@ -225,6 +294,14 @@ public final class B3SingleFormat {
       flags = 0;
     }
     return flags;
+  }
+
+  static byte[] asciiToNewByteArray(char[] buffer, int length) {
+    byte[] result = new byte[length];
+    for (int i = 0; i < length; i++) {
+      result[i] = (byte) buffer[i];
+    }
+    return result;
   }
 
   static final ThreadLocal<char[]> CHAR_BUFFER = new ThreadLocal<>();

--- a/brave/src/main/java/brave/propagation/B3SinglePropagation.java
+++ b/brave/src/main/java/brave/propagation/B3SinglePropagation.java
@@ -102,7 +102,7 @@ public final class B3SinglePropagation<K> implements Propagation<K> {
       if (b3 == null) b3 = getter.get(carrier, upperKey);
       if (b3 == null) return TraceContextOrSamplingFlags.EMPTY;
 
-      TraceContextOrSamplingFlags extracted = B3SingleFormat.maybeB3SingleFormat(b3);
+      TraceContextOrSamplingFlags extracted = B3SingleFormat.parseB3SingleFormat(b3);
       // if null, the trace context is malformed so return empty
       if (extracted == null) return TraceContextOrSamplingFlags.EMPTY;
       return extracted;

--- a/brave/src/main/java/brave/propagation/B3SinglePropagation.java
+++ b/brave/src/main/java/brave/propagation/B3SinglePropagation.java
@@ -4,31 +4,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * This format corresponds to the propagation key "b3" (or "B3"), which delimits fields in the
- * following manner.
- *
- * <pre>{@code
- * b3: {x-b3-traceid}-{x-b3-spanid}-{x-b3-sampled}-{x-b3-parentspanid}-{x-b3-flags}
- * }</pre>
- *
- * <p>For example, a sampled root span would look like:
- * {@code 4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1}
- *
- * <p>Like normal B3, it is valid to omit trace identifiers in order to only propagate a sampling
- * decision. For example, the following are valid downstream hints:
- * <ul>
- * <li>sampled - {@code b3: 1}</li>
- * <li>unsampled - {@code b3: 0}</li>
- * <li>debug - {@code b3: 1-1}</li>
- * </ul>
- * Note: {@code b3: 0-1} isn't supported as it doesn't make sense. Debug boosts ordinary sampling
- * decision to also affect the collector tier. {@code b3: 0-1} would be like saying, don't sample,
- * except at the collector tier, which is impossible as if you don't sample locally the data will
- * never arrive at a collector.
- *
- * <p>See <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
- */
+/** Implements the propagation format described in {@link B3SingleFormat}. */
 public final class B3SinglePropagation<K> implements Propagation<K> {
 
   public static final Factory FACTORY = new Factory() {

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -3,12 +3,109 @@ package brave.propagation;
 import org.junit.Test;
 
 import static brave.propagation.B3SingleFormat.parseB3SingleFormat;
+import static brave.propagation.B3SingleFormat.writeB3SingleAsBytes;
+import static brave.propagation.B3SingleFormat.writeB3SingleFormat;
+import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentId;
+import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentIdAsBytes;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class B3SingleFormatTest {
   String traceId = "0000000000000001";
   String parentId = "0000000000000002";
   String spanId = "0000000000000003";
+
+  @Test public void writeB3SingleFormat_notYetSampled() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).build();
+
+    assertThat(writeB3SingleFormat(context))
+        .isEqualTo(traceId + "-" + spanId)
+        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormat_unsampled() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build();
+
+    assertThat(writeB3SingleFormat(context))
+        .isEqualTo(traceId + "-" + spanId + "-0")
+        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormat_sampled() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).sampled(true).build();
+
+    assertThat(writeB3SingleFormat(context))
+        .isEqualTo(traceId + "-" + spanId + "-1")
+        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormat_debug() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).debug(true).build();
+
+    assertThat(writeB3SingleFormat(context))
+        .isEqualTo(traceId + "-" + spanId + "-1-1")
+        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormat_parent() {
+    TraceContext context =
+        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(true).build();
+
+    assertThat(writeB3SingleFormat(context))
+        .isEqualTo(traceId + "-" + spanId + "-1-" + parentId)
+        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormatWithoutParent_notYetSampled() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).build();
+
+    assertThat(writeB3SingleFormatWithoutParentId(context))
+        .isEqualTo(traceId + "-" + spanId)
+        .isEqualTo(new String(writeB3SingleFormatWithoutParentIdAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormatWithoutParent_unsampled() {
+    TraceContext context =
+        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(false).build();
+
+    assertThat(writeB3SingleFormatWithoutParentId(context))
+        .isEqualTo(traceId + "-" + spanId + "-0")
+        .isEqualTo(new String(writeB3SingleFormatWithoutParentIdAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormatWithoutParent_sampled() {
+    TraceContext context =
+        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(true).build();
+
+    assertThat(writeB3SingleFormatWithoutParentId(context))
+        .isEqualTo(traceId + "-" + spanId + "-1")
+        .isEqualTo(new String(writeB3SingleFormatWithoutParentIdAsBytes(context), UTF_8));
+  }
+
+  @Test public void writeB3SingleFormatWithoutParent_debug() {
+    TraceContext context =
+        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).debug(true).build();
+
+    assertThat(writeB3SingleFormatWithoutParentId(context))
+        .isEqualTo(traceId + "-" + spanId + "-1-1")
+        .isEqualTo(new String(writeB3SingleFormatWithoutParentIdAsBytes(context), UTF_8));
+  }
+
+  /** for example, parsing a w3c context */
+  @Test public void parseB3SingleFormat_middleOfString() {
+    String input = "b3=" + traceId + traceId + "-" + spanId + ",";
+    assertThat(parseB3SingleFormat(input, 3, input.length() - 1).context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceIdHigh(1).traceId(1).spanId(3).build()
+        );
+  }
+
+  /** for example, parsing a w3c context */
+  @Test public void parseB3SingleFormat_middleOfString_flags() {
+    String input = "b2=foo,b3=1-1,b4=bar";
+    assertThat(parseB3SingleFormat(input, 10, 13).samplingFlags())
+        .isSameAs(SamplingFlags.DEBUG);
+  }
 
   @Test public void parseB3SingleFormat_idsNotYetSampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId).context())
@@ -59,6 +156,11 @@ public class B3SingleFormatTest {
         );
   }
 
+  @Test public void parseB3SingleFormat_idsUnsampled_with_malformed_debug() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0-?"))
+        .isNull(); // instead of raising exception
+  }
+
   @Test public void parseB3SingleFormat_sampledFalse() {
     assertThat(parseB3SingleFormat("0"))
         .isEqualTo(TraceContextOrSamplingFlags.NOT_SAMPLED);
@@ -79,6 +181,26 @@ public class B3SingleFormatTest {
         .isEqualTo(TraceContextOrSamplingFlags.DEBUG);
   }
 
+  @Test public void parseB3SingleFormat_debug_malformed() {
+    assertThat(parseB3SingleFormat("1-?"))
+        .isNull(); // instead of raising exception
+  }
+
+  @Test public void parseB3SingleFormat_malformed_traceId() {
+    assertThat(parseB3SingleFormat(traceId.substring(0, 15) + "?-" + spanId))
+        .isNull(); // instead of raising exception
+  }
+
+  @Test public void parseB3SingleFormat_malformed_id() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15) + "?"))
+        .isNull(); // instead of raising exception
+  }
+
+  @Test public void parseB3SingleFormat_malformed_parentid() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15) + "?"))
+        .isNull(); // instead of raising exception
+  }
+
   @Test public void parseB3SingleFormat_malformed() {
     assertThat(parseB3SingleFormat("not-a-tumor"))
         .isNull(); // instead of raising exception
@@ -90,11 +212,15 @@ public class B3SingleFormatTest {
   }
 
   @Test public void parseB3SingleFormat_truncated() {
+    assertThat(parseB3SingleFormat(""))
+        .isNull(); // instead of raising exception
     assertThat(parseB3SingleFormat("-"))
         .isNull();
     assertThat(parseB3SingleFormat("-1"))
         .isNull();
     assertThat(parseB3SingleFormat("1-"))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId.substring(0, 15)))
         .isNull();
     assertThat(parseB3SingleFormat(traceId))
         .isNull();
@@ -108,12 +234,16 @@ public class B3SingleFormatTest {
         .isNull();
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-"))
         .isNull();
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15)))
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId.substring(0, 15)))
         .isNull();
   }
 
   @Test public void parseB3SingleFormat_tooBig() {
+    // overall length is ok, but it is malformed as parent is too long
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + traceId + traceId))
+        .isNull(); // instead of raising exception
+    // overall length is not ok
+    assertThat(parseB3SingleFormat(traceId + traceId + traceId + "-" + spanId + "-" + traceId))
         .isNull();
   }
 }

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -1,0 +1,119 @@
+package brave.propagation;
+
+import org.junit.Test;
+
+import static brave.propagation.B3SingleFormat.parseB3SingleFormat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class B3SingleFormatTest {
+  String traceId = "0000000000000001";
+  String parentId = "0000000000000002";
+  String spanId = "0000000000000003";
+
+  @Test public void parseB3SingleFormat_idsNotYetSampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId).context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceId(1).spanId(3).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_idsNotYetSampled128() {
+    assertThat(parseB3SingleFormat(traceId + traceId + "-" + spanId).context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceIdHigh(1).traceId(1).spanId(3).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_idsUnsampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0").context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_parent_unsampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0-" + parentId).context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(false).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_parent_debug() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId + "-1").context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).debug(true).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_idsWithDebug() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-1").context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceId(1).spanId(3).debug(true).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_idsUnsampled_with_redundant_debug() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0-0").context())
+        .isEqualToComparingFieldByField(
+            TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build()
+        );
+  }
+
+  @Test public void parseB3SingleFormat_sampledFalse() {
+    assertThat(parseB3SingleFormat("0"))
+        .isEqualTo(TraceContextOrSamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test public void parseB3SingleFormat_sampled() {
+    assertThat(parseB3SingleFormat("1"))
+        .isEqualTo(TraceContextOrSamplingFlags.SAMPLED);
+  }
+
+  @Test public void parseB3SingleFormat_sampled_redundant() {
+    assertThat(parseB3SingleFormat("1-0"))
+        .isEqualTo(TraceContextOrSamplingFlags.SAMPLED);
+  }
+
+  @Test public void parseB3SingleFormat_debug() {
+    assertThat(parseB3SingleFormat("1-1"))
+        .isEqualTo(TraceContextOrSamplingFlags.DEBUG);
+  }
+
+  @Test public void parseB3SingleFormat_malformed() {
+    assertThat(parseB3SingleFormat("not-a-tumor"))
+        .isNull(); // instead of raising exception
+  }
+
+  @Test public void parseB3SingleFormat_malformed_uuid() {
+    assertThat(parseB3SingleFormat("b970dafd-0d95-40aa-95d8-1d8725aebe40"))
+        .isNull(); // instead of raising exception
+  }
+
+  @Test public void parseB3SingleFormat_truncated() {
+    assertThat(parseB3SingleFormat("-"))
+        .isNull();
+    assertThat(parseB3SingleFormat("-1"))
+        .isNull();
+    assertThat(parseB3SingleFormat("1-"))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId + "-"))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId.substring(0, 15) + "-" + spanId))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15)))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-"))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-"))
+        .isNull();
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15)))
+        .isNull();
+  }
+
+  @Test public void parseB3SingleFormat_tooBig() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + traceId + traceId))
+        .isNull();
+  }
+}

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -3,7 +3,7 @@ package brave.propagation;
 import org.junit.Test;
 
 import static brave.propagation.B3SingleFormat.parseB3SingleFormat;
-import static brave.propagation.B3SingleFormat.writeB3SingleAsBytes;
+import static brave.propagation.B3SingleFormat.writeB3SingleFormatAsBytes;
 import static brave.propagation.B3SingleFormat.writeB3SingleFormat;
 import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentId;
 import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentIdAsBytes;
@@ -20,7 +20,7 @@ public class B3SingleFormatTest {
 
     assertThat(writeB3SingleFormat(context))
         .isEqualTo(traceId + "-" + spanId)
-        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+        .isEqualTo(new String(writeB3SingleFormatAsBytes(context), UTF_8));
   }
 
   @Test public void writeB3SingleFormat_unsampled() {
@@ -28,7 +28,7 @@ public class B3SingleFormatTest {
 
     assertThat(writeB3SingleFormat(context))
         .isEqualTo(traceId + "-" + spanId + "-0")
-        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+        .isEqualTo(new String(writeB3SingleFormatAsBytes(context), UTF_8));
   }
 
   @Test public void writeB3SingleFormat_sampled() {
@@ -36,7 +36,7 @@ public class B3SingleFormatTest {
 
     assertThat(writeB3SingleFormat(context))
         .isEqualTo(traceId + "-" + spanId + "-1")
-        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+        .isEqualTo(new String(writeB3SingleFormatAsBytes(context), UTF_8));
   }
 
   @Test public void writeB3SingleFormat_debug() {
@@ -44,7 +44,7 @@ public class B3SingleFormatTest {
 
     assertThat(writeB3SingleFormat(context))
         .isEqualTo(traceId + "-" + spanId + "-1-1")
-        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+        .isEqualTo(new String(writeB3SingleFormatAsBytes(context), UTF_8));
   }
 
   @Test public void writeB3SingleFormat_parent() {
@@ -53,7 +53,7 @@ public class B3SingleFormatTest {
 
     assertThat(writeB3SingleFormat(context))
         .isEqualTo(traceId + "-" + spanId + "-1-" + parentId)
-        .isEqualTo(new String(writeB3SingleAsBytes(context), UTF_8));
+        .isEqualTo(new String(writeB3SingleFormatAsBytes(context), UTF_8));
   }
 
   @Test public void writeB3SingleFormatWithoutParent_notYetSampled() {


### PR DESCRIPTION
This adds a huge amount of state checks to understand the source of
malform problems. This exposes B3SingleFormat methods so they can be
used in other code, such as w3c tracestate or JMS directly.

See #763