### PR TITLE
Migrates RxJava field names towards what's used in RxJava2Extensions

### DIFF
--- a/context/rxjava2/README.md
+++ b/context/rxjava2/README.md
@@ -1,6 +1,7 @@
 # brave-context-rxjava2
 `CurrentTraceContextAssemblyTracking` prevents traces from breaking
-during RxJava operations by scoping them with trace context.
+during RxJava operations by scoping trace context that existed
+at assembly time around callbacks or computation of new values.
 
 The design of this library borrows heavily from https://github.com/akaita/RxJava2Debug and https://github.com/akarnokd/RxJava2Extensions
 

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/Internal.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/Internal.java
@@ -17,28 +17,16 @@ public abstract class Internal {
   public static Internal instance;
 
   public abstract <T> Observer<T> wrap(
-      Observer<T> actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext
-  );
+      Observer<T> downstream, CurrentTraceContext contextScoper, TraceContext assembled);
 
   public abstract <T> SingleObserver<T> wrap(
-      SingleObserver<T> actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext
-  );
+      SingleObserver<T> downstream, CurrentTraceContext contextScoper, TraceContext assembled);
 
   public abstract <T> MaybeObserver<T> wrap(
-      MaybeObserver<T> actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext
-  );
+      MaybeObserver<T> downstream, CurrentTraceContext contextScoper, TraceContext assembled);
 
   public abstract CompletableObserver wrap(
-      CompletableObserver actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext
-  );
+      CompletableObserver downstream, CurrentTraceContext contextScoper, TraceContext assembled);
 
   Internal() {
   }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletable.java
