### PR TITLE
Fixes bug where we misclassified 1xx range as error (4.13.x)

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpParser.java
@@ -27,7 +27,7 @@ public class HttpParser {
   /**
    * Override to change what data from the http response or error are parsed into the span modeling
    * it. By default, this tags "http.status_code" when it is not 2xx. If there's an exception or the
-   * status code is neither 2xx nor 3xx, it tags "error".
+   * status code is below 1xx or above 3xx, it tags "error".
    *
    * <p>If you only want to change how exceptions are parsed, override {@link #error(Integer,
    * Throwable, SpanCustomizer)} instead.
@@ -40,16 +40,27 @@ public class HttpParser {
   // If this were not an abstraction, we'd use separate hooks for response and error.
   public <Resp> void response(HttpAdapter<?, Resp> adapter, @Nullable Resp res,
       @Nullable Throwable error, SpanCustomizer customizer) {
-    Integer httpStatus = res != null ? adapter.statusCode(res) : null;
-    if (httpStatus != null && (httpStatus < 200 || httpStatus > 299)) {
-      customizer.tag("http.status_code", String.valueOf(httpStatus));
+    int statusCode = 0;
+    if (res != null) {
+      statusCode = adapter.statusCode(res);
+      String maybeStatus = maybeStatusAsString(statusCode, 299);
+      if (maybeStatus != null) customizer.tag("http.status_code", maybeStatus);
     }
-    error(httpStatus, error, customizer);
+    error(statusCode, error, customizer);
+  }
+
+  /** The intent of this is to by default add "http.status_code", when not a success code */
+  @Nullable String maybeStatusAsString(int statusCode, int upperRange) {
+    if (statusCode != 0 && (statusCode < 200 || statusCode > upperRange)) {
+      return String.valueOf(statusCode);
+    }
+    return null;
   }
 
   /**
    * Override to change what data from the http error are parsed into the span modeling it. By
-   * default, this tags "error" as the exception or the status code if it is neither 2xx nor 3xx.
+   * default, this tags "error" as the exception or the status code if it is below 1xx or above
+   * 3xx.
    *
    * <p>Note: Either the httpStatus or error parameters may be null, but not both
    *
@@ -62,9 +73,27 @@ public class HttpParser {
       message = error.getMessage();
       if (message == null) message = error.getClass().getSimpleName();
     } else if (httpStatus != null) {
-      message = httpStatus < 200 || httpStatus > 399 ? String.valueOf(httpStatus) : null;
+      message = errorFromStatusCode(httpStatus);
     }
     if (message != null) customizer.tag("error", message);
+  }
+
+  // Unlike success path tagging, we only want to indicate something as error if it is not in a
+  // success range. 1xx-3xx are not errors. It is endpoint-specific if client codes like 404 are
+  // in fact errors. That's why this error parsing is overridable.
+  @Nullable String errorFromStatusCode(int httpStatus) {
+    // Instrumentation error should not make span errors. We don't know the difference between a
+    // library being unable to get the http status and a bad status (0). We don't classify zero as
+    // error in case instrumentation cannot read the status. This prevents tagging every response as
+    // error.
+    if (httpStatus == 0) return null;
+
+    // 1xx, 2xx, and 3xx codes are not all valid, but the math is good enough vs drift and opinion
+    // about individual codes in the range.
+    if (httpStatus < 100 || httpStatus > 399) {
+      return String.valueOf(httpStatus);
+    }
+    return null;
   }
 
   HttpParser() {

--- a/instrumentation/http/src/test/java/brave/http/HttpParserTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpParserTest.java
@@ -49,6 +49,25 @@ public class HttpParserTest {
     verify(customizer).tag("error", "400");
   }
 
+  @Test public void response_statusZeroIsNotAnError() {
+    when(adapter.statusCode(response)).thenReturn(0);
+
+    parser.response(adapter, response, null, customizer);
+
+    verify(customizer, never()).tag("http.status_code", "0");
+    verify(customizer, never()).tag("error", "0");
+  }
+
+  // Ensures "HTTP/1.1 101 Switching Protocols" aren't classified as error spans
+  @Test public void response_status101IsNotAnError() {
+    when(adapter.statusCode(response)).thenReturn(101);
+
+    parser.response(adapter, response, null, customizer);
+
+    verify(customizer).tag("http.status_code", "101");
+    verify(customizer, never()).tag("error", "101");
+  }
+
   @Test public void response_tagsErrorFromException() {
     parser.response(adapter, response, new RuntimeException("drat"), customizer);
 


### PR DESCRIPTION
Same as #875, but for the 4.13.x branch. Note, we don't have a current
schedule to do a last 4.13.x release, but we should prior to moving to
ASF at least to fix dependency versions.