### PR TITLE
Make cores types unloadable

### DIFF
--- a/brave-tests/src/main/java/brave/test/util/ClassLoaders.java
+++ b/brave-tests/src/main/java/brave/test/util/ClassLoaders.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.logging.LogManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,6 +69,11 @@ public final class ClassLoaders {
 
   /** Runs the type in a new classloader that recreates brave classes */
   public static void assertRunIsUnloadable(Class<? extends Runnable> runnable, ClassLoader parent) {
+    // We can't use log4j2's log manager. More importantly, we want to make sure loggers don't hold
+    // our test classloader from being collected.
+    System.setProperty("java.util.logging.manager", LogManager.class.getName());
+    assertThat(LogManager.getLogManager().getClass()).isSameAs(LogManager.class);
+
     WeakReference<ClassLoader> loader;
     try {
       loader = invokeRunFromNewClassLoader(runnable, parent);

--- a/brave-tests/src/main/java/brave/test/util/ClassLoaders.java
+++ b/brave-tests/src/main/java/brave/test/util/ClassLoaders.java
@@ -1,0 +1,145 @@
+package brave.test.util;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class ClassLoaders {
+
+  /** Runs the assertion in a new classloader. Needed when you are creating parameterized tests */
+  public static <T> void assertRunIsUnloadableWithSupplier(
+      Class<? extends ConsumerRunnable<T>> assertion,
+      Class<? extends Supplier<? extends T>> supplier
+  ) {
+    String property = assertion.getName() + ".supplier"; // assumes assertion is run only once
+    System.setProperty(property, supplier.getName());
+    try {
+      assertRunIsUnloadable(assertion, assertion.getClassLoader());
+    } finally {
+      System.getProperties().remove(property);
+    }
+  }
+
+  public static abstract class ConsumerRunnable<T> implements Runnable, Consumer<T> {
+    Class<? extends Supplier<T>> subjectSupplier;
+
+    protected ConsumerRunnable() {
+      try {
+        subjectSupplier =
+            (Class) Class.forName(System.getProperty(getClass().getName() + ".supplier"));
+      } catch (ClassNotFoundException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    @Override public void run() {
+      accept(newInstance(subjectSupplier, getClass().getClassLoader()).get());
+    }
+  }
+
+  /** Validating instance creator that ensures the supplier type is static or top-level */
+  public static <T> T newInstance(Class<T> type, ClassLoader loader) {
+    assertThat(type)
+        .withFailMessage(type + " should be a static member class")
+        .satisfies(c -> {
+          assertThat(c.isLocalClass()).isFalse();
+          assertThat(Modifier.isPublic(c.getModifiers())).isFalse();
+        });
+
+    try {
+      Class<T> classToInstantiate = (Class<T>) loader.loadClass(type.getName());
+      Constructor<T> ctor = classToInstantiate.getDeclaredConstructor();
+      ctor.setAccessible(true);
+
+      return ctor.newInstance();
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** Runs the type in a new classloader that recreates brave classes */
+  public static void assertRunIsUnloadable(Class<? extends Runnable> runnable, ClassLoader parent) {
+    WeakReference<ClassLoader> loader;
+    try {
+      loader = invokeRunFromNewClassLoader(runnable, parent);
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+
+    blockOnGC();
+
+    assertThat(loader.get())
+        .withFailMessage(runnable + " includes state that couldn't be garbage collected")
+        .isNull();
+  }
+
+  static void blockOnGC() {
+    System.gc();
+    try {
+      Thread.sleep(200L);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  static WeakReference<ClassLoader> invokeRunFromNewClassLoader(
+      Class<? extends Runnable> runnable, ClassLoader parent) throws Exception {
+
+    ClassLoader loader = ClassLoaders.reloadClassNamePrefix(parent, "brave");
+    Runnable instance = newInstance(runnable, loader);
+
+    // ensure the classes are indeed different
+    assertThat(instance.getClass()).isNotSameAs(runnable);
+
+    Method run = instance.getClass().getMethod("run");
+    run.setAccessible(true);
+
+    run.invoke(instance);
+
+    return new WeakReference<>(loader);
+  }
+
+  /**
+   * Creates a new classloader that reloads types matching the given prefix. This is used to test
+   * behavior such a leaked type in a thread local.
+   *
+   * <p>This works by using a bridge loader over the normal system one. The bridge loader always
+   * loads new classes when they are prefixed by brave types.
+   *
+   * <p>This approach is the same as what's used in Android's {@code tests.util.ClassLoaderBuilder}
+   * See https://android.googlesource.com/platform/libcore/+/master/support/src/test/java/tests/util/ClassLoaderBuilder.java
+   */
+  static ClassLoader reloadClassNamePrefix(ClassLoader parent, String prefix) {
+    ClassLoader bridge = new ClassLoader(parent) {
+      @Override
+      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.startsWith(prefix)) throw new ClassNotFoundException("reloading type: " + name);
+        return super.loadClass(name, resolve);
+      }
+    };
+    try {
+      return new URLClassLoader(classpathToUrls(), bridge);
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Couldn't read the current system classpath", e);
+    }
+  }
+
+  static URL[] classpathToUrls() throws MalformedURLException {
+    String[] classpath = System.getProperty("java.class.path").split(File.pathSeparator, -1);
+    URL[] result = new URL[classpath.length];
+    for (int i = 0; i < classpath.length; i++) {
+      result[i] = new File(classpath[i]).toURI().toURL();
+    }
+    return result;
+  }
+}

--- a/brave-tests/src/test/java/brave/TracerClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/TracerClassLoaderTest.java
@@ -1,0 +1,19 @@
+package brave;
+
+import org.junit.Test;
+import zipkin2.Span;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class TracerClassLoaderTest {
+  @Test public void unloadable_withLoggingReporter() {
+    assertRunIsUnloadable(UsingLoggingReporter.class, getClass().getClassLoader());
+  }
+
+  static class UsingLoggingReporter implements Runnable {
+    @Override public void run() {
+      Tracing.LoggingReporter reporter = new Tracing.LoggingReporter();
+      reporter.report(Span.newBuilder().traceId("a").id("b").build());
+    }
+  }
+}

--- a/brave-tests/src/test/java/brave/TracingClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/TracingClassLoaderTest.java
@@ -1,0 +1,32 @@
+package brave;
+
+import org.junit.Test;
+import zipkin2.reporter.Reporter;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class TracingClassLoaderTest {
+
+  @Test public void unloadable_afterClose() {
+    assertRunIsUnloadable(ClosesTracing.class, getClass().getClassLoader());
+  }
+
+  static class ClosesTracing implements Runnable {
+    @Override public void run() {
+      try (Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build()) {
+      }
+    }
+  }
+
+  @Test public void unloadable_afterBasicUsage() {
+    assertRunIsUnloadable(BasicUsage.class, getClass().getClassLoader());
+  }
+
+  static class BasicUsage implements Runnable {
+    @Override public void run() {
+      try (Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build()) {
+        tracing.tracer().newTrace().start().finish();
+      }
+    }
+  }
+}

--- a/brave-tests/src/test/java/brave/internal/PlatformClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/PlatformClassLoaderTest.java
@@ -1,0 +1,70 @@
+package brave.internal;
+
+import brave.test.util.ClassLoaders;
+import org.junit.Test;
+
+import static java.net.InetSocketAddress.createUnresolved;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlatformClassLoaderTest {
+  @Test public void unloadable_afterGet() {
+    assertRunIsUnloadable(GetPlatform.class);
+  }
+
+  static class GetPlatform implements Runnable {
+    @Override public void run() {
+      Platform platform = Platform.get();
+      assertThat(platform).isNotNull();
+    }
+  }
+
+  @Test public void unloadable_afterGetLinkLocalIp() {
+    assertRunIsUnloadable(GetPlatformLinkLocalIp.class);
+  }
+
+  static class GetPlatformLinkLocalIp implements Runnable {
+    @Override public void run() {
+      Platform platform = Platform.get();
+      platform.linkLocalIp();
+    }
+  }
+
+  @Test public void unloadable_afterGetNextTraceIdHigh() {
+    assertRunIsUnloadable(GetPlatformNextTraceIdHigh.class);
+  }
+
+  static class GetPlatformNextTraceIdHigh implements Runnable {
+    @Override public void run() {
+      Platform platform = Platform.get();
+      assertThat(platform.nextTraceIdHigh()).isNotZero();
+    }
+  }
+
+  @Test public void unloadable_afterGetHostString() {
+    assertRunIsUnloadable(GetPlatformHostString.class);
+  }
+
+  static class GetPlatformHostString implements Runnable {
+    @Override public void run() {
+      Platform platform = Platform.get();
+      assertThat(platform.getHostString(createUnresolved("1.2.3.4", 0)))
+          .isNotNull();
+    }
+  }
+
+  @Test public void unloadable_afterGetClock() {
+    assertRunIsUnloadable(GetPlatformClock.class);
+  }
+
+  static class GetPlatformClock implements Runnable {
+    @Override public void run() {
+      Platform platform = Platform.get();
+      assertThat(platform.clock().currentTimeMicroseconds())
+          .isPositive();
+    }
+  }
+
+  void assertRunIsUnloadable(Class<? extends Runnable> runnable) {
+    ClassLoaders.assertRunIsUnloadable(runnable, getClass().getClassLoader());
+  }
+}

--- a/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
@@ -1,0 +1,31 @@
+package brave.internal.recorder;
+
+import brave.internal.Platform;
+import brave.propagation.TraceContext;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class PendingSpansClassLoaderTest {
+
+  @Test public void unloadable_afterCreateAndRemove() {
+    assertRunIsUnloadable(CreateAndRemove.class, getClass().getClassLoader());
+  }
+
+  static class CreateAndRemove implements Runnable {
+    @Override public void run() {
+      PendingSpans pendingSpans = new PendingSpans(
+          Endpoint.newBuilder().serviceName("unknown").build(),
+          Platform.get().clock(),
+          Reporter.NOOP,
+          new AtomicBoolean());
+
+      TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+      pendingSpans.getOrCreate(context, true);
+      pendingSpans.remove(context);
+    }
+  }
+}

--- a/brave-tests/src/test/java/brave/internal/recorder/SpanReporterClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/SpanReporterClassLoaderTest.java
@@ -1,0 +1,52 @@
+package brave.internal.recorder;
+
+import brave.propagation.TraceContext;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class SpanReporterClassLoaderTest {
+
+  @Test public void unloadable_afterBasicUsage() {
+    assertRunIsUnloadable(BasicUsage.class, getClass().getClassLoader());
+  }
+
+  static class BasicUsage implements Runnable {
+    @Override public void run() {
+      SpanReporter reporter = new SpanReporter(
+          Endpoint.newBuilder().serviceName("unknown").build(),
+          Reporter.NOOP,
+          new AtomicBoolean());
+
+      TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+      MutableSpan span = new MutableSpan();
+      span.name("get /users/{userId}");
+      span.startTimestamp(1L);
+      span.tag("http.method", "GET");
+      span.annotate(2L, "cache.miss");
+      span.finishTimestamp(3L);
+
+      reporter.report(context, span);
+    }
+  }
+
+  @Test public void unloadable_afterErrorReporting() {
+    assertRunIsUnloadable(ErrorReporting.class, getClass().getClassLoader());
+  }
+
+  static class ErrorReporting implements Runnable {
+    @Override public void run() {
+      SpanReporter reporter = new SpanReporter(
+          Endpoint.newBuilder().serviceName("unknown").build(),
+          s -> {
+            throw new RuntimeException();
+          },
+          new AtomicBoolean());
+
+      reporter.report(TraceContext.newBuilder().traceId(1).spanId(2).build(), new MutableSpan());
+    }
+  }
+}

--- a/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
@@ -4,13 +4,21 @@ import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.test.propagation.PropagationTest;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class B3PropagationTest extends PropagationTest<String> {
-  @Override protected Propagation<String> propagation() {
-    return Propagation.B3_STRING;
+
+  @Override protected Class<? extends Supplier<Propagation<String>>> propagationSupplier() {
+    return PropagationSupplier.class;
+  }
+
+  static class PropagationSupplier implements Supplier<Propagation<String>> {
+    @Override public Propagation<String> get() {
+      return Propagation.B3_STRING;
+    }
   }
 
   @Override protected void inject(Map<String, String> map, @Nullable String traceId,
@@ -32,66 +40,66 @@ public class B3PropagationTest extends PropagationTest<String> {
   }
 
   @Test public void extractTraceContext_sampledFalse() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("X-B3-Sampled", "false");
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
 
   @Test public void extractTraceContext_sampledFalseUpperCase() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("X-B3-Sampled", "FALSE");
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
 
   @Test public void extractTraceContext_malformed() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124"); // ok
     map.put("X-B3-SpanId", "48485a3953bb6124"); // ok
     map.put("X-B3-ParentSpanId", "-"); // not ok
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
   @Test public void extractTraceContext_malformed_sampled() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("X-B3-TraceId", "-"); // not ok
     map.put("X-B3-Sampled", "1"); // ok
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
   @Test public void extractTraceContext_debug_with_ids() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("X-B3-TraceId", "463ac35c9f6413ad48485a3953bb6124"); // ok
     map.put("X-B3-SpanId", "48485a3953bb6124"); // ok
     map.put("X-B3-Flags", "1"); // accidentally missing sampled flag
 
-    TraceContext result = propagation().extractor(mapEntry).extract(map).context();
+    TraceContext result = propagation.extractor(mapEntry).extract(map).context();
 
     assertThat(result.sampled())
         .isTrue();
   }
 
   @Test public void extractTraceContext_singleHeaderFormat() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
 
     map.put("b3", "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7");
 
-    TraceContext result = propagation().extractor(mapEntry).extract(map).context();
+    TraceContext result = propagation.extractor(mapEntry).extract(map).context();
 
     assertThat(result.traceIdString())
         .isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");

--- a/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
@@ -3,13 +3,20 @@ package brave.propagation;
 import brave.internal.Nullable;
 import brave.test.propagation.PropagationTest;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class B3SinglePropagationTest extends PropagationTest<String> {
-  @Override protected Propagation<String> propagation() {
-    return Propagation.B3_SINGLE_STRING;
+  @Override protected Class<? extends Supplier<Propagation<String>>> propagationSupplier() {
+    return PropagationSupplier.class;
+  }
+
+  static class PropagationSupplier implements Supplier<Propagation<String>> {
+    @Override public Propagation<String> get() {
+      return Propagation.B3_SINGLE_STRING;
+    }
   }
 
   @Override protected void inject(Map<String, String> map, @Nullable String traceId,
@@ -40,41 +47,41 @@ public class B3SinglePropagationTest extends PropagationTest<String> {
   }
 
   @Test public void extractTraceContext_sampledFalse() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("b3", "0");
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
 
   @Test public void extractTraceContext_malformed() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("b3", "not-a-tumor");
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
   @Test public void extractTraceContext_malformed_uuid() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
     map.put("b3", "b970dafd-0d95-40aa-95d8-1d8725aebe40");
 
-    SamplingFlags result = propagation().extractor(mapEntry).extract(map).samplingFlags();
+    SamplingFlags result = propagation.extractor(mapEntry).extract(map).samplingFlags();
 
     assertThat(result)
         .isEqualTo(SamplingFlags.EMPTY);
   }
 
   @Test public void extractTraceContext_debug_with_ids() {
-    MapEntry mapEntry = new MapEntry();
+    MapEntry<String> mapEntry = new MapEntry<>();
 
     map.put("b3", "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-d");
 
-    TraceContext result = propagation().extractor(mapEntry).extract(map).context();
+    TraceContext result = propagation.extractor(mapEntry).extract(map).context();
 
     assertThat(result.debug())
         .isTrue();

--- a/brave-tests/src/test/java/brave/propagation/DefaultCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/DefaultCurrentTraceContextTest.java
@@ -1,0 +1,28 @@
+package brave.propagation;
+
+import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultCurrentTraceContextTest extends CurrentTraceContextTest {
+
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return CurrentTraceContext.Default.create();
+    }
+  }
+
+  @Test public void is_inheritable() throws Exception {
+    super.is_inheritable(CurrentTraceContext.Default.inheritable());
+  }
+
+  @Before public void ensureNoOtherTestsTaint() {
+    CurrentTraceContext.Default.INHERITABLE.set(null);
+    CurrentTraceContext.Default.DEFAULT.set(null);
+  }
+}

--- a/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
@@ -1,14 +1,21 @@
 package brave.propagation;
 
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StrictCurrentTraceContextTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return new StrictCurrentTraceContext();
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return new StrictCurrentTraceContext();
+    }
   }
 
   @Test public void scope_enforcesCloseOnSameThread() throws InterruptedException {

--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
@@ -1,21 +1,17 @@
 package brave.propagation;
 
 import brave.test.propagation.CurrentTraceContextTest;
-import org.junit.Before;
-import org.junit.Test;
+import java.util.function.Supplier;
 
 public class ThreadLocalCurrentTraceContextTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return CurrentTraceContext.Default.create();
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
   }
 
-  @Test public void is_inheritable() throws Exception {
-    super.is_inheritable(CurrentTraceContext.Default.inheritable());
-  }
-
-  @Before public void ensureNoOtherTestsTaint() {
-    CurrentTraceContext.Default.INHERITABLE.set(null);
-    CurrentTraceContext.Default.DEFAULT.set(null);
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return ThreadLocalCurrentTraceContext.newBuilder().build();
+    }
   }
 }

--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalSpanClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalSpanClassLoaderTest.java
@@ -1,0 +1,66 @@
+package brave.propagation;
+
+import brave.Tracing;
+import org.junit.Test;
+import zipkin2.reporter.Reporter;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class ThreadLocalSpanClassLoaderTest {
+
+  @Test public void noop_unloadable() {
+    assertRunIsUnloadable(CurrentTracerUnassigned.class, getClass().getClassLoader());
+  }
+
+  static class CurrentTracerUnassigned implements Runnable {
+    @Override public void run() {
+      ThreadLocalSpan.CURRENT_TRACER.next();
+    }
+  }
+
+  @Test public void currentTracer_basicUsage_unloadable() {
+    assertRunIsUnloadable(ExplicitTracerBasicUsage.class, getClass().getClassLoader());
+  }
+
+  static class ExplicitTracerBasicUsage implements Runnable {
+    @Override public void run() {
+      try (Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build()) {
+        ThreadLocalSpan tlSpan = ThreadLocalSpan.create(tracing.tracer());
+
+        tlSpan.next();
+        tlSpan.remove().finish();
+      }
+    }
+  }
+
+  @Test public void explicitTracer_basicUsage_unloadable() {
+    assertRunIsUnloadable(CurrentTracerBasicUsage.class, getClass().getClassLoader());
+  }
+
+  static class CurrentTracerBasicUsage implements Runnable {
+    @Override public void run() {
+      try (Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build()) {
+        ThreadLocalSpan tlSpan = ThreadLocalSpan.CURRENT_TRACER;
+
+        tlSpan.next();
+        tlSpan.remove().finish();
+      }
+    }
+  }
+
+  /**
+   * TODO: While it is an instrumentation bug to not complete a thread-local span, we should be
+   * tolerant, for example considering weak references or similar.
+   */
+  @Test(expected = AssertionError.class) public void unfinishedSpan_preventsUnloading() {
+    assertRunIsUnloadable(CurrentTracerDoesntFinishSpan.class, getClass().getClassLoader());
+  }
+
+  static class CurrentTracerDoesntFinishSpan implements Runnable {
+    @Override public void run() {
+      try (Tracing tracing = Tracing.newBuilder().spanReporter(Reporter.NOOP).build()) {
+        ThreadLocalSpan.CURRENT_TRACER.next();
+      }
+    }
+  }
+}

--- a/brave-tests/src/test/java/brave/propagation/TraceContextClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/propagation/TraceContextClassLoaderTest.java
@@ -1,0 +1,18 @@
+package brave.propagation;
+
+import org.junit.Test;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class TraceContextClassLoaderTest {
+
+  @Test public void unloadable_afterBasicUsage() {
+    assertRunIsUnloadable(BasicUsage.class, getClass().getClassLoader());
+  }
+
+  static class BasicUsage implements Runnable {
+    @Override public void run() {
+      TraceContext.newBuilder().traceId(1).spanId(2).build();
+    }
+  }
+}

--- a/brave-tests/src/test/java/brave/test/util/ClassLoadersTest.java
+++ b/brave-tests/src/test/java/brave/test/util/ClassLoadersTest.java
@@ -1,6 +1,7 @@
 package brave.test.util;
 
 import java.lang.ref.WeakReference;
+import java.util.logging.Logger;
 import org.junit.Test;
 
 import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
@@ -66,5 +67,22 @@ public class ClassLoadersTest {
   @Test public void assertRunIsUnloadable_threadLocalWithWeakRefToOurClassIsUnloadable() {
     assertRunIsUnloadable(PresentThreadLocalWithWeakRefToApplicationType.class,
         getClass().getClassLoader());
+  }
+
+  /**
+   * Mainly tests the internals of the assertion. Certain log managers can hold a reference to the
+   * class that looked up a logger. Ensuring log manager implementation is out-of-scope. This
+   * assertion is only here to avoid distraction of java logging interfering with class unloading.
+   */
+  @Test public void assertRunIsUnloadable_javaLoggerUnloadable() {
+    assertRunIsUnloadable(JavaLogger.class, getClass().getClassLoader());
+  }
+
+  static class JavaLogger implements Runnable {
+    final Logger javaLogger = Logger.getLogger(JavaLogger.class.getName());
+
+    @Override public void run() {
+      javaLogger.fine("foo");
+    }
   }
 }

--- a/brave-tests/src/test/java/brave/test/util/ClassLoadersTest.java
+++ b/brave-tests/src/test/java/brave/test/util/ClassLoadersTest.java
@@ -1,0 +1,70 @@
+package brave.test.util;
+
+import java.lang.ref.WeakReference;
+import org.junit.Test;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassLoadersTest {
+  static class Foo {
+  }
+
+  @Test public void createdNonDelegating_cantSeeCurrentClasspath() throws Exception {
+    Foo foo = new Foo(); // load the class
+
+    ClassLoader loader =
+        ClassLoaders.reloadClassNamePrefix(getClass().getClassLoader(), getClass().getName());
+    assertThat(loader.loadClass(Foo.class.getName()))
+        .isNotSameAs(foo.getClass());
+  }
+
+  static class PresentThreadLocalWithSystemType implements Runnable {
+    ThreadLocal<String> local = new ThreadLocal<>();
+
+    @Override public void run() {
+      local.set("foo");
+    }
+  }
+
+  @Test public void assertRunIsUnloadable_threadLocalWithSystemClassIsUnloadable() {
+    assertRunIsUnloadable(PresentThreadLocalWithSystemType.class, getClass().getClassLoader());
+  }
+
+  static class AbsentThreadLocalWithApplicationType implements Runnable {
+    ThreadLocal<ClassLoadersTest> local = new ThreadLocal<>();
+
+    @Override public void run() {
+    }
+  }
+
+  @Test public void assertRunIsUnloadable_absentThreadLocalWithOurClassIsUnloadable() {
+    assertRunIsUnloadable(AbsentThreadLocalWithApplicationType.class, getClass().getClassLoader());
+  }
+
+  static class PresentThreadLocalWithApplicationType implements Runnable {
+    ThreadLocal<ClassLoadersTest> local = new ThreadLocal<>();
+
+    @Override public void run() {
+      local.set(new ClassLoadersTest());
+    }
+  }
+
+  @Test(expected = AssertionError.class)
+  public void assertRunIsUnloadable_threadLocalWithOurClassIsntUnloadable() {
+    assertRunIsUnloadable(PresentThreadLocalWithApplicationType.class, getClass().getClassLoader());
+  }
+
+  static class PresentThreadLocalWithWeakRefToApplicationType implements Runnable {
+    ThreadLocal<WeakReference<ClassLoadersTest>> local = new ThreadLocal<>();
+
+    @Override public void run() {
+      local.set(new WeakReference<>(new ClassLoadersTest()));
+    }
+  }
+
+  @Test public void assertRunIsUnloadable_threadLocalWithWeakRefToOurClassIsUnloadable() {
+    assertRunIsUnloadable(PresentThreadLocalWithWeakRefToApplicationType.class,
+        getClass().getClassLoader());
+  }
+}

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -9,6 +9,7 @@ import brave.internal.recorder.PendingSpan;
 import brave.internal.recorder.PendingSpans;
 import brave.internal.recorder.SpanReporter;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.Propagation;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
@@ -441,7 +442,7 @@ public class Tracer {
     if (parent == null) parent = currentTraceContext.get();
     TraceContext context = parent != null ? nextContext(parent) : newRootContext();
 
-    CurrentTraceContext.Scope scope = currentTraceContext.newScope(context);
+    Scope scope = currentTraceContext.newScope(context);
     if (isNoop(context)) return new NoopScopedSpan(context, scope);
 
     PendingSpan pendingSpan = pendingSpans.getOrCreate(context, true);
@@ -454,10 +455,10 @@ public class Tracer {
 
   /** A span remains in the scope it was bound to until close is called. */
   public static final class SpanInScope implements Closeable {
-    final CurrentTraceContext.Scope scope;
+    final Scope scope;
 
     // This type hides the SPI type and allows us to double-check the SPI didn't return null.
-    SpanInScope(CurrentTraceContext.Scope scope) {
+    SpanInScope(Scope scope) {
       if (scope == null) throw new NullPointerException("scope == null");
       this.scope = scope;
     }

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -2,15 +2,14 @@ package brave.propagation;
 
 import brave.internal.HexCodec;
 import brave.internal.Nullable;
+import brave.internal.Platform;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.logging.Logger;
 
 import static brave.internal.HexCodec.writeHexLong;
 import static brave.internal.TraceContexts.FLAG_DEBUG;
 import static brave.internal.TraceContexts.FLAG_SAMPLED;
 import static brave.internal.TraceContexts.FLAG_SAMPLED_SET;
-import static java.util.logging.Level.FINE;
 
 /**
  * This format corresponds to the propagation key "b3" (or "B3"), which delimits fields in the
@@ -43,7 +42,6 @@ import static java.util.logging.Level.FINE;
  * <p>See <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>
  */
 public final class B3SingleFormat {
-  static final Logger logger = Logger.getLogger(B3SingleFormat.class.getName());
   static final int FORMAT_MAX_LENGTH = 32 + 1 + 16 + 2 + 16; // traceid128-spanid-1-parentid
 
   /**
@@ -136,7 +134,7 @@ public final class B3SingleFormat {
   public static TraceContextOrSamplingFlags parseB3SingleFormat(CharSequence b3, int beginIndex,
       int endIndex) {
     if (beginIndex == endIndex) {
-      logger.log(FINE, "Invalid input: empty");
+      Platform.get().log("Invalid input: empty", null);
       return null;
     }
 
@@ -147,10 +145,10 @@ public final class B3SingleFormat {
 
     // At this point we minimally expect a traceId-spanId pair
     if (endIndex < 16 + 1 + 16 /* traceid64-spanid */) {
-      logger.fine("Invalid input: truncated");
+      Platform.get().log("Invalid input: truncated", null);
       return null;
     } else if (endIndex > FORMAT_MAX_LENGTH) {
-      logger.fine("Invalid input: too long");
+      Platform.get().log("Invalid input: too long", null);
       return null;
     }
 
@@ -167,13 +165,13 @@ public final class B3SingleFormat {
     if (!checkHyphen(b3, pos++)) return null;
 
     if (traceIdHigh == 0L && traceId == 0L) {
-      logger.fine("Invalid input: expected a 16 or 32 lower hex trace ID at offset 0");
+      Platform.get().log("Invalid input: expected a 16 or 32 lower hex trace ID at offset 0", null);
       return null;
     }
 
     long spanId = tryParse16HexCharacters(b3, pos, endIndex);
     if (spanId == 0L) {
-      logger.log(FINE, "Invalid input: expected a 16 lower hex span ID at offset {0}", pos);
+      Platform.get().log("Invalid input: expected a 16 lower hex span ID at offset {0}", pos, null);
       return null;
     }
     pos += 16; // spanid
@@ -186,7 +184,7 @@ public final class B3SingleFormat {
       // If it is absent, but a parent ID is (which is strange), we'll have at least 17 characters.
       // Therefore, if we have less than two characters, the input is truncated.
       if (endIndex == pos + 1) {
-        logger.fine("Invalid input: truncated");
+        Platform.get().log("Invalid input: truncated", null);
         return null;
       }
       if (!checkHyphen(b3, pos++)) return null;
@@ -202,14 +200,15 @@ public final class B3SingleFormat {
       if (endIndex > pos) {
         // If we are at this point, we should have a parent ID, encoded as "-[0-9a-f]{16}"
         if (endIndex != pos + 17) {
-          logger.fine("Invalid input: truncated");
+          Platform.get().log("Invalid input: truncated", null);
           return null;
         }
 
         if (!checkHyphen(b3, pos++)) return null;
         parentId = tryParse16HexCharacters(b3, pos, endIndex);
         if (parentId == 0L) {
-          logger.log(FINE, "Invalid input: expected a 16 lower hex parent ID at offset {0}", pos);
+          Platform.get()
+              .log("Invalid input: expected a 16 lower hex parent ID at offset {0}", pos, null);
           return null;
         }
       }
@@ -233,7 +232,7 @@ public final class B3SingleFormat {
 
   static boolean checkHyphen(CharSequence b3, int pos) {
     if (b3.charAt(pos) == '-') return true;
-    logger.log(FINE, "Invalid input: expected a hyphen(-) delimiter offset {0}", pos);
+    Platform.get().log("Invalid input: expected a hyphen(-) delimiter offset {0}", pos, null);
     return false;
   }
 
@@ -264,7 +263,7 @@ public final class B3SingleFormat {
   }
 
   static void logInvalidSampled(int pos) {
-    logger.log(FINE, "Invalid input: expected 0, 1 or d for sampled at offset {0}", pos);
+    Platform.get().log("Invalid input: expected 0, 1 or d for sampled at offset {0}", pos, null);
   }
 
   static byte[] asciiToNewByteArray(char[] buffer, int length) {

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -3,6 +3,7 @@ package brave.propagation;
 import brave.internal.Nullable;
 import brave.internal.Platform;
 import brave.internal.TraceContexts;
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.List;
 
@@ -399,6 +400,8 @@ public final class TraceContext extends SamplingFlags {
    */
   @Override public boolean equals(Object o) {
     if (o == this) return true;
+    // Hack that allows PendingSpans to lookup without allocating a new object.
+    if (o instanceof WeakReference) o = ((WeakReference) o).get();
     if (!(o instanceof TraceContext)) return false;
     TraceContext that = (TraceContext) o;
     return (traceIdHigh == that.traceIdHigh)

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -59,6 +59,13 @@ public class TracerTest {
     Tracing.current().close();
   }
 
+  @Test public void reporter_hasNiceToString() {
+    tracer = Tracing.newBuilder().build().tracer();
+
+    assertThat(tracer.spanReporter)
+        .hasToString("LoggingReporter{name=brave.Tracer}");
+  }
+
   @Test public void sampler() {
     Sampler sampler = new Sampler() {
       @Override public boolean isSampled(long traceId) {

--- a/brave/src/test/java/brave/internal/PlatformTest.java
+++ b/brave/src/test/java/brave/internal/PlatformTest.java
@@ -43,11 +43,6 @@ public class PlatformTest {
         .hasToString("Clock.systemUTC().instant()");
   }
 
-  @Test public void reporter_hasNiceToString() {
-    assertThat(platform.reporter())
-        .hasToString("LoggingReporter{name=brave.Tracer}");
-  }
-
   // example from X-Amzn-Trace-Id: Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1
   @Test public void randomLong_epochSecondsPlusRandom() {
     mockStatic(System.class);

--- a/brave/src/test/java/brave/internal/recorder/MutableSpanConverterTest.java
+++ b/brave/src/test/java/brave/internal/recorder/MutableSpanConverterTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 public class MutableSpanConverterTest {
+  final MutableSpanConverter converter = new MutableSpanConverter();
+
   @Test public void minimumDurationIsOne() {
     MutableSpan span = new MutableSpan();
 
@@ -152,16 +154,16 @@ public class MutableSpanConverterTest {
     MutableSpan finishWithTimestamp = new MutableSpan();
     finishWithTimestamp.finishTimestamp(2L);
     Span.Builder finishWithTimestampBuilder = Span.newBuilder();
-    MutableSpanConverter.convert(finishWithTimestamp, finishWithTimestampBuilder);
+    converter.convert(finishWithTimestamp, finishWithTimestampBuilder);
 
     MutableSpan finishWithNoTimestamp = new MutableSpan();
     finishWithNoTimestamp.finishTimestamp(0L);
     Span.Builder finishWithNoTimestampBuilder = Span.newBuilder();
-    MutableSpanConverter.convert(finishWithNoTimestamp, finishWithNoTimestampBuilder);
+    converter.convert(finishWithNoTimestamp, finishWithNoTimestampBuilder);
 
     MutableSpan flush = new MutableSpan();
     Span.Builder flushBuilder = Span.newBuilder();
-    MutableSpanConverter.convert(flush, flushBuilder);
+    converter.convert(flush, flushBuilder);
 
     assertThat(finishWithTimestampBuilder)
         .isEqualToComparingFieldByFieldRecursively(finishWithNoTimestampBuilder)
@@ -170,7 +172,7 @@ public class MutableSpanConverterTest {
 
   Span convert(MutableSpan span) {
     Span.Builder result = Span.newBuilder().traceId(0L, 1L).id(1L);
-    MutableSpanConverter.convert(span, result);
+    converter.convert(span, result);
     return result.build();
   }
 }

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
@@ -5,6 +5,7 @@ import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.apache.log4j.MDC;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
@@ -13,8 +14,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return MDCCurrentTraceContext.create();
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return MDCCurrentTraceContext.create();
+    }
   }
 
   @Test public void is_inheritable() throws Exception {

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
@@ -6,6 +6,7 @@ import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.apache.log4j.MDC;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
@@ -14,10 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return ThreadLocalCurrentTraceContext.newBuilder()
-        .addScopeDecorator(MDCScopeDecorator.create())
-        .build();
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(MDCScopeDecorator.create())
+          .build();
+    }
   }
 
   @Test(expected = ComparisonFailure.class) // Log4J 1.2.x MDC is inheritable by default

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -5,14 +5,21 @@ import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.ThreadContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadContextCurrentTraceContextTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return ThreadContextCurrentTraceContext.create(CurrentTraceContext.Default.create());
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return ThreadContextCurrentTraceContext.create(CurrentTraceContext.Default.create());
+    }
   }
 
   @Override protected void verifyImplicitContext(@Nullable TraceContext context) {

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
@@ -6,16 +6,23 @@ import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.ThreadContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadContextScopeDecoratorTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return ThreadLocalCurrentTraceContext.newBuilder()
-        .addScopeDecorator(ThreadContextScopeDecorator.create())
-        .build();
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(ThreadContextScopeDecorator.create())
+          .build();
+    }
   }
 
   @Override protected void verifyImplicitContext(@Nullable TraceContext context) {

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -5,14 +5,21 @@ import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.slf4j.MDC;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return MDCCurrentTraceContext.create(CurrentTraceContext.Default.create());
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return MDCCurrentTraceContext.create(CurrentTraceContext.Default.create());
+    }
   }
 
   @Override protected void verifyImplicitContext(@Nullable TraceContext context) {

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
@@ -6,16 +6,23 @@ import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.propagation.CurrentTraceContextTest;
+import java.util.function.Supplier;
 import org.slf4j.MDC;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
 
-  @Override protected CurrentTraceContext newCurrentTraceContext() {
-    return ThreadLocalCurrentTraceContext.newBuilder()
-        .addScopeDecorator(MDCScopeDecorator.create())
-        .build();
+  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
+    return CurrentSupplier.class;
+  }
+
+  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
+    @Override public CurrentTraceContext get() {
+      return ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(MDCScopeDecorator.create())
+          .build();
+    }
   }
 
   protected void verifyImplicitContext(@Nullable TraceContext context) {

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -158,16 +158,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>brave-instrumentation-spring-rabbit</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.amqp</groupId>
-      <artifactId>spring-rabbit</artifactId>
-      <version>${spring-rabbit.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/instrumentation/benchmarks/src/main/java/brave/internal/recorder/MutableSpanConverterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/recorder/MutableSpanConverterBenchmarks.java
@@ -41,6 +41,7 @@ import static brave.internal.recorder.MutableSpanBenchmarks.newServerMutableSpan
 @State(Scope.Thread)
 @Threads(1)
 public class MutableSpanConverterBenchmarks {
+  final MutableSpanConverter converter = new MutableSpanConverter();
   final MutableSpan serverMutableSpan = newServerMutableSpan();
   final MutableSpan bigClientMutableSpan = newBigClientMutableSpan();
 
@@ -50,13 +51,13 @@ public class MutableSpanConverterBenchmarks {
    */
   @Benchmark public Span.Builder convertServerSpan() {
     Span.Builder builder = Span.newBuilder();
-    MutableSpanConverter.convert(serverMutableSpan, builder);
+    converter.convert(serverMutableSpan, builder);
     return builder;
   }
 
   @Benchmark public Span.Builder convertBigClientSpan() {
     Span.Builder builder = Span.newBuilder();
-    MutableSpanConverter.convert(bigClientMutableSpan, builder);
+    converter.convert(bigClientMutableSpan, builder);
     return builder;
   }
 

--- a/instrumentation/grpc/src/main/java/brave/grpc/TagContextBinaryMarshaller.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TagContextBinaryMarshaller.java
@@ -1,12 +1,10 @@
 package brave.grpc;
 
+import brave.internal.Platform;
 import io.grpc.Metadata.BinaryMarshaller;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.FINE;
 
 /**
  * This logs instead of throwing exceptions.
@@ -15,7 +13,6 @@ import static java.util.logging.Level.FINE;
  * https://github.com/census-instrumentation/opencensus-java/blob/master/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
  */
 final class TagContextBinaryMarshaller implements BinaryMarshaller<Map<String, String>> {
-  static final Logger logger = Logger.getLogger(TagContextBinaryMarshaller.class.getName());
   static final byte VERSION = 0, TAG_FIELD_ID = 0;
   static final byte[] EMPTY_BYTES = {};
 
@@ -43,7 +40,7 @@ final class TagContextBinaryMarshaller implements BinaryMarshaller<Map<String, S
     Buffer bytes = new Buffer(buf);
     byte version = bytes.readByte();
     if (version != VERSION) {
-      logger.log(FINE, "Invalid input: unsupported version {0}", version);
+      Platform.get().log("Invalid input: unsupported version {0}", version, null);
       return null;
     }
 
@@ -56,7 +53,7 @@ final class TagContextBinaryMarshaller implements BinaryMarshaller<Map<String, S
         if (val == null) break;
         result.put(key, val);
       } else {
-        logger.log(FINE, "Invalid input: expected TAG_FIELD_ID at offset {0}", bytes.pos);
+        Platform.get().log("Invalid input: expected TAG_FIELD_ID at offset {0}", bytes.pos, null);
         break;
       }
     }
@@ -132,7 +129,7 @@ final class TagContextBinaryMarshaller implements BinaryMarshaller<Map<String, S
     private int readVarint(byte b1) {
       int b2 = buf[pos++];
       if ((b2 & 0xf0) != 0) {
-        logger.log(FINE, "Greater than 14-bit varint at position {0}", pos);
+        Platform.get().log("Greater than 14-bit varint at position {0}", pos, null);
         return -1;
       }
       return b1 & 0x7f | b2 << 28;


### PR DESCRIPTION
This changes internal code so that thread locals don't hold references to Brave types. After this change, applications that use brave in a child classloader will themselves be unloadable.

See #785