### PR TITLE
Avoids redundant runs of tests during release upload

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -113,8 +113,13 @@ if ! is_pull_request && build_started_by_tag; then
   check_release_tag
 fi
 
+# During a release upload, don't run tests as they can flake or overrun the max time allowed by Travis.
 # skip license on travis due to #1512
-./mvnw install -nsu -Dlicense.skip=true
+if is_release_commit; then
+  ./mvnw install -nsu -Dlicense.skip=true -DskipTests
+else
+  ./mvnw install -nsu -Dlicense.skip=true
+fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
 if is_pull_request; then


### PR DESCRIPTION
Testing this first with Brave as this is the next thing to cut. If the shell script works as expected, I'll weave it into the zipkin repo which is currently unreleasable because of timeouts  related to the redundant runs of integration tests on the version tag. cc @openzipkin/devops-tooling 