### PR TITLE
Conditionally logs caller who allocated but didn't complete a span

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -773,6 +773,19 @@ Unlike previous implementations, Brave 4 only needs one timestamp per
 span. All annotations are recorded on an offset basis, using the less
 expensive and more precise `System.nanoTime()` function.
 
+## Troubleshooting instrumentation
+Instrumentation problems can lead to scope leaks and orphaned data. When
+testing instrumentation, use [StrictScopeDecorator](src/main/java/brave/propagation/StrictScopeDecorator.java), as it will throw
+errors on known scoping problems.
+
+If you see data with the annotation `brave.flush`, you may have an
+instrumentation bug. To see more information, set the Java logger named
+`brave.internal.recorder.PendingSpans` to FINE level. Do not do this in
+production as tracking abandoned data incurs higher overhead.
+
+Note: When using log4j2, set the following to ensure log settings apply:
+`-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager`
+
 ## Unit testing instrumentation
 
 When writing unit tests, there are a few tricks that will make bugs

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -62,6 +62,10 @@ public abstract class Platform {
     return PLATFORM;
   }
 
+  public boolean logEnabled() {
+    return LOG.isLoggable(Level.FINE);
+  }
+
   /** Like {@link Logger#log(Level, String) */
   public void log(String msg, @Nullable Throwable thrown) {
     if (!LOG.isLoggable(Level.FINE)) return; // fine level to not fill logs

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -62,10 +62,6 @@ public abstract class Platform {
     return PLATFORM;
   }
 
-  public boolean logEnabled() {
-    return LOG.isLoggable(Level.FINE);
-  }
-
   /** Like {@link Logger#log(Level, String) */
   public void log(String msg, @Nullable Throwable thrown) {
     if (!LOG.isLoggable(Level.FINE)) return; // fine level to not fill logs

--- a/brave/src/main/java/brave/internal/recorder/PendingSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpan.java
@@ -6,6 +6,7 @@ import brave.handler.MutableSpan;
 public final class PendingSpan {
   final MutableSpan state;
   final TickClock clock;
+  volatile Throwable caller;
 
   PendingSpan(MutableSpan state, TickClock clock) {
     this.state = state;


### PR DESCRIPTION
Sometimes instrumentation leaks spans, which leads to data with
"brave.flush" annotations. When brave logging is debug, this records
the calling stack trace for help debugging root cause of abandoned
spans.

Ex.
```
2019-03-02 21:04:01.988 DEBUG 13899 --- [nio-9000-exec-9] b.Tracer                                 : Span 5c7b60028c9b1dcf73fbccee02008284/0f6439f2e5df1ebc neither finished nor flushed before GC

java.lang.Throwable: Thread http-nio-9000-exec-3 allocated span here
	at brave.internal.recorder.PendingSpans.getOrCreate(PendingSpans.java:64) ~[brave-5.6.2-SNAPSHOT.jar:?]
	at brave.Tracer._toSpan(Tracer.java:349) ~[brave-5.6.2-SNAPSHOT.jar:?]
	at brave.Tracer.newChild(Tracer.java:208) ~[brave-5.6.2-SNAPSHOT.jar:?]
	at brave.Tracer.nextSpan(Tracer.java:436) ~[brave-5.6.2-SNAPSHOT.jar:?]
	at sleuth.webmvc.Backend.printDate(Backend.java:15) ~[classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_181]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
```

I tested this by running sleuth-webmvc-example backend with this diff and `-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager`

```diff
diff --git a/pom.xml b/pom.xml
index 0f9f1cd..dae267c 100644
--- a/pom.xml
+++ b/pom.xml
@@ -17,17 +17,28 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <sleuth.version>2.1.0.RELEASE</sleuth.version>
+    <brave.version>5.6.2-SNAPSHOT</brave.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
     <!-- Sends trace data to zipkin over http (defaults to http://localhost:9411/api/v2/spans) -->
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -37,6 +48,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-bom</artifactId>
+        <version>${brave.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Sleuth automatically adds trace interceptors when in the classpath -->
       <dependency>
         <groupId>org.springframework.cloud</groupId>
diff --git a/src/main/java/sleuth/webmvc/Backend.java b/src/main/java/sleuth/webmvc/Backend.java
index 5a148d6..b8af18a 100644
--- a/src/main/java/sleuth/webmvc/Backend.java
+++ b/src/main/java/sleuth/webmvc/Backend.java
@@ -1,5 +1,6 @@
 package sleuth.webmvc;
 
+import brave.Tracing;
 import java.util.Date;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class Backend {
 
   @RequestMapping("/api") public String printDate() {
+    Tracing.currentTracer().nextSpan();
     return new Date().toString();
   }
 
diff --git a/src/main/resources/application.properties b/src/main/resources/application.properties
index 7e91a4d..2013721 100644
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # spring.application.name and server.port are set in the main methods,
 # so not done here
 logging.level.org.springframework.web=DEBUG
+logging.level.brave=DEBUG
 spring.sleuth.traceId128=true
 spring.sleuth.sampler.probability=1.0
 # Adds trace and span IDs to logs (when a trace is in progress)
```

See #869