### PR TITLE
Decouples vertx thread locals from Brave types

### DIFF
--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -2,7 +2,6 @@ package brave.vertx.web;
 
 import brave.Span;
 import brave.Tracer;
-import brave.http.HttpServerAdapter;
 import brave.http.HttpServerHandler;
 import brave.http.HttpTracing;
 import brave.propagation.Propagation.Getter;
@@ -10,31 +9,18 @@ import brave.propagation.TraceContext;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * <h3>Why not rely on {@code context.request().endHandler()} to finish a span?</h3>
  * <p>There can be only one {@link HttpServerRequest#endHandler(Handler) end handler}. We can't
- * rely
- * on {@code endHandler()} as a user can override it in their route. If they did, we'd leak an
+ * rely on {@code endHandler()} as a user can override it in their route. If they did, we'd leak an
  * unfinished span. For this reason, we speculatively use both an end handler and an end header
  * handler.
  *
  * <p>The hint that we need to re-attach the headers handler on re-route came from looking at
  * {@code TracingHandler} in https://github.com/opentracing-contrib/java-vertx-web
- *
- * <h3>Why use a thread local for the http route when parsing {@linkplain HttpServerResponse}?</h3>
- * <p>When parsing the response, we use a thread local to make the current route's path visible.
- * This is an alternative to wrapping {@linkplain HttpServerResponse} or declaring a custom type. We
- * don't wrap {@linkplain HttpServerResponse}, because this would lock the instrumentation to the
- * signatures currently present on it (for example, if a method is added, we'd have to recompile).
- * If a wrapper is eventually provided by vertx, we could use that, but it didn't exist at the time.
- * We could also define a custom composite type like ResponseWithTemplate. However, this would
- * interfere with people using "instanceof" in http samplers or parsers: they'd have to depend on a
- * brave type. The least impact means was to use a thread local, as eventhough this costs a little,
- * it prevents revision lock or routine use of custom types.
  */
 final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   static final Getter<HttpServerRequest, String> GETTER = new Getter<HttpServerRequest, String>() {
@@ -48,14 +34,12 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   };
 
   final Tracer tracer;
-  final ThreadLocal<Route> currentRoute;
   final HttpServerHandler<HttpServerRequest, HttpServerResponse> serverHandler;
   final TraceContext.Extractor<HttpServerRequest> extractor;
 
   TracingRoutingContextHandler(HttpTracing httpTracing) {
     tracer = httpTracing.tracing().tracer();
-    currentRoute = new ThreadLocal<>();
-    serverHandler = HttpServerHandler.create(httpTracing, new Adapter(currentRoute));
+    serverHandler = HttpServerHandler.create(httpTracing, new VertxHttpServerAdapter());
     extractor = httpTracing.tracing().propagation().extractor(GETTER);
   }
 
@@ -91,77 +75,15 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
 
     @Override public void handle(Void aVoid) {
       if (!finished.compareAndSet(false, true)) return;
-      Route route = new Route(context.request().rawMethod(), context.currentRoute().getPath());
+      VertxHttpServerAdapter.setCurrentMethodAndPath(
+          context.request().rawMethod(),
+          context.currentRoute().getPath()
+      );
       try {
-        currentRoute.set(route);
         serverHandler.handleSend(context.response(), context.failure(), span);
       } finally {
-        currentRoute.remove();
+        VertxHttpServerAdapter.setCurrentMethodAndPath(null, null);
       }
-    }
-  }
-
-  static final class Route {
-    final String method, path;
-
-    Route(String method, String path) {
-      this.method = method;
-      this.path = path;
-    }
-
-    @Override public String toString() {
-      return "Route{method=" + method + ", path=" + path + "}";
-    }
-  }
-
-  static final class Adapter extends HttpServerAdapter<HttpServerRequest, HttpServerResponse> {
-    final ThreadLocal<Route> currentRoute;
-
-    Adapter(ThreadLocal<Route> currentRoute) {
-      this.currentRoute = currentRoute;
-    }
-
-    @Override public String method(HttpServerRequest request) {
-      return request.rawMethod();
-    }
-
-    @Override public String path(HttpServerRequest request) {
-      return request.path();
-    }
-
-    @Override public String url(HttpServerRequest request) {
-      return request.absoluteURI();
-    }
-
-    @Override public String requestHeader(HttpServerRequest request, String name) {
-      return request.headers().get(name);
-    }
-
-    @Override public String methodFromResponse(HttpServerResponse response) {
-      return currentRoute.get().method;
-    }
-
-    @Override public String route(HttpServerResponse response) {
-      String result = currentRoute.get().path;
-      return result != null ? result : "";
-    }
-
-    @Override public Integer statusCode(HttpServerResponse response) {
-      return statusCodeAsInt(response);
-    }
-
-    @Override public int statusCodeAsInt(HttpServerResponse response) {
-      return response.getStatusCode();
-    }
-
-    /**
-     * This sets the client IP:port to the {@linkplain HttpServerRequest#remoteAddress() remote
-     * address} if the {@link HttpServerAdapter#parseClientIpAndPort default parsing} fails.
-     */
-    @Override public boolean parseClientIpAndPort(HttpServerRequest req, Span span) {
-      if (parseClientIpFromXForwardedFor(req, span)) return true;
-      SocketAddress addr = req.remoteAddress();
-      return span.remoteIpAndPort(addr.host(), addr.port());
     }
   }
 }

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxHttpServerAdapter.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxHttpServerAdapter.java
@@ -1,0 +1,84 @@
+package brave.vertx.web;
+
+import brave.Span;
+import brave.http.HttpServerAdapter;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
+
+/**
+ * Why use a thread local for the http route when parsing {@linkplain HttpServerResponse}?</h3>
+ *
+ * <p>When parsing the response, we use a thread local to make the current route's path visible.
+ * This is an alternative to wrapping {@linkplain HttpServerResponse} or declaring a custom type. We
+ * don't wrap {@linkplain HttpServerResponse}, because this would lock the instrumentation to the
+ * signatures currently present on it (for example, if a method is added, we'd have to recompile).
+ * If a wrapper is eventually provided by vertx, we could use that, but it didn't exist at the time.
+ * We could also define a custom composite type like ResponseWithTemplate. However, this would
+ * interfere with people using "instanceof" in http samplers or parsers: they'd have to depend on a
+ * brave type. The least impact means was to use a thread local, as eventhough this costs a little,
+ * it prevents revision lock or routine use of custom types.
+ */
+class VertxHttpServerAdapter extends HttpServerAdapter<HttpServerRequest, HttpServerResponse> {
+
+  @Override public String method(HttpServerRequest request) {
+    return request.rawMethod();
+  }
+
+  @Override public String path(HttpServerRequest request) {
+    return request.path();
+  }
+
+  @Override public String url(HttpServerRequest request) {
+    return request.absoluteURI();
+  }
+
+  @Override public String requestHeader(HttpServerRequest request, String name) {
+    return request.headers().get(name);
+  }
+
+  @Override public String methodFromResponse(HttpServerResponse ignored) {
+    String[] methodAndPath = METHOD_AND_PATH.get();
+    return methodAndPath != null ? methodAndPath[0] : null;
+  }
+
+  @Override public String route(HttpServerResponse ignored) {
+    String[] methodAndPath = METHOD_AND_PATH.get();
+    String result = methodAndPath != null ? methodAndPath[1] : null;
+    return result != null ? result : "";
+  }
+
+  @Override public Integer statusCode(HttpServerResponse response) {
+    return statusCodeAsInt(response);
+  }
+
+  @Override public int statusCodeAsInt(HttpServerResponse response) {
+    return response.getStatusCode();
+  }
+
+  /**
+   * This sets the client IP:port to the {@linkplain HttpServerRequest#remoteAddress() remote
+   * address} if the {@link HttpServerAdapter#parseClientIpAndPort default parsing} fails.
+   */
+  @Override public boolean parseClientIpAndPort(HttpServerRequest req, Span span) {
+    if (parseClientIpFromXForwardedFor(req, span)) return true;
+    SocketAddress addr = req.remoteAddress();
+    return span.remoteIpAndPort(addr.host(), addr.port());
+  }
+
+  /**
+   * This uses a string array to avoid leaking a Brave type onto a thread local. If we used a Brave
+   * type, it would prevent unloading Brave classes.
+   */
+  static final ThreadLocal<String[]> METHOD_AND_PATH = new ThreadLocal<>();
+
+  static void setCurrentMethodAndPath(String method, String path) {
+    String[] methodAndPath = METHOD_AND_PATH.get();
+    if (methodAndPath == null) {
+      methodAndPath = new String[2];
+      METHOD_AND_PATH.set(methodAndPath);
+    }
+    methodAndPath[0] = method;
+    methodAndPath[1] = path;
+  }
+}

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/VertxHttpServerAdapterTest.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/VertxHttpServerAdapterTest.java
@@ -1,26 +1,25 @@
 package brave.vertx.web;
 
