### PR TITLE
Use AtomicInteger + mod instead of synchronizing threads in CountingS…

### DIFF
--- a/instrumentation/benchmarks/src/main/java/brave/sampler/SamplerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/sampler/SamplerBenchmarks.java
@@ -1,6 +1,7 @@
 package brave.sampler;
 
 import com.amazonaws.xray.strategy.sampling.reservoir.Reservoir;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -90,7 +91,8 @@ public class SamplerBenchmarks {
     return SAMPLER_RATE.isSampled(args.traceId);
   }
 
-  static final Sampler SAMPLER_RATE = CountingSampler.create(SAMPLE_RATE);
+  // Use fixed-seed Random so performance of runs can be compared.
+  static final Sampler SAMPLER_RATE = new CountingSampler(SAMPLE_RATE, new Random(1000));
 
   @Benchmark public boolean sampler_rateLimited_1(Args args) {
     return SAMPLER_RATE_LIMITED.isSampled(args.traceId);


### PR DESCRIPTION
…ampler.

When enabling sampling on a server and looking through the code out of curiosity, I was surprised to find `CountingSampler.isSampled` is synchronized. An `AtomicInteger` and modulus can handle it fine with much better performance.

After
```
Benchmark                                                               (traceId)    Mode      Cnt     Score   Error   Units
SamplerBenchmarks.sampler_counting                           -9223372036854775808  sample  1033355     0.083 ± 0.006   us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.00    -9223372036854775808  sample                ≈ 0           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.50    -9223372036854775808  sample              0.100           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.90    -9223372036854775808  sample              0.100           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.95    -9223372036854775808  sample              0.100           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.99    -9223372036854775808  sample              0.200           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.999   -9223372036854775808  sample              0.300           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.9999  -9223372036854775808  sample             17.472           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p1.00    -9223372036854775808  sample           1716.224           us/op
SamplerBenchmarks.sampler_counting:·gc.alloc.rate            -9223372036854775808  sample       15     0.231 ± 0.018  MB/sec
SamplerBenchmarks.sampler_counting:·gc.alloc.rate.norm       -9223372036854775808  sample       15     0.010 ± 0.001    B/op
SamplerBenchmarks.sampler_counting:·gc.count                 -9223372036854775808  sample       15       ≈ 0          counts
```

Before
```
Benchmark                                                                (traceId)    Mode     Cnt    Score   Error   Units
SamplerBenchmarks.sampler_counting                            -9223372036854775808  sample  758439    0.370 ± 0.010   us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.00     -9223372036854775808  sample              ≈ 0           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.50     -9223372036854775808  sample            0.100           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.90     -9223372036854775808  sample            0.200           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.95     -9223372036854775808  sample            0.600           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.99     -9223372036854775808  sample            8.000           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.999    -9223372036854775808  sample           42.020           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p0.9999   -9223372036854775808  sample           80.424           us/op
SamplerBenchmarks.sampler_counting:sampler_counting·p1.00     -9223372036854775808  sample          670.720           us/op
SamplerBenchmarks.sampler_counting:·gc.alloc.rate             -9223372036854775808  sample      15    0.304 ± 0.013  MB/sec
SamplerBenchmarks.sampler_counting:·gc.alloc.rate.norm        -9223372036854775808  sample      15    0.019 ± 0.001    B/op
SamplerBenchmarks.sampler_counting:·gc.churn.G1_Old_Gen       -9223372036854775808  sample      15    2.125 ± 5.995  MB/sec
SamplerBenchmarks.sampler_counting:·gc.churn.G1_Old_Gen.norm  -9223372036854775808  sample      15    0.134 ± 0.379    B/op
SamplerBenchmarks.sampler_counting:·gc.count                  -9223372036854775808  sample      15    2.000          counts
SamplerBenchmarks.sampler_counting:·gc.time                   -9223372036854775808  sample      15    6.000              ms
```