### PR TITLE
Remove use of internal Kafka APIs

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
@@ -5,9 +5,9 @@ import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Injector;
 import java.nio.charset.Charset;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import static brave.propagation.B3SingleFormat.writeB3SingleFormat;
 import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentIdAsBytes;
@@ -17,8 +17,10 @@ final class KafkaPropagation {
   static final Charset UTF_8 = Charset.forName("UTF-8");
 
   static final TraceContext TEST_CONTEXT = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
+  static final ProducerRecord<String, String> TEST_RECORD =
+      new ProducerRecord<>("dummy", "");
   static final Headers B3_SINGLE_TEST_HEADERS =
-      new RecordHeaders().add("b3", writeB3SingleFormat(TEST_CONTEXT).getBytes(UTF_8));
+      TEST_RECORD.headers().add("b3", writeB3SingleFormat(TEST_CONTEXT).getBytes(UTF_8));
 
   static final Injector<Headers> B3_SINGLE_INJECTOR = new Injector<Headers>() {
     @Override public void inject(TraceContext traceContext, Headers carrier) {

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -19,7 +19,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -126,7 +125,12 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
 
   // Do not use @Override annotation to avoid compatibility issue version < 1.0
   public void subscribe(Pattern pattern) {
-    delegate.subscribe(pattern, new NoOpConsumerRebalanceListener());
+    // replicate org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener behaviour
+    delegate.subscribe(pattern, new ConsumerRebalanceListener() {
+      @Override public void onPartitionsRevoked(Collection<TopicPartition> partitions) {}
+
+      @Override public void onPartitionsAssigned(Collection<TopicPartition> partitions) {}
+    });
   }
 
   @Override public void unsubscribe() {

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -36,6 +36,12 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   final Tracing tracing;
   final Injector<Headers> injector;
   final String remoteServiceName;
+  // replicate org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener behaviour
+  static final ConsumerRebalanceListener NO_OP_CONSUMER_REBALANCE_LISTENER =
+      new ConsumerRebalanceListener() {
+        @Override public void onPartitionsRevoked(Collection<TopicPartition> partitions) {}
+        @Override public void onPartitionsAssigned(Collection<TopicPartition> partitions) {}
+      };
 
   TracingConsumer(Consumer<K, V> delegate, KafkaTracing kafkaTracing) {
     this.delegate = delegate;
@@ -125,12 +131,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
 
   // Do not use @Override annotation to avoid compatibility issue version < 1.0
   public void subscribe(Pattern pattern) {
-    // replicate org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener behaviour
-    delegate.subscribe(pattern, new ConsumerRebalanceListener() {
-      @Override public void onPartitionsRevoked(Collection<TopicPartition> partitions) {}
-
-      @Override public void onPartitionsAssigned(Collection<TopicPartition> partitions) {}
-    });
+    delegate.subscribe(pattern, NO_OP_CONSUMER_REBALANCE_LISTENER);
   }
 
   @Override public void unsubscribe() {


### PR DESCRIPTION
Avoid using `.internals.` types from Kafka APIs. 

Changes:
- Replacing `RecordHeaders` by `ProducerRecord#headers()`
- Replacing `NoOpConsumerRebalanceListener` by local implementation.