### PR TITLE
Adds ability to redact fields from downstream propagation

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -377,7 +377,19 @@ tracingBuilder.propagationFactory(
 requestId = ExtraFieldPropagation.get("x-vcap-request-id");
 ```
 
-You may also need to propagate a trace context you aren't using. For example, you may be in an
+#### Appropriate usage
+
+Brave is an infrastructure library: you will create lock-in if you expose its apis into
+business code. Prefer exposing your own types for utility functions that use this class as this
+will insulate you from lock-in.
+
+While it may seem convenient, do not use this for security context propagation as it was not
+designed for this use case. For example, anything placed in here can be accessed by any code, in
+the same classloader!
+
+#### Passing through alternate trace contexts
+
+You may also need to propagate an second trace context transparently. For example, when in an
 Amazon Web Services environment, but not reporting data to X-Ray. To ensure X-Ray can co-exist
 correctly, pass-through its tracing header like so.
 
@@ -388,6 +400,7 @@ tracingBuilder.propagationFactory(
 ```
 
 #### Prefixed fields
+
 You can also prefix fields, if they follow a common pattern. For example, the following will
 propagate the field "x-vcap-request-id" as-is, but send the fields "country-code" and "user-id"
 on the wire as "baggage-country-code" and "baggage-user-id" respectively.

--- a/brave/README.md
+++ b/brave/README.md
@@ -384,7 +384,7 @@ business code. Prefer exposing your own types for utility functions that use thi
 will insulate you from lock-in.
 
 While it may seem convenient, do not use this for security context propagation as it was not
-designed for this use case. For example, anything placed in here can be accessed by any code, in
+designed for this use case. For example, anything placed in here can be accessed by any code in
 the same classloader!
 
 #### Passing through alternate trace contexts

--- a/brave/README.md
+++ b/brave/README.md
@@ -414,6 +414,11 @@ ExtraFieldPropagation.set(span.context(), "country-code", "FO");
 String countryCode = ExtraFieldPropagation.get(span.context(), "country-code");
 ```
 
+#### Redacting fields
+
+You may have some fields that you would like to propagate in-process, but not downstream to other
+hosts. Use `.addRedactedField()` to indicate a field which should not be injected into headers.
+
 ### Extracting a propagated context
 The `TraceContext.Extractor<C>` reads trace identifiers and sampling status
 from an incoming request or message. The carrier is usually a request object

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -36,8 +36,7 @@ import java.util.Set;
 /**
  * Allows you to propagate predefined request-scoped fields, usually but not always HTTP headers.
  *
- * <p>For example, if you are in a Cloud Foundry environment, you might want to pass the request
- * ID:
+ * <p>For example, if you are in a Cloud Foundry environment, you might want to pass the request ID:
  * <pre>{@code
  * // when you initialize the builder, define the extra field you want to propagate
  * tracingBuilder.propagationFactory(
@@ -51,7 +50,20 @@ import java.util.Set;
  * ExtraFieldPropagation.get("x-country-code", "FO");
  * }</pre>
  *
- * <p>You may also need to propagate a trace context you aren't using. For example, you may be in
+ * <h3>Appropriate usage</h3>
+ * It is generally not a good idea to use the tracing system for application logic or critical code
+ * such as security context propagation.
+ *
+ * <p>Brave is an infrastructure library: you will create lock-in if you expose its apis into
+ * business code. Prefer exposing your own types for utility functions that use this class as this
+ * will insulate you from lock-in.
+ *
+ * <p>While it may seem convenient, do not use this for security context propagation as it was not
+ * designed for this use case. For example, anything placed in here can be accessed by any code, in
+ * the same classloader!
+ *
+ * <h3>Passing through alternate trace contexts</h3>
+ * <p>You may also need to propagate an second trace context transparently. For example, when in
  * an Amazon Web Services environment, but not reporting data to X-Ray. To ensure X-Ray can co-exist
  * correctly, pass-through its tracing header like so.
  *
@@ -61,6 +73,7 @@ import java.util.Set;
  * );
  * }</pre>
  *
+ * <h3>Prefixed fields</h3>
  * <p>You can also prefix fields, if they follow a common pattern. For example, the following will
  * propagate the field "x-vcap-request-id" as-is, but send the fields "country-code" and "user-id"
  * on the wire as "baggage-country-code" and "baggage-user-id" respectively.

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -22,6 +22,7 @@ import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -88,7 +89,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
     String[] validated = ensureLowerCase(new LinkedHashSet<>(Arrays.asList(fieldNames)));
-    return new Factory(delegate, validated, validated);
+    return new Factory(delegate, validated, validated, new BitSet());
   }
 
   /** Wraps an underlying propagation implementation, pushing one or more fields */
@@ -97,7 +98,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
     String[] validated = ensureLowerCase(new LinkedHashSet<>(fieldNames));
-    return new Factory(delegate, validated, validated);
+    return new Factory(delegate, validated, validated, new BitSet());
   }
 
   public static FactoryBuilder newFactoryBuilder(Propagation.Factory delegate) {
@@ -107,11 +108,20 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   public static final class FactoryBuilder {
     final Propagation.Factory delegate;
     final Set<String> fieldNames = new LinkedHashSet<>();
+    final Set<String> redactedFieldNames = new LinkedHashSet<>();
     final Map<String, String[]> prefixedNames = new LinkedHashMap<>();
 
     FactoryBuilder(Propagation.Factory delegate) {
       if (delegate == null) throw new NullPointerException("delegate == null");
       this.delegate = delegate;
+    }
+
+    /** Same as {@link #addField} except that this field is redacted from downstream propagation. */
+    public FactoryBuilder addRedactedField(String fieldName) {
+      fieldName = validateFieldName(fieldName);
+      fieldNames.add(fieldName);
+      redactedFieldNames.add(fieldName);
+      return this;
     }
 
     /**
@@ -121,10 +131,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
      * <p>Note: {@code fieldName} will be implicitly lower-cased.
      */
     public FactoryBuilder addField(String fieldName) {
-      if (fieldName == null) throw new NullPointerException("fieldName == null");
-      fieldName = fieldName.trim();
-      if (fieldName.isEmpty()) throw new IllegalArgumentException("fieldName is empty");
-      fieldNames.add(fieldName.toLowerCase(Locale.ROOT));
+      fieldNames.add(validateFieldName(fieldName));
       return this;
     }
 
@@ -143,25 +150,20 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     }
 
     public Factory build() {
-      if (prefixedNames.isEmpty()) {
-        String[] validated = ensureLowerCase(fieldNames);
-        return new Factory(delegate, validated, validated);
-      }
+      BitSet redacted = new BitSet();
       List<String> fields = new ArrayList<>(), keys = new ArrayList<>();
       List<Integer> keyToFieldList = new ArrayList<>();
-      if (!fieldNames.isEmpty()) {
-        List<String> validated = Arrays.asList(ensureLowerCase(fieldNames));
-        for (int i = 0, length = validated.size(); i < length; i++) {
-          String nextFieldName = validated.get(i);
-          fields.add(nextFieldName);
-          keys.add(nextFieldName);
-          keyToFieldList.add(i);
-        }
+      int i = 0;
+      for (String fieldName : fieldNames) {
+        if (redactedFieldNames.contains(fieldName)) redacted.set(i);
+        fields.add(fieldName);
+        keys.add(fieldName);
+        keyToFieldList.add(i++);
       }
       for (Map.Entry<String, String[]> entry : prefixedNames.entrySet()) {
         String nextPrefix = entry.getKey();
         String[] nextFieldNames = entry.getValue();
-        for (int i = 0; i < nextFieldNames.length; i++) {
+        for (i = 0; i < nextFieldNames.length; i++) {
           String nextFieldName = nextFieldNames[i];
           int index = fields.indexOf(nextFieldName);
           if (index == -1) {
@@ -172,13 +174,12 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
           keyToFieldList.add(index);
         }
       }
-      int keysLength = keys.size();
-      int[] keyToField = new int[keysLength];
-      for (int i = 0; i < keysLength; i++) {
+      int[] keyToField = new int[keys.size()];
+      for (i = 0; i < keyToField.length; i++) {
         keyToField[i] = keyToFieldList.get(i);
       }
       return new Factory(delegate, fields.toArray(new String[0]), keys.toArray(new String[0]),
-          keyToField);
+        keyToField, redacted);
     }
   }
 
@@ -255,10 +256,11 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     final String[] fieldNames;
     final String[] keyNames;
     final int[] keyToField;
+    final BitSet redacted;
     final ExtraFactory extraFactory;
 
-    Factory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames) {
-      this(delegate, fieldNames, keyNames, keyToField(keyNames));
+    Factory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames, BitSet redacted) {
+      this(delegate, fieldNames, keyNames, keyToField(keyNames), redacted);
     }
 
     /**
@@ -272,11 +274,12 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     }
 
     Factory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames,
-        int[] keyToField) {
+      int[] keyToField, BitSet redacted) {
       this.delegate = delegate;
       this.keyToField = keyToField;
       this.fieldNames = fieldNames;
       this.keyNames = keyNames;
+      this.redacted = redacted;
       this.extraFactory = new ExtraFactory(fieldNames);
     }
 
@@ -295,7 +298,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       for (int i = 0; i < length; i++) {
         keys.add(keyFactory.create(keyNames[i]));
       }
-      return new ExtraFieldPropagation<>(this, keyFactory, keys);
+      return new ExtraFieldPropagation<>(this, keyFactory, keys, redacted);
     }
 
     @Override public TraceContext decorate(TraceContext context) {
@@ -307,11 +310,14 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   final Factory factory;
   final Propagation<K> delegate;
   final List<K> keys;
+  final BitSet redacted;
 
-  ExtraFieldPropagation(Factory factory, Propagation.KeyFactory<K> keyFactory, List<K> keys) {
+  ExtraFieldPropagation(Factory factory, Propagation.KeyFactory<K> keyFactory, List<K> keys,
+    BitSet redacted) {
     this.factory = factory;
     this.delegate = factory.delegate.create(keyFactory);
     this.keys = keys;
+    this.redacted = redacted;
   }
 
   /**
@@ -361,6 +367,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
 
     void inject(Extra fields, C carrier) {
       for (int i = 0, length = propagation.keys.size(); i < length; i++) {
+        if (propagation.redacted.get(i)) continue; // don't propagate downstream
         String maybeValue = fields.get(propagation.factory.keyToField[i]);
         if (maybeValue == null) continue;
         setter.put(carrier, propagation.keys.get(i), maybeValue);
@@ -444,5 +451,12 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   static String lowercase(String name) {
     if (name == null) throw new NullPointerException("name == null");
     return name.toLowerCase(Locale.ROOT);
+  }
+
+  static String validateFieldName(String fieldName) {
+    if (fieldName == null) throw new NullPointerException("fieldName == null");
+    fieldName = fieldName.toLowerCase(Locale.ROOT).trim();
+    if (fieldName.isEmpty()) throw new IllegalArgumentException("fieldName is empty");
+    return fieldName;
   }
 }

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -59,7 +59,7 @@ import java.util.Set;
  * will insulate you from lock-in.
  *
  * <p>While it may seem convenient, do not use this for security context propagation as it was not
- * designed for this use case. For example, anything placed in here can be accessed by any code, in
+ * designed for this use case. For example, anything placed in here can be accessed by any code in
  * the same classloader!
  *
  * <h3>Passing through alternate trace contexts</h3>

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -150,8 +150,7 @@ public final class TraceContext extends SamplingFlags {
   }
 
   /**
-   * True if we are contributing to a span started by another tracer (ex on a different host).
-   * Defaults to false.
+   * True if we are recording a server span with the same span ID parsed from incoming headers.
    *
    * <h3>Impact on indexing</h3>
    * <p>When an RPC trace is client-originated, it will be sampled and the same span ID is used for

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -14,7 +14,6 @@
 package brave.propagation;
 
 import brave.Tracing;
-import brave.internal.PredefinedPropagationFields;
 import brave.internal.PropagationFields;
 import brave.propagation.ExtraFieldPropagation.Extra;
 import java.util.Collections;
@@ -306,9 +305,47 @@ public class ExtraFieldPropagationTest {
     context = extractor.extract(carrier).context();
 
     assertThat(ExtraFieldPropagation.get(context, "userId"))
+      .isEqualTo("bob");
+    assertThat(ExtraFieldPropagation.get(context, "sessionId"))
+      .isEqualTo("12345");
+  }
+
+  /** Redaction only applies outbound. Inbound parsing should be unaffected */
+  @Test public void extract_redactedField() {
+    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+      .addRedactedField("userId")
+      .addField("sessionId")
+      .build();
+    initialize();
+
+    injector.inject(context, carrier);
+    carrier.put("userid", "bob");
+    carrier.put("sessionid", "12345");
+
+    context = extractor.extract(carrier).context();
+
+    assertThat(ExtraFieldPropagation.get(context, "userId"))
         .isEqualTo("bob");
     assertThat(ExtraFieldPropagation.get(context, "sessionId"))
         .isEqualTo("12345");
+  }
+
+  /** Redaction prevents named fields from being written downstream. */
+  @Test public void inject_redactedField() {
+    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+      .addRedactedField("userId")
+      .addField("sessionId")
+      .build();
+    initialize();
+
+    ExtraFieldPropagation.set(context, "userId", "bob");
+    ExtraFieldPropagation.set(context, "sessionId", "12345");
+
+    injector.inject(context, carrier);
+
+    assertThat(carrier)
+      .doesNotContainKey("userId")
+      .containsEntry("sessionid", "12345");
   }
 
   @Test public void inject_field_multiple_prefixes() {

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -313,8 +313,8 @@ public class ExtraFieldPropagationTest {
   /** Redaction only applies outbound. Inbound parsing should be unaffected */
   @Test public void extract_redactedField() {
     factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
-      .addRedactedField("userId")
-      .addField("sessionId")
+      .addRedactedField("userid")
+      .addField("sessionid")
       .build();
     initialize();
 
@@ -324,27 +324,27 @@ public class ExtraFieldPropagationTest {
 
     context = extractor.extract(carrier).context();
 
-    assertThat(ExtraFieldPropagation.get(context, "userId"))
+    assertThat(ExtraFieldPropagation.get(context, "userid"))
         .isEqualTo("bob");
-    assertThat(ExtraFieldPropagation.get(context, "sessionId"))
+    assertThat(ExtraFieldPropagation.get(context, "sessionid"))
         .isEqualTo("12345");
   }
 
   /** Redaction prevents named fields from being written downstream. */
   @Test public void inject_redactedField() {
     factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
-      .addRedactedField("userId")
-      .addField("sessionId")
+      .addRedactedField("userid")
+      .addField("sessionid")
       .build();
     initialize();
 
-    ExtraFieldPropagation.set(context, "userId", "bob");
-    ExtraFieldPropagation.set(context, "sessionId", "12345");
+    ExtraFieldPropagation.set(context, "userid", "bob");
+    ExtraFieldPropagation.set(context, "sessionid", "12345");
 
     injector.inject(context, carrier);
 
     assertThat(carrier)
-      .doesNotContainKey("userId")
+      .doesNotContainKey("userid")
       .containsEntry("sessionid", "12345");
   }
 


### PR DESCRIPTION
This lets you use the extra field propagation mechanism to propagate in,
but not out of process. This can be used to correlate properties with
logs in a way that doesn't add network overhead.

This design was chosen as it incurs very little in-process overhead and
has the least burden on the code base. It can be used as a stop-gap
until a more fully featured correlation context feature is developed.

Fixes #929
See also #577