### PR TITLE
Renames "b3SingleFormat" to "writeB3SingleFormat" and simplifies b3 impl

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
@@ -49,16 +49,6 @@ public class B3SinglePropagationTest extends PropagationTest<String> {
         .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
 
-  @Test public void extractTraceContext_sampledFalseUpperCase() {
-    MapEntry mapEntry = new MapEntry();
-    map.put("B3", "0");
-
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
-
-    assertThat(result)
-        .isEqualTo(SamplingFlags.NOT_SAMPLED);
-  }
-
   @Test public void extractTraceContext_malformed() {
     MapEntry mapEntry = new MapEntry();
     map.put("b3", "not-a-tumor");

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -5,8 +5,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static brave.internal.HexCodec.toLowerHex;
-import static brave.propagation.B3SinglePropagation.LOWER_NAME;
-import static brave.propagation.B3SinglePropagation.UPPER_NAME;
 import static java.util.Arrays.asList;
 
 /**
@@ -49,19 +47,18 @@ public final class B3Propagation<K> implements Propagation<K> {
    * "1" implies sampled and is a request to override collection-tier sampling policy.
    */
   static final String FLAGS_NAME = "X-B3-Flags";
-  final K lowerKey, upperKey, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey;
+  final K b3Key, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey;
   final List<K> fields;
 
   B3Propagation(KeyFactory<K> keyFactory) {
-    this.lowerKey = keyFactory.create(LOWER_NAME);
-    this.upperKey = keyFactory.create(UPPER_NAME);
+    this.b3Key = keyFactory.create("b3");
     this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
     this.spanIdKey = keyFactory.create(SPAN_ID_NAME);
     this.parentSpanIdKey = keyFactory.create(PARENT_SPAN_ID_NAME);
     this.sampledKey = keyFactory.create(SAMPLED_NAME);
     this.debugKey = keyFactory.create(FLAGS_NAME);
     this.fields = Collections.unmodifiableList(
-        asList(lowerKey, upperKey, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey)
+        asList(b3Key, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey)
     );
   }
 
@@ -110,8 +107,7 @@ public final class B3Propagation<K> implements Propagation<K> {
 
     B3Extractor(B3Propagation<K> propagation, Getter<C, K> getter) {
       this.propagation = propagation;
-      this.singleExtractor =
-          new B3SingleExtractor<>(propagation.lowerKey, propagation.upperKey, getter);
+      this.singleExtractor = new B3SingleExtractor<>(propagation.b3Key, getter);
       this.getter = getter;
     }
 

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -3,6 +3,8 @@ package brave.propagation;
 import brave.internal.Nullable;
 import java.util.List;
 
+import static brave.propagation.Propagation.KeyFactory.STRING;
+
 /**
  * Injects and extracts {@link TraceContext trace identifiers} as text into carriers that travel
  * in-band across process boundaries. Identifiers are often encoded as messaging or RPC request
@@ -18,9 +20,8 @@ import java.util.List;
  * @param <K> Usually, but not always a String
  */
 public interface Propagation<K> {
-  Propagation<String> B3_STRING = B3Propagation.FACTORY.create(Propagation.KeyFactory.STRING);
-  Propagation<String> B3_SINGLE_STRING =
-      B3SinglePropagation.FACTORY.create(Propagation.KeyFactory.STRING);
+  Propagation<String> B3_STRING = B3Propagation.FACTORY.create(STRING);
+  Propagation<String> B3_SINGLE_STRING = B3SinglePropagation.FACTORY.create(STRING);
 
   abstract class Factory {
     /**

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -158,6 +158,27 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-spring-rabbit</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit</artifactId>
+      <version>${spring-rabbit.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-jms</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-broker</artifactId>
+      <version>${activemq.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/instrumentation/benchmarks/src/main/java/brave/jms/JmsMessageProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jms/JmsMessageProducerBenchmarks.java
@@ -1,0 +1,126 @@
+package brave.jms;
+
+import brave.Tracing;
+import java.util.concurrent.TimeUnit;
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageNotWriteableException;
+import javax.jms.MessageProducer;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.reporter.Reporter;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class JmsMessageProducerBenchmarks {
+  ActiveMQTextMessage message = new ActiveMQTextMessage();
+  MessageProducer producer, tracingProducer;
+
+  @Setup(Level.Trial) public void init() throws MessageNotWriteableException {
+    Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build();
+    producer = new FakeMessageProducer();
+    message.setText("value");
+    tracingProducer = TracingMessageProducer.create(producer, JmsTracing.create(tracing));
+  }
+
+  @TearDown(Level.Trial) public void close() {
+    Tracing.current().close();
+  }
+
+  /** Should be near zero. This mainly ensures exceptions aren't raised */
+  @Benchmark public void send_baseCase() throws Exception {
+    producer.send(message);
+  }
+
+  @Benchmark public void send_traced() throws Exception {
+    tracingProducer.send(message);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + JmsMessageProducerBenchmarks.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  static final class FakeMessageProducer implements MessageProducer {
+
+    @Override public void setDisableMessageID(boolean value) {
+    }
+
+    @Override public boolean getDisableMessageID() {
+      return false;
+    }
+
+    @Override public void setDisableMessageTimestamp(boolean value) {
+    }
+
+    @Override public boolean getDisableMessageTimestamp() {
+      return false;
+    }
+
+    @Override public void setDeliveryMode(int deliveryMode) {
+    }
+
+    @Override public int getDeliveryMode() {
+      return 0;
+    }
+
+    @Override public void setPriority(int defaultPriority) {
+    }
+
+    @Override public int getPriority() {
+      return 0;
+    }
+
+    @Override public void setTimeToLive(long timeToLive) {
+    }
+
+    @Override public long getTimeToLive() {
+      return 0;
+    }
+
+    @Override public Destination getDestination() {
+      return null;
+    }
+
+    @Override public void close() {
+    }
+
+    @Override public void send(Message message) {
+    }
+
+    @Override public void send(Message message, int deliveryMode, int priority, long timeToLive) {
+    }
+
+    @Override public void send(Destination destination, Message message) {
+    }
+
+    @Override
+    public void send(Destination destination, Message message, int deliveryMode, int priority,
+        long timeToLive) {
+    }
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
@@ -48,7 +48,7 @@ public class TracingProducerBenchmarks {
     producer = new FakeProducer();
     tracingProducer = KafkaTracing.create(tracing).producer(producer);
     tracingB3SingleProducer =
-        KafkaTracing.newBuilder(tracing).b3SingleFormat(true).build().producer(producer);
+        KafkaTracing.newBuilder(tracing).writeB3SingleFormat(true).build().producer(producer);
   }
 
   @TearDown(Level.Trial) public void close() {

--- a/instrumentation/benchmarks/src/main/java/brave/spring/rabbit/TracingMessagePostProcessorBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/spring/rabbit/TracingMessagePostProcessorBenchmarks.java
@@ -36,7 +36,7 @@ public class TracingMessagePostProcessorBenchmarks {
     Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build();
     tracingPostProcessor = new TracingMessagePostProcessor(SpringRabbitTracing.create(tracing));
     tracingB3SinglePostProcessor = new TracingMessagePostProcessor(
-        SpringRabbitTracing.newBuilder(tracing).b3SingleFormat(true).build()
+        SpringRabbitTracing.newBuilder(tracing).writeB3SingleFormat(true).build()
     );
   }
 

--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -17,8 +17,6 @@
 
     <!-- disable errorprone override warning as we do this intentionally to allow JMS 1.1 -->
     <errorprone.args>-Xep:MissingOverride:OFF</errorprone.args>
-
-    <activemq.version>5.15.5</activemq.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
@@ -41,7 +41,7 @@ abstract class TracingConsumer<C> {
       long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
       span.start(timestamp).finish(timestamp);
     }
-    JmsTracing.addB3SingleHeader(span.context(), message);
+    jmsTracing.setNextParent(message, span.context());
   }
 
   abstract @Nullable Destination destination(Message message);

--- a/instrumentation/jms/src/main/java/brave/jms/TracingJMSProducer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingJMSProducer.java
@@ -36,7 +36,7 @@ import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentI
     this.extractor = jmsTracing.tracing.propagation().extractor(GETTER);
   }
 
-  @Override void addB3SingleHeader(TraceContext context, JMSProducer message) {
+  @Override void addB3SingleHeader(JMSProducer message, TraceContext context) {
     message.setProperty("b3", writeB3SingleFormatWithoutParentId(context));
   }
 

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageProducer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageProducer.java
@@ -36,8 +36,8 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     this.types = types;
   }
 
-  @Override void addB3SingleHeader(TraceContext context, Message message) {
-    JmsTracing.addB3SingleHeader(context, message);
+  @Override void addB3SingleHeader(Message message, TraceContext context) {
+    JmsTracing.addB3SingleHeader(message, context);
   }
 
   @Override void clearPropagationHeaders(Message message) {

--- a/instrumentation/jms/src/main/java/brave/jms/TracingProducer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingProducer.java
@@ -49,11 +49,11 @@ abstract class TracingProducer<P, M> {
       span.start();
     }
 
-    addB3SingleHeader(span.context(), message);
+    addB3SingleHeader(message, span.context());
     return span;
   }
 
-  abstract void addB3SingleHeader(TraceContext context, M message);
+  abstract void addB3SingleHeader(M message, TraceContext context);
 
   abstract void clearPropagationHeaders(M message);
 

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTest.java
@@ -2,6 +2,7 @@ package brave.jms;
 
 import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.Propagation;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.Enumeration;
@@ -22,6 +23,16 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class JmsTest {
+  static final Propagation.Setter<Message, String> SETTER =
+      new Propagation.Setter<Message, String>() {
+        @Override public void put(Message carrier, String key, String value) {
+          try {
+            carrier.setStringProperty(key, value);
+          } catch (JMSException e) {
+            throw new AssertionError(e);
+          }
+        }
+      };
 
   @After public void tearDown() {
     tracing.close();

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
@@ -1,0 +1,91 @@
+package brave.jms;
+
+import brave.Span;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.junit.Test;
+
+import static org.apache.activemq.command.ActiveMQDestination.QUEUE_TYPE;
+import static org.apache.activemq.command.ActiveMQDestination.createDestination;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class JmsTracingTest extends JmsTest {
+  ActiveMQTextMessage message = new ActiveMQTextMessage();
+
+  @Test public void nextSpan_prefers_b3_header() throws Exception {
+    message.setStringProperty("b3", "0000000000000001-0000000000000002-1");
+
+    Span child;
+    try (Scope ws = tracing.currentTraceContext()
+        .newScope(TraceContext.newBuilder().traceId(1).spanId(1).build())) {
+      child = jmsTracing.nextSpan(message);
+    }
+    assertThat(child.context().parentId())
+        .isEqualTo(2L);
+  }
+
+  @Test public void nextSpan_uses_current_context() {
+    Span child;
+    try (Scope ws = tracing.currentTraceContext()
+        .newScope(TraceContext.newBuilder().traceId(1).spanId(1).build())) {
+      child = jmsTracing.nextSpan(message);
+    }
+    assertThat(child.context().parentId())
+        .isEqualTo(1L);
+  }
+
+  @Test public void nextSpan_should_use_span_from_headers_as_parent() throws Exception {
+    message.setStringProperty("b3", "0000000000000001-0000000000000002-1");
+    Span span = jmsTracing.nextSpan(message);
+
+    assertThat(span.context().parentId()).isEqualTo(2L);
+  }
+
+  @Test public void nextSpan_should_create_span_if_no_headers() {
+    Span span = jmsTracing.nextSpan(message);
+
+    assertThat(span).isNotNull();
+  }
+
+  @Test public void nextSpan_should_tag_queue_when_no_incoming_context() throws Exception {
+    message.setDestination(createDestination("foo", QUEUE_TYPE));
+    jmsTracing.nextSpan(message).start().finish();
+
+    assertThat(takeSpan().tags())
+        .containsOnly(entry("jms.queue", "foo"));
+  }
+
+  /**
+   * We assume the queue is already tagged by the producer span. However, we can change this policy
+   * now, or later when dynamic policy is added to JmsTracing
+   */
+  @Test public void nextSpan_shouldnt_tag_queue_when_incoming_context() throws Exception {
+    message.setStringProperty("b3", "0000000000000001-0000000000000002-1");
+    message.setDestination(createDestination("foo", QUEUE_TYPE));
+    jmsTracing.nextSpan(message).start().finish();
+
+    assertThat(takeSpan().tags()).isEmpty();
+  }
+
+  @Test public void nextSpan_should_clear_propagation_headers() throws Exception {
+
+    TraceContext context =
+        TraceContext.newBuilder().traceId(1L).parentId(2L).spanId(3L).debug(true).build();
+    Propagation.B3_STRING.injector(SETTER).inject(context, message);
+    Propagation.B3_SINGLE_STRING.injector(SETTER).inject(context, message);
+
+    jmsTracing.nextSpan(message);
+    assertThat(JmsTest.propertiesToMap(message)).isEmpty();
+  }
+
+  @Test public void nextSpan_should_not_clear_other_headers() throws Exception {
+    message.setIntProperty("foo", 1);
+
+    jmsTracing.nextSpan(message);
+
+    assertThat(message.getIntProperty("foo")).isEqualTo(1);
+  }
+}

--- a/instrumentation/jms/src/test/java/brave/jms/TracingMessageListenerTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/TracingMessageListenerTest.java
@@ -44,7 +44,7 @@ public class TracingMessageListenerTest {
     tracing.close();
   }
 
-  @Test public void starts_new_trace_if_none_exists() throws Throwable {
+  @Test public void starts_new_trace_if_none_exists() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     onMessageConsumed(message);
 
@@ -53,7 +53,7 @@ public class TracingMessageListenerTest {
         .containsExactly(CONSUMER, null);
   }
 
-  @Test public void consumer_and_listener_have_names() throws Throwable {
+  @Test public void consumer_and_listener_have_names() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     onMessageConsumed(message);
 
@@ -62,7 +62,7 @@ public class TracingMessageListenerTest {
         .containsExactly("receive", "on-message");
   }
 
-  @Test public void consumer_has_remote_service_name() throws Throwable {
+  @Test public void consumer_has_remote_service_name() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     onMessageConsumed(message);
 
@@ -71,7 +71,7 @@ public class TracingMessageListenerTest {
         .containsExactly("my-service", null);
   }
 
-  @Test public void tags_consumer_span_but_not_listener() throws Throwable {
+  @Test public void tags_consumer_span_but_not_listener() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     message.setDestination(createDestination("foo", QUEUE_TYPE));
     onMessageConsumed(message);
@@ -84,7 +84,7 @@ public class TracingMessageListenerTest {
     assertThat(spans.get(1).tags()).isEmpty();
   }
 
-  @Test public void consumer_span_starts_before_listener() throws Throwable {
+  @Test public void consumer_span_starts_before_listener() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     onMessageConsumed(message);
 
@@ -99,7 +99,7 @@ public class TracingMessageListenerTest {
         .isPositive();
   }
 
-  @Test public void continues_parent_trace() throws Throwable {
+  @Test public void continues_parent_trace() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     message.setStringProperty("X-B3-TraceId", TRACE_ID);
     message.setStringProperty("X-B3-SpanId", SPAN_ID);
@@ -117,7 +117,7 @@ public class TracingMessageListenerTest {
         .contains(SPAN_ID);
   }
 
-  @Test public void continues_parent_trace_single_header() throws Throwable {
+  @Test public void continues_parent_trace_single_header() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     message.setStringProperty("b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
 
@@ -132,7 +132,7 @@ public class TracingMessageListenerTest {
         .contains(SPAN_ID);
   }
 
-  @Test public void reports_span_if_consume_fails() throws Throwable {
+  @Test public void reports_span_if_consume_fails() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     onMessageConsumeFailed(message, new RuntimeException("expected exception"));
 
@@ -147,7 +147,7 @@ public class TracingMessageListenerTest {
         .contains("expected exception");
   }
 
-  @Test public void reports_span_if_consume_fails_with_no_message() throws Throwable {
+  @Test public void reports_span_if_consume_fails_with_no_message() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
     onMessageConsumeFailed(message, new RuntimeException());
 
@@ -162,12 +162,12 @@ public class TracingMessageListenerTest {
         .containsOnly("RuntimeException");
   }
 
-  void onMessageConsumed(Message message) throws Throwable {
+  void onMessageConsumed(Message message) throws Exception {
     doNothing().when(delegate).onMessage(message);
     tracingMessageListener.onMessage(message);
   }
 
-  void onMessageConsumeFailed(Message message, Throwable throwable) throws Throwable {
+  void onMessageConsumeFailed(Message message, Throwable throwable) throws Exception {
     doThrow(throwable).when(delegate).onMessage(message);
 
     try {

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -8,7 +8,7 @@ Add decorators for Kafka producer and consumer to enable tracing.
 First, setup the generic Kafka component like this:
 ```java
 kafkaTracing = KafkaTracing.newBuilder(tracing)
-                           .b3SingleFormat(true) // for more efficient propagation
+                           .writeB3SingleFormat(true) // for more efficient propagation
                            .remoteServiceName("my-broker")
                            .build();
 ```

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
@@ -2,7 +2,7 @@ package brave.kafka.clients;
 
 import brave.Span;
 import brave.Tracing;
-import brave.internal.HexCodec;
+import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -18,28 +18,33 @@ import static org.mockito.Mockito.when;
 
 public class KafkaTracingTest extends BaseTracingTest {
 
-  @Test
-  public void nextSpan_should_use_span_from_headers_as_parent() {
-    addB3Headers(fakeRecord);
-    Span span = kafkaTracing.nextSpan(fakeRecord);
+  @Test public void nextSpan_prefers_b3_header() {
+    fakeRecord.headers().add("b3", "0000000000000001-0000000000000002-1".getBytes(UTF_8));
 
-    TraceContext context = span.context();
-    assertThat(HexCodec.toLowerHex(context.traceId())).isEqualTo(TRACE_ID);
-    assertThat(HexCodec.toLowerHex(context.parentId())).isEqualTo(SPAN_ID);
-    assertThat(context.sampled()).isEqualTo(true);
+    Span child;
+    try (CurrentTraceContext.Scope ws = tracing.currentTraceContext()
+        .newScope(TraceContext.newBuilder().traceId(1).spanId(1).build())) {
+      child = kafkaTracing.nextSpan(fakeRecord);
+    }
+    assertThat(child.context().parentId())
+        .isEqualTo(2L);
   }
 
-  @Test
-  public void nextSpan_should_create_span_if_no_headers() {
-    Span span = kafkaTracing.nextSpan(fakeRecord);
-
-    TraceContext context = span.context();
-    assertThat(HexCodec.toLowerHex(context.traceId())).isNotEmpty().isNotEqualTo(TRACE_ID);
-    assertThat(HexCodec.toLowerHex(context.spanId())).isNotEmpty().isNotEqualTo(SPAN_ID);
+  @Test public void nextSpan_uses_current_context() {
+    Span child;
+    try (CurrentTraceContext.Scope ws = tracing.currentTraceContext()
+        .newScope(TraceContext.newBuilder().traceId(1).spanId(1).build())) {
+      child = kafkaTracing.nextSpan(fakeRecord);
+    }
+    assertThat(child.context().parentId())
+        .isEqualTo(1L);
   }
 
-  @Test
-  public void nextSpan_should_tag_topic_and_key_when_no_incoming_context() {
+  @Test public void nextSpan_should_create_span_if_no_headers() {
+    assertThat(kafkaTracing.nextSpan(fakeRecord)).isNotNull();
+  }
+
+  @Test public void nextSpan_should_tag_topic_and_key_when_no_incoming_context() {
     kafkaTracing.nextSpan(fakeRecord).start().finish();
 
     assertThat(spans)
@@ -47,8 +52,7 @@ public class KafkaTracingTest extends BaseTracingTest {
         .containsOnly(entry("kafka.topic", TEST_TOPIC), entry("kafka.key", TEST_KEY));
   }
 
-  @Test
-  public void nextSpan_shouldnt_tag_null_key() {
+  @Test public void nextSpan_shouldnt_tag_null_key() {
     fakeRecord = new ConsumerRecord<>(TEST_TOPIC, 0, 1, null, TEST_VALUE);
 
     kafkaTracing.nextSpan(fakeRecord).start().finish();
@@ -58,8 +62,7 @@ public class KafkaTracingTest extends BaseTracingTest {
         .containsOnly(entry("kafka.topic", TEST_TOPIC));
   }
 
-  @Test
-  public void nextSpan_shouldnt_tag_binary_key() {
+  @Test public void nextSpan_shouldnt_tag_binary_key() {
     ConsumerRecord<byte[], String> record =
         new ConsumerRecord<>(TEST_TOPIC, 0, 1, new byte[1], TEST_VALUE);
 
@@ -74,8 +77,7 @@ public class KafkaTracingTest extends BaseTracingTest {
    * We assume topic and key are already tagged by the producer span. However, we can change this
    * policy now, or later when dynamic policy is added to KafkaTracing
    */
-  @Test
-  public void nextSpan_shouldnt_tag_topic_and_key_when_incoming_context() {
+  @Test public void nextSpan_shouldnt_tag_topic_and_key_when_incoming_context() {
     addB3Headers(fakeRecord);
     kafkaTracing.nextSpan(fakeRecord).start().finish();
 
@@ -84,16 +86,14 @@ public class KafkaTracingTest extends BaseTracingTest {
         .isEmpty();
   }
 
-  @Test
-  public void nextSpan_should_clear_propagation_headers() {
+  @Test public void nextSpan_should_clear_propagation_headers() {
     addB3Headers(fakeRecord);
 
     kafkaTracing.nextSpan(fakeRecord);
     assertThat(fakeRecord.headers().toArray()).isEmpty();
   }
 
-  @Test
-  public void nextSpan_should_not_clear_other_headers() {
+  @Test public void nextSpan_should_not_clear_other_headers() {
     fakeRecord.headers().add("foo", new byte[0]);
 
     kafkaTracing.nextSpan(fakeRecord);
@@ -113,9 +113,9 @@ public class KafkaTracingTest extends BaseTracingTest {
 
     assertThatThrownBy(() -> KafkaTracing.newBuilder(
         Tracing.newBuilder().propagationFactory(propagationFactory).build())
-        .b3SingleFormat(true)
+        .writeB3SingleFormat(true)
         .build()
     ).hasMessage(
-        "KafkaTracing.Builder.b3SingleFormat set, but Tracing.Builder.propagationFactory cannot parse this format!");
+        "KafkaTracing.Builder.writeB3SingleFormat set, but Tracing.Builder.propagationFactory cannot parse this format!");
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingProducerTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingProducerTest.java
@@ -86,7 +86,7 @@ public class TracingProducerTest extends BaseTracingTest {
   }
 
   @Test public void should_add_b3_single_header_to_message() {
-    tracingProducer = KafkaTracing.newBuilder(tracing).b3SingleFormat(true).build()
+    tracingProducer = KafkaTracing.newBuilder(tracing).writeB3SingleFormat(true).build()
         .producer(mockProducer);
 
     tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE));

--- a/instrumentation/spring-rabbit/README.md
+++ b/instrumentation/spring-rabbit/README.md
@@ -16,7 +16,7 @@ public Tracing tracing() {
 @Bean
 public SpringRabbitTracing springRabbitTracing(Tracing tracing) {
   return SpringRabbitTracing.newBuilder(tracing)
-                            .b3SingleFormat(true) // for more efficient propagation
+                            .writeB3SingleFormat(true) // for more efficient propagation
                             .remoteServiceName("my-mq-service")
                             .build();
 }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -95,9 +95,9 @@ public class SpringRabbitTracingTest {
 
     assertThatThrownBy(() -> SpringRabbitTracing.newBuilder(
         Tracing.newBuilder().propagationFactory(propagationFactory).build())
-        .b3SingleFormat(true)
+        .writeB3SingleFormat(true)
         .build()
     ).hasMessage(
-        "SpringRabbitTracing.Builder.b3SingleFormat set, but Tracing.Builder.propagationFactory cannot parse this format!");
+        "SpringRabbitTracing.Builder.writeB3SingleFormat set, but Tracing.Builder.propagationFactory cannot parse this format!");
   }
 }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingMessagePostProcessorTest.java
@@ -73,7 +73,7 @@ public class TracingMessagePostProcessorTest {
 
   @Test public void should_add_b3_single_header_to_message() {
     TracingMessagePostProcessor tracingMessagePostProcessor = new TracingMessagePostProcessor(
-        SpringRabbitTracing.newBuilder(tracing).b3SingleFormat(true).build()
+        SpringRabbitTracing.newBuilder(tracing).writeB3SingleFormat(true).build()
     );
 
     Message message = MessageBuilder.withBody(new byte[0]).build();

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <kafka.version>2.0.0</kafka.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
     <kafka-junit.version>4.1.2</kafka-junit.version>
-
+    <activemq.version>5.15.5</activemq.version>
     <spring-rabbit.version>1.7.9.RELEASE</spring-rabbit.version>
 
     <finagle.version>18.7.0</finagle.version>


### PR DESCRIPTION
This renames the setting "b3SingleFormat" to "writeB3SingleFormat" as
it only applies to outbound propagation. It also simplifies the "b3"
implementation by not checking for two keys (the old impl was also case
sensitive by default). This allows us to special case when only "b3" is
used. Finally, this backfills some JMS related tests and benchmarks.