### PR TITLE
Fix: Kafka Streams partitioning

### DIFF
--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -738,6 +738,51 @@ public class TracerTest {
     spanInScope.close();
   }
 
+  @Test public void joinSpan_whenJoinIsSupported_resultantSpanIsLocalRoot() {
+    tracer = Tracing.newBuilder().supportsJoin(true).build().tracer();
+
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+    Span span = tracer.joinSpan(context);
+
+    assertThat(span.context().spanId()).isEqualTo(span.context().localRootId());// Sanity check
+    assertThat(span.context().isLocalRoot()).isTrue();
+  }
+
+  @Test public void joinSpan_whenJoinIsNotSupported_resultantSpanIsLocalRoot() {
+    tracer = Tracing.newBuilder().supportsJoin(false).build().tracer();
+
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+    Span span = tracer.joinSpan(context);
+
+    assertThat(span.context().spanId()).isEqualTo(span.context().localRootId());// Sanity check
+    assertThat(span.context().isLocalRoot()).isTrue();
+  }
+
+  @Test public void newChild_resultantSpanIsLocalRoot() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+    Span span = tracer.newChild(context);
+
+    assertThat(span.context().spanId()).isEqualTo(span.context().localRootId());// Sanity check
+    assertThat(span.context().isLocalRoot()).isTrue();
+  }
+
+  @Test public void nextSpan_fromFlags_resultantSpanIsLocalRoot() {
+    TraceContextOrSamplingFlags traceContextOrSamplingFlags = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.SAMPLED).build();
+    Span span = tracer.nextSpan(traceContextOrSamplingFlags);
+
+    assertThat(span.context().spanId()).isEqualTo(span.context().localRootId());// Sanity check
+    assertThat(span.context().isLocalRoot()).isTrue();
+  }
+
+  @Test public void nextSpan_fromContext_resultantSpanIsLocalRoot() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+    TraceContextOrSamplingFlags traceContextOrSamplingFlags = TraceContextOrSamplingFlags.newBuilder().context(context).build();
+    Span span = tracer.nextSpan(traceContextOrSamplingFlags);
+
+    assertThat(span.context().spanId()).isEqualTo(span.context().localRootId());// Sanity check
+    assertThat(span.context().isLocalRoot()).isTrue();
+  }
+
   @Test public void localRootId_joinSpan_notYetSampled() {
     TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).build();
     TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).build();

--- a/instrumentation/kafka-streams/README.md
+++ b/instrumentation/kafka-streams/README.md
@@ -1,4 +1,4 @@
-# Brave Kafka Streams instrumentation
+# Brave Kafka Streams instrumentation [EXPERIMENTAL]
 
 Add decorators for Kafka Streams to enable tracing.
 * `TracingKafkaClientSupplier` a client supplier which traces poll and send operations.
@@ -77,6 +77,11 @@ will reference the initial span, and mark the end of a Stream Process.
 If intermediate steps on the Stream topology require tracing, then `TracingProcessorSupplier` and
 `TracingTransformerSupplier` will allow you to define a Processor/Transformer where execution is recorded as Span, 
 referencing the parent context stored on Headers, if available.
