### PR TITLE
Insulates RxJava2 code from future drift in internal packages

### DIFF
--- a/context/rxjava2/src/main/java/brave/context/rxjava2/CurrentTraceContextAssemblyTracking.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/CurrentTraceContextAssemblyTracking.java
@@ -1,16 +1,20 @@
 package brave.context.rxjava2;
 
+import brave.context.rxjava2.internal.Util;
+import brave.context.rxjava2.internal.fuseable.MaybeFuseable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
 import io.reactivex.Observable;
+import io.reactivex.Observer;
 import io.reactivex.Single;
+import io.reactivex.SingleObserver;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.Functions;
-import io.reactivex.internal.fuseable.ScalarCallable;
 import io.reactivex.observables.ConnectableObservable;
 import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.plugins.RxJavaPlugins;
@@ -72,7 +76,7 @@ public final class CurrentTraceContextAssemblyTracking {
         RxJavaPlugins.getOnCompletableAssembly();
     Function<? super Completable, ? extends Completable> oldCompletable = saveC;
     if (oldCompletable == null || !chain) {
-      oldCompletable = Functions.identity();
+      oldCompletable = Util.identity();
     }
     final Function<? super Completable, ? extends Completable> oldC = oldCompletable;
 
@@ -83,10 +87,7 @@ public final class CurrentTraceContextAssemblyTracking {
             if (!(c instanceof Callable)) {
               return new TraceContextCompletable(c, currentTraceContext, ctx);
             }
-            if (c instanceof ScalarCallable) {
-              return new TraceContextScalarCallableCompletable(c, currentTraceContext, ctx);
-            }
-            return new TraceContextCallableCompletable(c, currentTraceContext, ctx);
+            return MaybeFuseable.get().wrap(c, currentTraceContext, ctx);
           }
         });
 
@@ -95,7 +96,7 @@ public final class CurrentTraceContextAssemblyTracking {
     final Function<? super Maybe, ? extends Maybe> saveM = RxJavaPlugins.getOnMaybeAssembly();
     Function<? super Maybe, ? extends Maybe> oldMaybe = saveM;
     if (oldMaybe == null || !chain) {
-      oldMaybe = Functions.identity();
+      oldMaybe = Util.identity();
     }
     final Function<? super Maybe, ? extends Maybe> oldM = oldMaybe;
 
@@ -106,10 +107,7 @@ public final class CurrentTraceContextAssemblyTracking {
             if (!(m instanceof Callable)) {
               return new TraceContextMaybe(m, currentTraceContext, ctx);
             }
-            if (m instanceof ScalarCallable) {
-              return new TraceContextScalarCallableMaybe(m, currentTraceContext, ctx);
-            }
-            return new TraceContextCallableMaybe(m, currentTraceContext, ctx);
+            return MaybeFuseable.get().wrap(m, currentTraceContext, ctx);
           }
         });
 
@@ -118,7 +116,7 @@ public final class CurrentTraceContextAssemblyTracking {
     final Function<? super Single, ? extends Single> saveS = RxJavaPlugins.getOnSingleAssembly();
     Function<? super Single, ? extends Single> oldSingle = saveS;
     if (oldSingle == null || !chain) {
-      oldSingle = Functions.identity();
+      oldSingle = Util.identity();
     }
     final Function<? super Single, ? extends Single> oldS = oldSingle;
 
@@ -129,10 +127,7 @@ public final class CurrentTraceContextAssemblyTracking {
             if (!(s instanceof Callable)) {
               return new TraceContextSingle(s, currentTraceContext, ctx);
             }
-            if (s instanceof ScalarCallable) {
-              return new TraceContextScalarCallableSingle(s, currentTraceContext, ctx);
-            }
-            return new TraceContextCallableSingle(s, currentTraceContext, ctx);
+            return MaybeFuseable.get().wrap(s, currentTraceContext, ctx);
           }
         });
 
@@ -142,7 +137,7 @@ public final class CurrentTraceContextAssemblyTracking {
         RxJavaPlugins.getOnObservableAssembly();
     Function<? super Observable, ? extends Observable> oldObservable = saveO;
     if (oldObservable == null || !chain) {
-      oldObservable = Functions.identity();
+      oldObservable = Util.identity();
     }
     final Function<? super Observable, ? extends Observable> oldO = oldObservable;
 
@@ -153,10 +148,7 @@ public final class CurrentTraceContextAssemblyTracking {
             if (!(o instanceof Callable)) {
               return new TraceContextObservable(o, currentTraceContext, ctx);
             }
-            if (o instanceof ScalarCallable) {
-              return new TraceContextScalarCallableObservable(o, currentTraceContext, ctx);
-            }
-            return new TraceContextCallableObservable(o, currentTraceContext, ctx);
+            return MaybeFuseable.get().wrap(o, currentTraceContext, ctx);
           }
         });
 
