### PR TITLE
Migrates off rxjava2 Fuseable base types as they broke inheritance

### DIFF
--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.2</version>
       <scope>provided</scope>
     </dependency>
 
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.github.akarnokd</groupId>
       <artifactId>rxjava2-extensions</artifactId>
-      <version>0.20.0</version>
+      <version>0.20.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCallableObservable.java
@@ -1,6 +1,5 @@
 package brave.context.rxjava2;
 
-import brave.context.rxjava2.TraceContextObservable.Observer;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
@@ -26,7 +25,7 @@ final class TraceContextCallableObservable<T> extends Observable<T> implements C
   protected void subscribeActual(io.reactivex.Observer<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextObserver<>(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableObservable.java
@@ -1,6 +1,5 @@
 package brave.context.rxjava2;
 
-import brave.context.rxjava2.TraceContextObservable.Observer;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
@@ -26,7 +25,7 @@ final class TraceContextConnectableObservable<T> extends ConnectableObservable<T
   protected void subscribeActual(io.reactivex.Observer s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<T>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextObserver<T>(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
@@ -5,8 +5,6 @@ import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
-import io.reactivex.internal.fuseable.QueueDisposable;
-import io.reactivex.internal.observers.BasicFuseableObserver;
 
 final class TraceContextObservable<T> extends Observable<T> {
   final ObservableSource<T> source;
@@ -26,69 +24,9 @@ final class TraceContextObservable<T> extends Observable<T> {
   protected void subscribeActual(io.reactivex.Observer<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextObserver<>(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
-    }
-  }
-
-  static final class Observer<T> extends BasicFuseableObserver<T, T> {
-    final CurrentTraceContext currentTraceContext;
-    final TraceContext assemblyContext;
-
-    Observer(
-        io.reactivex.Observer<T> actual,
-        CurrentTraceContext currentTraceContext,
-        TraceContext assemblyContext) {
-      super(actual);
-      this.currentTraceContext = currentTraceContext;
-      this.assemblyContext = assemblyContext;
-    }
-
-    @Override
-    public void onNext(T t) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onNext(t);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onError(t);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onComplete() {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onComplete();
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public int requestFusion(int mode) {
-      QueueDisposable<T> qs = this.qs;
-      if (qs != null) {
-        int m = qs.requestFusion(mode);
-        sourceMode = m;
-        return m;
-      }
-      return NONE;
-    }
-
-    @Override
-    public T poll() throws Exception {
-      return qs.poll();
     }
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextScalarCallableObservable.java
@@ -1,6 +1,5 @@
 package brave.context.rxjava2;
 
-import brave.context.rxjava2.TraceContextObservable.Observer;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
@@ -27,7 +26,7 @@ final class TraceContextScalarCallableObservable<T> extends Observable<T>
   protected void subscribeActual(io.reactivex.Observer<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextObserver<>(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }


### PR DESCRIPTION
This inlines code we needed from Fuseable types in order to allow the
same library to work with RxJava 2.2 and 2.3+

See https://github.com/ReactiveX/RxJava/pull/6129/files#diff-173446df25e9a6926e322f1849bf6c35R31