### PR TITLE
Ensures extra fields are not accidentally cleared when trace IDs are

### DIFF
--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -258,20 +258,22 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   final Propagation<K> delegate;
   final ExtraFactory extraFactory;
   final String[] fieldNames;
-  final List<K> keys, allKeys;
+  final List<K> keys;
 
   ExtraFieldPropagation(Factory factory, Propagation.KeyFactory<K> keyFactory, List<K> keys) {
     this.delegate = factory.delegate.create(keyFactory);
     this.extraFactory = factory.extraFactory;
     this.fieldNames = factory.fieldNames;
     this.keys = keys;
-    List<K> allKeys = new ArrayList<>(delegate.keys());
-    allKeys.addAll(keys);
-    this.allKeys = allKeys;
   }
 
+  /**
+   * Only returns trace context keys. Extra field names are not returned to ensure tools don't
+   * delete them. This is to support users accessing extra fields without Brave apis (ex via
+   * headers).
+   */
   @Override public List<K> keys() {
-    return allKeys;
+    return delegate.keys();
   }
 
   @Override public <C> Injector<C> injector(Setter<C, K> setter) {

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -92,6 +92,10 @@ public interface Propagation<K> {
    * <p>For example, if the carrier is a single-use or immutable request object, you don't need to
    * clear fields as they couldn't have been set before. If it is a mutable, retryable object,
    * successive calls should clear these fields first.
+   *
+   * <p><em>Note:</em> If your implementation carries "extra fields", such as correlation IDs, do
+   * not return the names of those fields here. If you do, they will be deleted, which can interfere
+   * with user headers.
    */
   // The use cases of this are:
   // * allow pre-allocation of fields, especially in systems like gRPC Metadata

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -35,6 +35,15 @@ public class ExtraFieldPropagationTest {
         .build());
   }
 
+  /**
+   * Ensure extra fields aren't leaked. This prevents tools from deleting entries when clearing a
+   * trace.
+   */
+  @Test public void keysDontIncludeExtra() {
+    assertThat(factory.create(Propagation.KeyFactory.STRING).keys())
+        .isEqualTo(Propagation.B3_STRING.keys());
+  }
+
   @Test public void downcasesNames() {
     ExtraFieldPropagation.Factory factory =
         (ExtraFieldPropagation.Factory) ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
@@ -22,7 +22,6 @@ final class KafkaPropagation {
 
   static final Injector<Headers> B3_SINGLE_INJECTOR = new Injector<Headers>() {
     @Override public void inject(TraceContext traceContext, Headers carrier) {
-      carrier.remove("b3");
       carrier.add("b3", writeB3SingleFormatWithoutParentIdAsBytes(traceContext));
     }
 


### PR DESCRIPTION
There is some defensive logic in messaging to prevent re-processing the
same trace. This accidentally cleared extra fields which made it
impossible for folks to access them via headers later.

Fixes #783