### PR TITLE
Kafka Streams: Propagate context between stream operations

### DIFF
--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/BaseTracingTest.java
@@ -14,7 +14,11 @@
 package brave.kafka.clients;
 
 import brave.Tracing;
+import brave.internal.PropagationFieldsFactory;
+import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.Propagation;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.google.common.base.Charsets;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsPropagation.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsPropagation.java
@@ -14,6 +14,7 @@
 package brave.kafka.streams;
 
 import brave.propagation.Propagation.Getter;
+import brave.propagation.Propagation.Setter;
 import java.nio.charset.Charset;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -26,6 +27,11 @@ final class KafkaStreamsPropagation {
     Header header = carrier.lastHeader(key);
     if (header == null) return null;
     return new String(header.value(), UTF_8);
+  };
+
+  static final Setter<Headers, String> SETTER = (carrier, key, value) -> {
+    carrier.remove(key);
+    carrier.add(key, value.getBytes(UTF_8));
   };
 
   KafkaStreamsPropagation() {

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -47,10 +47,12 @@ public final class KafkaStreamsTracing {
 
   final Tracing tracing;
   final TraceContext.Extractor<Headers> extractor;
+  final TraceContext.Injector<Headers> injector;
 
   KafkaStreamsTracing(Builder builder) { // intentionally hidden constructor
     this.tracing = builder.tracing;
     this.extractor = tracing.propagation().extractor(KafkaStreamsPropagation.GETTER);
+    this.injector = tracing.propagation().injector(KafkaStreamsPropagation.SETTER);
   }
 
   public static KafkaStreamsTracing create(Tracing tracing) {

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingProcessor.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingProcessor.java
@@ -51,6 +51,7 @@ class TracingProcessor<K, V> implements Processor<K, V> {
 
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
       delegateProcessor.process(k, v);
+      kafkaStreamsTracing.injector.inject(span.context(), processorContext.headers());
     } catch (RuntimeException | Error e) {
       span.error(e); // finish as an exception means the callback won't finish the span
       throw e;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingTransformer.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingTransformer.java
@@ -50,7 +50,9 @@ class TracingTransformer<K, V, R> implements Transformer<K, V, R> {
     }
 
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-      return delegateTransformer.transform(k, v);
+      R transform = delegateTransformer.transform(k, v);
+      kafkaStreamsTracing.injector.inject(span.context(), processorContext.headers());
+      return transform;
     } catch (RuntimeException | Error e) {
       span.error(e); // finish as an exception means the callback won't finish the span
       throw e;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformer.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformer.java
@@ -50,7 +50,9 @@ class TracingValueTransformer<V, VR> implements ValueTransformer<V, VR> {
     }
 
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-      return delegateTransformer.transform(v);
+      VR transform = delegateTransformer.transform(v);
+      kafkaStreamsTracing.injector.inject(span.context(), processorContext.headers());
+      return transform;
     } catch (RuntimeException | Error e) {
       span.error(e); // finish as an exception means the callback won't finish the span
       throw e;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformerWithKey.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformerWithKey.java
@@ -50,7 +50,9 @@ class TracingValueTransformerWithKey<K, V, VR> implements ValueTransformerWithKe
     }
 
     try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-      return delegateTransformer.transform(k, v);
+      VR transform = delegateTransformer.transform(k, v);
+      kafkaStreamsTracing.injector.inject(span.context(), processorContext.headers());
+      return transform;
     } catch (RuntimeException | Error e) {
       span.error(e); // finish as an exception means the callback won't finish the span
       throw e;

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -15,6 +15,8 @@ package brave.kafka.streams;
 
 import brave.Tracing;
 import brave.kafka.clients.KafkaTracing;
+import brave.propagation.B3Propagation;
+import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
@@ -90,6 +92,8 @@ public class ITKafkaStreamsTracing {
       .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
           .addScopeDecorator(StrictScopeDecorator.create())
           .build())
+      .propagationFactory(
+          ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "user-id"))
       .spanReporter(spans::add)
       .build();
   KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.create(tracing);
@@ -224,14 +228,15 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_filter_predicate_true() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_filter_predicate_true()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-      .transform(kafkaStreamsTracing.filter("filter-1", (key, value) -> true))
-      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        .transform(kafkaStreamsTracing.filter("filter-1", (key, value) -> true))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -255,14 +260,15 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_filter_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_filter_predicate_false()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-      .transform(kafkaStreamsTracing.filter("filter-2", (key, value) -> false))
-      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        .transform(kafkaStreamsTracing.filter("filter-2", (key, value) -> false))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -285,14 +291,60 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_filter_not_predicate_true() throws Exception {
+  public void should_create_spans_and_propagate_extra_from_stream_with_multi_processor()
+      throws Exception {
+    String inputTopic = testName.getMethodName() + "-input";
+    String outputTopic = testName.getMethodName() + "-output";
+
+    StreamsBuilder builder = new StreamsBuilder();
+    Transformer<String, String, KeyValue<String, String>> transformer =
+        new Transformer<String, String, KeyValue<String, String>>() {
+          @Override public void init(ProcessorContext processorContext) {
+          }
+
+          @Override
+          public KeyValue<String, String> transform(String k, String v) {
+            String userId =
+                ExtraFieldPropagation.get(tracing.tracer().currentSpan().context(), "user-id");
+            assertThat(userId).isEqualTo("user1");
+            return KeyValue.pair(k, v);
+          }
+
+          @Override public void close() {
+          }
+        };
+
+    builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+        .transform(kafkaStreamsTracing.transformer("transform1", transformer))
+        .transform(kafkaStreamsTracing.transformer("transform2", transformer))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+    Topology topology = builder.build();
+
+    KafkaStreams streams = buildKafkaStreams(topology);
+
+    producer = createProducer();
+    ProducerRecord<String, String> record = new ProducerRecord<>(inputTopic, TEST_KEY, TEST_VALUE);
+    record.headers().add("user-id", "user1".getBytes());
+    producer.send(record).get();
+
+    waitForStreamToRun(streams);
+
+    Span spanInput = takeSpan(), spanTransform1 = takeSpan(), spanTransform2 = takeSpan(), spanOutput = takeSpan();
+
+    streams.close();
+    streams.cleanUp();
+  }
+
+  @Test
+  public void should_create_spans_from_stream_with_tracing_filter_not_predicate_true()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-      .transform(kafkaStreamsTracing.filterNot("filterNot-1", (key, value) -> true))
-      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        .transform(kafkaStreamsTracing.filterNot("filterNot-1", (key, value) -> true))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -315,14 +367,15 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_filter_not_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_filter_not_predicate_false()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-      .transform(kafkaStreamsTracing.filterNot("filterNot-2", (key, value) -> false))
-      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        .transform(kafkaStreamsTracing.filterNot("filterNot-2", (key, value) -> false))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -346,7 +399,8 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_as_filtered_predicate_true() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_filtered_predicate_true()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
@@ -378,15 +432,16 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_as_filtered_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_filtered_predicate_false()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-      .transformValues(kafkaStreamsTracing.markAsFiltered("filter-2", (key, value) -> false))
-      .filterNot((k, v) -> Objects.isNull(v))
-      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        .transformValues(kafkaStreamsTracing.markAsFiltered("filter-2", (key, value) -> false))
+        .filterNot((k, v) -> Objects.isNull(v))
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
 
     KafkaStreams streams = buildKafkaStreams(topology);
@@ -409,7 +464,8 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_as_not_filtered_predicate_true() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_not_filtered_predicate_true()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
@@ -440,13 +496,15 @@ public class ITKafkaStreamsTracing {
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_mark_as_not_filtered_predicate_false() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_mark_as_not_filtered_predicate_false()
+      throws Exception {
     String inputTopic = testName.getMethodName() + "-input";
     String outputTopic = testName.getMethodName() + "-output";
 
     StreamsBuilder builder = new StreamsBuilder();
     builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
-        .transformValues(kafkaStreamsTracing.markAsNotFiltered("filterNot-2", (key, value) -> false))
+        .transformValues(
+            kafkaStreamsTracing.markAsNotFiltered("filterNot-2", (key, value) -> false))
         .filterNot((k, v) -> Objects.isNull(v))
         .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
     Topology topology = builder.build();
@@ -605,7 +663,8 @@ public class ITKafkaStreamsTracing {
     Span spanProcessor = takeSpan();
 
     assertThat(spanProcessor.tags().size()).isEqualTo(2);
-    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id", "kafka.streams.task.id");
+    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id",
+        "kafka.streams.task.id");
 
     streams.close();
     streams.cleanUp();
@@ -688,7 +747,7 @@ public class ITKafkaStreamsTracing {
                 } catch (InterruptedException e) {
                   e.printStackTrace();
                 }
-                return Arrays.asList(KeyValue.pair(key, value), KeyValue.pair(key,value));
+                return Arrays.asList(KeyValue.pair(key, value), KeyValue.pair(key, value));
               }
 
               @Override
@@ -719,7 +778,8 @@ public class ITKafkaStreamsTracing {
 
     assertThat(inputSpan.parentId()).isNull();
     assertThat(spanProcessor.tags().size()).isEqualTo(2);
-    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id", "kafka.streams.task.id");
+    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id",
+        "kafka.streams.task.id");
     assertThat(spanProcessor.traceId()).isEqualTo(inputSpan.traceId());
     assertThat(outputSpan1.traceId()).isEqualTo(spanProcessor.traceId());
     assertThat(outputSpan2.traceId()).isEqualTo(spanProcessor.traceId());
@@ -776,7 +836,8 @@ public class ITKafkaStreamsTracing {
     Span spanProcessor = takeSpan();
 
     assertThat(spanProcessor.tags().size()).isEqualTo(2);
-    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id", "kafka.streams.task.id");
+    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id",
+        "kafka.streams.task.id");
 
     streams.close();
     streams.cleanUp();
@@ -997,14 +1058,16 @@ public class ITKafkaStreamsTracing {
     Span spanProcessor = takeSpan();
 
     assertThat(spanProcessor.tags().size()).isEqualTo(2);
-    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id", "kafka.streams.task.id");
+    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id",
+        "kafka.streams.task.id");
 
     streams.close();
     streams.cleanUp();
   }
 
   @Test
-  public void should_create_spans_from_stream_with_tracing_valueTransformerWithKey() throws Exception {
+  public void should_create_spans_from_stream_with_tracing_valueTransformerWithKey()
+      throws Exception {
     ValueTransformerWithKeySupplier<String, String, String> transformerSupplier =
         kafkaStreamsTracing.valueTransformerWithKey(
             "transformer-1",
@@ -1107,7 +1170,8 @@ public class ITKafkaStreamsTracing {
     Span spanProcessor = takeSpan();
 
     assertThat(spanProcessor.tags().size()).isEqualTo(2);
-    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id", "kafka.streams.task.id");
+    assertThat(spanProcessor.tags()).containsKeys("kafka.streams.application.id",
+        "kafka.streams.task.id");
 
     streams.close();
     streams.cleanUp();

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -322,6 +322,13 @@ public class ITKafkaStreamsTracing {
 
     Span spanInput = takeSpan(), spanTransform1 = takeSpan(), spanTransform2 = takeSpan(), spanOutput = takeSpan();
 
+    assertThat(spanInput.traceId()).isEqualTo(spanOutput.traceId());
+    assertThat(spanInput.traceId()).isEqualTo(spanTransform1.traceId());
+    assertThat(spanInput.traceId()).isEqualTo(spanTransform2.traceId());
+    assertThat(spanInput.id()).isEqualTo(spanTransform1.parentId());
+    assertThat(spanTransform1.id()).isEqualTo(spanTransform2.parentId());
+    assertThat(spanTransform2.id()).isEqualTo(spanOutput.parentId());
+
     streams.close();
     streams.cleanUp();
   }


### PR DESCRIPTION
Fix #956 

Current implementation is treating each stream operation as a child of the span created at initial consumption.

This leads to issues like #956, as there is no propagation between stream operations.

This PR fix this by injecting context before leaving each operation.