### PR TITLE
Teaches spring-rabbit to resume from headers when sending a message

### DIFF
--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -49,7 +49,7 @@ public class RealSpanTest {
 
     assertThat(spans).hasSize(1).first()
         .extracting(zipkin2.Span::timestamp)
-        .containsExactly(2L);
+        .isEqualTo(2L);
   }
 
   @Test public void finish() {
@@ -58,7 +58,7 @@ public class RealSpanTest {
 
     assertThat(spans).hasSize(1).first()
         .extracting(zipkin2.Span::duration)
-        .doesNotContainNull();
+        .isNotNull();
   }
 
   @Test public void finish_timestamp() {
@@ -67,7 +67,7 @@ public class RealSpanTest {
 
     assertThat(spans).hasSize(1).first()
         .extracting(zipkin2.Span::duration)
-        .containsExactly(3L);
+        .isEqualTo(3L);
   }
 
   @Test public void abandon() {

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -240,7 +240,7 @@ public class TracerTest {
     assertThat(tracer.toSpan(context))
         .isInstanceOf(RealSpan.class)
         .extracting(Span::context)
-        .containsExactly(context);
+        .isEqualToComparingFieldByField(context);
   }
 
   @Test public void toSpan_noop() {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -178,7 +178,7 @@ public abstract class ITHttpServer extends ITHttp {
     Span span = takeSpan();
     assertThat(span.remoteEndpoint())
         .extracting(Endpoint::ipv4)
-        .contains("1.2.3.4");
+        .isEqualTo("1.2.3.4");
   }
 
   @Test

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitPropagation.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitPropagation.java
@@ -1,0 +1,31 @@
+package brave.spring.rabbit;
+
+import brave.propagation.Propagation.Getter;
+import brave.propagation.Propagation.Setter;
+import org.springframework.amqp.core.MessageProperties;
+
+final class SpringRabbitPropagation {
+
+  static final Setter<MessageProperties, String> SETTER = new Setter<MessageProperties, String>() {
+    @Override public void put(MessageProperties carrier, String key, String value) {
+      carrier.setHeader(key, value);
+    }
+
+    @Override public String toString() {
+      return "MessageProperties::setHeader";
+    }
+  };
+
+  static final Getter<MessageProperties, String> GETTER = new Getter<MessageProperties, String>() {
+    @Override public String get(MessageProperties carrier, String key) {
+      return (String) carrier.getHeaders().get(key);
+    }
+
+    @Override public String toString() {
+      return "MessageProperties::setHeader";
+    }
+  };
+
+  SpringRabbitPropagation() {
+  }
+}

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/ITSpringRabbitTracing.java
@@ -193,7 +193,9 @@ public class ITSpringRabbitTracing {
   public static class CommonRabbitConfig {
     @Bean
     public ConnectionFactory connectionFactory() {
-      return new CachingConnectionFactory();
+      CachingConnectionFactory result = new CachingConnectionFactory();
+      result.setAddresses("127.0.0.1");
+      return result;
     }
 
     @Bean

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/MessagePropertiesSetterTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/MessagePropertiesSetterTest.java
@@ -5,7 +5,8 @@ import brave.test.propagation.PropagationSetterTest;
 import java.util.Collections;
 import org.springframework.amqp.core.MessageProperties;
 
-import static brave.spring.rabbit.TracingRabbitListenerAdvice.GETTER;
+import static brave.spring.rabbit.SpringRabbitPropagation.GETTER;
+import static brave.spring.rabbit.SpringRabbitPropagation.SETTER;
 
 public class MessagePropertiesSetterTest extends PropagationSetterTest<MessageProperties, String> {
   MessageProperties carrier = new MessageProperties();
@@ -19,7 +20,7 @@ public class MessagePropertiesSetterTest extends PropagationSetterTest<MessagePr
   }
 
   @Override protected Propagation.Setter<MessageProperties, String> setter() {
-    return TracingMessagePostProcessor.SETTER;
+    return SETTER;
   }
 
   @Override protected Iterable<String> read(MessageProperties carrier, String key) {

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
@@ -1,10 +1,14 @@
 package brave.spring.rabbit;
 
 import brave.Tracing;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.After;
 import org.junit.Test;
@@ -20,15 +24,45 @@ public class TracingMessagePostProcessorTest {
       .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
-  TracingMessagePostProcessor tracingMessagePostProcessor =
-      new TracingMessagePostProcessor(tracing, "my-exchange");
+  TracingMessagePostProcessor tracingMessagePostProcessor = new TracingMessagePostProcessor(
+      SpringRabbitTracing.newBuilder(tracing).remoteServiceName("my-exchange").build()
+  );
 
   @After public void close() {
     tracing.close();
   }
 
+  @Test public void should_attempt_to_resume_headers() {
+    TraceContext parent = TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
+    Message message = MessageBuilder.withBody(new byte[0]).build();
+    message.getMessageProperties().setHeader("b3", B3SingleFormat.writeB3SingleFormat(parent));
+
+    Message postProcessMessage = tracingMessagePostProcessor.postProcessMessage(message);
+
+    Map<String, Object> headers = postProcessMessage.getMessageProperties().getHeaders();
+    assertThat(headers).containsEntry("X-B3-ParentSpanId", "0000000000000001");
+  }
+
+  @Test public void should_prefer_current_span() {
+    TraceContext grandparent =
+        TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
+    TraceContext parent = grandparent.toBuilder().parentId(grandparent.spanId()).spanId(2L).build();
+
+    // Will be either a bug, or a missing processor stage which can result in an old span in headers
+    Message message = MessageBuilder.withBody(new byte[0]).build();
+    message.getMessageProperties().setHeader("b3", B3SingleFormat.writeB3SingleFormat(grandparent));
+
+    Message postProcessMessage;
+    try (Scope scope = tracing.currentTraceContext().newScope(parent)) {
+      postProcessMessage = tracingMessagePostProcessor.postProcessMessage(message);
+    }
+
+    Map<String, Object> headers = postProcessMessage.getMessageProperties().getHeaders();
+    assertThat(headers).containsEntry("X-B3-ParentSpanId", "0000000000000002");
+  }
+
   @Test public void should_add_b3_headers_to_message() {
-    Message message = MessageBuilder.withBody(new byte[] {}).build();
+    Message message = MessageBuilder.withBody(new byte[0]).build();
     Message postProcessMessage = tracingMessagePostProcessor.postProcessMessage(message);
 
     List<String> expectedHeaders = Arrays.asList("X-B3-TraceId", "X-B3-SpanId", "X-B3-Sampled");
@@ -38,14 +72,14 @@ public class TracingMessagePostProcessorTest {
   }
 
   @Test public void should_report_span() {
-    Message message = MessageBuilder.withBody(new byte[] {}).build();
+    Message message = MessageBuilder.withBody(new byte[0]).build();
     tracingMessagePostProcessor.postProcessMessage(message);
 
     assertThat(spans).hasSize(1);
   }
 
   @Test public void should_set_remote_service() {
-    Message message = MessageBuilder.withBody(new byte[] {}).build();
+    Message message = MessageBuilder.withBody(new byte[0]).build();
     tracingMessagePostProcessor.postProcessMessage(message);
 
     assertThat(spans.get(0).remoteServiceName())

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
@@ -31,8 +31,9 @@ public class TracingRabbitListenerAdviceTest {
       .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
-  TracingRabbitListenerAdvice tracingRabbitListenerAdvice =
-      new TracingRabbitListenerAdvice(tracing, "my-service");
+  TracingRabbitListenerAdvice tracingRabbitListenerAdvice = new TracingRabbitListenerAdvice(
+      SpringRabbitTracing.newBuilder(tracing).remoteServiceName("my-exchange").build()
+  );
   MethodInvocation methodInvocation = mock(MethodInvocation.class);
 
   @After public void close() {
@@ -63,7 +64,7 @@ public class TracingRabbitListenerAdviceTest {
 
     assertThat(spans)
         .extracting(Span::remoteServiceName)
-        .containsExactly("my-service", null);
+        .containsExactly("my-exchange", null);
   }
 
   @Test public void tags_consumer_span_but_not_listener() throws Throwable {

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <netty.version>4.1.27.Final</netty.version>
     <sparkjava.version>2.7.1</sparkjava.version>
     <junit.version>4.12</junit.version>
-    <assertj.version>3.10.0</assertj.version>
+    <assertj.version>3.11.0</assertj.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <mockito.version>2.21.0</mockito.version>
     <!-- last version on jax-rs 2.0 per https://jersey.github.io/download.html -->


### PR DESCRIPTION
Per #754, there are scenarios where a span could not be in scope, yet
still be in headers. This implements the same logic as Kafka, where the
current span is checked first before looking at headers.