### PR TITLE
Exposes ExtraField keys for OpenTracing Baggage integration

### DIFF
--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -70,7 +70,7 @@ import java.util.Map;
  */
 public final class ExtraFieldPropagation<K> implements Propagation<K> {
   /** Wraps an underlying propagation implementation, pushing one or more fields */
-  public static Propagation.Factory newFactory(Propagation.Factory delegate, String... fieldNames) {
+  public static Factory newFactory(Propagation.Factory delegate, String... fieldNames) {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
     String[] validated = ensureLowerCase(Arrays.asList(fieldNames));
@@ -78,7 +78,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   }
 
   /** Wraps an underlying propagation implementation, pushing one or more fields */
-  public static Propagation.Factory newFactory(Propagation.Factory delegate,
+  public static Factory newFactory(Propagation.Factory delegate,
       Collection<String> fieldNames) {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
@@ -219,7 +219,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     PropagationFields.put(context, lowercase(name), value, Extra.class);
   }
 
-  static final class Factory extends Propagation.Factory {
+  public static final class Factory extends Propagation.Factory {
     final Propagation.Factory delegate;
     final String[] fieldNames;
     final String[] keyNames;
@@ -240,7 +240,8 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       return delegate.requires128BitTraceId();
     }
 
-    @Override public final <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+    @Override
+    public final <K> ExtraFieldPropagation<K> create(Propagation.KeyFactory<K> keyFactory) {
       int length = fieldNames.length;
       List<K> keys = new ArrayList<>(length);
       for (int i = 0; i < length; i++) {
@@ -265,6 +266,16 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     this.extraFactory = factory.extraFactory;
     this.fieldNames = factory.fieldNames;
     this.keys = keys;
+  }
+
+  /**
+   * Returns the extra keys this component can extract. This result is lowercase and does not
+   * include any {@link #keys() trace context keys}.
+   */
+  // This is here to support extraction from carriers missing a get field by name function. The only
+  // known example is OpenTracing TextMap https://github.com/opentracing/opentracing-java/issues/305
+  public List<K> extraKeys() {
+    return keys;
   }
 
   /**

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -16,7 +16,7 @@ public class ExtraFieldPropagationTest {
   String awsTraceId =
       "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1";
   String uuid = "f4308d05-2228-4468-80f6-92a8377ba193";
-  Propagation.Factory factory = ExtraFieldPropagation.newFactory(
+  ExtraFieldPropagation.Factory factory = ExtraFieldPropagation.newFactory(
       B3Propagation.FACTORY, "x-vcap-request-id", "x-amzn-trace-id"
   );
 
@@ -42,6 +42,14 @@ public class ExtraFieldPropagationTest {
   @Test public void keysDontIncludeExtra() {
     assertThat(factory.create(Propagation.KeyFactory.STRING).keys())
         .isEqualTo(Propagation.B3_STRING.keys());
+  }
+
+  /**
+   * Ensures OpenTracing 0.31 can read the extra keys, as its TextMap has no get by name function.
+   */
+  @Test public void extraKeysDontIncludeTraceContextKeys() {
+    assertThat(factory.create(Propagation.KeyFactory.STRING).extraKeys())
+        .containsExactly("x-vcap-request-id", "x-amzn-trace-id");
   }
 
   @Test public void downcasesNames() {


### PR DESCRIPTION
Fixing ca2ec95af85e3701d30d292c4a9918c3aa0eb78e broke OpenTracing
baggage integration. The root cause of the break is that OpenTracing's
`TextMap` has no get-by-name functionality. That means adapters have to
scan to figure out what keys it might need. When we fixed the accidental
deletion of extra keys, we accidentally broke the OpenTracing
workaround. I've raised opentracing/opentracing-java#305 in attempts to
get rid of needing a workaround in the first place. However, this will
restore functionality.