### PR TITLE
Allow adding annotations with a relative timestamp.

### DIFF
--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -46,6 +46,10 @@ final class NoopSpan extends Span {
     return this;
   }
 
+  @Override public Span annotateRelative(long microsFromStart, String value) {
+    return this;
+  }
+
   @Override public Span remoteServiceName(String remoteServiceName) {
     return this;
   }

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -101,6 +101,16 @@ final class RealSpan extends Span {
     return this;
   }
 
+  @Override public Span annotateRelative(long microsFromStart, String value) {
+    synchronized (state) {
+      long startTimestamp = state.startTimestamp();
+      if (startTimestamp == 0) {
+        throw new IllegalStateException("Span.annotateRelative must be called after Span.start.");
+      }
+      return annotate(startTimestamp + microsFromStart, value);
+    }
+  }
+
   @Override public Span tag(String key, String value) {
     synchronized (state) {
       state.tag(key, value);

--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -106,6 +106,13 @@ public abstract class Span implements SpanCustomizer {
    */
   public abstract Span annotate(long timestamp, String value);
 
+  /**
+   * Like {@link #annotate(String)}, except with a relative timestamp from the start of the span,
+   * in microseconds. This method can only be called after {@link #start()} or {@link #start(long)}
+   * has been called.
+   */
+  public abstract Span annotateRelative(long microsFromStart, String value);
+
   /** {@inheritDoc} */
   @Override public abstract Span tag(String key, String value);
 

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -41,6 +41,7 @@ public class NoopSpanTest {
     span.start(1L);
     span.annotate("foo");
     span.annotate(2L, "foo");
+    span.annotateRelative(5L, "cat");
     span.tag("bar", "baz");
     span.remoteServiceName("aloha");
     span.remoteIpAndPort("1.2.3.4", 9000);

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -9,6 +9,7 @@ import zipkin2.Annotation;
 import zipkin2.Endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 public class RealSpanTest {
@@ -100,6 +101,21 @@ public class RealSpanTest {
 
     assertThat(spans).flatExtracting(zipkin2.Span::annotations)
         .containsExactly(Annotation.create(2L, "foo"));
+  }
+
+  @Test public void annotate_relative() {
+    span.start(5);
+
+    span.annotateRelative(2, "foo");
+    span.flush();
+
+    assertThat(spans).flatExtracting(zipkin2.Span::annotations)
+        .containsExactly(Annotation.create(7L, "foo"));
+  }
+
+  @Test public void annotate_relative_not_started() {
+    assertThatThrownBy(() -> span.annotateRelative(2, "foo"))
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test public void tag() {


### PR DESCRIPTION
In https://github.com/line/armeria/pull/1423 I am working on adding a timestamp for wire send / receive using `System.nanoTime()` and would like to be able to annotate the span with a relative timestamp. I guess this may be reasonably common usage as many systems will have their own logging facade which is interfaced with Brave in some way, so hopefully it makes sense to add some API to `Span` for it.