-import brave.vertx.web.TracingRoutingContextHandler.Adapter;
-import brave.vertx.web.TracingRoutingContextHandler.Route;
 import io.vertx.core.http.HttpServerResponse;
 import java.lang.reflect.Proxy;
 import org.junit.After;
 import org.junit.Test;
 
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TracingRoutingContextHandlerAdapterTest {
-  ThreadLocal<Route> currentRoute = new ThreadLocal<>();
-  Adapter adapter = new Adapter(currentRoute);
+public class VertxHttpServerAdapterTest {
+  VertxHttpServerAdapter adapter = new VertxHttpServerAdapter();
 
   @After public void clear() {
-    currentRoute.remove();
+    VertxHttpServerAdapter.METHOD_AND_PATH.remove();
   }
 
   @Test public void methodFromResponse() {
     HttpServerResponse response = dummyResponse();
 
-    currentRoute.set(new Route("GET", null));
+    VertxHttpServerAdapter.setCurrentMethodAndPath("GET", null);
+
     assertThat(adapter.methodFromResponse(response))
         .isEqualTo("GET");
   }
@@ -28,16 +27,31 @@ public class TracingRoutingContextHandlerAdapterTest {
   @Test public void route_emptyByDefault() {
     HttpServerResponse response = dummyResponse();
 
-    currentRoute.set(new Route("GET", null));
+    VertxHttpServerAdapter.setCurrentMethodAndPath("GET", null);
+
     assertThat(adapter.route(response)).isEmpty();
   }
 
   @Test public void route() {
     HttpServerResponse response = dummyResponse();
 
-    currentRoute.set(new Route("GET", "/users/:userID"));
+    VertxHttpServerAdapter.setCurrentMethodAndPath("GET", "/users/:userID");
+
     assertThat(adapter.route(response))
         .isEqualTo("/users/:userID");
+  }
+
+  @Test public void setCurrentMethodAndPath_doesntPreventClassUnloading() {
+    assertRunIsUnloadable(MethodFromResponse.class, getClass().getClassLoader());
+  }
+
+  static class MethodFromResponse implements Runnable {
+    final VertxHttpServerAdapter adapter = new VertxHttpServerAdapter();
+
+    @Override public void run() {
+      VertxHttpServerAdapter.setCurrentMethodAndPath("GET", null);
+      adapter.methodFromResponse(null);
+    }
   }
 
   /** In JRE 1.8, mockito crashes with 'Mockito cannot mock this class' */


### PR DESCRIPTION
This change makes sure thread locals used for vert.x do not hold strong
references to Brave types by using normal strings instead. This ensures
vertx instrumentation can be unloaded in application servers.

See #785