+
+### Partitioning
+
+Be aware that operations that require `builder.transformer(...)` will cause re-partitioning when 
+grouping or joining downstream ([Kafka docs](https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html#applying-processors-and-transformers-processor-api-integration)).
 
 ## Notes
 

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -247,6 +247,10 @@ public final class KafkaStreamsTracing {
 
   /**
    * Create a filter transformer.
+   *
+   * WARNING: as this filter is based on Transformer API, if followed by a grouping or joining
+   * will lead to re-partitioning
+   *
    *<p>Simple example using Kafka Streams DSL:
    *<pre>{@code
    *StreamsBuilder builder = new StreamsBuilder();
@@ -262,6 +266,10 @@ public final class KafkaStreamsTracing {
 
   /**
    * Create a filterNot transformer.
+   *
+   * WARNING: as this filter is based on Transformer API, if followed by a grouping or joining
+   * will lead to re-partitioning
+   *
    *<p>Simple example using Kafka Streams DSL:
    *<pre>{@code
    *StreamsBuilder builder = new StreamsBuilder();

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -284,6 +284,46 @@ public final class KafkaStreamsTracing {
   }
 
   /**
+   * Create a markFilter valueTransformer.
+   *
+   * Instead of filtering, and not emitting a value as {@code filter} does,
+   * it creates span marking it as filtered or not. If filtered, value returned
+   * will be {@code null}
+   *
+   *<p>Simple example using Kafka Streams DSL:
+   *<pre>{@code
+   *StreamsBuilder builder = new StreamsBuilder();
+   *builder.stream(inputTopic)
+   *       .transformValues(kafkaStreamsTracing.markFilter("myFilter", (k, v) -> ...)
+   *       .filterNot((k, v) -> Objects.isNull(v))
+   *       .to(outputTopic);
+   *}</pre>
+   */
+  public <K, V> ValueTransformerWithKeySupplier<K, V, V> markFilter(String spanName, Predicate<K, V> predicate) {
+    return new TracingFilterValueTransformerWithKeySupplier<>(this, spanName, predicate, false);
+  }
+
+  /**
+   * Create a markFilterNot valueTransformer.
+   *
+   * Instead of filtering, and not emitting a value as {@code filterNot} does,
+   * it creates span marking it as filtered or not. If filtered, value returned
+   * will be {@code null}
+   *
+   *<p>Simple example using Kafka Streams DSL:
+   *<pre>{@code
+   *StreamsBuilder builder = new StreamsBuilder();
+   *builder.stream(inputTopic)
+   *       .transformValues(kafkaStreamsTracing.markFilterNot("myFilter", (k, v) -> ...)
+   *       .filterNot((k, v) -> Objects.isNull(v))
+   *       .to(outputTopic);
+   *}</pre>
+   */
+  public <K, V> ValueTransformerWithKeySupplier<K, V, V> markFilterNot(String spanName, Predicate<K, V> predicate) {
+    return new TracingFilterValueTransformerWithKeySupplier<>(this, spanName, predicate, true);
+  }
+
+  /**
    * Create a mapValues transformer, similar to {@link KStream#mapValues(ValueMapperWithKey)}, where its mapper action
    * will be recorded in a new span with the indicated name.
    *

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -43,7 +43,7 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
 /** Use this class to decorate Kafka Stream Topologies and enable Tracing. */
-public final class  KafkaStreamsTracing {
+public final class KafkaStreamsTracing {
 
   final Tracing tracing;
   final TraceContext.Extractor<Headers> extractor;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -249,7 +249,7 @@ public final class KafkaStreamsTracing {
    * Create a filter transformer.
    *
    * WARNING: as this filter is based on Transformer API, if followed by a grouping or joining
-   * will lead to re-partitioning
+   * will lead to re-partitioning. Consider using it when none of these happen after this.
    *
    *<p>Simple example using Kafka Streams DSL:
    *<pre>{@code
@@ -268,7 +268,7 @@ public final class KafkaStreamsTracing {
    * Create a filterNot transformer.
    *
    * WARNING: as this filter is based on Transformer API, if followed by a grouping or joining
-   * will lead to re-partitioning
+   * will lead to re-partitioning. Consider using it when none of these happen after.
    *
    *<p>Simple example using Kafka Streams DSL:
    *<pre>{@code

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -248,8 +248,10 @@ public final class KafkaStreamsTracing {
   /**
    * Create a filter transformer.
    *
-   * WARNING: as this filter is based on Transformer API, if followed by a grouping or joining
-   * will lead to re-partitioning. Consider using it when none of these happen after this.
+   * WARNING: this filter implementation uses the Streams transform API, meaning that re-partitioning
+   * can occur if a key modifying operation like grouping or joining operation is applied after this filter.
+   * In that case, consider using {@link #markFilter(String, Predicate)} instead which
+   * uses {@link ValueTransformerWithKey} API instead.
    *
    *<p>Simple example using Kafka Streams DSL:
    *<pre>{@code
@@ -267,8 +269,10 @@ public final class KafkaStreamsTracing {
   /**
    * Create a filterNot transformer.
    *
-   * WARNING: as this filter is based on Transformer API, if followed by a grouping or joining
-   * will lead to re-partitioning. Consider using it when none of these happen after.
+   * WARNING: this filter implementation uses the Streams transform API, meaning that re-partitioning
+   * can occur if a key modifying operation like grouping or joining operation is applied after this filter.
+   * In that case, consider using {@link #markFilterNot(String, Predicate)} instead
+   * which uses {@link ValueTransformerWithKey} API instead.
    *
    *<p>Simple example using Kafka Streams DSL:
    *<pre>{@code

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilter.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.kafka.streams;
+
+import brave.Span;
+import brave.Tracer;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.processor.ProcessorContext;
+
+import static brave.kafka.streams.KafkaStreamsTags.KAFKA_STREAMS_FILTERED_TAG;
+
+abstract class TracingFilter<K, V, R> {
+
+  final KafkaStreamsTracing kafkaStreamsTracing;
+  final String spanName;
+  final Predicate<K, V> delegatePredicate;
+  final Tracer tracer;
+  final boolean filterNot;
+  ProcessorContext processorContext;
+
+  TracingFilter(KafkaStreamsTracing tracing, String spanName,
+      Predicate<K, V> delegatePredicate, boolean filterNot) {
+    this.kafkaStreamsTracing = tracing;
+    this.tracer = kafkaStreamsTracing.tracing.tracer();
+    this.spanName = spanName;
+    this.delegatePredicate = delegatePredicate;
+    this.filterNot = filterNot;
+  }
+
+  public void init(ProcessorContext context) {
+    processorContext = context;
+  }
+
+  public R transform(K key, V value) {
+    Span span = kafkaStreamsTracing.nextSpan(processorContext);
+    if (!span.isNoop()) {
+      span.name(spanName);
+      span.start();
+    }
+
+    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
+      if (filterNot ^ delegatePredicate.test(key, value)) {
+        span.tag(KAFKA_STREAMS_FILTERED_TAG, "false");
+        return result(key, value);
+      } else {
+        span.tag(KAFKA_STREAMS_FILTERED_TAG, "true");
+        return null; // meaning KV pair will not be forwarded thus effectively filtered
+      }
+    } catch (RuntimeException | Error e) {
+      span.error(e); // finish as an exception means the callback won't finish the span
+      throw e;
+    } finally {
+      span.finish();
+    }
+  }
+
+  abstract R result(K key, V value);
+}

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilterValueTransformerWithKey.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilterValueTransformerWithKey.java
@@ -13,14 +13,14 @@
  */
 package brave.kafka.streams;
 
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Predicate;
-import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
-class TracingFilterTransformer<K, V> extends TracingFilter<K, V, KeyValue<K, V>> implements Transformer<K, V, KeyValue<K, V>> {
+class TracingFilterValueTransformerWithKey<K, V> extends TracingFilter<K, V, V> implements
+  ValueTransformerWithKey<K, V, V> {
 
-  TracingFilterTransformer(KafkaStreamsTracing tracing, String spanName,
+  TracingFilterValueTransformerWithKey(KafkaStreamsTracing tracing, String spanName,
       Predicate<K, V> delegatePredicate, boolean filterNot) {
     super(tracing, spanName, delegatePredicate, filterNot);
   }
@@ -31,14 +31,14 @@ class TracingFilterTransformer<K, V> extends TracingFilter<K, V, KeyValue<K, V>>
   }
 
   @Override
-  public KeyValue<K, V> transform(K key, V value) {
+  public V transform(K key, V value) {
     return super.transform(key, value);
   }
 
   @Override public void close() {
   }
 
-  @Override KeyValue<K, V> result(K key, V value) {
-    return KeyValue.pair(key, value);
+  @Override V result(K key, V value) {
+    return value;
   }
 }

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilterValueTransformerWithKeySupplier.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilterValueTransformerWithKeySupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.kafka.streams;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+
+public class TracingFilterValueTransformerWithKeySupplier<K, V> implements
+  ValueTransformerWithKeySupplier<K, V, V> {
+
+  final KafkaStreamsTracing kafkaStreamsTracing;
+  final String spanName;
+  final Predicate<K, V> delegatePredicate;
+  final boolean filterNot;
+
+  public TracingFilterValueTransformerWithKeySupplier(KafkaStreamsTracing kafkaStreamsTracing,
+      String spanName, Predicate<K, V> delegatePredicate, boolean filterNot) {
+    this.kafkaStreamsTracing = kafkaStreamsTracing;
+    this.spanName = spanName;
+    this.delegatePredicate = delegatePredicate;
+    this.filterNot = filterNot;
+  }
+
+  @Override public ValueTransformerWithKey<K, V, V> get() {
+    return new TracingFilterValueTransformerWithKey<>(kafkaStreamsTracing, spanName, delegatePredicate,
+        filterNot);
+  }
+}

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -346,13 +346,13 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_filter_predicate_true() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_filtered_predicate_true() throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transformValues(kafkaStreamsTracing.markFilter("filter-1", (key, value) -> true))
+        .transformValues(kafkaStreamsTracing.markAsFiltered("filter-1", (key, value) -> true))
         .filterNot((k, v) -> Objects.isNull(v))
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
@@ -378,13 +378,13 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_filter_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_filtered_predicate_false() throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-      .transformValues(kafkaStreamsTracing.markFilter("filter-2", (key, value) -> false))
+      .transformValues(kafkaStreamsTracing.markAsFiltered("filter-2", (key, value) -> false))
       .filterNot((k, v) -> Objects.isNull(v))
       .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
@@ -409,13 +409,13 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_filter_not_predicate_true() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_not_filtered_predicate_true() throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transformValues(kafkaStreamsTracing.markFilterNot("filterNot-1", (key, value) -> true))
+        .transformValues(kafkaStreamsTracing.markAsNotFiltered("filterNot-1", (key, value) -> true))
         .filterNot((k, v) -> Objects.isNull(v))
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
@@ -440,13 +440,13 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_filter_not_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_not_filtered_predicate_false() throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transformValues(kafkaStreamsTracing.markFilterNot("filterNot-2", (key, value) -> false))
+        .transformValues(kafkaStreamsTracing.markAsNotFiltered("filterNot-2", (key, value) -> false))
         .filterNot((k, v) -> Objects.isNull(v))
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -284,13 +284,16 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_filternot_predicate_true() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_filter_not_predicate_true() throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
         .transform(kafkaStreamsTracing.filterNot("filterNot-1", (key, value) -> true))
+        .peek((s, s2) -> {
+          System.out.println(s + "-" + s2);
+        })
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
@@ -314,7 +317,7 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_filternot_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_filter_not_predicate_false() throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
@@ -353,7 +356,7 @@ public class ITKafkaStreamsTracing {
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transform(kafkaStreamsTracing.peek("peek-1", (key, value) -> {
+        .transformValues(kafkaStreamsTracing.peek("peek-1", (key, value) -> {
           try {
             Thread.sleep(100L);
           } catch (InterruptedException e) {
@@ -390,7 +393,7 @@ public class ITKafkaStreamsTracing {
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transform(kafkaStreamsTracing.mark("mark-1"))
+        .transformValues(kafkaStreamsTracing.mark("mark-1"))
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -291,9 +291,6 @@ public class ITKafkaStreamsTracing {
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
         .transform(kafkaStreamsTracing.filterNot("filterNot-1", (key, value) -> true))
-        .peek((s, s2) -> {
-          System.out.println(s + "-" + s2);
-        })
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -22,6 +22,7 @@ import com.github.charithe.kafka.KafkaJunitRule;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -229,8 +230,8 @@ public class ITKafkaStreamsTracing {
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transform(kafkaStreamsTracing.filter("filter-1", (key, value) -> true))
-        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+      .transform(kafkaStreamsTracing.filter("filter-1", (key, value) -> true))
+      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -260,8 +261,8 @@ public class ITKafkaStreamsTracing {
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transform(kafkaStreamsTracing.filter("filter-2", (key, value) -> false))
-        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+      .transform(kafkaStreamsTracing.filter("filter-2", (key, value) -> false))
+      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -290,8 +291,8 @@ public class ITKafkaStreamsTracing {
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transform(kafkaStreamsTracing.filterNot("filterNot-1", (key, value) -> true))
-        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+      .transform(kafkaStreamsTracing.filterNot("filterNot-1", (key, value) -> true))
+      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -320,7 +321,133 @@ public class ITKafkaStreamsTracing {
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transform(kafkaStreamsTracing.filterNot("filterNot-2", (key, value) -> false))
+      .transform(kafkaStreamsTracing.filterNot("filterNot-2", (key, value) -> false))
+      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+    Topology topology = builder.build();
+
+    KafkaStreams streams = buildKafkaStreams(topology);
+
+    producer = createProducer();
+    producer.send(new ProducerRecord<>(inputTopic, TEST_KEY, TEST_VALUE)).get();
+
+    waitForStreamToRun(streams);
+
+    // the filterNot transformer returns true so record is not dropped
+    Span spanInput = takeSpan(), spanProcessor = takeSpan(), spanOutput = takeSpan();
+
+    assertThat(spanInput.kind().name()).isEqualTo(brave.Span.Kind.CONSUMER.name());
+    assertThat(spanInput.traceId()).isEqualTo(spanProcessor.traceId());
+    assertThat(spanProcessor.traceId()).isEqualTo(spanOutput.traceId());
+    assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
+    assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "false");
+
+    streams.close();
+    streams.cleanUp();
+  }
+
+  @Test
+  public void should_create_spans_from_stream_with_tracing_mark_filter_predicate_true() throws Exception {
+    String inputTopic = testName.getMethodName() + "-input";
+    String outputTopic = testName.getMethodName() + "-output";
+
+    StreamsBuilder builder = new StreamsBuilder();
+    builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+        .transformValues(kafkaStreamsTracing.markFilter("filter-1", (key, value) -> true))
+        .filterNot((k, v) -> Objects.isNull(v))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+    Topology topology = builder.build();
+
+    KafkaStreams streams = buildKafkaStreams(topology);
+
+    producer = createProducer();
+    producer.send(new ProducerRecord<>(inputTopic, TEST_KEY, TEST_VALUE)).get();
+
+    waitForStreamToRun(streams);
+
+    // the filter transformer returns true so record is not dropped
+    Span spanInput = takeSpan(), spanProcessor = takeSpan(), spanOutput = takeSpan();
+
+    assertThat(spanInput.kind().name()).isEqualTo(brave.Span.Kind.CONSUMER.name());
+    assertThat(spanInput.traceId()).isEqualTo(spanProcessor.traceId());
+    assertThat(spanProcessor.traceId()).isEqualTo(spanOutput.traceId());
+    assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
+    assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "false");
+
+    streams.close();
+    streams.cleanUp();
+  }
+
+  @Test
+  public void should_create_spans_from_stream_with_tracing_mark_filter_predicate_false() throws Exception {
+    String inputTopic = testName.getMethodName() + "-input";
+    String outputTopic = testName.getMethodName() + "-output";
+
+    StreamsBuilder builder = new StreamsBuilder();
+    builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+      .transformValues(kafkaStreamsTracing.markFilter("filter-2", (key, value) -> false))
+      .filterNot((k, v) -> Objects.isNull(v))
+      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+    Topology topology = builder.build();
+
+    KafkaStreams streams = buildKafkaStreams(topology);
+
+    producer = createProducer();
+    producer.send(new ProducerRecord<>(inputTopic, TEST_KEY, TEST_VALUE)).get();
+
+    waitForStreamToRun(streams);
+
+    // the filter transformer returns false so record is dropped
+    Span spanInput = takeSpan(), spanProcessor = takeSpan();
+
+    assertThat(spanInput.kind().name()).isEqualTo(brave.Span.Kind.CONSUMER.name());
+    assertThat(spanInput.traceId()).isEqualTo(spanProcessor.traceId());
+    assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
+    assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "true");
+
+    streams.close();
+    streams.cleanUp();
+  }
+
+  @Test
+  public void should_create_spans_from_stream_with_tracing_mark_filter_not_predicate_true() throws Exception {
+    String inputTopic = testName.getMethodName() + "-input";
+    String outputTopic = testName.getMethodName() + "-output";
+
+    StreamsBuilder builder = new StreamsBuilder();
+    builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+        .transformValues(kafkaStreamsTracing.markFilterNot("filterNot-1", (key, value) -> true))
+        .filterNot((k, v) -> Objects.isNull(v))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+    Topology topology = builder.build();
+
+    KafkaStreams streams = buildKafkaStreams(topology);
+
+    producer = createProducer();
+    producer.send(new ProducerRecord<>(inputTopic, TEST_KEY, TEST_VALUE)).get();
+
+    waitForStreamToRun(streams);
+
+    // the filterNot transformer returns true so record is dropped
+    Span spanInput = takeSpan(), spanProcessor = takeSpan();
+
+    assertThat(spanInput.kind().name()).isEqualTo(brave.Span.Kind.CONSUMER.name());
+    assertThat(spanInput.traceId()).isEqualTo(spanProcessor.traceId());
+    assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
+    assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "true");
+
+    streams.close();
+    streams.cleanUp();
+  }
+
+  @Test
+  public void should_create_spans_from_stream_with_tracing_mark_filter_not_predicate_false() throws Exception {
+    String inputTopic = testName.getMethodName() + "-input";
+    String outputTopic = testName.getMethodName() + "-output";
+
+    StreamsBuilder builder = new StreamsBuilder();
+    builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+        .transformValues(kafkaStreamsTracing.markFilterNot("filterNot-2", (key, value) -> false))
+        .filterNot((k, v) -> Objects.isNull(v))
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 


### PR DESCRIPTION
Fixes #942 

Some Kafka Streams instrumented operations are implemented by using `Transformer` API that, **if followed by grouping or joining**, causes re-partitioning (new topic to store data with potentially new key).

Operations affected:
- `peek`
- `mark`

**Filter:**

`filter` and `filterNot` are a special case, as if they are changed to `ValueTransformerWithKey` will anyway emit a `KeyValue` with `value=null` downstream, breaking the filtering.

CC @jorgheymans 