### PR TITLE
add druid support more database

### DIFF
--- a/instrumentation/druid/README.md
+++ b/instrumentation/druid/README.md
@@ -1,0 +1,24 @@
+# brave-instrumentation-druid
+
+## Druid Filter
+
+This is a tracing filter for  [Alibaba Druid 1.1.14 ](https://github.com/alibaba/druid)，support more databases(mysql、postgresql、oracle、Microsoft、DB2、sqlite etc.) to tracing sql query and can replace brave-instrumentation-mysql.
+
+## Configuration
+
+    <bean id="tracingStatementFilter" class="brave.druid.TracingStatementFilter">
+	<property name="zipkinServiceName" value="dbServer" /></bean>
+
+  	<bean id="dataSource"  class="com.alibaba.druid.pool.DruidDataSource"
+       init-method="init" destroy-method="close">
+      <property name="url" value="jdbc:derby:memory:spring-test;create=true" />
+      <property name="initialSize" value="1" />
+      <property name="maxActive" value="20" />
+      <property name="proxyFilters">
+          <list>
+              <ref bean="tracingStatementFilter" />
+          </list>
+      </property>
+  	</bean>
+
+By default the service name corresponding to your database uses the format `${database}`

--- a/instrumentation/druid/pom.xml
+++ b/instrumentation/druid/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>brave-instrumentation-parent</artifactId>
+        <groupId>io.zipkin.brave</groupId>
+        <version>5.6.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>brave-instrumentation-druid</artifactId>
+    <name>Brave Instrumentation: Druid</name>
+
+
+    <properties>
+        <main.basedir>${project.basedir}/../..</main.basedir>
+        <!-- mysql-connector-java < v6 requires Java 6 -->
+        <main.java.version>1.6</main.java.version>
+        <main.signature.artifact>java16</main.signature.artifact>
+    </properties>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>druid</artifactId>
+            <version>1.1.14</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.47</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>brave.druid</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/instrumentation/druid/src/main/java/brave/druid/TracingStatementFilter.java
+++ b/instrumentation/druid/src/main/java/brave/druid/TracingStatementFilter.java
@@ -1,0 +1,235 @@
+package brave.druid;
+
+/**
+ * @author tianjunwei
+ * @date 2019/3/19 17:46
+ */
+
+import brave.Span;
+import brave.propagation.ThreadLocalSpan;
+import com.alibaba.druid.filter.FilterEventAdapter;
+import com.alibaba.druid.proxy.jdbc.ResultSetProxy;
+import com.alibaba.druid.proxy.jdbc.StatementProxy;
+
+import java.net.URI;
+import java.sql.SQLException;
+
+/**
+ * A DB statement interceptor that will report to Zipkin how long each statement takes.
+ */
+public class TracingStatementFilter extends FilterEventAdapter {
+
+
+    private String zipkinServiceName;
+
+    public TracingStatementFilter(String zipkinServiceName){
+        this.zipkinServiceName = zipkinServiceName;
+    }
+
+    public TracingStatementFilter(){
+
+    }
+
+
+    @Override
+    protected void statementExecuteUpdateBefore(StatementProxy statement, String sql) {
+
+        super.statementExecuteUpdateBefore(statement,sql);
+
+        try {
+            Before(statement,sql);
+        }catch (Exception e){
+
+        }
+
+
+    }
+
+    @Override
+    protected void statementExecuteUpdateAfter(StatementProxy statement, String sql, int updateCount) {
+
+        super.statementExecuteUpdateAfter(statement,sql,updateCount);
+
+        try {
+            After(statement,sql);
+        }catch (Exception e){
+
+        }
+
+
+
+    }
+
+    @Override
+    protected void statementExecuteQueryBefore(StatementProxy statement, String sql) {
+
+        super.statementExecuteQueryBefore(statement,sql);
+
+        try {
+            Before(statement,sql);
+        }catch (Exception e){
+
+        }
+
+    }
+
+    @Override
+    protected void statementExecuteQueryAfter(StatementProxy statement, String sql, ResultSetProxy resultSet) {
+
+        super.statementExecuteQueryAfter(statement,sql,resultSet);
+
+        try {
+            After(statement,sql);
+        }catch (Exception e){
+
+        }
+
+
+    }
+
+    @Override
+    protected void statementExecuteBefore(StatementProxy statement, String sql) {
+
+        super.statementExecuteBefore(statement,sql);
+
+        try {
+            Before(statement,sql);
+        }catch (Exception e){
+
+        }
+
+    }
+
+    @Override
+    protected void statementExecuteAfter(StatementProxy statement, String sql, boolean result) {
+
+        super.statementExecuteAfter(statement,sql,result);
+
+        try {
+            After(statement,sql);
+        }catch (Exception e){
+
+        }
+
+
+
+    }
+
+    @Override
+    protected void statementExecuteBatchBefore(StatementProxy statement) {
+
+        super.statementExecuteBatchBefore(statement);
+
+        try {
+            Before(statement , null);
+        }catch (Exception e){
+
+        }
+
+
+    }
+
+    @Override
+    protected void statementExecuteBatchAfter(StatementProxy statement, int[] result) {
+        super.statementExecuteBatchAfter(statement , result);
+
+        try {
+            After(statement , null);
+        }catch (Exception e){
+
+        }
+
+    }
+
+    @Override
+    protected void statement_executeErrorAfter(StatementProxy statement, String sql, Throwable error) {
+
+        super.statement_executeErrorAfter(statement , sql , error);
+
+        try {
+            ErrorAfter(statement , sql , error);
+        }catch (Exception e){
+
+        }
+
+    }
+
+
+    protected void Before(StatementProxy statement, String sql) {
+
+        Span span = ThreadLocalSpan.CURRENT_TRACER.next();
+        if (span == null || span.isNoop()) {
+            return;
+        }
+
+        if(sql == null){
+            sql = statement.getLastExecuteSql();
+        }
+        // Allow span names of single-word statements like COMMIT
+
+        int spaceIndex = sql.indexOf(' ');
+        span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+        span.tag("sql.query", sql);
+
+        parseServerIpAndPort(statement,span);
+        span.start();
+
+    }
+
+    protected void After(StatementProxy statement, String sql) {
+
+        Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+        if (span == null || span.isNoop()) {
+            return;
+        }
+
+        span.finish();
+
+        return ;
+    }
+
+    protected void ErrorAfter(StatementProxy statement, String sql, Throwable error) {
+
+        Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+        if (span == null || span.isNoop()) {
+            return;
+        }
+
+        if (error instanceof SQLException) {
+            span.tag("error", Integer.toString(((SQLException) error).getErrorCode()));
+        }
+        span.finish();
+
+        return ;
+
+    }
+
+
+    public void parseServerIpAndPort(StatementProxy statement, Span span) {
+        try {
+            URI url = URI.create(statement.getConnection().getMetaData().getURL().substring(5));
+            if (getZipkinServiceName() == null || "".equals(getZipkinServiceName())) {
+                try {
+                    zipkinServiceName = "DB"+url.getPath();
+                }catch (Exception e){
+                    ;
+                }
+            }
+            span.remoteServiceName(getZipkinServiceName());
+            String host = url.getHost();
+            if (host != null) {
+                span.remoteIpAndPort(host, url.getPort());
+            }
+        } catch (Exception e) {
+            // remote address is optional
+        }
+    }
+
+    public String getZipkinServiceName() {
+        return zipkinServiceName;
+    }
+
+    public void setZipkinServiceName(String zipkinServiceName) {
+        this.zipkinServiceName = zipkinServiceName;
+    }
+}

--- a/instrumentation/druid/src/test/java/brave/druid/TracingStatementFilterTest.java
+++ b/instrumentation/druid/src/test/java/brave/druid/TracingStatementFilterTest.java
@@ -1,0 +1,52 @@
+package brave.druid;
+
+import com.alibaba.druid.filter.Filter;
+import com.alibaba.druid.pool.DruidDataSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TracingStatementFilterTest {
+
+
+    @Test
+    public void druid() throws Exception {
+
+        Connection connection = null;
+        Statement statement = null;
+        ResultSet resultSet = null;
+
+        DruidDataSource druidDataSource = new DruidDataSource();
+        druidDataSource.setUrl("jdbc:mysql://localhost:3306/db?user=root&password=root&useUnicode=true&characterEncoding=UTF8");
+        druidDataSource.setUsername("root");
+        druidDataSource.setPassword("root");
+
+        List<Filter> filters = new ArrayList<>();
+        TracingStatementFilter tracingStatementFilter = new TracingStatementFilter("testServer");
+        filters.add(tracingStatementFilter);
+
+        druidDataSource.setProxyFilters(filters);
+
+        connection = druidDataSource.getConnection();
+
+        statement = connection.createStatement();
+        String sql = "SELECT  1 ";
+        resultSet = statement.executeQuery(sql);
+
+        resultSet.beforeFirst();
+        while (resultSet.next()) {
+            System.out.println(resultSet.getString(1));
+        }
+    }
+
+}

--- a/instrumentation/druid/src/test/java/brave/druid/TracingStatementFilterTest.java
+++ b/instrumentation/druid/src/test/java/brave/druid/TracingStatementFilterTest.java
@@ -1,16 +1,26 @@
 package brave.druid;
 
+import brave.ScopedSpan;
+import brave.Tracing;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.sampler.Sampler;
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import zipkin2.Span;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assume.assumeTrue;
 
 /**
  *
@@ -18,18 +28,26 @@ import java.util.List;
 @RunWith(MockitoJUnitRunner.class)
 public class TracingStatementFilterTest {
 
+    static final String QUERY = "select 'hello world'";
 
-    @Test
-    public void druid() throws Exception {
+    /** JDBC is synchronous and we aren't using thread pools: everything happens on the main thread */
+    ArrayList<Span> spans = new ArrayList<>();
 
-        Connection connection = null;
-        Statement statement = null;
-        ResultSet resultSet = null;
+    Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
+    Connection connection;
+
+    @Before
+    public void init() throws SQLException {
+        StringBuilder url = new StringBuilder("jdbc:mysql://");
+        url.append(envOr("MYSQL_HOST", "127.0.0.1"));
+        url.append(":").append(envOr("MYSQL_TCP_PORT", 3306));
+        String db = envOr("MYSQL_DB", null);
+        if (db != null) url.append("/").append(db);
 
         DruidDataSource druidDataSource = new DruidDataSource();
-        druidDataSource.setUrl("jdbc:mysql://localhost:3306/db?user=root&password=root&useUnicode=true&characterEncoding=UTF8");
-        druidDataSource.setUsername("root");
-        druidDataSource.setPassword("root");
+        druidDataSource.setUrl(url.toString());
+        druidDataSource.setUsername(System.getenv("MYSQL_USER"));
+        druidDataSource.setPassword(envOr("MYSQL_PASS", ""));
 
         List<Filter> filters = new ArrayList<>();
         TracingStatementFilter tracingStatementFilter = new TracingStatementFilter("testServer");
@@ -38,15 +56,98 @@ public class TracingStatementFilterTest {
         druidDataSource.setProxyFilters(filters);
 
         connection = druidDataSource.getConnection();
+        spans.clear();
+    }
 
-        statement = connection.createStatement();
-        String sql = "SELECT  1 ";
-        resultSet = statement.executeQuery(sql);
+    @After
+    public void close() throws SQLException {
+        Tracing.current().close();
+        if (connection != null) connection.close();
+    }
 
-        resultSet.beforeFirst();
-        while (resultSet.next()) {
-            System.out.println(resultSet.getString(1));
+    @Test
+    public void makesChildOfCurrentSpan() throws Exception {
+        ScopedSpan parent = tracing.tracer().startScopedSpan("test");
+        try {
+            prepareExecuteSelect(QUERY);
+        } finally {
+            parent.finish();
         }
+
+        assertThat(spans)
+                .hasSize(2);
+    }
+
+    @Test
+    public void reportsClientKindToZipkin() throws Exception {
+        prepareExecuteSelect(QUERY);
+
+        assertThat(spans)
+                .extracting(Span::kind)
+                .containsExactly(Span.Kind.CLIENT);
+    }
+
+    @Test
+    public void defaultSpanNameIsOperationName() throws Exception {
+        prepareExecuteSelect(QUERY);
+
+        assertThat(spans)
+                .extracting(Span::name)
+                .containsExactly("select");
+    }
+
+    /** This intercepts all SQL, not just queries. This ensures single-word statements work */
+    @Test
+    public void defaultSpanNameIsOperationName_oneWord() throws Exception {
+        connection.setAutoCommit(false);
+        connection.commit();
+
+        assertThat(spans)
+                .extracting(Span::name)
+                .contains("commit");
+    }
+
+    @Test
+    public void addsQueryTag() throws Exception {
+        prepareExecuteSelect(QUERY);
+
+        assertThat(spans)
+                .flatExtracting(s -> s.tags().entrySet())
+                .containsExactly(entry("sql.query", QUERY));
+    }
+
+    @Test
+    public void reportsServerAddress() throws Exception {
+        prepareExecuteSelect(QUERY);
+
+        assertThat(spans)
+                .extracting(Span::remoteServiceName)
+                .contains("myservice");
+    }
+
+    void prepareExecuteSelect(String query) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(query)) {
+            try (ResultSet resultSet = ps.executeQuery()) {
+                while (resultSet.next()) {
+                    resultSet.getString(1);
+                }
+            }
+        }
+    }
+
+    Tracing.Builder tracingBuilder(Sampler sampler) {
+        return Tracing.newBuilder()
+                .spanReporter(spans::add)
+                .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+                .sampler(sampler);
+    }
+
+    static int envOr(String key, int fallback) {
+        return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : fallback;
+    }
+
+    static String envOr(String key, String fallback) {
+        return System.getenv(key) != null ? System.getenv(key) : fallback;
     }
 
 }

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -41,6 +41,7 @@
     <module>kafka-streams</module>
     <module>netty-codec-http</module>
     <module>vertx-web</module>
+    <module>druid</module>
   </modules>
 
   <!-- ${project.groupId}:brave version is set in the root pom.


### PR DESCRIPTION
This is a tracing filter for  Alibaba Druid 1.1.14 (https://github.com/alibaba/druid)，support more databases(mysql、postgresql、oracle、Microsoft、DB2、sqlite etc.) to tracing sql query and can replace brave-instrumentation-mysql.