### PR TITLE
Opts out of reporting empty spans

### DIFF
--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -79,6 +79,24 @@ public final class MutableSpan implements Cloneable {
     // lazy initialize annotations
   }
 
+  /** Returns true if there was no data added. Usually this indicates an instrumentation bug. */
+  public boolean isEmpty() {
+    return kind == null
+      && !shared
+      && startTimestamp == 0L
+      && finishTimestamp == 0L
+      && name == null
+      && localServiceName == null
+      && localIp == null
+      && remoteServiceName == null
+      && remoteIp == null
+      && localPort == 0
+      && remotePort == 0
+      && tags.isEmpty()
+      && annotations == null
+      && error == null;
+  }
+
   /** Returns the {@link brave.Span#name(String) span name} or null */
   @Nullable public String name() {
     return name;

--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -132,12 +132,18 @@ public final class PendingSpans extends ReferenceQueue<TraceContext> {
           contextKey.localRootId, 0L, contextKey.spanId,
           Collections.emptyList()
       );
-      value.state.annotate(flushTime, "brave.flush");
 
+      boolean isEmpty = value.state.isEmpty();
       Throwable caller = value.caller;
       if (caller != null) {
-        LOG.log(Level.FINE, "Span " + context + " neither finished nor flushed before GC", caller);
+        String message = isEmpty
+          ? "Span " + context + " was allocated but never used"
+          : "Span " + context + " neither finished nor flushed before GC";
+        LOG.log(Level.FINE, message, caller);
       }
+      if (isEmpty) continue;
+
+      value.state.annotate(flushTime, "brave.flush");
 
       try {
         zipkinHandler.handle(context, value.state);

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -13,6 +13,7 @@
  */
 package brave.handler;
 
+import brave.Span;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -142,6 +143,75 @@ public class MutableSpanTest {
         entry(2L, "SSN=xxx-xx-xxxx"),
         entry(3L, "3")
     );
+  }
+
+  @Test public void isEmpty() {
+    assertThat(new MutableSpan().isEmpty()).isTrue();
+    {
+      MutableSpan span = new MutableSpan();
+      span.name("a");
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.startTimestamp(1);
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.finishTimestamp(1);
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.kind(Span.Kind.CLIENT);
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.localServiceName("a");
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.localIp("1.2.3.4");
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.localPort(1);
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.remoteServiceName("a");
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.remoteIpAndPort("1.2.3.4", 1);
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.annotate(1L, "a");
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.error(new RuntimeException());
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.tag("a", "b");
+      assertThat(span.isEmpty()).isFalse();
+    }
+    {
+      MutableSpan span = new MutableSpan();
+      span.setShared();
+      assertThat(span.isEmpty()).isFalse();
+    }
   }
 
   @Test public void accessorScansTags() {

--- a/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
+++ b/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
@@ -40,6 +40,7 @@ public class PendingSpansTest {
         if (!Boolean.TRUE.equals(ctx.sampled())) return true;
 
         Span.Builder b = Span.newBuilder().traceId(ctx.traceIdString()).id(ctx.traceIdString());
+        b.name(span.name());
         span.forEachAnnotation(Span.Builder::addAnnotation, b);
         spans.add(b.build());
         return true;
@@ -179,7 +180,9 @@ public class PendingSpansTest {
   @Test
   public void reportOrphanedSpans_afterGC() throws Exception {
     TraceContext context1 = context.toBuilder().traceId(1).spanId(1).build();
-    pendingSpans.getOrCreate(context1, false);
+    PendingSpan span = pendingSpans.getOrCreate(context1, false);
+    span.state.name("foo");
+    span = null; // clear reference so GC occurs
     TraceContext context2 = context.toBuilder().traceId(2).spanId(2).build();
     pendingSpans.getOrCreate(context2, false);
     TraceContext context3 = context.toBuilder().traceId(3).spanId(3).build();
@@ -207,15 +210,12 @@ public class PendingSpansTest {
     assertThat(pendingSpans.delegate.keySet()).extracting(o -> ((Reference) o).get())
         .containsExactlyInAnyOrder(context3, context4);
 
-    // We also expect only the sampled (remote) spans to have been reported with a flush annotation
-    assertThat(spans).flatExtracting(Span::id)
-        .containsExactlyInAnyOrder("0000000000000001", "0000000000000002");
-    assertThat(spans).flatExtracting(Span::annotations).extracting(Annotation::value)
-        .containsExactly("brave.flush", "brave.flush");
-
-    // we also expect the clock to have been called only once
-    assertThat(spans).flatExtracting(Span::annotations).extracting(Annotation::timestamp)
-        .allSatisfy(t -> assertThat(t).isEqualTo((initialClockVal + 1) * 1000));
+    // We also expect only the sampled span containing data to have been reported
+    assertThat(spans).hasSize(1);
+    assertThat(spans.get(0).id()).isEqualTo("0000000000000001");
+    assertThat(spans.get(0).name()).isEqualTo("foo"); // data was flushed
+    assertThat(spans.get(0).annotations())
+      .containsExactly(Annotation.create((initialClockVal + 1) * 1000, "brave.flush"));
   }
 
   @Test


### PR DESCRIPTION
This refines the log message instead of reporting defunct spans

Fixes #869