### PR TITLE
Fixes where abandoned spans were not reported to zipkin

### DIFF
--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -104,7 +104,7 @@ public final class PendingSpans extends ReferenceQueue<TraceContext> {
       if (flushTime == 0L) flushTime = clock.currentTimeMicroseconds();
 
       TraceContext context = InternalPropagation.instance.newTraceContext(
-          InternalPropagation.FLAG_SAMPLED,
+          InternalPropagation.FLAG_SAMPLED_SET | InternalPropagation.FLAG_SAMPLED,
           contextKey.traceIdHigh, contextKey.traceId,
           0L, contextKey.spanId,
           Collections.emptyList()

--- a/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
+++ b/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
@@ -24,6 +24,8 @@ public class PendingSpansTest {
   @Before public void init() {
     init(new FinishedSpanHandler() {
       @Override public boolean handle(TraceContext ctx, MutableSpan span) {
+        if (!Boolean.TRUE.equals(ctx.sampled())) return true;
+
         Span.Builder b = Span.newBuilder().traceId(ctx.traceIdString()).id(ctx.traceIdString());
         span.forEachAnnotation(Span.Builder::addAnnotation, b);
         spans.add(b.build());


### PR DESCRIPTION
There was a slight logic glitch found by @tutufool which prevented spans
accidentally abandoned from being reported to zipkin. Nice detective
work!

Fixes #831