### PR TITLE
change enforcer rule to require jdk version >= jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,12)</version>
+                  <version>[11,12)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
to avoid compilation errors on lower jdk versions:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project brave-context-jfr:
Compilation failure: Compilation failure:
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[7,15] package jdk.jfr does not exist
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[8,15] package jdk.jfr does not exist
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[9,15] package jdk.jfr does not exist
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[10,15] package jdk.jfr does not exist
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[33,41] cannot find symbol
[ERROR]   symbol:   class Event
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[30,4] cannot find symbol
[ERROR]   symbol:   class Category
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[31,4] cannot find symbol
[ERROR]   symbol:   class Label
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[32,4] cannot find symbol
[ERROR]   symbol:   class Description
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[34,6] cannot find symbol
[ERROR]   symbol:   class Label
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator.ScopeEvent
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[35,6] cannot find symbol
[ERROR]   symbol:   class Label
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator.ScopeEvent
[ERROR] C:\RC\src\brave\context\jfr\src\main\java\brave\context\jfr\JfrScopeDecorator.java:[36,6] cannot find symbol
[ERROR]   symbol:   class Label
[ERROR]   location: class brave.context.jfr.JfrScopeDecorator.ScopeEvent
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :brave-context-jfr
```