@@ -9,23 +9,21 @@ import io.reactivex.CompletableSource;
 
 final class TraceContextCompletable extends Completable {
   final CompletableSource source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextCompletable(
-      CompletableSource source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      CompletableSource source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override
   protected void subscribeActual(CompletableObserver s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new TraceContextCompletableObserver(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextCompletableObserver(s, contextScoper, assembled));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletableObserver.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextCompletableObserver.java
@@ -8,54 +8,52 @@ import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
 
 final class TraceContextCompletableObserver implements CompletableObserver, Disposable {
-  final CompletableObserver actual;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
-  Disposable d;
+  final CompletableObserver downstream;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
+  Disposable upstream;
 
   TraceContextCompletableObserver(
-      CompletableObserver actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
-    this.actual = actual;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+      CompletableObserver downstream, CurrentTraceContext contextScoper, TraceContext assembled) {
+    this.downstream = downstream;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override public void onSubscribe(Disposable d) {
-    if (!Util.validate(this.d, d)) return;
-    this.d = d;
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    if (!Util.validate(upstream, d)) return;
+    upstream = d;
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onSubscribe(this);
+      downstream.onSubscribe(this);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onError(Throwable t) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onError(t);
+      downstream.onError(t);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onComplete() {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onComplete();
+      downstream.onComplete();
     } finally {
       scope.close();
     }
   }
 
   @Override public boolean isDisposed() {
-    return d.isDisposed();
+    return upstream.isDisposed();
   }
 
   @Override public void dispose() {
-    d.dispose();
+    upstream.dispose();
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextFlowable.java
@@ -10,20 +10,20 @@ import org.reactivestreams.Subscriber;
 
 final class TraceContextFlowable<T> extends Flowable<T> {
   final Publisher<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextFlowable(
-      Publisher<T> source, CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      Publisher<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(Subscriber s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(MaybeFuseable.get().wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(MaybeFuseable.get().wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybe.java
@@ -9,22 +9,20 @@ import io.reactivex.MaybeSource;
 
 final class TraceContextMaybe<T> extends Maybe<T> {
   final MaybeSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextMaybe(
-      MaybeSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      MaybeSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(MaybeObserver<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new TraceContextMaybeObserver<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextMaybeObserver<>(s, contextScoper, assembled));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybeObserver.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextMaybeObserver.java
@@ -8,63 +8,61 @@ import io.reactivex.MaybeObserver;
 import io.reactivex.disposables.Disposable;
 
 final class TraceContextMaybeObserver<T> implements MaybeObserver<T>, Disposable {
-  final MaybeObserver<T> actual;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
-  Disposable d;
+  final MaybeObserver<T> downstream;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
+  Disposable upstream;
 
   TraceContextMaybeObserver(
-      MaybeObserver actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
-    this.actual = actual;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+      MaybeObserver<T> downstream, CurrentTraceContext contextScoper, TraceContext assembled) {
+    this.downstream = downstream;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override public void onSubscribe(Disposable d) {
-    if (!Util.validate(this.d, d)) return;
-    this.d = d;
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    if (!Util.validate(upstream, d)) return;
+    upstream = d;
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onSubscribe(this);
+      downstream.onSubscribe(this);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onError(Throwable t) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onError(t);
+      downstream.onError(t);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onSuccess(T value) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onSuccess(value);
+      downstream.onSuccess(value);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onComplete() {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onComplete();
+      downstream.onComplete();
     } finally {
       scope.close();
     }
   }
 
   @Override public boolean isDisposed() {
-    return d.isDisposed();
+    return upstream.isDisposed();
   }
 
   @Override public void dispose() {
-    d.dispose();
+    upstream.dispose();
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextObservable.java
@@ -8,22 +8,20 @@ import io.reactivex.ObservableSource;
 
 final class TraceContextObservable<T> extends Observable<T> {
   final ObservableSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextObservable(
-      ObservableSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      ObservableSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(io.reactivex.Observer<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new TraceContextObserver<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextObserver<>(s, contextScoper, assembled));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingle.java
@@ -9,22 +9,20 @@ import io.reactivex.SingleSource;
 
 final class TraceContextSingle<T> extends Single<T> {
   final SingleSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextSingle(
-      SingleSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      SingleSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(SingleObserver<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(new TraceContextSingleObserver<>(s, currentTraceContext, assemblyContext));
+      source.subscribe(new TraceContextSingleObserver<>(s, contextScoper, assembled));
     } finally {
       scope.close();
     }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingleObserver.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/TraceContextSingleObserver.java
@@ -8,54 +8,52 @@ import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 
 final class TraceContextSingleObserver<T> implements SingleObserver<T>, Disposable {
-  final SingleObserver<T> actual;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
-  Disposable d;
+  final SingleObserver<T> downstream;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
+  Disposable upstream;
 
   TraceContextSingleObserver(
-      SingleObserver<T> actual,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
-    this.actual = actual;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+      SingleObserver<T> downstream, CurrentTraceContext contextScoper, TraceContext assembled) {
+    this.downstream = downstream;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override public void onSubscribe(Disposable d) {
-    if (!Util.validate(this.d, d)) return;
-    this.d = d;
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    if (!Util.validate(upstream, d)) return;
+    upstream = d;
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onSubscribe(this);
+      downstream.onSubscribe(this);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onError(Throwable t) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onError(t);
+      downstream.onError(t);
     } finally {
       scope.close();
     }
   }
 
   @Override public void onSuccess(T value) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      actual.onSuccess(value);
+      downstream.onSuccess(value);
     } finally {
       scope.close();
     }
   }
 
   @Override public boolean isDisposed() {
-    return d.isDisposed();
+    return upstream.isDisposed();
   }
 
   @Override public void dispose() {
-    d.dispose();
+    upstream.dispose();
   }
 }

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableFlowable.java
@@ -1,27 +1,29 @@
 package brave.context.rxjava2.internal.fuseable;
 
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.Flowable;
 import java.util.concurrent.Callable;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
 final class TraceContextCallableFlowable<T> extends Flowable<T> implements Callable<T> {
   final Publisher<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextCallableFlowable(
-      Publisher<T> source, CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      Publisher<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
-  @Override protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
-    CurrentTraceContext.Scope scope = currentTraceContext.maybeScope(assemblyContext);
+  @Override protected void subscribeActual(Subscriber<? super T> s) {
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(MaybeFuseable.get().wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(MaybeFuseable.get().wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
@@ -29,7 +31,7 @@ final class TraceContextCallableFlowable<T> extends Flowable<T> implements Calla
 
   @SuppressWarnings("unchecked")
   @Override public T call() throws Exception {
-    CurrentTraceContext.Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
       return ((Callable<T>) source).call();
     } finally {

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableMaybe.java
@@ -11,22 +11,20 @@ import java.util.concurrent.Callable;
 
 final class TraceContextCallableMaybe<T> extends Maybe<T> implements Callable<T> {
   final MaybeSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextCallableMaybe(
-      MaybeSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      MaybeSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(MaybeObserver<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
@@ -34,7 +32,7 @@ final class TraceContextCallableMaybe<T> extends Maybe<T> implements Callable<T>
 
   @SuppressWarnings("unchecked")
   @Override public T call() throws Exception {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
       return ((Callable<T>) source).call();
     } finally {

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextCallableSingle.java
@@ -11,22 +11,20 @@ import java.util.concurrent.Callable;
 
 final class TraceContextCallableSingle<T> extends Single<T> implements Callable<T> {
   final SingleSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextCallableSingle(
-      SingleSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      SingleSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(SingleObserver<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
@@ -34,7 +32,7 @@ final class TraceContextCallableSingle<T> extends Single<T> implements Callable<
 
   @SuppressWarnings("unchecked")
   @Override public T call() throws Exception {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
       return ((Callable<T>) source).call();
     } finally {

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableFlowable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableFlowable.java
@@ -6,32 +6,32 @@ import brave.propagation.TraceContext;
 import io.reactivex.Flowable;
 import io.reactivex.internal.fuseable.ScalarCallable;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
 public final class TraceContextScalarCallableFlowable<T> extends Flowable<T>
     implements ScalarCallable<T> {
   final Publisher<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextScalarCallableFlowable(
-      Publisher<T> source, CurrentTraceContext currentTraceContext, TraceContext assemblyContext) {
+      Publisher<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
-  @Override
-  protected void subscribeActual(org.reactivestreams.Subscriber<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+  @Override protected void subscribeActual(Subscriber<? super T> s) {
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(MaybeFuseable.get().wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(MaybeFuseable.get().wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
   }
 
   /**
-   * A scalar value is computed at assembly time. Since call() is at runtime, we shouldn't add
+   * A scalar value is computed at assembled time. Since call() is at runtime, we shouldn't add
    * overhead of scoping, only to return a constant!
    *
    * <p>See https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0#callable-and-scalarcallable

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableMaybe.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableMaybe.java
@@ -11,29 +11,27 @@ import io.reactivex.internal.fuseable.ScalarCallable;
 
 final class TraceContextScalarCallableMaybe<T> extends Maybe<T> implements ScalarCallable<T> {
   final MaybeSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextScalarCallableMaybe(
-      MaybeSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      MaybeSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(MaybeObserver<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
   }
 
   /**
-   * A scalar value is computed at assembly time. Since call() is at runtime, we shouldn't add
+   * A scalar value is computed at assembled time. Since call() is at runtime, we shouldn't add
    * overhead of scoping, only to return a constant!
    *
    * <p>See https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0#callable-and-scalarcallable

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableObservable.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableObservable.java
@@ -6,34 +6,33 @@ import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
 import io.reactivex.internal.fuseable.ScalarCallable;
 
 final class TraceContextScalarCallableObservable<T> extends Observable<T>
     implements ScalarCallable<T> {
   final ObservableSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextScalarCallableObservable(
-      ObservableSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      ObservableSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
-  @Override protected void subscribeActual(io.reactivex.Observer<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+  @Override protected void subscribeActual(Observer<? super T> s) {
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
   }
 
   /**
-   * A scalar value is computed at assembly time. Since call() is at runtime, we shouldn't add
+   * A scalar value is computed at assembled time. Since call() is at runtime, we shouldn't add
    * overhead of scoping, only to return a constant!
    *
    * <p>See https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0#callable-and-scalarcallable

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableSingle.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/fuseable/TraceContextScalarCallableSingle.java
@@ -11,29 +11,27 @@ import io.reactivex.internal.fuseable.ScalarCallable;
 
 final class TraceContextScalarCallableSingle<T> extends Single<T> implements ScalarCallable<T> {
   final SingleSource<T> source;
-  final CurrentTraceContext currentTraceContext;
-  final TraceContext assemblyContext;
+  final CurrentTraceContext contextScoper;
+  final TraceContext assembled;
 
   TraceContextScalarCallableSingle(
-      SingleSource<T> source,
-      CurrentTraceContext currentTraceContext,
-      TraceContext assemblyContext) {
+      SingleSource<T> source, CurrentTraceContext contextScoper, TraceContext assembled) {
     this.source = source;
-    this.currentTraceContext = currentTraceContext;
-    this.assemblyContext = assemblyContext;
+    this.contextScoper = contextScoper;
+    this.assembled = assembled;
   }
 
   @Override protected void subscribeActual(SingleObserver<? super T> s) {
-    Scope scope = currentTraceContext.maybeScope(assemblyContext);
+    Scope scope = contextScoper.maybeScope(assembled);
     try { // retrolambda can't resolve this try/finally
-      source.subscribe(Internal.instance.wrap(s, currentTraceContext, assemblyContext));
+      source.subscribe(Internal.instance.wrap(s, contextScoper, assembled));
     } finally {
       scope.close();
     }
   }
 
   /**
-   * A scalar value is computed at assembly time. Since call() is at runtime, we shouldn't add
+   * A scalar value is computed at assembled time. Since call() is at runtime, we shouldn't add
    * overhead of scoping, only to return a constant!
    *
    * <p>See https://github.com/ReactiveX/RxJava/wiki/Writing-operators-for-2.0#callable-and-scalarcallable


### PR DESCRIPTION
By migrating the field names, it is easier to compare behavior with a
reliable implementation.

See https://github.com/akarnokd/RxJava2Extensions/tree/master/src/main/java/hu/akarnokd/rxjava2/debug