### PR TITLE
Adds missing link to email

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,6 +4,4 @@ about: This issue tracker is not for questions. If you want to ask how to do som
 
 ---
 
-This issue tracker is not for questions. If you want to ask how to do something, or to understand why something isn't working the way you expect it to, please use [Gitter](https://gitter.im/openzipkin/zipkin) or [Stack Overflow](https://stackoverflow.com/questions/tagged/zipkin).
-
-
+This issue tracker is not for questions. If you want to ask how to do something, or to understand why something isn't working the way you expect it to, please use [Gitter](https://gitter.im/openzipkin/zipkin), [Stack Overflow](https://stackoverflow.com/questions/tagged/zipkin) or [email zipkin-user@googlegroups.com](https://groups.google.com/forum/#!forum/zipkin-user)


### PR DESCRIPTION
Not everyone can or desires to join gitter. email is an alternative. Thanks @alonbl for noticing the missing link