### PR TITLE
Forces invoker to run the IT tests we thought it did

### DIFF
--- a/instrumentation/grpc/src/it/grpc12/pom.xml
+++ b/instrumentation/grpc/src/it/grpc12/pom.xml
@@ -75,10 +75,15 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-failsafe-plugin.version@</version>
         <configuration>
           <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
         </configuration>
       </plugin>
       <plugin>

--- a/instrumentation/kafka-clients/src/it/kafka1/pom.xml
+++ b/instrumentation/kafka-clients/src/it/kafka1/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.github.charithe</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>@kafka-junit.version@</version>
+      <version>4.0.0</version>
     </dependency>
   </dependencies>
 

--- a/instrumentation/kafka-clients/src/it/kafka1/pom.xml
+++ b/instrumentation/kafka-clients/src/it/kafka1/pom.xml
@@ -59,10 +59,15 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-failsafe-plugin.version@</version>
         <configuration>
           <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/servlet/src/it/servlet25/pom.xml
+++ b/instrumentation/servlet/src/it/servlet25/pom.xml
@@ -67,10 +67,16 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-failsafe-plugin.version@</version>
         <configuration>
           <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/Test.java</include>
+            <include>**/IT*.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -53,10 +53,15 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-failsafe-plugin.version@</version>
         <configuration>
           <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -35,6 +35,14 @@
       <scope>test</scope>
     </dependency>
 
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>@httpclient.version@</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
@@ -81,10 +81,15 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-failsafe-plugin.version@</version>
         <configuration>
           <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
@@ -76,7 +76,7 @@
           <includes>
             <include>**/ITTracingHandlerInterceptor*.java</include>
             <include>**/BaseITSpanCustomizingHandlerInterceptor*.java</include>
-            <include>**/TestController*.java</include>
+            <include>**/Servlet25TestController*.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/instrumentation/spring-webmvc/src/it/servlet25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/servlet25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -3,9 +3,16 @@ package brave.spring.webmvc;
 import java.util.EnumSet;
 import org.eclipse.jetty.server.DispatcherType;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Test;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 public class ITSpanCustomizingHandlerInterceptor extends BaseITSpanCustomizingHandlerInterceptor {
   @Override protected void addDelegatingTracingFilter(ServletContextHandler handler) {
     handler.addFilter(DelegatingTracingFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+  }
+
+  @Override
+  protected void registerTestController(AnnotationConfigWebApplicationContext appContext) {
+    appContext.register(Servlet25TestController.class); // the test resource
   }
 }

--- a/instrumentation/spring-webmvc/src/it/spring25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/spring25/pom.xml
@@ -69,10 +69,15 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>@maven-failsafe-plugin.version@</version>
         <configuration>
           <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
@@ -27,7 +27,7 @@ public class ITSpanCustomizingAsyncHandlerInterceptor extends ITServletContainer
 
     Span span = takeSpan();
     assertThat(span.tags())
-        .containsEntry("mvc.controller.class", "TestController")
+        .containsEntry("mvc.controller.class", "Servlet3TestController")
         .containsEntry("mvc.controller.method", "foo");
   }
 
@@ -50,7 +50,7 @@ public class ITSpanCustomizingAsyncHandlerInterceptor extends ITServletContainer
           }
         };
 
