### PR TITLE
Properly implements old call-path of status codes

### DIFF
--- a/brave/src/test/java/brave/SpanCustomizerShieldTest.java
+++ b/brave/src/test/java/brave/SpanCustomizerShieldTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package brave;
 
 import org.junit.Test;

--- a/instrumentation/http/src/test/java/brave/http/features/TracingInterceptor.java
+++ b/instrumentation/http/src/test/java/brave/http/features/TracingInterceptor.java
@@ -68,8 +68,9 @@ final class TracingInterceptor implements Interceptor {
       return request.header(name);
     }
 
-    @Override public Integer statusCode(Response response) {
-      return statusCodeAsInt(response);
+    @Override @Nullable public Integer statusCode(Response response) {
+      int result = statusCodeAsInt(response);
+      return result != 0 ? result : null;
     }
 
     @Override public int statusCodeAsInt(Response response) {

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -17,6 +17,7 @@ import brave.Span;
 import brave.Tracing;
 import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.Propagation;
@@ -32,6 +33,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.concurrent.FutureCallback;
@@ -157,12 +159,14 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
       return result != null ? result.getValue() : null;
     }
 
-    @Override public Integer statusCode(HttpResponse response) {
-      return statusCodeAsInt(response);
+    @Override @Nullable public Integer statusCode(HttpResponse response) {
+      int result = statusCodeAsInt(response);
+      return result != 0 ? result : null;
     }
 
     @Override public int statusCodeAsInt(HttpResponse response) {
-      return response.getStatusLine().getStatusCode();
+      StatusLine statusLine = response.getStatusLine();
+      return statusLine != null ? statusLine.getStatusCode() : 0;
     }
   }
 

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpAdapterTest.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpAdapterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.httpasyncclient;
+
+import brave.httpasyncclient.TracingHttpAsyncClientBuilder.HttpAdapter;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpAdapterTest {
+  @Mock HttpResponse response;
+  @Mock StatusLine statusLine;
+  HttpAdapter adapter = new HttpAdapter();
+
+  @Test public void statusCodeAsInt() {
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+
+    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
+    assertThat(adapter.statusCode(response)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zeroWhenNoStatusLine() {
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
+  }
+}

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/HttpAdapter.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/HttpAdapter.java
@@ -14,10 +14,12 @@
 package brave.httpclient;
 
 import brave.Span;
+import brave.internal.Nullable;
 import java.net.InetAddress;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpRequestWrapper;
 
 final class HttpAdapter extends brave.http.HttpClientAdapter<HttpRequestWrapper, HttpResponse> {
@@ -42,12 +44,14 @@ final class HttpAdapter extends brave.http.HttpClientAdapter<HttpRequestWrapper,
     return result != null ? result.getValue() : null;
   }
 
-  @Override public Integer statusCode(HttpResponse response) {
-    return statusCodeAsInt(response);
+  @Override @Nullable public Integer statusCode(HttpResponse response) {
+    int result = statusCodeAsInt(response);
+    return result != 0 ? result : null;
   }
 
   @Override public int statusCodeAsInt(HttpResponse response) {
-    return response.getStatusLine().getStatusCode();
+    StatusLine statusLine = response.getStatusLine();
+    return statusLine != null ? statusLine.getStatusCode() : 0;
   }
 
   static void parseTargetAddress(HttpRequestWrapper httpRequest, Span span) {

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -19,6 +19,7 @@ import brave.Tracer.SpanInScope;
 import brave.Tracing;
 import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext;
 import javax.annotation.Priority;
@@ -110,12 +111,14 @@ public final class TracingClientFilter implements ClientRequestFilter, ClientRes
       return request.getHeaderString(name);
     }
 
-    @Override public Integer statusCode(ClientResponseContext response) {
-      return statusCodeAsInt(response);
+    @Override @Nullable public Integer statusCode(ClientResponseContext response) {
+      int result = statusCodeAsInt(response);
+      return result != 0 ? result : null;
     }
 
     @Override public int statusCodeAsInt(ClientResponseContext response) {
-      return response.getStatus();
+      int result = response.getStatus();
+      return result != -1 ? result : 0;
     }
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/HttpAdapterTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/HttpAdapterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jaxrs2;
+
+import brave.jaxrs2.TracingClientFilter.HttpAdapter;
+import javax.ws.rs.client.ClientResponseContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpAdapterTest {
+  @Mock ClientResponseContext response;
+  HttpAdapter adapter = new HttpAdapter();
+
+  @Test public void statusCodeAsInt() {
+    when(response.getStatus()).thenReturn(200);
+
+    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
+    assertThat(adapter.statusCode(response)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zeroWhenNegative() {
+    when(response.getStatus()).thenReturn(-1);
+
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
+  }
+}

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -18,6 +18,7 @@ import brave.Tracer;
 import brave.http.HttpServerAdapter;
 import brave.http.HttpServerHandler;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import brave.propagation.Propagation.Getter;
 import brave.propagation.TraceContext;
 import javax.inject.Inject;
@@ -101,8 +102,9 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
       return (String) event.getContainerRequest().getProperty("http.route");
     }
 
-    @Override public Integer statusCode(RequestEvent event) {
-      return statusCodeAsInt(event);
+    @Override @Nullable public Integer statusCode(RequestEvent response) {
+      int result = statusCodeAsInt(response);
+      return result != 0 ? result : null;
     }
 
     @Override public int statusCodeAsInt(RequestEvent event) {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerAdapterTest.java
@@ -40,14 +40,14 @@ public class TracingApplicationEventListenerAdapterTest {
     when(request.getMethod()).thenReturn("GET");
 
     assertThat(adapter.methodFromResponse(event))
-        .isEqualTo("GET");
+      .isEqualTo("GET");
   }
 
   @Test public void path_prefixesSlashWhenMissing() {
     when(request.getPath(false)).thenReturn("bar");
 
     assertThat(adapter.path(request))
-        .isEqualTo("/bar");
+      .isEqualTo("/bar");
   }
 
   @Test public void route() {
@@ -55,20 +55,7 @@ public class TracingApplicationEventListenerAdapterTest {
     when(request.getProperty("http.route")).thenReturn("/items/{itemId}");
 
     assertThat(adapter.route(event))
-        .isEqualTo("/items/{itemId}");
-  }
-
-  @Test public void statusCodeAsInt() {
-    when(event.getContainerResponse()).thenReturn(response);
-    when(response.getStatus()).thenReturn(200);
-
-    assertThat(adapter.statusCodeAsInt(event))
-        .isEqualTo(200);
-  }
-
-  @Test public void statusCodeAsInt_noResponse() {
-    assertThat(adapter.statusCodeAsInt(event))
-        .isZero();
+      .isEqualTo("/items/{itemId}");
   }
 
   @Test public void url_derivedFromExtendedUriInfo() {
@@ -77,6 +64,19 @@ public class TracingApplicationEventListenerAdapterTest {
     when(uriInfo.getRequestUri()).thenReturn(URI.create("http://foo:8080/bar?hello=world"));
 
     assertThat(adapter.url(request))
-        .isEqualTo("http://foo:8080/bar?hello=world");
+      .isEqualTo("http://foo:8080/bar?hello=world");
+  }
+
+  @Test public void statusCodeAsInt() {
+    when(event.getContainerResponse()).thenReturn(response);
+    when(response.getStatus()).thenReturn(200);
+
+    assertThat(adapter.statusCodeAsInt(event)).isEqualTo(200);
+    assertThat(adapter.statusCode(event)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zeroNoResponse() {
+    assertThat(adapter.statusCodeAsInt(event)).isZero();
+    assertThat(adapter.statusCode(event)).isNull();
   }
 }

--- a/instrumentation/jms/src/it/jms11/src/test/resources/log4j2.properties
+++ b/instrumentation/jms/src/it/jms11/src/test/resources/log4j2.properties
@@ -1,0 +1,9 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT
+

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/HttpNettyAdapter.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/HttpNettyAdapter.java
@@ -14,8 +14,10 @@
 package brave.netty.http;
 
 import brave.http.HttpServerAdapter;
+import brave.internal.Nullable;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 final class HttpNettyAdapter extends HttpServerAdapter<HttpRequest, HttpResponse> {
   @Override public String method(HttpRequest request) {
@@ -33,11 +35,13 @@ final class HttpNettyAdapter extends HttpServerAdapter<HttpRequest, HttpResponse
     return request.headers().get(name);
   }
 
-  @Override public Integer statusCode(HttpResponse response) {
-    return statusCodeAsInt(response);
+  @Override @Nullable public Integer statusCode(HttpResponse response) {
+    int result = statusCodeAsInt(response);
+    return result != 0 ? result : null;
   }
 
   @Override public int statusCodeAsInt(HttpResponse response) {
-    return response.status().code();
+    HttpResponseStatus status = response.status();
+    return status != null ? status.code() : 0;
   }
 }

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/HttpNettyAdapterTest.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/HttpNettyAdapterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.netty.http;
+
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpNettyAdapterTest {
+  @Mock HttpResponse response;
+  @Mock HttpResponseStatus status;
+  HttpNettyAdapter adapter = new HttpNettyAdapter();
+
+  @Test public void statusCodeAsInt() {
+    when(response.status()).thenReturn(status);
+    when(status.code()).thenReturn(200);
+
+    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
+    assertThat(adapter.statusCode(response)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zeroNoResponse() {
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
+  }
+}

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
@@ -18,6 +18,7 @@ import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext;
 import java.io.IOException;
@@ -108,8 +109,9 @@ public final class TracingInterceptor implements Interceptor {
       return request.header(name);
     }
 
-    @Override public Integer statusCode(Response response) {
-      return statusCodeAsInt(response);
+    @Override @Nullable public Integer statusCode(Response response) {
+      int result = statusCodeAsInt(response);
+      return result != 0 ? result : null;
     }
 
     @Override public int statusCodeAsInt(Response response) {

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/HttpAdapterTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/HttpAdapterTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.okhttp3;
+
+import brave.okhttp3.TracingInterceptor.HttpAdapter;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpAdapterTest {
+  HttpAdapter adapter = new HttpAdapter();
+  Response.Builder responseBuilder = new Response.Builder()
+    .request(new Request.Builder().url("http://localhost/foo").build())
+    .protocol(Protocol.HTTP_1_1);
+
+  @Test public void statusCodeAsInt() {
+    Response response = responseBuilder.code(200).message("ok").build();
+
+    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
+    assertThat(adapter.statusCode(response)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zero() {
+    Response response = responseBuilder.code(0).message("ice cream!").build();
+
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
+  }
+}

--- a/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet/ServletRuntime25Test.java
+++ b/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet/ServletRuntime25Test.java
@@ -45,7 +45,7 @@ public class ServletRuntime25Test {
 
   @Test public void status_fromInvalidMethod() throws Exception {
     assertThat(ServletRuntime.get().status(new WithInvalidGetStatus()))
-        .isNull();
+        .isZero();
   }
 
   public static class WithInvalidGetStatus extends WithoutGetStatus {

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
@@ -15,6 +15,7 @@ package brave.servlet;
 
 import brave.Span;
 import brave.http.HttpServerAdapter;
+import brave.internal.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
@@ -88,7 +89,12 @@ public class HttpServletAdapter extends HttpServerAdapter<HttpServletRequest, Ht
     return null;
   }
 
-  @Override public Integer statusCode(HttpServletResponse response) {
+  @Override @Nullable public Integer statusCode(HttpServletResponse response) {
+    int result = statusCodeAsInt(response);
+    return result != 0 ? result : null;
+  }
+
+  @Override public int statusCodeAsInt(HttpServletResponse response) {
     return servlet.status(response);
   }
 

--- a/instrumentation/servlet/src/main/java/brave/servlet/ServletRuntime.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/ServletRuntime.java
@@ -15,7 +15,6 @@ package brave.servlet;
 
 import brave.Span;
 import brave.http.HttpServerHandler;
-import brave.internal.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
@@ -44,7 +43,7 @@ abstract class ServletRuntime {
     return (HttpServletResponse) response;
   }
 
-  abstract @Nullable Integer status(HttpServletResponse response);
+  abstract int status(HttpServletResponse response);
 
   abstract boolean isAsync(HttpServletRequest request);
 
@@ -80,7 +79,7 @@ abstract class ServletRuntime {
       return request.isAsyncStarted();
     }
 
-    @Override @Nullable Integer status(HttpServletResponse response) {
+    @Override int status(HttpServletResponse response) {
       return response.getStatus();
     }
 
@@ -167,7 +166,7 @@ abstract class ServletRuntime {
      * Eventhough the Servlet 2.5 version of HttpServletResponse doesn't have the getStatus method,
      * routine servlet runtimes, do, for example {@code org.eclipse.jetty.server.Response}
      */
-    @Override @Nullable Integer status(HttpServletResponse response) {
+    @Override int status(HttpServletResponse response) {
       // unwrap if we've decorated the response
       if (response instanceof HttpServletAdapter.DecoratedHttpServletResponse) {
         HttpServletResponseWrapper decorated = ((HttpServletResponseWrapper) response);
@@ -182,12 +181,12 @@ abstract class ServletRuntime {
       Object getStatusMethod = classesToCheck.get(clazz);
       if (getStatusMethod == RETURN_NULL ||
           (getStatusMethod == null && classesToCheck.size() == 10)) { // limit size
-        return null;
+        return 0;
       }
 
       // Now, we either have a cached method or we have room to cache a method
       if (getStatusMethod == null) {
-        if (clazz.isLocalClass() || clazz.isAnonymousClass()) return null; // don't cache
+        if (clazz.isLocalClass() || clazz.isAnonymousClass()) return 0; // don't cache
         try {
           // we don't check for accessibility as isAccessible is deprecated: just fail later
           getStatusMethod = clazz.getMethod("getStatus");
@@ -195,7 +194,7 @@ abstract class ServletRuntime {
         } catch (Throwable throwable) {
           Call.propagateIfFatal(throwable);
           getStatusMethod = RETURN_NULL;
-          return null;
+          return 0;
         } finally {
           // regardless of success or fail, replace the cache
           Map<Class<?>, Object> replacement = new LinkedHashMap<>(classesToCheck);
@@ -212,7 +211,7 @@ abstract class ServletRuntime {
         Map<Class<?>, Object> replacement = new LinkedHashMap<>(classesToCheck);
         replacement.put(clazz, RETURN_NULL);
         classToGetStatus.set(replacement); // prefer overriding on failure
-        return null;
+        return 0;
       }
     }
   }
@@ -246,7 +245,7 @@ abstract class ServletRuntime {
       super.setStatus(sc);
     }
 
-    public int getStatusInServlet25() {
+    int getStatusInServlet25() {
       return httpStatus;
     }
   }

--- a/instrumentation/servlet/src/main/java/brave/servlet/ServletRuntime.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/ServletRuntime.java
@@ -245,7 +245,7 @@ abstract class ServletRuntime {
       super.setStatus(sc);
     }
 
-    int getStatusInServlet25() {
+    public int getStatusInServlet25() {
       return httpStatus;
     }
   }

--- a/instrumentation/servlet/src/test/java/brave/servlet/HttpServletAdapterTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/HttpServletAdapterTest.java
@@ -15,6 +15,7 @@ package brave.servlet;
 
 import brave.Span;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,18 +30,19 @@ import static org.mockito.Mockito.when;
 public class HttpServletAdapterTest {
   HttpServletAdapter adapter = new HttpServletAdapter();
   @Mock HttpServletRequest request;
+  @Mock HttpServletResponse response;
   @Mock Span span;
 
   @Test public void path_doesntCrashOnNullUrl() {
     assertThat(adapter.path(request))
-        .isNull();
+      .isNull();
   }
 
   @Test public void path_getRequestURI() {
     when(request.getRequestURI()).thenReturn("/bar");
 
     assertThat(adapter.path(request))
-        .isEqualTo("/bar");
+      .isEqualTo("/bar");
   }
 
   @Test public void url_derivedFromUrlAndQueryString() {
@@ -48,7 +50,7 @@ public class HttpServletAdapterTest {
     when(request.getQueryString()).thenReturn("hello=world");
 
     assertThat(adapter.url(request))
-        .isEqualTo("http://foo:8080/bar?hello=world");
+      .isEqualTo("http://foo:8080/bar?hello=world");
   }
 
   @Test public void parseClientIpAndPort_prefersXForwardedFor() {
@@ -79,5 +81,17 @@ public class HttpServletAdapterTest {
 
     verify(span).remoteIpAndPort("1.2.3.4", 61687);
     verifyNoMoreInteractions(span);
+  }
+
+  @Test public void statusCodeAsInt() {
+    when(response.getStatus()).thenReturn(200);
+
+    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
+    assertThat(adapter.statusCode(response)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zeroNoResponse() {
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
   }
 }

--- a/instrumentation/servlet/src/test/java/brave/servlet/ServletRuntimeTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/ServletRuntimeTest.java
@@ -35,7 +35,7 @@ public class ServletRuntimeTest {
       }
     };
     assertThat(servlet25.status(jettyResponse))
-        .isNull();
+      .isZero();
   }
 
   @Test public void servlet25_status_doesntParseLocalTypes() throws Exception {
@@ -43,7 +43,7 @@ public class ServletRuntimeTest {
     class LocalResponse extends HttpServletResponseImpl {
     }
     assertThat(servlet25.status(new LocalResponse()))
-        .isNull();
+      .isZero();
   }
 
   class ExceptionResponse extends HttpServletResponseImpl {
@@ -54,7 +54,7 @@ public class ServletRuntimeTest {
 
   @Test public void servlet25_status_nullOnException() throws Exception {
     assertThat(servlet25.status(new ExceptionResponse()))
-        .isNull();
+      .isZero();
   }
 
   class Response1 extends HttpServletResponseImpl {
@@ -112,7 +112,7 @@ public class ServletRuntimeTest {
     assertThat(servlet25.status(new Response10()))
         .isEqualTo(200);
     assertThat(servlet25.status(new Response11()))
-        .isNull();
+         .isZero();
   }
 
   public static class HttpServletResponseImpl implements HttpServletResponse {

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
@@ -18,6 +18,7 @@ import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext;
 import java.io.IOException;
@@ -88,11 +89,16 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
       return result != null ? result.toString() : "";
     }
 
-    @Override public Integer statusCode(ClientHttpResponse response) {
+    @Override @Nullable public Integer statusCode(ClientHttpResponse response) {
+      int result = statusCodeAsInt(response);
+      return result != 0 ? result : null;
+    }
+
+    @Override public int statusCodeAsInt(ClientHttpResponse response) {
       try {
         return response.getRawStatusCode();
-      } catch (IOException e) {
-        return null;
+      } catch (IllegalArgumentException | IOException e) {
+        return 0;
       }
     }
   }

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/HttpAdapterTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/HttpAdapterTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.spring.web;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.client.ClientHttpResponse;
+
+import static brave.spring.web.TracingClientHttpRequestInterceptor.HttpAdapter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpAdapterTest {
+  @Mock ClientHttpResponse response;
+  HttpAdapter adapter = new HttpAdapter();
+
+  @Test public void statusCodeAsInt() throws IOException {
+    when(response.getRawStatusCode()).thenReturn(200);
+
+    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
+    assertThat(adapter.statusCode(response)).isEqualTo(200);
+  }
+
+  @Test public void statusCodeAsInt_zeroOnIOE() throws IOException {
+    when(response.getRawStatusCode()).thenThrow(new IOException());
+
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
+  }
+
+  @Test public void statusCodeAsInt_zeroOnIAE() throws IOException {
+    when(response.getRawStatusCode()).thenThrow(new IllegalArgumentException());
+
+    assertThat(adapter.statusCodeAsInt(response)).isZero();
+    assertThat(adapter.statusCode(response)).isNull();
+  }
+}

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxHttpServerAdapter.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/VertxHttpServerAdapter.java
@@ -15,6 +15,7 @@ package brave.vertx.web;
 
 import brave.Span;
 import brave.http.HttpServerAdapter;
+import brave.internal.Nullable;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.net.SocketAddress;
@@ -61,8 +62,9 @@ class VertxHttpServerAdapter extends HttpServerAdapter<HttpServerRequest, HttpSe
     return result != null ? result : "";
   }
 
-  @Override public Integer statusCode(HttpServerResponse response) {
-    return statusCodeAsInt(response);
+  @Override @Nullable public Integer statusCode(HttpServerResponse response) {
+    int result = statusCodeAsInt(response);
+    return result != 0 ? result : null;
   }
 
   @Override public int statusCodeAsInt(HttpServerResponse response) {


### PR DESCRIPTION
Eventhough new instrumentation don't use it, old could.

See https://github.com/spring-cloud/spring-cloud-sleuth/pull/1387