### PR TITLE
Fixes broken logic around local root

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -183,30 +183,12 @@ public class Tracer {
    */
   public final Span joinSpan(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
-    if (!supportsJoin) return newChild(context);
-    int flags = InternalPropagation.instance.flags(context);
-    if (alwaysSampleLocal && (flags & FLAG_SAMPLED_LOCAL) != FLAG_SAMPLED_LOCAL) {
-      flags |= FLAG_SAMPLED_LOCAL;
+    long parentId = context.parentIdAsLong(), spanId = context.spanId();
+    if (!supportsJoin) {
+      parentId = context.spanId();
+      spanId = 0L;
     }
-    // If we are joining a trace, we are sharing IDs with the caller
-    // If the sampled flag was left unset, we need to make the decision here
-    if ((flags & FLAG_SAMPLED_SET) != FLAG_SAMPLED_SET) { // cheap check for not yet sampled
-      // then the caller didn't contribute data
-      flags = InternalPropagation.sampled(sampler.isSampled(context.traceId()), flags);
-    } else if ((flags & FLAG_SAMPLED) == FLAG_SAMPLED) {
-      // we are recording and contributing to the same span ID
-      flags = flags | FLAG_SHARED;
-    }
-    context = InternalPropagation.instance.newTraceContext(
-        flags | FLAG_LOCAL_ROOT,
-        context.traceIdHigh(),
-        context.traceId(),
-        context.spanId(), // local root
-        context.parentIdAsLong(),
-        context.spanId(),
-        context.extra()
-    );
-    return _toSpan(propagationFactory.decorate(context));
+    return _toSpan(decorateContext(context, parentId, spanId));
   }
 
   /**
@@ -218,62 +200,91 @@ public class Tracer {
    */
   public Span newChild(TraceContext parent) {
     if (parent == null) throw new NullPointerException("parent == null");
-    return _toSpan(nextContext(parent));
+    return _toSpan(decorateContext(parent, parent.spanId(), 0L));
   }
 
   TraceContext newRootContext() {
-    return nextContext(FLAG_LOCAL_ROOT, 0L, 0L, 0L, 0L, Collections.emptyList());
+    return decorateContext(0, 0L, 0L, 0L, 0L, 0L, Collections.emptyList());
   }
 
   /**
-   * Called by methods which can accept externally supplied parent trace contexts: Ex. {@link
+   * Decorates a context after backfilling any missing data such as span IDs or sampling state.
+   *
+   * <p>Called by methods which can accept externally supplied parent trace contexts: Ex. {@link
    * #newChild(TraceContext)} and {@link #startScopedSpanWithParent(String, TraceContext)}. This
    * implies the {@link TraceContext#localRootId()} could be zero, if the context was manually
    * created.
    */
-  TraceContext nextContext(TraceContext parent) {
-    return nextContext(
-        InternalPropagation.instance.flags(parent),
-        parent.traceIdHigh(),
-        parent.traceId(),
-        parent.localRootId(),
-        parent.spanId(),
-        parent.extra()
+  TraceContext decorateContext(TraceContext parent, long parentId, long spanId) {
+    int flags = InternalPropagation.instance.flags(parent);
+    if (spanId != 0L) flags |= FLAG_SHARED;
+    return decorateContext(
+      flags,
+      parent.traceIdHigh(),
+      parent.traceId(),
+      parent.localRootId(),
+      parentId,
+      spanId,
+      parent.extra()
     );
   }
 
-  TraceContext nextContext(
-      int flags,
-      long traceIdHigh,
-      long traceId,
-      long localRootId,
-      long parentId,
-      List<Object> extra
+  /**
+   * Decorates a context after backfilling any missing data such as span IDs or sampling state.
+   *
+   * <p>This primarily supports sampling use cases and ensures special cases such as "local root"
+   * and "shared" concepts are applied consistently. All parameters except span ID can be empty in
+   * the case of a new root span.
+   *
+   * @param flags any incoming flags from a parent context.
+   * @param traceIdHigh See {@link TraceContext#traceIdHigh()}
+   * @param traceId Zero is a new trace. Otherwise, {@link TraceContext#traceId()}.
+   * @param localRootId Zero is a new local root. Otherwise, {@link TraceContext#localRootId()}.
+   * @param parentId Same as {@link TraceContext#parentIdAsLong()}.
+   * @param spanId When non-zero this is a shared span. See {@link TraceContext#spanId()}.
+   * @param extra Any incoming {@link TraceContext#extra() extra fields}.
+   * @return a decorated, sampled context with local root information applied.
+   */
+  TraceContext decorateContext(
+    int flags,
+    long traceIdHigh,
+    long traceId,
+    long localRootId,
+    long parentId,
+    long spanId,
+    List<Object> extra
   ) {
     if (alwaysSampleLocal && (flags & FLAG_SAMPLED_LOCAL) != FLAG_SAMPLED_LOCAL) {
       flags |= FLAG_SAMPLED_LOCAL;
     }
-    long nextId = nextId();
+
+    if (spanId == 0L) spanId = nextId();
+
     if (traceId == 0L) { // make a new trace ID
       traceIdHigh = traceId128Bit ? Platform.get().nextTraceIdHigh() : 0L;
-      traceId = nextId;
-    } else { // child of an existing span. ensure the shared flag is unset
-      flags &= ~(FLAG_SHARED | FLAG_LOCAL_ROOT);
+      traceId = spanId;
     }
-    long spanId = nextId;
+
     if ((flags & FLAG_SAMPLED_SET) != FLAG_SAMPLED_SET) { // cheap check for not yet sampled
       flags = InternalPropagation.sampled(sampler.isSampled(traceId), flags);
+      flags &= ~FLAG_SHARED; // cannot be shared if not yet sampled
     }
+
     // Zero when root or an externally managed context was passed to newChild or scopedWithParent
-    if (localRootId == 0L) localRootId = spanId;
+    if (localRootId == 0L) {
+      localRootId = spanId;
+      flags |= FLAG_LOCAL_ROOT;
+    } else {
+      flags &= ~FLAG_LOCAL_ROOT;
+    }
     return propagationFactory.decorate(InternalPropagation.instance.newTraceContext(
-        flags,
-        traceIdHigh,
-        traceId,
-        localRootId,
-        parentId,
-        spanId,
-        extra
+      flags,
+      traceIdHigh,
+      traceId,
+      localRootId,
+      parentId,
+      spanId,
+      extra
     ));
   }
 
@@ -312,13 +323,14 @@ public class Tracer {
 
     TraceIdContext traceIdContext = extracted.traceIdContext();
     if (traceIdContext != null) {
-      return _toSpan(nextContext(
-          InternalPropagation.instance.flags(extracted.traceIdContext()),
-          traceIdContext.traceIdHigh(),
-          traceIdContext.traceId(),
-          0L,
-          0L,
-          extracted.extra()
+      return _toSpan(decorateContext(
+        InternalPropagation.instance.flags(extracted.traceIdContext()),
+        traceIdContext.traceIdHigh(),
+        traceIdContext.traceId(),
+        0L,
+        0L,
+        0L,
+        extracted.extra()
       ));
     }
 
@@ -340,24 +352,24 @@ public class Tracer {
     } else {
       flags = InternalPropagation.instance.flags(samplingFlags);
     }
-    return _toSpan(nextContext(flags, traceIdHigh, traceId, localRootId, spanId, extra));
+    return _toSpan(decorateContext(flags, traceIdHigh, traceId, localRootId, spanId, 0L, extra));
   }
 
   /** Converts the context to a Span object after decorating it for propagation */
   public Span toSpan(TraceContext context) {
-    return _toSpan(decorateExternal(context));
-  }
-
-  TraceContext decorateExternal(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
-    if (alwaysSampleLocal) {
-      int flags = InternalPropagation.instance.flags(context);
-      if ((flags & FLAG_SAMPLED_LOCAL) != FLAG_SAMPLED_LOCAL) {
-        context = InternalPropagation.instance.withFlags(context, flags | FLAG_SAMPLED_LOCAL);
-      }
+    if (isDecorated(context)) {
+      return _toSpan(decorateContext(
+        InternalPropagation.instance.flags(context),
+        context.traceIdHigh(),
+        context.traceId(),
+        context.localRootId(),
+        context.parentIdAsLong(),
+        context.spanId(),
+        context.extra()
+      ));
     }
-    // decorating here addresses join, new traces or children and ad-hoc trace contexts
-    return propagationFactory.decorate(context);
+    return _toSpan(context);
   }
 
   Span _toSpan(TraceContext decorated) {
@@ -437,14 +449,16 @@ public class Tracer {
    * will never return null.
    */
   @Nullable public Span currentSpan() {
-    TraceContext currentContext = currentTraceContext.get();
-    if (currentContext == null) return null;
-    TraceContext decorated = decorateExternal(currentContext);
-    if (isNoop(decorated)) return new NoopSpan(decorated);
+    TraceContext context = currentTraceContext.get();
+    if (context == null) return null;
+    if (isDecorated(context)) { // It wasn't initialized by our tracer, so we must decorate.
+      context = decorateContext(context, context.parentIdAsLong(), context.spanId());
+    }
+    if (isNoop(context)) return new NoopSpan(context);
 
     // Returns a lazy span to reduce overhead when tracer.currentSpan() is invoked just to see if
     // one exists, or when the result is never used.
-    return new LazySpan(this, decorated);
+    return new LazySpan(this, context);
   }
 
   /**
@@ -490,7 +504,8 @@ public class Tracer {
   public ScopedSpan startScopedSpanWithParent(String name, @Nullable TraceContext parent) {
     if (name == null) throw new NullPointerException("name == null");
     if (parent == null) parent = currentTraceContext.get();
-    TraceContext context = parent != null ? nextContext(parent) : newRootContext();
+    TraceContext context =
+      parent != null ? decorateContext(parent, parent.spanId(), 0L) : newRootContext();
 
     Scope scope = currentTraceContext.newScope(context);
     if (isNoop(context)) return new NoopScopedSpan(context, scope);
@@ -536,6 +551,15 @@ public class Tracer {
     int flags = InternalPropagation.instance.flags(context);
     if ((flags & FLAG_SAMPLED_LOCAL) == FLAG_SAMPLED_LOCAL) return false;
     return (flags & FLAG_SAMPLED) != FLAG_SAMPLED;
+  }
+
+  /**
+   * To save overhead, we shouldn't re-decorate a context on operations such as {@link
+   * #toSpan(TraceContext)} or {@link #currentSpan()}. As the {@link TraceContext#localRootId()} can
+   * only be set internally, we use this as a signal that we've already decorated.
+   */
+  static boolean isDecorated(TraceContext context) {
+    return context.localRootId() == 0L;
   }
 
   /** Generates a new 64-bit ID, taking care to dodge zero which can be confused with absent */

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -360,18 +360,17 @@ public class Tracer {
   /** Converts the context to a Span object after decorating it for propagation */
   public Span toSpan(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
-    if (isDecorated(context)) {
-      return _toSpan(decorateContext(
-        InternalPropagation.instance.flags(context),
-        context.traceIdHigh(),
-        context.traceId(),
-        context.localRootId(),
-        context.parentIdAsLong(),
-        context.spanId(),
-        context.extra()
-      ));
-    }
-    return _toSpan(context);
+    if (isDecorated(context)) return _toSpan(context);
+
+    return _toSpan(decorateContext(
+      InternalPropagation.instance.flags(context),
+      context.traceIdHigh(),
+      context.traceId(),
+      context.localRootId(),
+      context.parentIdAsLong(),
+      context.spanId(),
+      context.extra()
+    ));
   }
 
   Span _toSpan(TraceContext decorated) {
@@ -453,7 +452,7 @@ public class Tracer {
   @Nullable public Span currentSpan() {
     TraceContext context = currentTraceContext.get();
     if (context == null) return null;
-    if (isDecorated(context)) { // It wasn't initialized by our tracer, so we must decorate.
+    if (!isDecorated(context)) { // It wasn't initialized by our tracer, so we must decorate.
       context = decorateContext(context, context.parentIdAsLong(), context.spanId());
     }
     if (isNoop(context)) return new NoopSpan(context);
@@ -561,7 +560,7 @@ public class Tracer {
    * only be set internally, we use this as a signal that we've already decorated.
    */
   static boolean isDecorated(TraceContext context) {
-    return context.localRootId() == 0L;
+    return context.localRootId() != 0L;
   }
 
   /** Generates a new 64-bit ID, taking care to dodge zero which can be confused with absent */

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -230,11 +230,13 @@ public class Tracer {
   }
 
   /**
-   * Decorates a context after backfilling any missing data such as span IDs or sampling state.
+   * Creates a trace context object holding the below fields. When fields such as span ID are
+   * absent, they will be backfilled. Then, any missing state managed by the tracer are applied,
+   * such as the "local root". Finally, decoration hooks apply to ensure any propagation state are
+   * added to the "extra" section of the result. This supports functionality like extra field
+   * propagation.
    *
-   * <p>This primarily supports sampling use cases and ensures special cases such as "local root"
-   * and "shared" concepts are applied consistently. All parameters except span ID can be empty in
-   * the case of a new root span.
+   * <p>All parameters except span ID can be empty in the case of a new root span.
    *
    * @param flags any incoming flags from a parent context.
    * @param traceIdHigh See {@link TraceContext#traceIdHigh()}

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -219,13 +219,13 @@ public class Tracer {
     int flags = InternalPropagation.instance.flags(parent);
     if (spanId != 0L) flags |= FLAG_SHARED;
     return decorateContext(
-      flags,
-      parent.traceIdHigh(),
-      parent.traceId(),
-      parent.localRootId(),
-      parentId,
-      spanId,
-      parent.extra()
+        flags,
+        parent.traceIdHigh(),
+        parent.traceId(),
+        parent.localRootId(),
+        parentId,
+        spanId,
+        parent.extra()
     );
   }
 
@@ -246,13 +246,13 @@ public class Tracer {
    * @return a decorated, sampled context with local root information applied.
    */
   TraceContext decorateContext(
-    int flags,
-    long traceIdHigh,
-    long traceId,
-    long localRootId,
-    long parentId,
-    long spanId,
-    List<Object> extra
+      int flags,
+      long traceIdHigh,
+      long traceId,
+      long localRootId,
+      long parentId,
+      long spanId,
+      List<Object> extra
   ) {
     if (alwaysSampleLocal && (flags & FLAG_SAMPLED_LOCAL) != FLAG_SAMPLED_LOCAL) {
       flags |= FLAG_SAMPLED_LOCAL;
@@ -278,13 +278,13 @@ public class Tracer {
       flags &= ~FLAG_LOCAL_ROOT;
     }
     return propagationFactory.decorate(InternalPropagation.instance.newTraceContext(
-      flags,
-      traceIdHigh,
-      traceId,
-      localRootId,
-      parentId,
-      spanId,
-      extra
+        flags,
+        traceIdHigh,
+        traceId,
+        localRootId,
+        parentId,
+        spanId,
+        extra
     ));
   }
 
@@ -324,13 +324,13 @@ public class Tracer {
     TraceIdContext traceIdContext = extracted.traceIdContext();
     if (traceIdContext != null) {
       return _toSpan(decorateContext(
-        InternalPropagation.instance.flags(extracted.traceIdContext()),
-        traceIdContext.traceIdHigh(),
-        traceIdContext.traceId(),
-        0L,
-        0L,
-        0L,
-        extracted.extra()
+          InternalPropagation.instance.flags(extracted.traceIdContext()),
+          traceIdContext.traceIdHigh(),
+          traceIdContext.traceId(),
+          0L,
+          0L,
+          0L,
+          extracted.extra()
       ));
     }
 

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -112,6 +112,9 @@ public final class TraceContext extends SamplingFlags {
    *
    * <p>This does not group together multiple points of entry in the same trace. For example,
    * repetitive consumption of the same incoming message results in different local roots.
+   *
+   * @return the {@link #spanId() span ID} of the local root or zero if this context wasn't
+   * initialized by a {@link brave.Tracer}.
    */
   // This is the first span ID that became a Span or ScopedSpan
   public long localRootId() {

--- a/brave/src/test/java/brave/LazySpanTest.java
+++ b/brave/src/test/java/brave/LazySpanTest.java
@@ -30,8 +30,8 @@ public class LazySpanTest {
     .spanReporter(spans::add)
     .build();
 
-  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
-  TraceContext context2 = TraceContext.newBuilder().traceId(1L).spanId(2L).sampled(true).build();
+  TraceContext context = tracing.tracer().newTrace().context();
+  TraceContext context2 = tracing.tracer().newTrace().context();
 
   @After public void close() {
     tracing.close();

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -33,8 +33,8 @@ public class RealSpanTest {
     .spanReporter(spans::add)
     .build();
 
-  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
-  TraceContext context2 = TraceContext.newBuilder().traceId(1L).spanId(2L).sampled(true).build();
+  TraceContext context = tracing.tracer().newTrace().context();
+  TraceContext context2 = tracing.tracer().newTrace().context();
 
   Span span = tracing.tracer().newTrace();
 

--- a/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
+++ b/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
@@ -73,8 +73,7 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
       assertThat(fields1).isSameAs(fields2);
 
       // we no longer have the same span ID, so we should decouple our extra fields
-      TraceContext context3 =
-          tracing.tracer().toSpan(context1.toBuilder().spanId(1L).build()).context();
+      TraceContext context3 = tracing.tracer().newChild(context1).context();
       PropagationFields fields3 = (PropagationFields) context3.extra().get(0);
 
       // we have different instances of extra


### PR DESCRIPTION
This fixes various places where local root was improperly reported.

We didn't have enough tests to cover the fields around local root. This
finishes work from @lambcode and sorts out logic by centralizing how we
initialize potentially unmanaged trace contexts.

See #944