### PR TITLE
Implements proof-of-concept of advanced sampling discussed at Netflix

### DIFF
--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static brave.internal.InternalPropagation.FLAG_SAMPLED;
+import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 import static brave.internal.Lists.concatImmutableLists;
 import static brave.internal.Lists.ensureImmutable;
@@ -51,44 +52,26 @@ public final class TraceContextOrSamplingFlags {
     return value.sampled();
   }
 
+  /** Returns {@link SamplingFlags#sampledLocal()}}, regardless of subtype. */
+  public final boolean sampledLocal() {
+    return (value.flags & FLAG_SAMPLED_LOCAL) == FLAG_SAMPLED_LOCAL;
+  }
+
   /** @deprecated do not use object variant.. only set when you have a sampling decision */
   @Deprecated
   public TraceContextOrSamplingFlags sampled(@Nullable Boolean sampled) {
     if (sampled != null) return sampled(sampled.booleanValue());
-    if (value.flags == 0) return this; // save effort if no change
-
-    switch (type) {
-      case 1:
-        // use bitwise as trace context can have other flags like shared
-        int flags = value.flags & ~(FLAG_SAMPLED_SET | FLAG_SAMPLED);
-        TraceContext context = InternalPropagation.instance.withFlags((TraceContext) value, flags);
-        return new TraceContextOrSamplingFlags(type, context, extra);
-      case 2:
-        return new TraceContextOrSamplingFlags(type, idContextWithFlags(0), extra);
-      case 3:
-        if (extra.isEmpty()) return EMPTY;
-        return new TraceContextOrSamplingFlags(type, SamplingFlags.EMPTY, extra);
-    }
-    throw new AssertionError("programming error");
+    int flags = value.flags;
+    flags &= ~FLAG_SAMPLED_SET;
+    flags &= ~FLAG_SAMPLED;
+    if (flags == value.flags) return this; // save effort if no change
+    return withFlags(flags);
   }
 
   public TraceContextOrSamplingFlags sampled(boolean sampled) {
     int flags = InternalPropagation.sampled(sampled, value.flags);
     if (flags == value.flags) return this; // save effort if no change
-
-    switch (type) {
-      case 1:
-        TraceContext context = InternalPropagation.instance.withFlags((TraceContext) value, flags);
-        return new TraceContextOrSamplingFlags(type, context, extra);
-      case 2:
-        TraceIdContext traceIdContext = idContextWithFlags(flags);
-        return new TraceContextOrSamplingFlags(type, traceIdContext, extra);
-      case 3:
-        SamplingFlags samplingFlags = toSamplingFlags(sampled, flags);
-        if (extra.isEmpty()) return create(samplingFlags);
-        return new TraceContextOrSamplingFlags(type, samplingFlags, extra);
-    }
-    throw new AssertionError("programming error");
+    return withFlags(flags);
   }
 
   @Nullable public TraceContext context() {
@@ -161,6 +144,7 @@ public final class TraceContextOrSamplingFlags {
     int type;
     SamplingFlags value;
     List<Object> extra = emptyList();
+    boolean sampledLocal = false;
 
     /** @see TraceContextOrSamplingFlags#context() */
     public final Builder context(TraceContext context) {
@@ -175,6 +159,12 @@ public final class TraceContextOrSamplingFlags {
       if (traceIdContext == null) throw new NullPointerException("traceIdContext == null");
       type = 2;
       value = traceIdContext;
+      return this;
+    }
+
+    /** @see TraceContext#sampledLocal() */
+    public Builder sampledLocal() {
+      this.sampledLocal = true;
       return this;
     }
 
@@ -209,17 +199,23 @@ public final class TraceContextOrSamplingFlags {
 
     /** Returns an immutable result from the values currently in the builder */
     public final TraceContextOrSamplingFlags build() {
+      final TraceContextOrSamplingFlags result;
       if (!extra.isEmpty() && type == 1) { // move extra to the trace context
         TraceContext context = (TraceContext) value;
         if (context.extra().isEmpty()) {
           context = InternalPropagation.instance.withExtra(context, ensureImmutable(extra));
         } else {
-          context = InternalPropagation.instance.withExtra(context, concatImmutableLists(context.extra(), extra));
+          context = InternalPropagation.instance.withExtra(context,
+              concatImmutableLists(context.extra(), extra));
         }
-        return new TraceContextOrSamplingFlags(type, context, emptyList());
+        result = new TraceContextOrSamplingFlags(type, context, emptyList());
+      } else {
+        // make sure the extra data is immutable and unmodifiable
+        result = new TraceContextOrSamplingFlags(type, value, ensureImmutable(extra));
       }
-      // make sure the extra data is immutable and unmodifiable
-      return new TraceContextOrSamplingFlags(type, value, ensureImmutable(extra));
+
+      if (!sampledLocal) return result; // save effort if no change
+      return result.withFlags(value.flags | FLAG_SAMPLED_LOCAL);
     }
 
     Builder() { // no external implementations
@@ -246,14 +242,20 @@ public final class TraceContextOrSamplingFlags {
     return h;
   }
 
-  static SamplingFlags toSamplingFlags(boolean sampled, int flags) {
-    if (flags == SamplingFlags.DEBUG.flags) {
-      return SamplingFlags.DEBUG;
-    } else if (sampled) {
-      return SamplingFlags.SAMPLED;
-    } else {
-      return SamplingFlags.NOT_SAMPLED;
+  TraceContextOrSamplingFlags withFlags(int flags) {
+    switch (type) {
+      case 1:
+        TraceContext context = InternalPropagation.instance.withFlags((TraceContext) value, flags);
+        return new TraceContextOrSamplingFlags(type, context, extra);
+      case 2:
+        TraceIdContext traceIdContext = idContextWithFlags(flags);
+        return new TraceContextOrSamplingFlags(type, traceIdContext, extra);
+      case 3:
+        SamplingFlags samplingFlags = SamplingFlags.toSamplingFlags(flags);
+        if (extra.isEmpty()) return create(samplingFlags);
+        return new TraceContextOrSamplingFlags(type, samplingFlags, extra);
     }
+    throw new AssertionError("programming error");
   }
 
   TraceIdContext idContextWithFlags(int flags) {

--- a/brave/src/test/java/brave/features/propagation/SecondarySampling.java
+++ b/brave/src/test/java/brave/features/propagation/SecondarySampling.java
@@ -1,0 +1,179 @@
+package brave.features.propagation;
+
+import brave.firehose.MutableSpan;
+import brave.propagation.Propagation.Getter;
+import brave.propagation.Propagation.KeyFactory;
+import brave.propagation.Propagation.Setter;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.Sampler;
+import com.google.common.base.Splitter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class SecondarySampling {
+  public static final class FirehoseHandler extends brave.firehose.FirehoseHandler {
+    final Map<String, brave.firehose.FirehoseHandler> configuredHandlers;
+
+    public FirehoseHandler(Map<String, brave.firehose.FirehoseHandler> configuredHandlers) {
+      this.configuredHandlers = configuredHandlers;
+    }
+
+    @Override public boolean handle(TraceContext context, MutableSpan span) {
+      Extra extra = context.findExtra(Extra.class);
+      if (extra == null) return true;
+      for (String state : extra.states.keySet()) {
+        brave.firehose.FirehoseHandler handler = configuredHandlers.get(state);
+        if (handler != null) handler.handle(context, span);
+      }
+      return true;
+    }
+  }
+
+  public static final class PropagationFactory extends Propagation.Factory {
+    final Propagation.Factory delegate;
+    final Set<String> configuredStates;
+
+    PropagationFactory(Propagation.Factory delegate, Set<String> configuredStates) {
+      this.delegate = delegate;
+      this.configuredStates = configuredStates;
+    }
+
+    @Override public boolean supportsJoin() {
+      return delegate.supportsJoin();
+    }
+
+    @Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+      return new Propagation<>(delegate.create(keyFactory), keyFactory, configuredStates);
+    }
+  }
+
+  static final class Extra {
+    Map<String, Map<String, String>> states = new LinkedHashMap<>();
+
+    @Override public String toString() {
+      return states.entrySet()
+          .stream()
+          .map(s -> s.getKey() + ":" + Extra.toString(s.getValue()))
+          .collect(Collectors.joining(";"));
+    }
+
+    static String toString(Map<String, String> s) {
+      return s.entrySet()
+          .stream()
+          .map(e -> e.getKey() + "=" + e.getValue())
+          .collect(Collectors.joining(","));
+    }
+  }
+
+  static class Propagation<K> implements brave.propagation.Propagation<K> {
+
+    final brave.propagation.Propagation<K> delegate;
+    final Set<String> configuredStates;
+    final K samplingKey;
+
+    Propagation(brave.propagation.Propagation<K> delegate, KeyFactory<K> keyFactory,
+        Set<String> configuredStates) {
+      this.delegate = delegate;
+      this.configuredStates = configuredStates;
+      this.samplingKey = keyFactory.create("sampling");
+    }
+
+    @Override public List<K> keys() {
+      return delegate.keys();
+    }
+
+    @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+      if (setter == null) throw new NullPointerException("setter == null");
+      return new Injector<>(this, setter);
+    }
+
+    @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+      return new Extractor<>(this, getter);
+    }
+  }
+
+  static final class Injector<C, K> implements TraceContext.Injector<C> {
+    final TraceContext.Injector<C> delegate;
+    final Setter<C, K> setter;
+    final K samplingKey;
+
+    Injector(Propagation<K> propagation, brave.propagation.Propagation.Setter<C, K> setter) {
+      this.delegate = propagation.delegate.injector(setter);
+      this.setter = setter;
+      this.samplingKey = propagation.samplingKey;
+    }
+
+    @Override public void inject(TraceContext traceContext, C carrier) {
+      delegate.inject(traceContext, carrier);
+      Extra sampled = traceContext.findExtra(Extra.class);
+      if (sampled == null || sampled.states.isEmpty()) return;
+      setter.put(carrier, samplingKey, sampled.toString());
+    }
+  }
+
+  static final class Extractor<C, K> implements TraceContext.Extractor<C> {
+    final TraceContext.Extractor<C> delegate;
+    final Getter<C, K> getter;
+    final Set<String> configuredStates;
+    final K samplingKey;
+
+    Extractor(Propagation<K> propagation, Getter<C, K> getter) {
+      this.delegate = propagation.delegate.extractor(getter);
+      this.getter = getter;
+      this.configuredStates = propagation.configuredStates;
+      this.samplingKey = propagation.samplingKey;
+    }
+
+    @Override public TraceContextOrSamplingFlags extract(C carrier) {
+      TraceContextOrSamplingFlags result = delegate.extract(carrier);
+
+      String maybeValue = getter.get(carrier, samplingKey);
+      Extra extra = new Extra();
+      TraceContextOrSamplingFlags.Builder builder = result.toBuilder().addExtra(extra);
+      if (maybeValue == null) return builder.build();
+
+      for (String entry : Splitter.on(";").split(maybeValue)) {
+        String[] nameValue = entry.split(":");
+        String name = nameValue[0];
+        Map<String, String> state = Splitter.on(",").withKeyValueSeparator("=").split(nameValue[1]);
+
+        if (configuredStates.contains(name)) {
+          state = new LinkedHashMap<>(state); // make mutable
+          if (update(state)) {
+            if (state.get("sampled").equals("1")) {
+              builder.sampledLocal(); // this allows us to override the default decision
+            }
+            extra.states.put(name, state);
+          }
+        } else {
+          extra.states.put(name, state);
+        }
+      }
+
+      return builder.build();
+    }
+  }
+
+  static boolean update(Map<String, String> state) {
+    // if there's a rate, convert it to a sampling decision
+    String rate = state.remove("rate");
+    if (rate != null) {
+      // in real life the sampler would be cached
+      boolean decision = Sampler.create(Float.parseFloat(rate)).isSampled(1L);
+      state.put("sampled", decision ? "1" : "0");
+    } else if (state.containsKey("ttl")) {
+      // decrement ttl if there is one
+      String ttl = state.remove("ttl");
+      if (ttl != null && !ttl.equals("1")) {
+        state.put("ttl", Integer.toString(Integer.parseInt(ttl) - 1));
+      } else {
+        return false; // remove the out-dated decision
+      }
+    }
+    return true;
+  }
+}

--- a/brave/src/test/java/brave/features/propagation/SecondarySamplingTest.java
+++ b/brave/src/test/java/brave/features/propagation/SecondarySamplingTest.java
@@ -1,0 +1,159 @@
+package brave.features.propagation;
+
+import brave.Span;
+import brave.Span.Kind;
+import brave.Tracer;
+import brave.Tracing;
+import brave.firehose.FirehoseHandler;
+import brave.firehose.MutableSpan;
+import brave.propagation.B3SinglePropagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+
+import static brave.features.propagation.SecondarySampling.Extra;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecondarySamplingTest {
+  List<zipkin2.Span> zipkin = new ArrayList<>();
+  List<MutableSpan> zeus = new ArrayList<>(), apollo = new ArrayList<>();
+  Map<String, FirehoseHandler> stateToFirehoseHandler = ImmutableMap.of(
+      "zeus", new FirehoseHandler() {
+        @Override public boolean handle(TraceContext context, MutableSpan span) {
+          return zeus.add(span);
+        }
+      },
+      "apollo", new FirehoseHandler() {
+        @Override public boolean handle(TraceContext context, MutableSpan span) {
+          return apollo.add(span);
+        }
+      }
+  );
+
+  Tracing tracing = Tracing.newBuilder()
+      .addFirehoseHandler(new SecondarySampling.FirehoseHandler(stateToFirehoseHandler))
+      .propagationFactory(new SecondarySampling.PropagationFactory(
+          B3SinglePropagation.FACTORY, stateToFirehoseHandler.keySet()
+      ))
+      .spanReporter(zipkin::add)
+      .build();
+
+  TraceContext.Extractor<Map<String, String>> extractor = tracing.propagation().extractor(Map::get);
+  TraceContext.Injector<Map<String, String>> injector = tracing.propagation().injector(Map::put);
+
+  Map<String, String> map = new LinkedHashMap<>();
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  /** This shows when primary trace status is not sampled, we can send to handlers anyway. */
+  @Test public void integrationTest() {
+    map.put("b3", "0");
+    map.put("sampling", "zeus:rate=1.0,ttl=3;apollo:sampled=1;wookie:rate=0.05");
+
+    Tracer tracer = tracing.tracer();
+    Span span1 = tracer.nextSpan(extractor.extract(map)).name("span1").kind(Kind.SERVER).start();
+    Span span2 = tracer.newChild(span1.context()).kind(Kind.CLIENT).name("span2").start();
+    injector.inject(span2.context(), map);
+    assertThat(map).containsEntry("sampling",
+        "zeus:ttl=3,sampled=1;apollo:sampled=1;wookie:rate=0.05");
+
+    // hop 1
+    Span span3 = tracer.joinSpan(extractor.extract(map).context()).kind(Kind.SERVER).start();
+    Span span4 = tracer.newChild(span3.context()).kind(Kind.CLIENT).name("span3").start();
+    injector.inject(span4.context(), map);
+    assertThat(map).containsEntry("sampling",
+        "zeus:sampled=1,ttl=2;apollo:sampled=1;wookie:rate=0.05");
+
+    // hop 2
+    Span span5 = tracer.joinSpan(extractor.extract(map).context()).kind(Kind.SERVER).start();
+    Span span6 = tracer.newChild(span5.context()).kind(Kind.CLIENT).name("span4").start();
+    injector.inject(span6.context(), map);
+    assertThat(map).containsEntry("sampling",
+        "zeus:sampled=1,ttl=1;apollo:sampled=1;wookie:rate=0.05");
+
+    // hop 3
+    Span span7 = tracer.joinSpan(extractor.extract(map).context()).kind(Kind.SERVER).start();
+    Span span8 = tracer.newChild(span7.context()).kind(Kind.CLIENT).name("span5").start();
+    injector.inject(span8.context(), map);
+    assertThat(map).containsEntry("sampling", "apollo:sampled=1;wookie:rate=0.05");
+
+    // hop 4
+    Span span9 = tracer.joinSpan(extractor.extract(map).context()).kind(Kind.SERVER).start();
+    Span span10 = tracer.newChild(span9.context()).kind(Kind.CLIENT).name("span6").start();
+    injector.inject(span10.context(), map);
+    assertThat(map).containsEntry("sampling", "apollo:sampled=1;wookie:rate=0.05");
+
+    asList(span1, span2, span3, span4, span5, span6, span7, span8, span9, span10)
+        .forEach(Span::finish);
+
+    assertThat(zipkin).isEmpty();
+    assertThat(zeus).filteredOn(s -> s.kind() == Kind.SERVER).hasSize(4);
+    assertThat(apollo).filteredOn(s -> s.kind() == Kind.SERVER).hasSize(5);
+  }
+
+  @Test public void extract_samplesLocalWhenConfigured() {
+    map.put("b3", "0");
+    map.put("sampling", "apollo:sampled=0;wookie:rate=0.05");
+
+    assertThat(extractor.extract(map).sampledLocal()).isFalse();
+
+    map.put("b3", "0");
+    map.put("sampling", "apollo:sampled=0;wookie:sampled=1");
+
+    assertThat(extractor.extract(map).sampledLocal()).isFalse();
+
+    map.put("b3", "0");
+    map.put("sampling", "apollo:sampled=1;wookie:rate=0.05");
+
+    assertThat(extractor.extract(map).sampledLocal()).isTrue();
+  }
+
+  @Test public void extract_convertsConfiguredRateToDecision() {
+    map.put("b3", "0");
+    map.put("sampling", "zeus:rate=1.0,ttl=3;apollo:sampled=0;wookie:rate=0.05");
+
+    TraceContextOrSamplingFlags extracted = extractor.extract(map);
+    Extra extra = (Extra) extracted.extra().get(0);
+    assertThat(extra.states)
+        .containsEntry("zeus", ImmutableMap.of("sampled", "1", "ttl", "3"))
+        .containsEntry("apollo", ImmutableMap.of("sampled", "0"))
+        .containsEntry("wookie", ImmutableMap.of("rate", "0.05"));
+  }
+
+  @Test public void extract_decrementsTtlWhenConfigured() {
+    map.put("b3", "0");
+    map.put("sampling", "zeus:sampled=1,ttl=3;apollo:sampled=0,ttl=1;wookie:rate=0.05");
+
+    TraceContextOrSamplingFlags extracted = extractor.extract(map);
+    Extra extra = (Extra) extracted.extra().get(0);
+    assertThat(extra.states)
+        .containsEntry("zeus", ImmutableMap.of("sampled", "1", "ttl", "2"))
+        .doesNotContainKey("apollo")
+        .containsEntry("wookie", ImmutableMap.of("rate", "0.05"));
+  }
+
+  @Test public void injectWritesAllStates() {
+    Extra extra = new Extra();
+    extra.states.put("zeus", ImmutableMap.of("rate", "1.0", "ttl", "3"));
+    extra.states.put("apollo", ImmutableMap.of("sampled", "0"));
+    extra.states.put("wookie", ImmutableMap.of("rate", "0.05"));
+
+    injector.inject(TraceContext.newBuilder()
+        .traceId(1L).spanId(2L)
+        .sampled(false)
+        .extra(asList(extra))
+        .build(), map);
+
+    assertThat(map)
+        .containsEntry("sampling", "zeus:rate=1.0,ttl=3;apollo:sampled=0;wookie:rate=0.05");
+  }
+}


### PR DESCRIPTION
This makes a slight adjustment, proving it is possible to hold multiple,
degrading secondary sampling decisions.

Thanks @narayaruna for all the thought work!

See https://cwiki.apache.org/confluence/display/ZIPKIN/2018-07-18+Aggregation+and+Analysis+at+Netflix