### PR TITLE
Temporarily stops publishing kafka-streams

### DIFF
--- a/instrumentation/kafka-streams/pom.xml
+++ b/instrumentation/kafka-streams/pom.xml
@@ -59,6 +59,13 @@
   <build>
     <plugins>
       <plugin>
+        <!-- temporarily stop deployment -->
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>


### PR DESCRIPTION
kafka-streams has not been released yet, and it likely shouldn't until
we sort out making intermediate spans. Meanwhile, folks can copy/paste
the small amount of setup that exists.