### PR TITLE
Begins work to bridge from alibaba to apache dubbo

### DIFF
--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -28,9 +28,7 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
-    <!-- TODO: not compile compatible with apache dubbo until 2.7.2
-         See https://github.com/apache/incubator-zipkin-brave/issues/867 -->
-    <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
+    <dubbo.version>2.7.3</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -30,12 +30,12 @@
     <main.signature.artifact>java16</main.signature.artifact>
     <!-- TODO: not compile compatible with apache dubbo until 2.7.2
          See https://github.com/apache/incubator-zipkin-brave/issues/867 -->
-    <dubbo.version>2.6.6</dubbo.version>
+    <dubbo.version>2.7.3-SNAPSHOT</dubbo.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>com.alibaba</groupId>
+      <groupId>org.apache.dubbo</groupId>
       <artifactId>dubbo</artifactId>
       <version>${dubbo.version}</version>
     </dependency>

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -23,8 +23,6 @@ import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.extension.Activate;
-import com.alibaba.dubbo.common.extension.ExtensionLoader;
-import com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory;
 import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
 import com.alibaba.dubbo.rpc.Filter;
 import com.alibaba.dubbo.rpc.Invocation;
@@ -48,10 +46,14 @@ public final class TracingFilter implements Filter {
   TraceContext.Injector<Map<String, String>> injector;
 
   /**
-   * {@link ExtensionLoader} supplies the tracing implementation which must be named "tracing". For
-   * example, if using the {@link SpringExtensionFactory}, only a bean named "tracing" will be
-   * injected.
+   * <h3>Notes for com.alibaba:dubbo</h3>
+   *
+   * {@code com.alibaba.dubbo.common.extension.ExtensionLoader} supplies the tracing implementation
+   * which must be named "tracing". For example, if using the
+   * {@code com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory}, only a bean named
+   * "tracing" will be injected.
    */
+  // TODO: port the above comment for org.apache.dubbo:dubbo
   public void setTracing(Tracing tracing) {
     tracer = tracing.tracer();
     extractor = tracing.propagation().extractor(GETTER);


### PR DESCRIPTION
Starting with the 2.7.3 all of our main code can compile with
org.apache.dubbo:dubbo and also com.alibaba:dubbo

There is some strange work here because the spring integrations were not
backported. Until such time as it is, we need reflection to actually
load the extensions. As this is fragile, this change shouldn't merge
until a maven invoker test is setup to prove the tests also pass with
com.alibaba:dubbo still. Also, we need to cleanup documentation around
spring as it will mention types that don't exist.

Fixes #867