### PR TITLE
Update broken link in documentation

### DIFF
--- a/brave/src/main/java/brave/sampler/BoundarySampler.java
+++ b/brave/src/main/java/brave/sampler/BoundarySampler.java
@@ -14,7 +14,7 @@ import java.util.Random;
  * defend against nodes in the same cluster sampling exactly the same subset of trace ids. The goal
  * was full 64-bit coverage of trace IDs on multi-host deployments.
  *
- * <p>Based on https://github.com/twitter/finagle/blob/develop/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Sampler.scala#L68
+ * <p>Based on https://github.com/twitter/finagle/blob/b6b1d0414fa24ed0c8bb5112985a4e9c9bcd3c9e/finagle-zipkin-core/src/main/scala/com/twitter/finagle/zipkin/core/Sampler.scala#L68
  */
 public final class BoundarySampler extends Sampler {
   static final long SALT = new Random().nextLong();


### PR DESCRIPTION
I updated the link pointing to Twitter finagle. Included is a fix to the folder which changed from `finagle-zipkin` to `finagle-zipkin-core`. Also included in the url is the commit blob to ensure the link with the line number doesn't change unintentionally.

I'm not sure if the line number is still the correct, and I would appreciate if a maintainer could double check. Perhaps @adriancole ?