### PR TITLE
Adds concept of "local root" used to partition spans by entry point

### DIFF
--- a/brave/src/main/java/brave/internal/InternalPropagation.java
+++ b/brave/src/main/java/brave/internal/InternalPropagation.java
@@ -1,5 +1,7 @@
 package brave.internal;
 
+import brave.ScopedSpan;
+import brave.Span;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
 import java.util.List;
@@ -20,6 +22,7 @@ public abstract class InternalPropagation {
   public static final int FLAG_DEBUG = 1 << 3;
   public static final int FLAG_SHARED = 1 << 4;
   public static final int FLAG_SAMPLED_LOCAL = 1 << 5;
+  public static final int FLAG_LOCAL_ROOT = 1 << 6;
 
   public static InternalPropagation instance;
 
@@ -35,10 +38,14 @@ public abstract class InternalPropagation {
     return flags;
   }
 
+  /**
+   * @param localRootId must be non-zero prior to instantiating {@link Span} or {@link ScopedSpan}
+   */
   public abstract TraceContext newTraceContext(
       int flags,
       long traceIdHigh,
       long traceId,
+      long localRootId,
       long parentId,
       long spanId,
       List<Object> extra

--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -74,6 +74,7 @@ public final class PendingSpans extends ReferenceQueue<TraceContext> {
           context.traceIdHigh(),
           context.traceId(),
           0,
+          0,
           spanId,
           Collections.emptyList()
       ));
@@ -106,7 +107,7 @@ public final class PendingSpans extends ReferenceQueue<TraceContext> {
       TraceContext context = InternalPropagation.instance.newTraceContext(
           InternalPropagation.FLAG_SAMPLED_SET | InternalPropagation.FLAG_SAMPLED,
           contextKey.traceIdHigh, contextKey.traceId,
-          0L, contextKey.spanId,
+          contextKey.localRootId, 0L, contextKey.spanId,
           Collections.emptyList()
       );
       value.state.annotate(flushTime, "brave.flush");
@@ -130,7 +131,7 @@ public final class PendingSpans extends ReferenceQueue<TraceContext> {
     final int hashCode;
 
     // Copy the identity fields from the trace context, so we can use them when the reference clears
-    final long traceIdHigh, traceId, spanId;
+    final long traceIdHigh, traceId, localRootId, spanId;
     final boolean sampled;
 
     RealKey(TraceContext context, ReferenceQueue<TraceContext> queue) {
@@ -138,6 +139,7 @@ public final class PendingSpans extends ReferenceQueue<TraceContext> {
       hashCode = context.hashCode();
       traceIdHigh = context.traceIdHigh();
       traceId = context.traceId();
+      localRootId = context.localRootId();
       spanId = context.spanId();
       sampled = Boolean.TRUE.equals(context.sampled());
     }

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -221,6 +221,7 @@ public final class B3SingleFormat {
         flags,
         traceIdHigh,
         traceId,
+        0L, // localRootId is the first ID used in process, not necessarily the one extracted
         parentId,
         spanId,
         Collections.emptyList()

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -23,9 +23,9 @@ public class SamplingFlags {
       }
 
       @Override
-      public TraceContext newTraceContext(int flags, long traceIdHigh, long traceId, long parentId,
-          long spanId, List<Object> extra) {
-        return new TraceContext(flags, traceIdHigh, traceId, parentId, spanId, extra);
+      public TraceContext newTraceContext(int flags, long traceIdHigh, long traceId,
+          long localRootId, long parentId, long spanId, List<Object> extra) {
+        return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extra);
       }
 
       @Override public TraceContext withExtra(TraceContext context, List<Object> extra) {

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -1,6 +1,9 @@
 package brave;
 
+import brave.Span.Kind;
 import brave.Tracer.SpanInScope;
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
 import brave.propagation.B3Propagation;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
@@ -11,7 +14,10 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import brave.propagation.TraceIdContext;
 import brave.sampler.Sampler;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.Endpoint;
@@ -95,14 +101,16 @@ public class TracerTest {
   @Test public void localServiceName() {
     tracer = Tracing.newBuilder().localServiceName("my-foo").build().tracer();
 
-    assertThat(tracer).extracting("finishedSpanHandler.delegate.converter.localEndpoint.serviceName")
+    assertThat(tracer).extracting(
+        "finishedSpanHandler.delegate.converter.localEndpoint.serviceName")
         .containsExactly("my-foo");
   }
 
   @Test public void localServiceName_defaultIsUnknown() {
     tracer = Tracing.newBuilder().build().tracer();
 
-    assertThat(tracer).extracting("finishedSpanHandler.delegate.converter.localEndpoint.serviceName")
+    assertThat(tracer).extracting(
+        "finishedSpanHandler.delegate.converter.localEndpoint.serviceName")
         .containsExactly("unknown");
   }
 
@@ -127,7 +135,7 @@ public class TracerTest {
         .isNotZero();
   }
 
-  @Test public void newTrace_unsampled_tracer() {
+  @Test public void newTrace_notSampled_tracer() {
     tracer = tracer.withSampler(Sampler.NEVER_SAMPLE);
 
     assertThat(tracer.newTrace())
@@ -150,8 +158,8 @@ public class TracerTest {
    * other for the server.
    */
   @Test public void join_sharedDataIsSeparate() {
-    Span clientSide = tracer.newTrace().kind(Span.Kind.CLIENT).start(1L);
-    Span serverSide = tracer.joinSpan(clientSide.context()).kind(Span.Kind.SERVER).start(2L);
+    Span clientSide = tracer.newTrace().kind(Kind.CLIENT).start(1L);
+    Span serverSide = tracer.joinSpan(clientSide.context()).kind(Kind.SERVER).start(2L);
     serverSide.finish(3L);
     clientSide.finish(4L);
 
@@ -285,11 +293,11 @@ public class TracerTest {
         .isInstanceOf(RealSpan.class);
   }
 
-  @Test public void toSpan_unsampledIsNoop() {
-    TraceContext unsampled =
+  @Test public void toSpan_notSampledIsNoop() {
+    TraceContext notSampled =
         tracer.newTrace().context().toBuilder().sampled(false).build();
 
-    assertThat(tracer.toSpan(unsampled))
+    assertThat(tracer.toSpan(notSampled))
         .isInstanceOf(NoopSpan.class);
   }
 
@@ -330,11 +338,11 @@ public class TracerTest {
         .isInstanceOf(NoopSpan.class);
   }
 
-  @Test public void newChild_unsampledIsNoop() {
-    TraceContext unsampled =
+  @Test public void newChild_notSampledIsNoop() {
+    TraceContext notSampled =
         tracer.newTrace().context().toBuilder().sampled(false).build();
 
-    assertThat(tracer.newChild(unsampled))
+    assertThat(tracer.newChild(notSampled))
         .isInstanceOf(NoopSpan.class);
   }
 
@@ -343,7 +351,7 @@ public class TracerTest {
         .isSameAs(NoopSpanCustomizer.INSTANCE);
   }
 
-  @Test public void currentSpanCustomizer_noop_when_unsampled() {
+  @Test public void currentSpanCustomizer_noop_when_notSampled() {
     ScopedSpan parent = tracer.withSampler(Sampler.NEVER_SAMPLE).startScopedSpan("parent");
     try {
       assertThat(tracer.currentSpanCustomizer())
@@ -667,5 +675,139 @@ public class TracerTest {
         .isEqualTo("foo");
     assertThat(spans.get(0).durationAsLong())
         .isPositive();
+  }
+
+  @Test public void localRootId_joinSpan_notYetSampled() {
+    TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).build();
+    TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).build();
+    localRootId(context1, context2, ctx -> tracer.joinSpan(ctx.context()));
+  }
+
+  @Test public void localRootId_joinSpan_notSampled() {
+    TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).build();
+    TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build();
+    localRootId(context1, context2, ctx -> tracer.joinSpan(ctx.context()));
+  }
+
+  @Test public void localRootId_joinSpan_sampled() {
+    TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+    TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).sampled(true).build();
+    localRootId(context1, context2, ctx -> tracer.joinSpan(ctx.context()));
+  }
+
+  @Test public void localRootId_nextSpan_notYetSampled() {
+    TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).build();
+    TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).build();
+    localRootId(context1, context2, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_notSampled() {
+    TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).build();
+    TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build();
+    localRootId(context1, context2, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_sampled() {
+    TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+    TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).sampled(true).build();
+    localRootId(context1, context2, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_ids_notYetSampled() {
+    TraceIdContext context1 = TraceIdContext.newBuilder().traceId(1).build();
+    TraceIdContext context2 = TraceIdContext.newBuilder().traceId(2).build();
+    localRootId(context1, context2, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_ids_notSampled() {
+    TraceIdContext context1 = TraceIdContext.newBuilder().traceId(1).sampled(false).build();
+    TraceIdContext context2 = TraceIdContext.newBuilder().traceId(2).sampled(false).build();
+    localRootId(context1, context2, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_ids_sampled() {
+    TraceIdContext context1 = TraceIdContext.newBuilder().traceId(1).sampled(true).build();
+    TraceIdContext context2 = TraceIdContext.newBuilder().traceId(2).sampled(true).build();
+    localRootId(context1, context2, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_flags_empty() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.EMPTY;
+    localRootId(flags, flags, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_flags_notSampled() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.NOT_SAMPLED;
+    localRootId(flags, flags, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_flags_sampled() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.SAMPLED;
+    localRootId(flags, flags, ctx -> tracer.nextSpan(ctx));
+  }
+
+  @Test public void localRootId_nextSpan_flags_debug() {
+    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.DEBUG;
+    localRootId(flags, flags, ctx -> tracer.nextSpan(ctx));
+  }
+
+  void localRootId(TraceContext c1, TraceContext c2, Function<TraceContextOrSamplingFlags, Span> fn) {
+    localRootId(TraceContextOrSamplingFlags.create(c1), TraceContextOrSamplingFlags.create(c2), fn);
+  }
+
+  void localRootId(TraceIdContext c1, TraceIdContext c2,
+      Function<TraceContextOrSamplingFlags, Span> fn) {
+    localRootId(TraceContextOrSamplingFlags.create(c1), TraceContextOrSamplingFlags.create(c2), fn);
+  }
+
+  void localRootId(TraceContextOrSamplingFlags ctx1, TraceContextOrSamplingFlags ctx2,
+      Function<TraceContextOrSamplingFlags, Span> ctxFn
+  ) {
+    Map<Long, List<String>> reportedNames = tracerThatPartitionsNamesOnlocalRootId();
+    Span server1 = ctxFn.apply(ctx1).name("server1").kind(Kind.SERVER).start();
+    Span server2 = ctxFn.apply(ctx2).name("server2").kind(Kind.SERVER).start();
+    try {
+      Span client1 = tracer.newChild(server1.context()).name("client1").kind(Kind.CLIENT).start();
+      ScopedSpan processor1 = tracer.startScopedSpanWithParent("processor1", server1.context());
+      try {
+        try {
+          ScopedSpan processor2 = tracer.startScopedSpanWithParent("processor2", server2.context());
+          try {
+            tracer.nextSpan().name("client2").kind(Kind.CLIENT).start().finish();
+            tracer.nextSpan().name("client3").kind(Kind.CLIENT).start().finish();
+          } finally {
+            processor2.finish();
+          }
+        } finally {
+          server2.finish();
+        }
+      } finally {
+        client1.finish();
+        processor1.finish();
+      }
+    } finally {
+      server1.finish();
+    }
+
+    assertThat(reportedNames).hasSize(2).containsValues(
+        asList("client1", "processor1", "server1"),
+        asList("client2", "client3", "processor2", "server2")
+    );
+  }
+
+  Map<Long, List<String>> tracerThatPartitionsNamesOnlocalRootId() {
+    Map<Long, List<String>> reportedNames = new LinkedHashMap<>();
+    tracer = Tracing.newBuilder().addFinishedSpanHandler(new FinishedSpanHandler() {
+      @Override public boolean handle(TraceContext context, MutableSpan span) {
+        assertThat(context.localRootId()).isNotZero();
+        reportedNames.computeIfAbsent(context.localRootId(), k -> new ArrayList<>()).add(span.name());
+        return true; // retain
+      }
+
+      @Override public boolean alwaysSampleLocal() {
+        return true;
+      }
+    }).spanReporter(Reporter.NOOP).build().tracer();
+    return reportedNames;
   }
 }

--- a/brave/src/test/java/brave/features/handler/DefaultTagsTest.java
+++ b/brave/src/test/java/brave/features/handler/DefaultTagsTest.java
@@ -1,0 +1,57 @@
+package brave.features.handler;
+
+import brave.ScopedSpan;
+import brave.Tracing;
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * This shows how you can add a tag once per span as it enters a process. This is helpful for
+ * environment details that are not request-specific, such as region.
+ */
+public class DefaultTagsTest {
+  List<zipkin2.Span> spans = new ArrayList<>();
+  Tracing tracing = Tracing.newBuilder()
+      .addFinishedSpanHandler(new FinishedSpanHandler() {
+        @Override public boolean handle(TraceContext context, MutableSpan span) {
+          if (context.isLocalRoot()) {
+            // pretend these are sourced from the environment
+            span.tag("env", "prod");
+            span.tag("region", "east");
+          }
+          return true;
+        }
+      })
+      .spanReporter(spans::add)
+      .build();
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  @Test public void defaultTagsOnlyAddedOnce() {
+    ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
+    try {
+      tracing.tracer().startScopedSpan("child").finish();
+    } finally {
+      parent.finish();
+    }
+
+    assertThat(spans.get(0).name()).isEqualTo("child");
+    assertThat(spans.get(0).tags()).isEmpty();
+
+    assertThat(spans.get(1).name()).isEqualTo("parent");
+    assertThat(spans.get(1).tags()).containsExactly(
+        entry("env", "prod"),
+        entry("region", "east")
+    );
+  }
+}

--- a/brave/src/test/java/brave/features/handler/SkeletalSpansTest.java
+++ b/brave/src/test/java/brave/features/handler/SkeletalSpansTest.java
@@ -136,7 +136,7 @@ public class SkeletalSpansTest {
   /** Executes the linker for each collected trace */
   static List<DependencyLink> link(Map<String, List<zipkin2.Span>> spans) {
     DependencyLinker linker = new DependencyLinker();
-    spans.values().forEach(trace -> linker.putTrace(trace.iterator()));
+    spans.values().forEach(trace -> linker.putTrace(trace));
     return linker.link();
   }
 

--- a/brave/src/test/java/brave/features/handler/SkeletalSpansTest.java
+++ b/brave/src/test/java/brave/features/handler/SkeletalSpansTest.java
@@ -1,0 +1,204 @@
+package brave.features.handler;
+
+import brave.ScopedSpan;
+import brave.Span;
+import brave.Span.Kind;
+import brave.Tracer;
+import brave.Tracing;
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.DependencyLink;
+import zipkin2.Endpoint;
+import zipkin2.internal.DependencyLinker;
+import zipkin2.reporter.Reporter;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This shows how you can skip local spans to reduce the cost of storage. In this example we are
+ * cherry-picking data used by the dependency linker, mostly to make it simpler.
+ */
+public class SkeletalSpansTest {
+
+  class ReportSkeletalSpans extends FinishedSpanHandler {
+    final String localServiceName;
+    final Reporter<zipkin2.Span> delegate;
+
+    ReportSkeletalSpans(String localServiceName, Reporter<zipkin2.Span> delegate) {
+      this.localServiceName = localServiceName;
+      this.delegate = delegate;
+    }
+
+    @Override public boolean handle(TraceContext context, MutableSpan span) {
+      if (span.kind() == null) return false; // skip local spans
+
+      zipkin2.Span.Builder builder = zipkin2.Span.newBuilder()
+          .traceId(context.traceIdHigh(), context.traceId())
+          .parentId(context.isLocalRoot() ? 0L : context.localRootId()) // rewrite the parent ID
+          .id(context.spanId())
+          .name(span.name())
+          .kind(zipkin2.Span.Kind.valueOf(span.kind().name()))
+          .localEndpoint(Endpoint.newBuilder().serviceName(localServiceName).build());
+
+      if (span.error() != null || span.tag("error") != null) {
+        builder.putTag("error", ""); // linking counts errors: the value isn't important
+      }
+      if (span.remoteServiceName() != null) {
+        builder.remoteEndpoint(Endpoint.newBuilder().serviceName(span.remoteServiceName()).build());
+      }
+
+      delegate.report(builder.build());
+      return false; // end of the line
+    }
+  }
+
+  Map<String, List<zipkin2.Span>>
+      spans = new LinkedHashMap<>(),
+      skeletalSpans = new LinkedHashMap<>();
+
+  Tracer server1Tracer = Tracing.newBuilder()
+      .localServiceName("server1")
+      .spanReporter(toReporter(spans))
+      .build().tracer();
+
+  Tracer server2Tracer = Tracing.newBuilder()
+      .localServiceName("server2")
+      .spanReporter(toReporter(spans))
+      .build().tracer();
+
+  Tracer server1SkeletalTracer = Tracing.newBuilder()
+      .addFinishedSpanHandler(new ReportSkeletalSpans("server1", toReporter(skeletalSpans)))
+      .spanReporter(Reporter.NOOP)
+      .build().tracer();
+
+  Tracer server2SkeletalTracer = Tracing.newBuilder()
+      .addFinishedSpanHandler(new ReportSkeletalSpans("server2", toReporter(skeletalSpans)))
+      .spanReporter(Reporter.NOOP)
+      .build().tracer();
+
+  @Before public void acceptTwoServerRequests() {
+    acceptTwoServerRequests(server1Tracer, server2Tracer);
+    acceptTwoServerRequests(server1SkeletalTracer, server2SkeletalTracer);
+  }
+
+  @After public void close() {
+    Tracing.current().close();
+  }
+
+  @Test public void skeletalSpans_skipLocalSpans() {
+    assertThat(spans.values())
+        .extracting(s -> s.stream().map(zipkin2.Span::name).collect(Collectors.toList()))
+        .containsExactly(
+            asList("post", "post", "controller", "get"),
+            asList("async1"),
+            asList("async2"),
+            asList("post", "post", "post", "controller2", "get")
+        );
+
+    assertThat(skeletalSpans.values())
+        .extracting(s -> s.stream().map(zipkin2.Span::name).collect(Collectors.toList()))
+        .containsExactly(
+            asList("post", "post", "get"),
+            asList("post", "post", "post", "get")
+        );
+  }
+
+  @Test public void skeletalSpans_produceSameServiceGraph() {
+    assertThat(link(spans))
+        .containsExactly(
+            DependencyLink.newBuilder()
+                .parent("server1")
+                .child("server2")
+                .callCount(2L)
+                .errorCount(1L)
+                .build(),
+            DependencyLink.newBuilder()
+                .parent("server1")
+                .child("uninstrumentedserver")
+                .callCount(1L)
+                .errorCount(1L)
+                .build()
+        )
+        .isEqualTo(link(skeletalSpans));
+  }
+
+  /** Executes the linker for each collected trace */
+  static List<DependencyLink> link(Map<String, List<zipkin2.Span>> spans) {
+    DependencyLinker linker = new DependencyLinker();
+    spans.values().forEach(trace -> linker.putTrace(trace.iterator()));
+    return linker.link();
+  }
+
+  /** Simulates some service calls */
+  static void acceptTwoServerRequests(Tracer server1Tracer, Tracer server2Tracer) {
+    Span server1 = server1Tracer.newTrace().name("get").kind(Kind.SERVER).start();
+    Span server2 = server1Tracer.newTrace().name("get").kind(Kind.SERVER).start();
+    try {
+      Span client1 =
+          server1Tracer.newChild(server1.context()).name("post").kind(Kind.CLIENT).start();
+
+      server2Tracer.joinSpan(fakeUseOfHeaders(client1.context()))
+          .name("post")
+          .kind(Kind.SERVER)
+          .start().finish();
+
+      ScopedSpan local1 = server1Tracer.startScopedSpanWithParent("controller", server1.context());
+      try {
+        try {
+          server1Tracer.newTrace().name("async1").start().finish();
+          server2Tracer.newTrace().name("async2").start().finish();
+
+          ScopedSpan local2 =
+              server1Tracer.startScopedSpanWithParent("controller2", server2.context());
+          Span client2 = server1Tracer.nextSpan().name("post").kind(Kind.CLIENT).start();
+          try {
+            server2Tracer.joinSpan(fakeUseOfHeaders(client2.context()))
+                .name("post")
+                .kind(Kind.SERVER)
+                .start().error(new RuntimeException()).finish();
+
+            server1Tracer.nextSpan()
+                .name("post")
+                .kind(Kind.CLIENT)
+                .start()
+                .remoteServiceName("uninstrumentedServer")
+                .error(new RuntimeException())
+                .finish();
+          } finally {
+            client2.finish();
+            local2.finish();
+          }
+        } finally {
+          server2.finish();
+        }
+      } finally {
+        client1.finish();
+        local1.finish();
+      }
+    } finally {
+      server1.finish();
+    }
+  }
+
+  /** Ensures reporting is partitioned by trace ID */
+  static Reporter<zipkin2.Span> toReporter(Map<String, List<zipkin2.Span>> spans) {
+    return s -> spans.computeIfAbsent(s.traceId(), k -> new ArrayList<>()).add(s);
+  }
+
+  /** To reduce code, we don't use real client-server instrumentation. This fakes headers. */
+  static TraceContext fakeUseOfHeaders(TraceContext context) {
+    return B3SingleFormat.parseB3SingleFormat(B3SingleFormat.writeB3SingleFormat(context))
+        .context();
+  }
+}


### PR DESCRIPTION
Subgraphs are often "squashed" when processing dependency links.
Usually, we have to skip data server-side to achieve this, for example,
"skipping up" the tree until we find the root-most span in that process.

Moreover, several conversations led to a desire for "skeletal spans"
which contain no intermediate info between inbound and outbound
requests. This allows for 100% sampling in edge cases such as surges or
very large amounts of traffic.

Finally, some APM systems require reporting that groups together entry
points for reasons of squashing or post-processing a trace. For example,
Amazon X-Ray have a type Segment which is only for exit spans, reserving
SubSegment for local ones. Having some means to partition data allows
post-processing such as this, for example bundling.

"local root" is the solution to this problem and similar. By adding a
property: `localRootId` to the trace context, we can track spans by
entry point. This means we can re-write parents to squash intermediates.
We can also expose this in logging contexts to accomodate correlation.