-    appContext.register(TestController.class); // the test resource
+    appContext.register(Servlet3TestController.class); // the test resource
     appContext.register(TracingConfig.class); // generic tracing setup
     DispatcherServlet servlet = new DispatcherServlet(appContext);
     servlet.setDispatchOptionsRequest(true);

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -3,9 +3,15 @@ package brave.spring.webmvc;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 public class ITSpanCustomizingHandlerInterceptor extends BaseITSpanCustomizingHandlerInterceptor {
   @Override protected void addDelegatingTracingFilter(ServletContextHandler handler) {
     handler.addFilter(DelegatingTracingFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+  }
+
+  @Override
+  protected void registerTestController(AnnotationConfigWebApplicationContext appContext) {
+    appContext.register(Servlet3TestController.class); // the test resource
   }
 }

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
@@ -5,7 +5,6 @@ import brave.http.HttpTracing;
 import brave.propagation.ExtraFieldPropagation;
 import brave.test.http.ITHttp;
 import java.io.IOException;
-import java.util.concurrent.Callable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +13,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-@Controller class TestController {
+@Controller class Servlet25TestController {
   final Tracer tracer;
 
-  @Autowired TestController(HttpTracing httpTracing) {
+  @Autowired Servlet25TestController(HttpTracing httpTracing) {
     this.tracer = httpTracing.tracing().tracer();
   }
 
@@ -47,31 +46,14 @@ import org.springframework.web.bind.annotation.RequestMethod;
     return new ResponseEntity<>(HttpStatus.OK);
   }
 
-  @RequestMapping(value = "/async")
-  public Callable<ResponseEntity<Void>> async() {
-    return () -> new ResponseEntity<>(HttpStatus.OK);
-  }
-
   @RequestMapping(value = "/exception")
   public ResponseEntity<Void> disconnect() throws IOException {
     throw new IOException();
   }
 
-  @RequestMapping(value = "/exceptionAsync")
-  public Callable<ResponseEntity<Void>> disconnectAsync() {
-    return () -> {
-      throw new IOException();
-    };
-  }
-
   @RequestMapping(value = "/items/{itemId}")
   public ResponseEntity<String> items(@PathVariable("itemId") String itemId) {
     return new ResponseEntity<String>(itemId, HttpStatus.OK);
-  }
-
-  @RequestMapping(value = "/async_items/{itemId}")
-  public Callable<ResponseEntity<String>> asyncItems(@PathVariable("itemId") String itemId) {
-    return () -> new ResponseEntity<String>(itemId, HttpStatus.OK);
   }
 
   @Controller

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
@@ -1,0 +1,35 @@
+package brave.spring.webmvc;
+
+import brave.http.HttpTracing;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller class Servlet3TestController extends Servlet25TestController {
+
+  @Autowired Servlet3TestController(HttpTracing httpTracing) {
+    super(httpTracing);
+  }
+
+  @RequestMapping(value = "/async")
+  public Callable<ResponseEntity<Void>> async() {
+    return () -> new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/exceptionAsync")
+  public Callable<ResponseEntity<Void>> disconnectAsync() {
+    return () -> {
+      throw new IOException();
+    };
+  }
+
+  @RequestMapping(value = "/async_items/{itemId}")
+  public Callable<ResponseEntity<String>> asyncItems(@PathVariable("itemId") String itemId) {
+    return () -> new ResponseEntity<String>(itemId, HttpStatus.OK);
+  }
+}

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/TracingRoutingContextHandlerAdapterTest.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/TracingRoutingContextHandlerAdapterTest.java
@@ -3,38 +3,51 @@ package brave.vertx.web;
 import brave.vertx.web.TracingRoutingContextHandler.Adapter;
 import brave.vertx.web.TracingRoutingContextHandler.Route;
 import io.vertx.core.http.HttpServerResponse;
+import java.lang.reflect.Proxy;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TracingRoutingContextHandlerAdapterTest {
   ThreadLocal<Route> currentRoute = new ThreadLocal<>();
   Adapter adapter = new Adapter(currentRoute);
-  @Mock HttpServerResponse response;
 
   @After public void clear() {
     currentRoute.remove();
   }
 
   @Test public void methodFromResponse() {
+    HttpServerResponse response = dummyResponse();
+
     currentRoute.set(new Route("GET", null));
     assertThat(adapter.methodFromResponse(response))
         .isEqualTo("GET");
   }
 
   @Test public void route_emptyByDefault() {
+    HttpServerResponse response = dummyResponse();
+
     currentRoute.set(new Route("GET", null));
     assertThat(adapter.route(response)).isEmpty();
   }
 
   @Test public void route() {
+    HttpServerResponse response = dummyResponse();
+
     currentRoute.set(new Route("GET", "/users/:userID"));
     assertThat(adapter.route(response))
         .isEqualTo("/users/:userID");
+  }
+
+  /** In JRE 1.8, mockito crashes with 'Mockito cannot mock this class' */
+  HttpServerResponse dummyResponse() {
+    return (HttpServerResponse) Proxy.newProxyInstance(
+        getClass().getClassLoader(),
+        new Class[] {HttpServerResponse.class},
+        (proxy, method, methodArgs) -> {
+          throw new UnsupportedOperationException(
+              "Unsupported method: " + method.getName());
+        });
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,12 @@
     <finagle.version>18.7.0</finagle.version>
     <log4j.version>2.11.0</log4j.version>
     <okhttp.version>3.11.0</okhttp.version>
+    <httpclient.version>4.5.6</httpclient.version>
+
     <grpc.version>1.14.0</grpc.version>
     <!-- prefer grpc's version of netty -->
     <netty.version>4.1.27.Final</netty.version>
+
     <sparkjava.version>2.7.1</sparkjava.version>
     <junit.version>4.12</junit.version>
     <assertj.version>3.11.0</assertj.version>
@@ -205,12 +208,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-cache</artifactId>
-            <version>4.5.6</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
We meant to run tests named `IT*` which are typically executed with the failsafe plugin (not the surefire one as that looks for tests name `*Test`. The invoker plugin doesn't run the verify phase which would have invoked failsafe. Attempting various things to no avail, this fakes the plugin that does run (surefire) to run the tests we meant to run.