### PR TITLE
Reduces allocations when using ID correlation by caching hex values

### DIFF
--- a/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
@@ -166,7 +166,7 @@ public abstract class PropagationTest<K> {
       injector.inject(ctx, map);
 
       assertThat(extractor.extract(map).context())
-          .isEqualToComparingFieldByField(ctx);
+          .isEqualToIgnoringGivenFields(ctx, "traceIdString", "spanIdString");
     }
   }
 }

--- a/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
@@ -1,6 +1,5 @@
 package brave.propagation;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.test.propagation.PropagationTest;
 import java.util.Map;
@@ -103,7 +102,7 @@ public class B3PropagationTest extends PropagationTest<String> {
 
     assertThat(result.traceIdString())
         .isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
-    assertThat(HexCodec.toLowerHex(result.spanId()))
+    assertThat(result.spanIdString())
         .isEqualTo("00f067aa0ba902b7");
   }
 }

--- a/brave/src/main/java/brave/internal/HexCodec.java
+++ b/brave/src/main/java/brave/internal/HexCodec.java
@@ -1,7 +1,5 @@
 package brave.internal;
 
-import brave.propagation.TraceContext;
-
 // code originally imported from zipkin.Util
 public final class HexCodec {
 
@@ -52,38 +50,6 @@ public final class HexCodec {
         lowerHex + " should be a 1 to 32 character lower-hex string with no prefix");
   }
 
