### PR TITLE
Adds b3SingleFormat flag to message instrumentation

### DIFF
--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -143,6 +143,34 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-kafka-clients</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-spring-rabbit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit</artifactId>
+      <version>${spring-rabbit.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
       <version>${undertow.version}</version>

--- a/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
@@ -1,0 +1,126 @@
+package brave.kafka.clients;
+
+import brave.Tracing;
+import com.google.common.util.concurrent.Futures;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.reporter.Reporter;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class TracingProducerBenchmarks {
+  ProducerRecord<String, String> record = new ProducerRecord<>("topic", "key", "value");
+  Producer<String, String> producer, tracingProducer, tracingB3SingleProducer;
+
+  @Setup(Level.Trial) public void init() {
+    Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build();
+    producer = new FakeProducer();
+    tracingProducer = KafkaTracing.create(tracing).producer(producer);
+    tracingB3SingleProducer =
+        KafkaTracing.newBuilder(tracing).b3SingleFormat(true).build().producer(producer);
+  }
+
+  @TearDown(Level.Trial) public void close() {
+    Tracing.current().close();
+  }
+
+  @Benchmark public RecordMetadata send_baseCase() throws Exception {
+    return producer.send(record).get();
+  }
+
+  @Benchmark public RecordMetadata send_traced() throws Exception {
+    return tracingProducer.send(record).get();
+  }
+
+  @Benchmark public RecordMetadata send_traced_b3Single() throws Exception {
+    return tracingB3SingleProducer.send(record).get();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + TracingProducerBenchmarks.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  static final class FakeProducer implements Producer<String, String> {
+    @Override public void initTransactions() {
+    }
+
+    @Override public void beginTransaction() {
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> map, String s) {
+    }
+
+    @Override public void commitTransaction() {
+    }
+
+    @Override public void abortTransaction() {
+    }
+
+    @Override public Future<RecordMetadata> send(ProducerRecord<String, String> record) {
+      return send(record, null);
+    }
+
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord<String, String> record, Callback callback) {
+      TopicPartition tp = new TopicPartition(record.topic(), 0);
+      RecordMetadata rm = new RecordMetadata(tp, -1L, -1L, 1L, 2L, 3, 4);
+      if (callback != null) callback.onCompletion(rm, null);
+      return Futures.immediateFuture(rm);
+    }
+
+    @Override public void flush() {
+    }
+
+    @Override public List<PartitionInfo> partitionsFor(String s) {
+      return null;
+    }
+
+    @Override public Map<MetricName, ? extends Metric> metrics() {
+      return null;
+    }
+
+    @Override public void close() {
+    }
+
+    @Override public void close(long l, TimeUnit timeUnit) {
+    }
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/spring/rabbit/TracingMessagePostProcessorBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/spring/rabbit/TracingMessagePostProcessorBenchmarks.java
@@ -1,0 +1,64 @@
+package brave.spring.rabbit;
+
+import brave.Tracing;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import zipkin2.reporter.Reporter;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class TracingMessagePostProcessorBenchmarks {
+  Message message = MessageBuilder.withBody(new byte[0]).build();
+  TracingMessagePostProcessor tracingPostProcessor, tracingB3SinglePostProcessor;
+
+  @Setup(Level.Trial) public void init() {
+    Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build();
+    tracingPostProcessor = new TracingMessagePostProcessor(SpringRabbitTracing.create(tracing));
+    tracingB3SinglePostProcessor = new TracingMessagePostProcessor(
+        SpringRabbitTracing.newBuilder(tracing).b3SingleFormat(true).build()
+    );
+  }
+
+  @TearDown(Level.Trial) public void close() {
+    Tracing.current().close();
+  }
+
+  @Benchmark public Message send_traced() {
+    return tracingPostProcessor.postProcessMessage(message);
+  }
+
+  @Benchmark public Message send_traced_b3Single() {
+    return tracingB3SinglePostProcessor.postProcessMessage(message);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + TracingMessagePostProcessorBenchmarks.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -8,6 +8,7 @@ Add decorators for Kafka producer and consumer to enable tracing.
 First, setup the generic Kafka component like this:
 ```java
 kafkaTracing = KafkaTracing.newBuilder(tracing)
+                           .b3SingleFormat(true) // for more efficient propagation
                            .remoteServiceName("my-broker")
                            .build();
 ```

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
@@ -2,13 +2,34 @@ package brave.kafka.clients;
 
 import brave.propagation.Propagation.Getter;
 import brave.propagation.Propagation.Setter;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContext.Injector;
 import java.nio.charset.Charset;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
+import static brave.propagation.B3SingleFormat.writeB3SingleFormat;
+import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentIdAsBytes;
 
 final class KafkaPropagation {
 
   static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  static final TraceContext TEST_CONTEXT = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
+  static final Headers B3_SINGLE_TEST_HEADERS =
+      new RecordHeaders().add("b3", writeB3SingleFormat(TEST_CONTEXT).getBytes(UTF_8));
+
+  static final Injector<Headers> B3_SINGLE_INJECTOR = new Injector<Headers>() {
+    @Override public void inject(TraceContext traceContext, Headers carrier) {
+      carrier.remove("b3");
+      carrier.add("b3", writeB3SingleFormatWithoutParentIdAsBytes(traceContext));
+    }
+
+    @Override public String toString() {
+      return "Headers::add(\"b3\",singleHeaderFormatWithoutParent)";
+    }
+  };
 
   static final Setter<Headers, String> SETTER = (carrier, key, value) -> {
     carrier.remove(key);

--- a/instrumentation/spring-rabbit/README.md
+++ b/instrumentation/spring-rabbit/README.md
@@ -16,6 +16,7 @@ public Tracing tracing() {
 @Bean
 public SpringRabbitTracing springRabbitTracing(Tracing tracing) {
   return SpringRabbitTracing.newBuilder(tracing)
+                            .b3SingleFormat(true) // for more efficient propagation
                             .remoteServiceName("my-mq-service")
                             .build();
 }

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -14,7 +14,6 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
-    <spring-rabbit.version>1.7.9.RELEASE</spring-rabbit.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitPropagation.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitPropagation.java
@@ -2,9 +2,30 @@ package brave.spring.rabbit;
 
 import brave.propagation.Propagation.Getter;
 import brave.propagation.Propagation.Setter;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContext.Injector;
 import org.springframework.amqp.core.MessageProperties;
 
+import static brave.propagation.B3SingleFormat.writeB3SingleFormat;
+import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentId;
+
 final class SpringRabbitPropagation {
+  static final TraceContext TEST_CONTEXT = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
+  static final MessageProperties B3_SINGLE_TEST_HEADERS = new MessageProperties();
+
+  static {
+    B3_SINGLE_TEST_HEADERS.setHeader("b3", writeB3SingleFormat(TEST_CONTEXT));
+  }
+
+  static final Injector<MessageProperties> B3_SINGLE_INJECTOR = new Injector<MessageProperties>() {
+    @Override public void inject(TraceContext traceContext, MessageProperties carrier) {
+      carrier.setHeader("b3", writeB3SingleFormatWithoutParentId(traceContext));
+    }
+
+    @Override public String toString() {
+      return "MessageProperties::setHeader(\"b3\",singleHeaderFormatWithoutParent)";
+    }
+  };
 
   static final Setter<MessageProperties, String> SETTER = new Setter<MessageProperties, String>() {
     @Override public void put(MessageProperties carrier, String key, String value) {

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
@@ -7,7 +7,6 @@ import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Injector;
-import brave.propagation.TraceContextOrSamplingFlags;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.MessageProperties;
@@ -45,11 +44,10 @@ final class TracingMessagePostProcessor implements MessagePostProcessor {
     // always clear message headers after reading.
     Span span;
     if (maybeParent == null) {
-      TraceContextOrSamplingFlags extracted = springRabbitTracing.extractAndClearHeaders(message);
-      span = tracer.nextSpan(extracted);
+      span = tracer.nextSpan(springRabbitTracing.extractAndClearHeaders(message));
     } else {
+      // If we have a span in scope assume headers were cleared before
       span = tracer.newChild(maybeParent);
-      springRabbitTracing.clearHeaders(message.getMessageProperties().getHeaders());
     }
 
     if (!span.isNoop()) {

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
@@ -71,6 +71,20 @@ public class TracingMessagePostProcessorTest {
     assertThat(headerKeys).containsAll(expectedHeaders);
   }
 
+  @Test public void should_add_b3_single_header_to_message() {
+    TracingMessagePostProcessor tracingMessagePostProcessor = new TracingMessagePostProcessor(
+        SpringRabbitTracing.newBuilder(tracing).b3SingleFormat(true).build()
+    );
+
+    Message message = MessageBuilder.withBody(new byte[0]).build();
+    Message postProcessMessage = tracingMessagePostProcessor.postProcessMessage(message);
+
+    assertThat(postProcessMessage.getMessageProperties().getHeaders())
+      .containsOnlyKeys("b3");
+    assertThat(postProcessMessage.getMessageProperties().getHeaders().get("b3").toString())
+        .matches("^[0-9a-f]{16}-[0-9a-f]{16}-1$");
+  }
+
   @Test public void should_report_span() {
     Message message = MessageBuilder.withBody(new byte[0]).build();
     tracingMessagePostProcessor.postProcessMessage(message);

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <!-- Ensure older versions of spring still work -->
     <spring4.version>4.3.18.RELEASE</spring4.version>
     <spring.version>3.2.18.RELEASE</spring.version>
+
     <!-- don't use apis not in jetty 7.6* else testing servlet 2.5 will imply duplication -->
     <jetty.version>8.1.22.v20160922</jetty.version>
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
@@ -77,6 +78,8 @@
     <kafka.version>2.0.0</kafka.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
     <kafka-junit.version>4.1.2</kafka-junit.version>
+
+    <spring-rabbit.version>1.7.9.RELEASE</spring-rabbit.version>
 
     <finagle.version>18.7.0</finagle.version>
     <log4j.version>2.11.0</log4j.version>


### PR DESCRIPTION
by building message integration with the flag "b3SingleFormat" downstream propagation will use the single header format (#763) which is much more efficient and JMS compatible.

Ex `b3: 4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1` for a sampled span