### PR TITLE
Ensures Kafka callback has span in scope

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingCallback.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingCallback.java
@@ -2,28 +2,51 @@ package brave.kafka.clients;
 
 import brave.Span;
 import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
- * Decorator which finish producer span. Allows tracing to register the time between batching for
- * send and actual send.
+ * Decorates, then finishes a producer span. Allows tracing to record the duration between batching
+ * for send and actual send.
  */
-final class TracingCallback implements Callback {
-
-  final Span span;
-  @Nullable final Callback wrappedCallback;
-
-  TracingCallback(Span span, @Nullable Callback wrappedCallback) {
-    this.span = span;
-    this.wrappedCallback = wrappedCallback;
+final class TracingCallback {
+  static Callback create(@Nullable Callback delegate, Span span, CurrentTraceContext current) {
+    if (span.isNoop()) return delegate; // save allocation overhead
+    if (delegate == null) return new FinishSpan(span);
+    return new DelegateAndFinishSpan(delegate, span, current);
   }
 
-  @Override public void onCompletion(RecordMetadata metadata, @Nullable Exception exception) {
-    if (exception != null) span.error(exception);
-    span.finish();
-    if (wrappedCallback != null) {
-      wrappedCallback.onCompletion(metadata, exception);
+  static class FinishSpan implements Callback {
+    final Span span;
+
+    FinishSpan(Span span) {
+      this.span = span;
+    }
+
+    @Override public void onCompletion(RecordMetadata metadata, @Nullable Exception exception) {
+      if (exception != null) span.error(exception);
+      span.finish();
+    }
+  }
+
+  static final class DelegateAndFinishSpan extends FinishSpan {
+    final Callback delegate;
+    final CurrentTraceContext current;
+
+    DelegateAndFinishSpan(Callback delegate, Span span, CurrentTraceContext current) {
+      super(span);
+      this.delegate = delegate;
+      this.current = current;
+    }
+
+    @Override public void onCompletion(RecordMetadata metadata, @Nullable Exception exception) {
+      try (Scope ws = current.maybeScope(span.context())) {
+        delegate.onCompletion(metadata, exception);
+      } finally {
+        super.onCompletion(metadata, exception);
+      }
     }
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
@@ -1,6 +1,8 @@
 package brave.kafka.clients;
 
 import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.google.common.base.Charsets;
 import java.nio.charset.Charset;
@@ -29,9 +31,12 @@ abstract class BaseTracingTest {
 
   ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
   Tracing tracing = Tracing.newBuilder()
-      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
       .spanReporter(spans::add)
       .build();
+  CurrentTraceContext current = tracing.currentTraceContext();
   KafkaTracing kafkaTracing = KafkaTracing.create(tracing);
 
   @After public void tearDown() {

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingCallbackTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingCallbackTest.java
@@ -1,32 +1,75 @@
 package brave.kafka.clients;
 
 import brave.Span;
+import brave.sampler.Sampler;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class TracingCallbackTest extends BaseTracingTest {
-  @Test
-  public void on_completion_should_finish_span() throws Exception {
-    Span span = tracing.tracer().nextSpan();
-    span.start();
-    TracingCallback callback = new TracingCallback(span, null);
-    callback.onCompletion(createRecordMetadata(), null);
+  @Test public void create_returns_input_on_noop() {
+    Span span = tracing.tracer().withSampler(Sampler.NEVER_SAMPLE).nextSpan();
+
+    Callback delegate = mock(Callback.class);
+    Callback tracingCallback = TracingCallback.create(delegate, span, current);
+
+    assertThat(tracingCallback).isSameAs(delegate);
+  }
+
+  @Test public void on_completion_should_finish_span() {
+    Span span = tracing.tracer().nextSpan().start();
+
+    Callback tracingCallback = TracingCallback.create(null, span, current);
+    tracingCallback.onCompletion(createRecordMetadata(), null);
 
     assertThat(spans.getFirst()).isNotNull();
   }
 
-  @Test
-  public void on_completion_should_tag_if_exception() throws Exception {
-    Span span = tracing.tracer().nextSpan();
-    span.start();
-    TracingCallback callback = new TracingCallback(span, null);
-    callback.onCompletion(null, new Exception("Test exception"));
+  @Test public void on_completion_should_tag_if_exception() {
+    Span span = tracing.tracer().nextSpan().start();
+
+    Callback tracingCallback = TracingCallback.create(null, span, current);
+    tracingCallback.onCompletion(null, new Exception("Test exception"));
 
     assertThat(spans.getFirst().tags())
-        .containsKey("error");
+        .containsEntry("error", "Test exception");
+  }
+
+  @Test public void on_completion_should_forward_then_finish_span() {
+    Span span = tracing.tracer().nextSpan().start();
+
+    Callback delegate = mock(Callback.class);
+    Callback tracingCallback = TracingCallback.create(delegate, span, current);
+    RecordMetadata md = createRecordMetadata();
+    tracingCallback.onCompletion(md, null);
+
+    verify(delegate).onCompletion(md, null);
+    assertThat(spans.getFirst()).isNotNull();
+  }
+
+  @Test public void on_completion_should_have_span_in_scope() {
+    Span span = tracing.tracer().nextSpan().start();
+
+    Callback delegate = (metadata, exception) -> assertThat(current.get()).isSameAs(span.context());
+
+    TracingCallback.create(delegate, span, current).onCompletion(createRecordMetadata(), null);
+  }
+
+  @Test public void on_completion_should_forward_then_tag_if_exception() {
+    Span span = tracing.tracer().nextSpan().start();
+
+    Callback delegate = mock(Callback.class);
+    Callback tracingCallback = TracingCallback.create(delegate, span, current);
+    RecordMetadata md = createRecordMetadata();
+    Exception e = new Exception("Test exception");
+    tracingCallback.onCompletion(md, e);
+
+    verify(delegate).onCompletion(md, e);
 
     assertThat(spans.getFirst().tags())
         .containsEntry("error", "Test exception");
@@ -38,7 +81,6 @@ public class TracingCallbackTest extends BaseTracingTest {
     int keySize = 3;
     int valueSize = 5;
     Long checksum = 908923L;
-
     return new RecordMetadata(tp, -1L, -1L, timestamp, checksum, keySize, valueSize);
   }
 }


### PR DESCRIPTION
Callbacks should have a span in scope so that log IDs are assigned.