### PR TITLE
Correct statement about BOM properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ instrumentation. Also any indirect use will have versions aligned:
 </dependency>
 ```
 
-With the above in place, you can use the properties `brave.version`,
-`zipkin-reporter.version` or `zipkin.version` to override dependency
+With the above in place, you can use the property `brave.version` to override dependency
 versions coherently. This is most commonly to test a new feature or fix.
 
 Note: If you override a version, always double check that your version


### PR DESCRIPTION
Removed mention of properties defined in the Brave BOM since they cannot be used in POMs that import the Brave BOM. Only the properties defined in the project's POM or its parents can be used.