-  /** Returns 16 or 32 character hex string depending on if {@code high} is zero. */
-  public static String toLowerHex(long high, long low) {
-    char[] result = new char[high != 0 ? 32 : 16];
-    int pos = 0;
-    if (high != 0) {
-      writeHexLong(result, pos, high);
-      pos += 16;
-    }
-    writeHexLong(result, pos, low);
-    return new String(result);
-  }
-
-  public static boolean lowerHexEqualsUnsignedLong(CharSequence lowerHex, long unsigned) {
-    if (lowerHex == null || lowerHex.length() != 16) return false;
-    return lowerHexEqualsUnsignedLong(lowerHex, 0, unsigned);
-  }
-
-  public static boolean lowerHexEqualsTraceId(CharSequence lowerHex, TraceContext context) {
-    if (lowerHex == null) return false;
-    int length = lowerHex.length();
-    long high = context.traceIdHigh(), low = context.traceId();
-
-    int pos = 0;
-    if (length == 32) {
-      if (!lowerHexEqualsUnsignedLong(lowerHex, pos, high)) return false;
-      pos += 16;
-    } else if (length != 16 || high != 0L) {
-      return false;
-    }
-    return lowerHexEqualsUnsignedLong(lowerHex, pos, low);
-  }
-
   /** Inspired by {@code okio.Buffer.writeLong} */
   public static String toLowerHex(long v) {
     char[] data = new char[16];
@@ -106,25 +72,9 @@ public final class HexCodec {
   static final char[] HEX_DIGITS =
       {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
-  public static void writeHexByte(char[] data, int pos, byte b) {
+  static void writeHexByte(char[] data, int pos, byte b) {
     data[pos + 0] = HEX_DIGITS[(b >> 4) & 0xf];
     data[pos + 1] = HEX_DIGITS[b & 0xf];
-  }
-
-  static boolean lowerHexEqualsUnsignedLong(CharSequence data, int pos, long v) {
-    if (!hexEqualsByte(data, pos + 0, (byte) ((v >>> 56L) & 0xff))) return false;
-    if (!hexEqualsByte(data, pos + 2, (byte) ((v >>> 48L) & 0xff))) return false;
-    if (!hexEqualsByte(data, pos + 4, (byte) ((v >>> 40L) & 0xff))) return false;
-    if (!hexEqualsByte(data, pos + 6, (byte) ((v >>> 32L) & 0xff))) return false;
-    if (!hexEqualsByte(data, pos + 8, (byte) ((v >>> 24L) & 0xff))) return false;
-    if (!hexEqualsByte(data, pos + 10, (byte) ((v >>> 16L) & 0xff))) return false;
-    if (!hexEqualsByte(data, pos + 12, (byte) ((v >>> 8L) & 0xff))) return false;
-    return hexEqualsByte(data, pos + 14, (byte) (v & 0xff));
-  }
-
-  static boolean hexEqualsByte(CharSequence data, int pos, byte b) {
-    return data.charAt(pos + 0) == HEX_DIGITS[(b >> 4) & 0xf] &&
-        data.charAt(pos + 1) == HEX_DIGITS[b & 0xf];
   }
 
   HexCodec() {

--- a/brave/src/main/java/brave/internal/handler/ZipkinFinishedSpanHandler.java
+++ b/brave/src/main/java/brave/internal/handler/ZipkinFinishedSpanHandler.java
@@ -22,9 +22,9 @@ public final class ZipkinFinishedSpanHandler extends FinishedSpanHandler {
     if (!Boolean.TRUE.equals(context.sampled())) return true;
 
     Span.Builder builderWithContextData = Span.newBuilder()
-        .traceId(context.traceIdHigh(), context.traceId())
-        .parentId(context.parentIdAsLong())
-        .id(context.spanId());
+        .traceId(context.traceIdString())
+        .parentId(context.parentIdString())
+        .id(context.spanIdString());
     if (context.debug()) builderWithContextData.debug(true);
 
     converter.convert(span, builderWithContextData);

--- a/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
+++ b/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecorator.java
@@ -1,13 +1,9 @@
 package brave.internal.propagation;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import brave.propagation.TraceContext;
-
-import static brave.internal.HexCodec.lowerHexEqualsTraceId;
-import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
 
 /**
  * Adds correlation properties "traceId", "parentId" and "spanId" when a {@link
@@ -55,19 +51,19 @@ public abstract class CorrelationFieldScopeDecorator implements ScopeDecorator {
       @Nullable String previousParentId,
       String previousSpanId
   ) {
-    boolean sameTraceId = lowerHexEqualsTraceId(previousTraceId, currentSpan);
-    if (!sameTraceId) put("traceId", currentSpan.traceIdString());
+    String traceId = currentSpan.traceIdString();
+    if (!traceId.equals(previousTraceId)) put("traceId", currentSpan.traceIdString());
 
-    long parentId = currentSpan.parentIdAsLong();
-    if (parentId == 0L) {
+    String parentId = currentSpan.parentIdString();
+    if (parentId == null) {
       remove("parentId");
     } else {
-      boolean sameParentId = lowerHexEqualsUnsignedLong(previousParentId, parentId);
-      if (!sameParentId) put("parentId", HexCodec.toLowerHex(parentId));
+      boolean sameParentId = parentId.equals(previousParentId);
+      if (!sameParentId) put("parentId", parentId);
     }
 
-    boolean sameSpanId = lowerHexEqualsUnsignedLong(previousSpanId, currentSpan.spanId());
-    if (!sameSpanId) put("spanId", HexCodec.toLowerHex(currentSpan.spanId()));
+    String spanId = currentSpan.spanIdString();
+    if (!spanId.equals(previousSpanId)) put("spanId", spanId);
   }
 
   /**

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -4,7 +4,6 @@ import brave.propagation.B3SinglePropagation.B3SingleExtractor;
 import java.util.Collections;
 import java.util.List;
 
-import static brave.internal.HexCodec.toLowerHex;
 import static java.util.Arrays.asList;
 
 /**
@@ -82,10 +81,10 @@ public final class B3Propagation<K> implements Propagation<K> {
 
     @Override public void inject(TraceContext traceContext, C carrier) {
       setter.put(carrier, propagation.traceIdKey, traceContext.traceIdString());
-      setter.put(carrier, propagation.spanIdKey, toLowerHex(traceContext.spanId()));
-      long parentId = traceContext.parentIdAsLong();
-      if (parentId != 0L) {
-        setter.put(carrier, propagation.parentSpanIdKey, toLowerHex(parentId));
+      setter.put(carrier, propagation.spanIdKey, traceContext.spanIdString());
+      String parentId = traceContext.parentIdString();
+      if (parentId != null) {
+        setter.put(carrier, propagation.parentSpanIdKey, parentId);
       }
       if (traceContext.debug()) {
         setter.put(carrier, propagation.debugKey, "1");

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
+import static brave.internal.HexCodec.toLowerHex;
 import static brave.internal.HexCodec.writeHexLong;
 import static brave.internal.InternalPropagation.FLAG_LOCAL_ROOT;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED;
@@ -177,22 +178,60 @@ public final class TraceContext extends SamplingFlags {
     return new Builder(this);
   }
 
+  volatile String traceIdString; // Lazily initialized and cached.
+
   /** Returns the hex representation of the span's trace ID */
   public String traceIdString() {
-    if (traceIdHigh != 0) {
-      char[] result = new char[32];
-      writeHexLong(result, 0, traceIdHigh);
-      writeHexLong(result, 16, traceId);
-      return new String(result);
+    String r = traceIdString;
+    if (r == null) {
+      if (traceIdHigh != 0) {
+        char[] result = new char[32];
+        writeHexLong(result, 0, traceIdHigh);
+        writeHexLong(result, 16, traceId);
+        r = new String(result);
+      } else {
+        r = toLowerHex(traceId);
+      }
+      traceIdString = r;
     }
-    char[] result = new char[16];
-    writeHexLong(result, 0, traceId);
-    return new String(result);
+    return r;
+  }
+
+  volatile String parentIdString; // Lazily initialized and cached.
+
+  /** Returns the hex representation of the span's parent ID */
+  @Nullable public String parentIdString() {
+    String r = parentIdString;
+    if (r == null && parentId != 0L) {
+      r = parentIdString = toLowerHex(parentId);
+    }
+    return r;
+  }
+
+  volatile String localRootIdString; // Lazily initialized and cached.
+
+  /** Returns the hex representation of the span's local root ID */
+  @Nullable public String localRootIdString() {
+    String r = localRootIdString;
+    if (r == null && localRootId != 0L) {
+      r = localRootIdString = toLowerHex(localRootId);
+    }
+    return r;
+  }
+
+  volatile String spanIdString; // Lazily initialized and cached.
+
+  /** Returns the hex representation of the span's ID */
+  public String spanIdString() {
+    String r = spanIdString;
+    if (r == null) {
+      r = spanIdString = toLowerHex(spanId);
+    }
+    return r;
   }
 
   /** Returns {@code $traceId/$spanId} */
-  @Override
-  public String toString() {
+  @Override public String toString() {
     boolean traceHi = traceIdHigh != 0;
     char[] result = new char[((traceHi ? 3 : 2) * 16) + 1]; // 2 ids and the delimiter
     int pos = 0;
@@ -209,7 +248,8 @@ public final class TraceContext extends SamplingFlags {
 
   public static final class Builder {
     long traceIdHigh, traceId, parentId, spanId;
-    long localRootId; // intentionally only mutable by the copy constructor in order to control usage.
+    long localRootId;
+        // intentionally only mutable by the copy constructor in order to control usage.
     int flags;
     List<Object> extra = Collections.emptyList();
 
@@ -461,6 +501,8 @@ public final class TraceContext extends SamplingFlags {
         && ((flags & FLAG_SHARED) == (that.flags & FLAG_SHARED));
   }
 
+  volatile int hashCode; // Lazily initialized and cached.
+
   /**
    * Includes mandatory fields {@link #traceIdHigh()}, {@link #traceId()}, {@link #spanId()} and the
    * {@link #shared() shared flag}.
@@ -470,15 +512,18 @@ public final class TraceContext extends SamplingFlags {
    * side.
    */
   @Override public int hashCode() {
-    int h = 1;
-    h *= 1000003;
-    h ^= (int) ((traceIdHigh >>> 32) ^ traceIdHigh);
-    h *= 1000003;
-    h ^= (int) ((traceId >>> 32) ^ traceId);
-    h *= 1000003;
-    h ^= (int) ((spanId >>> 32) ^ spanId);
-    h *= 1000003;
-    h ^= flags & FLAG_SHARED;
+    int h = hashCode;
+    if (h == 0) {
+      h = 1000003;
+      h ^= (int) ((traceIdHigh >>> 32) ^ traceIdHigh);
+      h *= 1000003;
+      h ^= (int) ((traceId >>> 32) ^ traceId);
+      h *= 1000003;
+      h ^= (int) ((spanId >>> 32) ^ spanId);
+      h *= 1000003;
+      h ^= flags & FLAG_SHARED;
+      hashCode = h;
+    }
     return h;
   }
 

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -248,8 +248,7 @@ public final class TraceContext extends SamplingFlags {
 
   public static final class Builder {
     long traceIdHigh, traceId, parentId, spanId;
-    long localRootId;
-        // intentionally only mutable by the copy constructor in order to control usage.
+    long localRootId; // intentionally only mutable by the copy constructor to control usage.
     int flags;
     List<Object> extra = Collections.emptyList();
 

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -150,7 +150,7 @@ public class TracerTest {
     assertThat(joined.shared())
         .isTrue();
     assertThat(joined)
-        .isEqualToComparingFieldByField(fromIncomingRequest.toBuilder().shared(true).build());
+        .isEqualToIgnoringGivenFields(fromIncomingRequest.toBuilder().shared(true).build(), "hashCode");
   }
 
   /**
@@ -307,7 +307,7 @@ public class TracerTest {
     assertThat(tracer.newChild(parent))
         .satisfies(c -> {
           assertThat(c.context().traceIdString()).isEqualTo(parent.traceIdString());
-          assertThat(c.context().parentId()).isEqualTo(parent.spanId());
+          assertThat(c.context().parentIdString()).isEqualTo(parent.spanIdString());
         })
         .isInstanceOf(RealSpan.class);
   }

--- a/brave/src/test/java/brave/features/handler/SkeletalSpansTest.java
+++ b/brave/src/test/java/brave/features/handler/SkeletalSpansTest.java
@@ -44,9 +44,9 @@ public class SkeletalSpansTest {
       if (span.kind() == null) return false; // skip local spans
 
       zipkin2.Span.Builder builder = zipkin2.Span.newBuilder()
-          .traceId(context.traceIdHigh(), context.traceId())
-          .parentId(context.isLocalRoot() ? 0L : context.localRootId()) // rewrite the parent ID
-          .id(context.spanId())
+          .traceId(context.traceIdString())
+          .parentId(context.isLocalRoot() ? null : context.localRootIdString()) // rewrite the parent ID
+          .id(context.spanIdString())
           .name(span.name())
           .kind(zipkin2.Span.Kind.valueOf(span.kind().name()))
           .localEndpoint(Endpoint.newBuilder().serviceName(localServiceName).build());

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -98,7 +98,7 @@ public class MutableSpanTest {
     span.forEachAnnotation((target, timestamp, value) -> {
       LogRecord record = new LogRecord(Level.FINE, value);
       record.setParameters(
-          new Object[] {context.traceIdString(), Long.toHexString(context.spanId())});
+          new Object[] {context.traceIdString(), context.spanIdString()});
       record.setMillis(timestamp / 1000L);
       target.log(record);
     }, logger);

--- a/brave/src/test/java/brave/internal/HexCodecTest.java
+++ b/brave/src/test/java/brave/internal/HexCodecTest.java
@@ -1,10 +1,7 @@
 package brave.internal;
 
-import brave.propagation.TraceContext;
 import org.junit.Test;
 
-import static brave.internal.HexCodec.lowerHexEqualsTraceId;
-import static brave.internal.HexCodec.lowerHexEqualsUnsignedLong;
 import static brave.internal.HexCodec.lowerHexToUnsignedLong;
 import static brave.internal.HexCodec.toLowerHex;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,58 +86,5 @@ public class HexCodecTest {
   @Test
   public void toLowerHex_fixedLength() {
     assertThat(toLowerHex(0L)).isEqualTo("0000000000000000");
-  }
-
-  @Test public void toLowerHex_whenNotHigh_16Chars() {
-    assertThat(toLowerHex(0L, 12345678L))
-        .hasToString("0000000000bc614e");
-  }
-
-  @Test public void toLowerHex_whenHigh_32Chars() {
-    assertThat(toLowerHex(1234L, 5678L))
-        .hasToString("00000000000004d2000000000000162e");
-  }
-
-  @Test public void lowerHexEqualsUnsignedLong_minValue() {
-    assertThat(lowerHexEqualsUnsignedLong("7fffffffffffffff", Long.MAX_VALUE))
-        .isTrue();
-  }
-
-  @Test public void lowerHexEqualsUnsignedLong_midValue() {
-    assertThat(lowerHexEqualsUnsignedLong("00000000cafebabe", 3405691582L))
-        .isTrue();
-  }
-
-  @Test public void lowerHexEqualsUnsignedLong_whenNotHigh_16Chars() {
-    TraceContext context = TraceContext.newBuilder()
-        .traceId(12345678L)
-        .spanId(1L)
-        .build();
-    assertThat(lowerHexEqualsTraceId("0000000000bc614e", context))
-        .isTrue();
-    assertThat(lowerHexEqualsTraceId("00000000000000000000000000bc614e", context))
-        .isTrue();
-  }
-
-  @Test public void lowerHexEqualsUnsignedLong_paddedTraceIdOk() {
-    TraceContext context = TraceContext.newBuilder()
-        .traceId(12345678L)
-        .spanId(1L)
-        .build();
-    assertThat(lowerHexEqualsTraceId("00000000000000000000000000bc614e", context))
-        .isTrue();
-  }
-
-  @Test public void lowerHexEqualsUnsignedLong_whenHigh_32Chars() {
-    TraceContext context = TraceContext.newBuilder()
-        .traceIdHigh(1234L)
-        .traceId(5678L)
-        .spanId(1L)
-        .build();
-
-    assertThat(lowerHexEqualsTraceId("000000000000162e", context))
-        .isFalse();
-    assertThat(lowerHexEqualsTraceId("00000000000004d2000000000000162e", context))
-        .isTrue();
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceContextTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextTest.java
@@ -329,4 +329,75 @@ public class TraceContextTest {
         .extracting("extra")
         .containsExactly(emptyList());
   }
+
+  @Test public void caches_hashCode() {
+    TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(3L).build();
+
+    assertThat(context.hashCode).isZero();
+    assertThat(context.hashCode())
+        .isNotZero()
+        .isEqualTo(TraceContext.newBuilder().traceId(333L).spanId(3L).build().hashCode());
+  }
+
+  @Test public void traceIdString_caches() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
+
+    assertThat(context.traceIdString).isNull();
+    assertThat(context.traceIdString())
+        .isNotNull()
+        .isEqualTo("0000000000000001");
+    assertThat(context.traceIdString)
+        .isEqualTo("0000000000000001");
+  }
+
+  @Test public void parentIdString_caches() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).parentId(2L).spanId(3L).build();
+
+    assertThat(context.parentIdString).isNull();
+    assertThat(context.parentIdString())
+        .isNotNull()
+        .isEqualTo("0000000000000002");
+    assertThat(context.parentIdString)
+        .isEqualTo("0000000000000002");
+  }
+
+  @Test public void parentIdString_doesNotCacheNull() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(3L).build();
+
+    assertThat(context.parentIdString).isNull();
+    assertThat(context.parentIdString()).isNull();
+    assertThat(context.parentIdString).isNull();
+  }
+
+  @Test public void localRootIdString_caches() {
+    TraceContext.Builder builder = TraceContext.newBuilder().traceId(1L);
+    builder.localRootId = 2L;
+    TraceContext context = builder.spanId(3L).build();
+
+    assertThat(context.localRootIdString).isNull();
+    assertThat(context.localRootIdString())
+        .isNotNull()
+        .isEqualTo("0000000000000002");
+    assertThat(context.localRootIdString)
+        .isEqualTo("0000000000000002");
+  }
+
+  @Test public void localRootIdString_doesNotCacheNull() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(3L).build();
+
+    assertThat(context.localRootIdString).isNull();
+    assertThat(context.localRootIdString()).isNull();
+    assertThat(context.localRootIdString).isNull();
+  }
+
+  @Test public void spanIdString_caches() {
+    TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
+
+    assertThat(context.spanIdString).isNull();
+    assertThat(context.spanIdString())
+        .isNotNull()
+        .isEqualTo("0000000000000002");
+    assertThat(context.spanIdString)
+        .isEqualTo("0000000000000002");
+  }
 }

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
@@ -1,6 +1,5 @@
 package brave.context.log4j12;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
@@ -42,11 +41,10 @@ public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(MDC.get("traceId"))
           .isEqualTo(context.traceIdString());
-      long parentId = context.parentIdAsLong();
       assertThat(MDC.get("parentId"))
-          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+          .isEqualTo(context.parentIdString());
       assertThat(MDC.get("spanId"))
-          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+          .isEqualTo(context.spanIdString());
     } else {
       assertThat(MDC.get("traceId"))
           .isNull();

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
@@ -1,6 +1,5 @@
 package brave.context.log4j12;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalCurrentTraceContext;
@@ -57,11 +56,10 @@ public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(MDC.get("traceId"))
           .isEqualTo(context.traceIdString());
-      long parentId = context.parentIdAsLong();
       assertThat(MDC.get("parentId"))
-          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+          .isEqualTo(context.parentIdString());
       assertThat(MDC.get("spanId"))
-          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+          .isEqualTo(context.spanIdString());
     } else {
       assertThat(MDC.get("traceId"))
           .isNull();

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -1,6 +1,5 @@
 package brave.context.log4j2;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
@@ -26,11 +25,10 @@ public class ThreadContextCurrentTraceContextTest extends CurrentTraceContextTes
     if (context != null) {
       assertThat(ThreadContext.get("traceId"))
           .isEqualTo(context.traceIdString());
-      long parentId = context.parentIdAsLong();
       assertThat(ThreadContext.get("parentId"))
-          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+          .isEqualTo(context.parentIdString());
       assertThat(ThreadContext.get("spanId"))
-          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+          .isEqualTo(context.spanIdString());
     } else {
       assertThat(ThreadContext.get("traceId"))
           .isNull();

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
@@ -1,6 +1,5 @@
 package brave.context.log4j2;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalCurrentTraceContext;
@@ -29,11 +28,10 @@ public class ThreadContextScopeDecoratorTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(ThreadContext.get("traceId"))
           .isEqualTo(context.traceIdString());
-      long parentId = context.parentIdAsLong();
       assertThat(ThreadContext.get("parentId"))
-          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+          .isEqualTo(context.parentIdString());
       assertThat(ThreadContext.get("spanId"))
-          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+          .isEqualTo(context.spanIdString());
     } else {
       assertThat(ThreadContext.get("traceId"))
           .isNull();

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -1,6 +1,5 @@
 package brave.context.slf4j;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
@@ -26,11 +25,10 @@ public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(MDC.get("traceId"))
           .isEqualTo(context.traceIdString());
-      long parentId = context.parentIdAsLong();
       assertThat(MDC.get("parentId"))
-          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+          .isEqualTo(context.parentIdString());
       assertThat(MDC.get("spanId"))
-          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+          .isEqualTo(context.spanIdString());
     } else {
       assertThat(MDC.get("traceId"))
           .isNull();

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
@@ -1,6 +1,5 @@
 package brave.context.slf4j;
 
-import brave.internal.HexCodec;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ThreadLocalCurrentTraceContext;
@@ -29,11 +28,10 @@ public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
     if (context != null) {
       assertThat(MDC.get("traceId"))
           .isEqualTo(context.traceIdString());
-      long parentId = context.parentIdAsLong();
       assertThat(MDC.get("parentId"))
-          .isEqualTo(parentId != 0L ? HexCodec.toLowerHex(parentId) : null);
+          .isEqualTo(context.parentIdString());
       assertThat(MDC.get("spanId"))
-          .isEqualTo(HexCodec.toLowerHex(context.spanId()));
+          .isEqualTo(context.spanIdString());
     } else {
       assertThat(MDC.get("traceId"))
           .isNull();

--- a/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/http/HttpServerBenchmarks.java
@@ -91,6 +91,10 @@ public abstract class HttpServerBenchmarks {
     get("/tracedextra");
   }
 
+  @Benchmark public void tracedCorrelatedServer_get() throws Exception {
+    get("/tracedcorrelated");
+  }
+
   @Benchmark public void tracedExtraServer_get_request_id() throws Exception {
     client.newCall(new Request.Builder().url(baseUrl() + "/tracedextra")
         .header("x-vcap-request-id", "216a2aea45d08fc9")

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -2,7 +2,6 @@ package brave.test.http;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.internal.HexCodec;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ExtraFieldPropagation;
@@ -143,7 +142,7 @@ public abstract class ITHttp {
           boolean contextLeak = false;
           if (current != null) {
             // add annotation in addition to throwing, in case we are off the main thread
-            if (HexCodec.toLowerHex(current.spanId()).equals(s.id())) {
+            if (current.spanIdString().equals(s.id())) {
               s = s.toBuilder().addAnnotation(s.timestampAsLong(), CONTEXT_LEAK).build();
               contextLeak = true;
             }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -2,7 +2,6 @@ package brave.test.http;
 
 import brave.ScopedSpan;
 import brave.Tracer;
-import brave.internal.HexCodec;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
@@ -40,7 +39,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
         assertThat(request.getHeader("x-b3-traceId"))
             .isEqualTo(parent.context().traceIdString());
         assertThat(request.getHeader("x-b3-parentspanid"))
-            .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+            .isEqualTo(parent.context().spanIdString());
       }
     } finally {
       otherSpan.finish();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -7,7 +7,6 @@ import brave.http.HttpAdapter;
 import brave.http.HttpClientParser;
 import brave.http.HttpRuleSampler;
 import brave.http.HttpTracing;
-import brave.internal.HexCodec;
 import brave.propagation.ExtraFieldPropagation;
 import brave.sampler.Sampler;
 import java.util.Arrays;
@@ -76,7 +75,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
     assertThat(request.getHeader("x-b3-traceId"))
         .isEqualTo(parent.context().traceIdString());
     assertThat(request.getHeader("x-b3-parentspanid"))
-        .isEqualTo(HexCodec.toLowerHex(parent.context().spanId()));
+        .isEqualTo(parent.context().spanIdString());
 
     assertThat(Arrays.asList(takeSpan(), takeSpan()))
         .extracting(Span::kind)

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -195,7 +195,7 @@ public class ITKafkaTracing {
           .containsEntry(KAFKA_TOPIC_TAG, record.topic());
 
       assertThat(processor.context().traceIdString()).isEqualTo(consumerSpan.traceId());
-      assertThat(HexCodec.toLowerHex(processor.context().parentId())).isEqualTo(consumerSpan.id());
+      assertThat(processor.context().parentIdString()).isEqualTo(consumerSpan.id());
 
       processor.start().name("processor").finish();
 


### PR DESCRIPTION
Before, whenever hex operations were needed, a new string was allocated.
This meant if a span was scoped multiple times, all ids would be
generated multiple times. This removes that problem and also caches
hashCode as it is used as a key.

Fixes #844