### PR TITLE
Preventing NPE when header value is null

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
@@ -39,7 +39,7 @@ final class KafkaPropagation {
 
   static final Getter<Headers, String> GETTER = (carrier, key) -> {
     Header header = carrier.lastHeader(key);
-    if (header == null) return null;
+    if (header == null || header.value() == null) return null;
     return new String(header.value(), UTF_8);
   };
 


### PR DESCRIPTION
We found some NPE in the logs caused by headers containing null values, i.e. sending `X-B3-TraceId=c58fc8808ff23375,X-B3-SpanId=6c57f7b2afdc87c6,X-B3-ParentSpanId=NULL,X-B3-Flags=0,X-B3-Sampled=1`