@@ -166,7 +158,7 @@ public final class CurrentTraceContextAssemblyTracking {
         RxJavaPlugins.getOnFlowableAssembly();
     Function<? super Flowable, ? extends Flowable> oldFlowable = saveF;
     if (oldFlowable == null || !chain) {
-      oldFlowable = Functions.identity();
+      oldFlowable = Util.identity();
     }
     final Function<? super Flowable, ? extends Flowable> oldF = oldFlowable;
 
@@ -177,10 +169,7 @@ public final class CurrentTraceContextAssemblyTracking {
             if (!(f instanceof Callable)) {
               return new TraceContextFlowable(f, currentTraceContext, ctx);
             }
-            if (f instanceof ScalarCallable) {
-              return new TraceContextScalarCallableFlowable(f, currentTraceContext, ctx);
-            }
-            return new TraceContextCallableFlowable(f, currentTraceContext, ctx);
+            return MaybeFuseable.get().wrap(f, currentTraceContext, ctx);
           }
         });
 
@@ -190,7 +179,7 @@ public final class CurrentTraceContextAssemblyTracking {
         RxJavaPlugins.getOnConnectableFlowableAssembly();
     Function<? super ConnectableFlowable, ? extends ConnectableFlowable> oldConnFlow = saveCF;
     if (oldConnFlow == null || !chain) {
-      oldConnFlow = Functions.identity();
+      oldConnFlow = Util.identity();
     }
     final Function<? super ConnectableFlowable, ? extends ConnectableFlowable> oldCF = oldConnFlow;
 
@@ -208,7 +197,7 @@ public final class CurrentTraceContextAssemblyTracking {
         RxJavaPlugins.getOnConnectableObservableAssembly();
     Function<? super ConnectableObservable, ? extends ConnectableObservable> oldConnObs = saveCO;
     if (oldConnObs == null || !chain) {
-      oldConnObs = Functions.identity();
+      oldConnObs = Util.identity();
     }
     final Function<? super ConnectableObservable, ? extends ConnectableObservable> oldCO =
         oldConnObs;
@@ -227,7 +216,7 @@ public final class CurrentTraceContextAssemblyTracking {
         RxJavaPlugins.getOnParallelAssembly();
     Function<? super ParallelFlowable, ? extends ParallelFlowable> oldParFlow = savePF;
     if (oldParFlow == null || !chain) {
-      oldParFlow = Functions.identity();
+      oldParFlow = Util.identity();
     }
     final Function<? super ParallelFlowable, ? extends ParallelFlowable> oldPF = oldParFlow;
 
@@ -287,5 +276,29 @@ public final class CurrentTraceContextAssemblyTracking {
     }
 
     abstract T applyActual(T t, TraceContext ctx);
+  }
+
+  static {
+    Internal.instance = new Internal() {
+      @Override public <T> Observer<T> wrap(Observer<T> actual,
+          CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+        return new TraceContextObserver<>(actual, currentTraceContext, assemblyContext);
+      }
+
+      @Override public <T> SingleObserver<T> wrap(SingleObserver<T> actual,
+          CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+        return new TraceContextSingleObserver<>(actual, currentTraceContext, assemblyContext);
+      }
+
+      @Override public <T> MaybeObserver<T> wrap(MaybeObserver<T> actual,
+          CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+        return new TraceContextMaybeObserver<>(actual, currentTraceContext, assemblyContext);
+      }
+
+      @Override public CompletableObserver wrap(CompletableObserver actual,
+          CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+        return new TraceContextCompletableObserver(actual, currentTraceContext, assemblyContext);
+      }
+    };
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/Internal.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/Internal.java
@@ -1,0 +1,45 @@
+package brave.context.rxjava2;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import io.reactivex.CompletableObserver;
+import io.reactivex.MaybeObserver;
+import io.reactivex.Observer;
+import io.reactivex.SingleObserver;
+
+/**
+ * Escalate internal APIs in {@code brave.context.rxjava2} so they can be used from outside
+ * packages. The only implementation is in {@link CurrentTraceContextAssemblyTracking}.
+ *
+ * <p>Inspired by {@code okhttp3.internal.Internal}.
+ */
+public abstract class Internal {
+  public static Internal instance;
+
+  public abstract <T> Observer<T> wrap(
+      Observer<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract <T> SingleObserver<T> wrap(
+      SingleObserver<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract <T> MaybeObserver<T> wrap(
+      MaybeObserver<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract CompletableObserver wrap(
+      CompletableObserver actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  Internal() {
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletable.java
@@ -6,8 +6,6 @@ import brave.propagation.TraceContext;
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.CompletableSource;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
 
 final class TraceContextCompletable extends Completable {
   final CompletableSource source;
@@ -27,67 +25,9 @@ final class TraceContextCompletable extends Completable {
   protected void subscribeActual(CompletableObserver s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextCompletableObserver(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
-    }
-  }
-
-  static final class Observer implements CompletableObserver, Disposable {
-    final CompletableObserver actual;
-    final CurrentTraceContext currentTraceContext;
-    final TraceContext assemblyContext;
-    Disposable d;
-
-    Observer(
-        CompletableObserver actual,
-        CurrentTraceContext currentTraceContext,
-        TraceContext assemblyContext) {
-      this.actual = actual;
-      this.currentTraceContext = currentTraceContext;
-      this.assemblyContext = assemblyContext;
-    }
-
-    @Override
-    public void onSubscribe(Disposable d) {
-      if (!DisposableHelper.validate(this.d, d)) return;
-      this.d = d;
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onSubscribe(this);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onError(t);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onComplete() {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onComplete();
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public boolean isDisposed() {
-      return d.isDisposed();
-    }
-
-    @Override
-    public void dispose() {
-      d.dispose();
     }
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletableObserver.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletableObserver.java
@@ -4,65 +4,58 @@ import brave.context.rxjava2.internal.Util;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.Observer;
+import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.plugins.RxJavaPlugins;
 
-final class TraceContextObserver<T> implements Observer<T> {
-  final Observer<T> downstream;
+final class TraceContextCompletableObserver implements CompletableObserver, Disposable {
+  final CompletableObserver actual;
   final CurrentTraceContext currentTraceContext;
   final TraceContext assemblyContext;
-  Disposable upstream;
-  boolean done;
+  Disposable d;
 
-  TraceContextObserver(
-      Observer<T> downstream,
+  TraceContextCompletableObserver(
+      CompletableObserver actual,
       CurrentTraceContext currentTraceContext,
       TraceContext assemblyContext) {
-    this.downstream = downstream;
+    this.actual = actual;
     this.currentTraceContext = currentTraceContext;
     this.assemblyContext = assemblyContext;
   }
 
-  @Override public final void onSubscribe(Disposable d) {
-    if (Util.validate(upstream, d)) {
-      downstream.onSubscribe((upstream = d));
-    }
-  }
-
-  @Override public void onNext(T t) {
+  @Override public void onSubscribe(Disposable d) {
+    if (!Util.validate(this.d, d)) return;
+    this.d = d;
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      downstream.onNext(t);
+      actual.onSubscribe(this);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onError(Throwable t) {
-    if (done) {
-      RxJavaPlugins.onError(t);
-      return;
-    }
-    done = true;
-
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      downstream.onError(t);
+      actual.onError(t);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onComplete() {
-    if (done) return;
-    done = true;
-
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      downstream.onComplete();
+      actual.onComplete();
     } finally {
       scope.close();
     }
+  }
+
+  @Override public boolean isDisposed() {
+    return d.isDisposed();
+  }
+
+  @Override public void dispose() {
+    d.dispose();
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableFlowable.java
@@ -1,12 +1,12 @@
 package brave.context.rxjava2;
 
+import brave.context.rxjava2.internal.fuseable.MaybeFuseable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.internal.fuseable.ConditionalSubscriber;
 
 final class TraceContextConnectableFlowable<T> extends ConnectableFlowable<T> {
   final ConnectableFlowable<T> source;
@@ -22,24 +22,16 @@ final class TraceContextConnectableFlowable<T> extends ConnectableFlowable<T> {
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
+  @Override protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      if (s instanceof ConditionalSubscriber) {
-        source.subscribe(
-            new TraceContextConditionalSubscriber<>(
-                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
-      } else {
-        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
-      }
+      source.subscribe(MaybeFuseable.get().wrap(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }
   }
 
-  @Override
-  public void connect(Consumer<? super Disposable> connection) {
+  @Override public void connect(Consumer<? super Disposable> connection) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       source.connect(connection);

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextConnectableObservable.java
@@ -21,8 +21,7 @@ final class TraceContextConnectableObservable<T> extends ConnectableObservable<T
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(io.reactivex.Observer s) {
+  @Override protected void subscribeActual(io.reactivex.Observer s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       source.subscribe(new TraceContextObserver<T>(s, currentTraceContext, assemblyContext));
@@ -31,8 +30,7 @@ final class TraceContextConnectableObservable<T> extends ConnectableObservable<T
     }
   }
 
-  @Override
-  public void connect(Consumer<? super Disposable> connection) {
+  @Override public void connect(Consumer<? super Disposable> connection) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       source.connect(connection);

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextFlowable.java
@@ -1,10 +1,10 @@
 package brave.context.rxjava2;
 
+import brave.context.rxjava2.internal.fuseable.MaybeFuseable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.Flowable;
-import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -20,17 +20,10 @@ final class TraceContextFlowable<T> extends Flowable<T> {
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(Subscriber s) {
+  @Override protected void subscribeActual(Subscriber s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      if (s instanceof ConditionalSubscriber) {
-        source.subscribe(
-            new TraceContextConditionalSubscriber<>(
-                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
-      } else {
-        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
-      }
+      source.subscribe(MaybeFuseable.get().wrap(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybe.java
@@ -6,8 +6,6 @@ import brave.propagation.TraceContext;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.MaybeSource;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
 
 final class TraceContextMaybe<T> extends Maybe<T> {
   final MaybeSource<T> source;
@@ -23,81 +21,12 @@ final class TraceContextMaybe<T> extends Maybe<T> {
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(MaybeObserver<? super T> s) {
+  @Override protected void subscribeActual(MaybeObserver<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextMaybeObserver<>(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
-    }
-  }
-
-  static final class Observer<T> implements MaybeObserver<T>, Disposable {
-    final MaybeObserver<T> actual;
-    final CurrentTraceContext currentTraceContext;
-    final TraceContext assemblyContext;
-    Disposable d;
-
-    Observer(
-        MaybeObserver actual,
-        CurrentTraceContext currentTraceContext,
-        TraceContext assemblyContext) {
-      this.actual = actual;
-      this.currentTraceContext = currentTraceContext;
-      this.assemblyContext = assemblyContext;
-    }
-
-    @Override
-    public void onSubscribe(Disposable d) {
-      if (!DisposableHelper.validate(this.d, d)) return;
-      this.d = d;
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onSubscribe(this);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onError(t);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onSuccess(T value) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onSuccess(value);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onComplete() {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onComplete();
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public boolean isDisposed() {
-      return d.isDisposed();
-    }
-
-    @Override
-    public void dispose() {
-      d.dispose();
     }
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
@@ -20,8 +20,7 @@ final class TraceContextObservable<T> extends Observable<T> {
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(io.reactivex.Observer<? super T> s) {
+  @Override protected void subscribeActual(io.reactivex.Observer<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       source.subscribe(new TraceContextObserver<>(s, currentTraceContext, assemblyContext));

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextParallelFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextParallelFlowable.java
@@ -1,9 +1,9 @@
 package brave.context.rxjava2;
 
+import brave.context.rxjava2.internal.fuseable.MaybeFuseable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.parallel.ParallelFlowable;
 import org.reactivestreams.Subscriber;
 
@@ -21,26 +21,18 @@ final class TraceContextParallelFlowable<T> extends ParallelFlowable<T> {
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  public int parallelism() {
+  @Override public int parallelism() {
     return source.parallelism();
   }
 
-  @Override
-  public void subscribe(Subscriber<? super T>[] s) {
+  @Override public void subscribe(Subscriber<? super T>[] s) {
     if (!validate(s)) return;
     int n = s.length;
     @SuppressWarnings("unchecked")
     Subscriber<? super T>[] parents = new Subscriber[n];
     for (int i = 0; i < n; i++) {
       Subscriber<? super T> z = s[i];
-      if (z instanceof ConditionalSubscriber) {
-        parents[i] =
-            new TraceContextConditionalSubscriber<>(
-                (ConditionalSubscriber<? super T>) z, currentTraceContext, assemblyContext);
-      } else {
-        parents[i] = new TraceContextSubscriber<>(z, currentTraceContext, assemblyContext);
-      }
+      parents[i] = MaybeFuseable.get().wrap(z, currentTraceContext, assemblyContext);
     }
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingle.java
@@ -6,8 +6,6 @@ import brave.propagation.TraceContext;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.SingleSource;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.disposables.DisposableHelper;
 
 final class TraceContextSingle<T> extends Single<T> {
   final SingleSource<T> source;
@@ -23,71 +21,12 @@ final class TraceContextSingle<T> extends Single<T> {
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(SingleObserver<? super T> s) {
+  @Override protected void subscribeActual(SingleObserver<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextSingleObserver<>(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
-    }
-  }
-
-  static final class Observer<T> implements SingleObserver<T>, Disposable {
-    final SingleObserver<T> actual;
-    final CurrentTraceContext currentTraceContext;
-    final TraceContext assemblyContext;
-    Disposable d;
-
-    Observer(
-        SingleObserver actual,
-        CurrentTraceContext currentTraceContext,
-        TraceContext assemblyContext) {
-      this.actual = actual;
-      this.currentTraceContext = currentTraceContext;
-      this.assemblyContext = assemblyContext;
-    }
-
-    @Override
-    public void onSubscribe(Disposable d) {
-      if (!DisposableHelper.validate(this.d, d)) return;
-      this.d = d;
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onSubscribe(this);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onError(t);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public void onSuccess(T value) {
-      Scope scope = currentTraceContext.maybeScope(assemblyContext);
-      try { // retrolambda can't resolve this try/finally
-        actual.onSuccess(value);
-      } finally {
-        scope.close();
-      }
-    }
-
-    @Override
-    public boolean isDisposed() {
-      return d.isDisposed();
-    }
-
-    @Override
-    public void dispose() {
-      d.dispose();
     }
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingleObserver.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingleObserver.java
@@ -4,65 +4,58 @@ import brave.context.rxjava2.internal.Util;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.Observer;
+import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.plugins.RxJavaPlugins;
 
-final class TraceContextObserver<T> implements Observer<T> {
-  final Observer<T> downstream;
+final class TraceContextSingleObserver<T> implements SingleObserver<T>, Disposable {
+  final SingleObserver<T> actual;
   final CurrentTraceContext currentTraceContext;
   final TraceContext assemblyContext;
-  Disposable upstream;
-  boolean done;
+  Disposable d;
 
-  TraceContextObserver(
-      Observer<T> downstream,
+  TraceContextSingleObserver(
+      SingleObserver<T> actual,
       CurrentTraceContext currentTraceContext,
       TraceContext assemblyContext) {
-    this.downstream = downstream;
+    this.actual = actual;
     this.currentTraceContext = currentTraceContext;
     this.assemblyContext = assemblyContext;
   }
 
-  @Override public final void onSubscribe(Disposable d) {
-    if (Util.validate(upstream, d)) {
-      downstream.onSubscribe((upstream = d));
-    }
-  }
-
-  @Override public void onNext(T t) {
+  @Override public void onSubscribe(Disposable d) {
+    if (!Util.validate(this.d, d)) return;
+    this.d = d;
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      downstream.onNext(t);
+      actual.onSubscribe(this);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onError(Throwable t) {
-    if (done) {
-      RxJavaPlugins.onError(t);
-      return;
-    }
-    done = true;
-
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      downstream.onError(t);
+      actual.onError(t);
     } finally {
       scope.close();
     }
   }
 
-  @Override public void onComplete() {
-    if (done) return;
-    done = true;
-
+  @Override public void onSuccess(T value) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      downstream.onComplete();
+      actual.onSuccess(value);
     } finally {
       scope.close();
     }
+  }
+
+  @Override public boolean isDisposed() {
+    return d.isDisposed();
+  }
+
+  @Override public void dispose() {
+    d.dispose();
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/Util.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/Util.java
@@ -1,0 +1,53 @@
+package brave.context.rxjava2.internal;
+
+import io.reactivex.disposables.Disposable;
+import io.reactivex.exceptions.ProtocolViolationException;
+import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
+import org.reactivestreams.Subscription;
+
+/** Junk drawer to avoid dependencies on internal RxJava types. */
+public final class Util {
+  static final Function<Object, Object> IDENTITY = new Function<Object, Object>() {
+    @Override public Object apply(Object v) {
+      return v;
+    }
+
+    @Override public String toString() {
+      return "IdentityFunction";
+    }
+  };
+
+  // io.reactivex.internal.functions.Functions.identity()
+  public static <T> Function<T, T> identity() {
+    return (Function<T, T>) IDENTITY;
+  }
+
+  // io.reactivex.internal.disposables.DisposableHelper.validate(Disposable, Disposable)
+  public static boolean validate(Disposable current, Disposable next) {
+    if (next == null) {
+      RxJavaPlugins.onError(new NullPointerException("next is null"));
+      return false;
+    }
+    if (current != null) {
+      next.dispose();
+      RxJavaPlugins.onError(new ProtocolViolationException("Disposable already set!"));
+      return false;
+    }
+    return true;
+  }
+
+  // io.reactivex.internal.subscriptions.SubscriptionHelper.validate(Subscription, Subscription)
+  public static boolean validate(Subscription current, Subscription next) {
+    if (next == null) {
+      RxJavaPlugins.onError(new NullPointerException("next is null"));
+      return false;
+    }
+    if (current != null) {
+      next.cancel();
+      RxJavaPlugins.onError(new ProtocolViolationException("Subscription already set!"));
+      return false;
+    }
+    return true;
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/MaybeFuseable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/MaybeFuseable.java
@@ -1,0 +1,168 @@
+package brave.context.rxjava2.internal.fuseable;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.SingleSource;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.internal.fuseable.ScalarCallable;
+import org.reactivestreams.Subscriber;
+
+/**
+ * Leniently tries to lookup the currently internal types {@link ScalarCallable} and {@link
+ * ConditionalSubscriber}.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.platform.Platform}
+ */
+public abstract class MaybeFuseable {
+  private static final MaybeFuseable INSTANCE = detectFuseable();
+
+  public abstract <T> Subscriber<T> wrap(
+      Subscriber<T> downstream,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext);
+
+  public abstract Completable wrap(
+      Completable actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract <T> Maybe<T> wrap(
+      Maybe<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract <T> Single<T> wrap(
+      SingleSource<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract <T> Observable<T> wrap(
+      Observable<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  public abstract <T> Flowable<T> wrap(
+      Flowable<T> actual,
+      CurrentTraceContext currentTraceContext,
+      TraceContext assemblyContext
+  );
+
+  MaybeFuseable() {
+  }
+
+  public static MaybeFuseable get() {
+    return INSTANCE;
+  }
+
+  /**
+   * NOTE: If/when the fuseable package becomes non-internal, we'll likely need to do a reflective
+   * approach to keep supporting the rxjava 2.x versions where these types were internal.
+   */
+  private static MaybeFuseable detectFuseable() {
+    // Find fuseable classes
+    try {
+      Class.forName("io.reactivex.internal.fuseable.ScalarCallable");
+      Class.forName("io.reactivex.internal.fuseable.ConditionalSubscriber");
+      return new Present();
+    } catch (ClassNotFoundException e) {
+      // Maybe fuseable is no longer internal
+    }
+
+    return new Absent();
+  }
+
+  static final class Present extends MaybeFuseable {
+    @Override public <T> Subscriber<T> wrap(Subscriber<T> downstream,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      if (downstream instanceof ConditionalSubscriber) {
+        return new TraceContextConditionalSubscriber<>((ConditionalSubscriber<T>) downstream,
+            currentTraceContext, assemblyContext);
+      }
+      return new TraceContextSubscriber<>(downstream, currentTraceContext, assemblyContext);
+    }
+
+    @Override public Completable wrap(Completable actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      if (actual instanceof ScalarCallable) {
+        return new TraceContextScalarCallableCompletable<>(actual, currentTraceContext,
+            assemblyContext);
+      }
+      return new TraceContextCallableCompletable<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Maybe<T> wrap(Maybe<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      if (actual instanceof ScalarCallable) {
+        return new TraceContextScalarCallableMaybe<>(actual, currentTraceContext, assemblyContext);
+      }
+      return new TraceContextCallableMaybe<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Single<T> wrap(SingleSource<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      if (actual instanceof ScalarCallable) {
+        return new TraceContextScalarCallableSingle<>(actual, currentTraceContext, assemblyContext);
+      }
+      return new TraceContextCallableSingle<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Observable<T> wrap(Observable<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      if (actual instanceof ScalarCallable) {
+        return new TraceContextScalarCallableObservable<>(actual, currentTraceContext,
+            assemblyContext);
+      }
+      return new TraceContextCallableObservable<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Flowable<T> wrap(Flowable<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      if (actual instanceof ScalarCallable) {
+        return new TraceContextScalarCallableFlowable<>(actual, currentTraceContext,
+            assemblyContext);
+      }
+      return new TraceContextCallableFlowable<>(actual, currentTraceContext, assemblyContext);
+    }
+  }
+
+  static final class Absent extends MaybeFuseable {
+    @Override public <T> Subscriber<T> wrap(Subscriber<T> downstream,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      return new TraceContextSubscriber<>(downstream, currentTraceContext, assemblyContext);
+    }
+
+    @Override public Completable wrap(Completable actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      return new TraceContextCallableCompletable<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Maybe<T> wrap(Maybe<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      return new TraceContextCallableMaybe<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Single<T> wrap(SingleSource<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      return new TraceContextCallableSingle<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Observable<T> wrap(Observable<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      return new TraceContextCallableObservable<>(actual, currentTraceContext, assemblyContext);
+    }
+
+    @Override public <T> Flowable<T> wrap(Flowable<T> actual,
+        CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      return new TraceContextCallableFlowable<>(actual, currentTraceContext, assemblyContext);
+    }
+  }
+}

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableMaybe.java
@@ -1,21 +1,21 @@
-package brave.context.rxjava2;
+package brave.context.rxjava2.internal.fuseable;
 
-import brave.context.rxjava2.TraceContextSingle.Observer;
+import brave.context.rxjava2.Internal;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.Single;
-import io.reactivex.SingleObserver;
-import io.reactivex.SingleSource;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
 import java.util.concurrent.Callable;
 
-final class TraceContextCallableSingle<T> extends Single<T> implements Callable<T> {
-  final SingleSource<T> source;
+final class TraceContextCallableMaybe<T> extends Maybe<T> implements Callable<T> {
+  final MaybeSource<T> source;
   final CurrentTraceContext currentTraceContext;
   final TraceContext assemblyContext;
 
-  TraceContextCallableSingle(
-      SingleSource<T> source,
+  TraceContextCallableMaybe(
+      MaybeSource<T> source,
       CurrentTraceContext currentTraceContext,
       TraceContext assemblyContext) {
     this.source = source;
@@ -23,19 +23,17 @@ final class TraceContextCallableSingle<T> extends Single<T> implements Callable<
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(SingleObserver<? super T> s) {
+  @Override protected void subscribeActual(MaybeObserver<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Override
-  public T call() throws Exception {
+  @Override public T call() throws Exception {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       return ((Callable<T>) source).call();

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextConditionalSubscriber.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextConditionalSubscriber.java
@@ -1,10 +1,10 @@
-package brave.context.rxjava2;
+package brave.context.rxjava2.internal.fuseable;
 
+import brave.context.rxjava2.internal.Util;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.internal.fuseable.ConditionalSubscriber;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import org.reactivestreams.Subscription;
 
@@ -16,7 +16,7 @@ final class TraceContextConditionalSubscriber<T> implements ConditionalSubscribe
   boolean done;
 
   TraceContextConditionalSubscriber(
-      ConditionalSubscriber downstream,
+      ConditionalSubscriber<T> downstream,
       CurrentTraceContext currentTraceContext,
       TraceContext assemblyContext) {
     this.downstream = downstream;
@@ -25,7 +25,7 @@ final class TraceContextConditionalSubscriber<T> implements ConditionalSubscribe
   }
 
   @Override public final void onSubscribe(Subscription s) {
-    if (SubscriptionHelper.validate(upstream, s)) {
+    if (Util.validate(upstream, s)) {
       downstream.onSubscribe((upstream = s));
     }
   }
@@ -48,8 +48,7 @@ final class TraceContextConditionalSubscriber<T> implements ConditionalSubscribe
     }
   }
 
-  @Override
-  public void onError(Throwable t) {
+  @Override public void onError(Throwable t) {
     if (done) {
       RxJavaPlugins.onError(t);
       return;

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableCompletable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableCompletable.java
@@ -1,20 +1,22 @@
-package brave.context.rxjava2;
+package brave.context.rxjava2.internal.fuseable;
 
+import brave.context.rxjava2.Internal;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
 import io.reactivex.internal.fuseable.ScalarCallable;
 
-final class TraceContextScalarCallableObservable<T> extends Observable<T>
+public final class TraceContextScalarCallableCompletable<T> extends Completable
     implements ScalarCallable<T> {
-  final ObservableSource<T> source;
+  final CompletableSource source;
   final CurrentTraceContext currentTraceContext;
   final TraceContext assemblyContext;
 
-  TraceContextScalarCallableObservable(
-      ObservableSource<T> source,
+  TraceContextScalarCallableCompletable(
+      CompletableSource source,
       CurrentTraceContext currentTraceContext,
       TraceContext assemblyContext) {
     this.source = source;
@@ -22,19 +24,17 @@ final class TraceContextScalarCallableObservable<T> extends Observable<T>
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(io.reactivex.Observer<? super T> s) {
+  @Override protected void subscribeActual(CompletableObserver s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new TraceContextObserver<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Override
-  public T call() {
+  @Override public T call() {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       return ((ScalarCallable<T>) source).call();

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableFlowable.java
@@ -1,14 +1,14 @@
-package brave.context.rxjava2;
+package brave.context.rxjava2.internal.fuseable;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.Flowable;
-import io.reactivex.internal.fuseable.ConditionalSubscriber;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import org.reactivestreams.Publisher;
 
-final class TraceContextScalarCallableFlowable<T> extends Flowable<T> implements ScalarCallable<T> {
+public final class TraceContextScalarCallableFlowable<T> extends Flowable<T>
+    implements ScalarCallable<T> {
   final Publisher<T> source;
   final CurrentTraceContext currentTraceContext;
   final TraceContext assemblyContext;
@@ -24,13 +24,7 @@ final class TraceContextScalarCallableFlowable<T> extends Flowable<T> implements
   protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      if (s instanceof ConditionalSubscriber) {
-        source.subscribe(
-            new TraceContextConditionalSubscriber<>(
-                (ConditionalSubscriber) s, currentTraceContext, assemblyContext));
-      } else {
-        source.subscribe(new TraceContextSubscriber<>(s, currentTraceContext, assemblyContext));
-      }
+      source.subscribe(MaybeFuseable.get().wrap(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableSingle.java
@@ -1,21 +1,21 @@
-package brave.context.rxjava2;
+package brave.context.rxjava2.internal.fuseable;
 
-import brave.context.rxjava2.TraceContextCompletable.Observer;
+import brave.context.rxjava2.Internal;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.Completable;
-import io.reactivex.CompletableObserver;
-import io.reactivex.CompletableSource;
-import java.util.concurrent.Callable;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.internal.fuseable.ScalarCallable;
 
-final class TraceContextCallableCompletable<T> extends Completable implements Callable<T> {
-  final CompletableSource source;
+final class TraceContextScalarCallableSingle<T> extends Single<T> implements ScalarCallable<T> {
+  final SingleSource<T> source;
   final CurrentTraceContext currentTraceContext;
   final TraceContext assemblyContext;
 
-  TraceContextCallableCompletable(
-      CompletableSource source,
+  TraceContextScalarCallableSingle(
+      SingleSource<T> source,
       CurrentTraceContext currentTraceContext,
       TraceContext assemblyContext) {
     this.source = source;
@@ -23,22 +23,20 @@ final class TraceContextCallableCompletable<T> extends Completable implements Ca
     this.assemblyContext = assemblyContext;
   }
 
-  @Override
-  protected void subscribeActual(CompletableObserver s) {
+  @Override protected void subscribeActual(SingleObserver<? super T> s) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new Observer(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
     } finally {
       scope.close();
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Override
-  public T call() throws Exception {
+  @Override public T call() {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
-      return ((Callable<T>) source).call();
+      return ((ScalarCallable<T>) source).call();
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextSubscriber.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextSubscriber.java
@@ -1,9 +1,9 @@
-package brave.context.rxjava2;
+package brave.context.rxjava2.internal.fuseable;
 
+import brave.context.rxjava2.internal.Util;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -26,13 +26,12 @@ final class TraceContextSubscriber<T> implements Subscriber<T> {
   }
 
   @Override public final void onSubscribe(Subscription s) {
-    if (SubscriptionHelper.validate(upstream, s)) {
+    if (Util.validate(upstream, s)) {
       downstream.onSubscribe((upstream = s));
     }
   }
 
-  @Override
-  public void onNext(T t) {
+  @Override public void onNext(T t) {
     Scope scope = currentTraceContext.maybeScope(assemblyContext);
     try { // retrolambda can't resolve this try/finally
       downstream.onNext(t);
@@ -41,8 +40,7 @@ final class TraceContextSubscriber<T> implements Subscriber<T> {
     }
   }
 
-  @Override
-  public void onError(Throwable t) {
+  @Override public void onError(Throwable t) {
     if (done) {
       RxJavaPlugins.onError(t);
       return;
@@ -57,8 +55,7 @@ final class TraceContextSubscriber<T> implements Subscriber<T> {
     }
   }
 
-  @Override
-  public void onComplete() {
+  @Override public void onComplete() {
     if (done) return;
     done = true;
 

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/package-info.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The {@code io.reactivex.internal.fuseable} fuseable package has been internal since RxJava 2.0
+ * came out. This allows safe access to those features in case they are later renamed.
+ */
+package brave.context.rxjava2.internal.fuseable;


### PR DESCRIPTION
The "fuseable" package came out in RxJava 2.0 and is as yet still
internal. This puts insulation around it in case it ever becomes not
internal.

Meanwhile there is still risk that some parts of these internal code
drift, for example renaming a method inside `ScalarCallable` or
`ConditionalSubscriber`. If this happens, the code will still break.

See #805