### PR TITLE
Tightens up code and tests around FinishedSpanHandler prior to updates

### DIFF
--- a/brave/src/main/java/brave/internal/handler/FinishedSpanHandlers.java
+++ b/brave/src/main/java/brave/internal/handler/FinishedSpanHandlers.java
@@ -17,45 +17,37 @@ import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.internal.Platform;
 import brave.propagation.TraceContext;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class FinishedSpanHandlers {
-  public static FinishedSpanHandler compose(List<FinishedSpanHandler> finishedSpanHandlers) {
-    if (finishedSpanHandlers == null) {
-      throw new NullPointerException("finishedSpanHandlers == null");
+  public static FinishedSpanHandler compose(Set<FinishedSpanHandler> finishedSpanHandlers) {
+    if (finishedSpanHandlers.size() < 2) throw new IllegalArgumentException("don't compose < 2");
+    int i = 0;
+    boolean alwaysSampleLocal = false;
+    FinishedSpanHandler[] copy = new FinishedSpanHandler[finishedSpanHandlers.size()];
+    for (FinishedSpanHandler finishedSpanHandler : finishedSpanHandlers) {
+      if (finishedSpanHandler.alwaysSampleLocal()) alwaysSampleLocal = true;
+      copy[i++] = finishedSpanHandler;
     }
-    int length = finishedSpanHandlers.size();
-    if (length == 0) return FinishedSpanHandler.NOOP;
-
-    // This composes by nesting to keep code small and avoid allocating iterators at handle() time
-    FinishedSpanHandler result = FinishedSpanHandler.NOOP;
-    for (int i = 0; i < length; i++) {
-      FinishedSpanHandler next = finishedSpanHandlers.get(i);
-      if (next == FinishedSpanHandler.NOOP) continue;
-      if (result == FinishedSpanHandler.NOOP) {
-        result = next;
-        continue;
-      }
-      result = new CompositeFinishedSpanHandler(result, next);
-    }
-    return result;
+    return new CompositeFinishedSpanHandler(copy, alwaysSampleLocal);
   }
 
   /**
    * When {@code noop}, this drops input spans by returning false. Otherwise, it logs exceptions
-   * instead of raising an error, as the supplied firehoseHandler could have bugs.
+   * instead of raising an error, as the supplied handler could have bugs.
    */
   public static FinishedSpanHandler noopAware(FinishedSpanHandler handler, AtomicBoolean noop) {
     if (handler == FinishedSpanHandler.NOOP) return handler;
-    return new NoopAwareFinishedSpan(handler, noop);
+    return new NoopAwareFinishedSpanHandler(handler, noop);
   }
 
-  static final class NoopAwareFinishedSpan extends FinishedSpanHandler {
+  static final class NoopAwareFinishedSpanHandler extends FinishedSpanHandler {
     final FinishedSpanHandler delegate;
     final AtomicBoolean noop;
 
-    NoopAwareFinishedSpan(FinishedSpanHandler delegate, AtomicBoolean noop) {
+    NoopAwareFinishedSpanHandler(FinishedSpanHandler delegate, AtomicBoolean noop) {
       if (delegate == null) throw new NullPointerException("delegate == null");
       this.delegate = delegate;
       this.noop = noop;
@@ -81,17 +73,19 @@ public final class FinishedSpanHandlers {
   }
 
   static final class CompositeFinishedSpanHandler extends FinishedSpanHandler {
-    final FinishedSpanHandler first, second;
+    final FinishedSpanHandler[] handlers; // Array ensures no iterators are created at runtime
     final boolean alwaysSampleLocal;
 
-    CompositeFinishedSpanHandler(FinishedSpanHandler first, FinishedSpanHandler second) {
-      this.first = first;
-      this.second = second;
-      this.alwaysSampleLocal = first.alwaysSampleLocal() || second.alwaysSampleLocal();
+    CompositeFinishedSpanHandler(FinishedSpanHandler[] handlers, boolean alwaysSampleLocal) {
+      this.handlers = handlers;
+      this.alwaysSampleLocal = alwaysSampleLocal;
     }
 
     @Override public boolean handle(TraceContext context, MutableSpan span) {
-      return first.handle(context, span) && second.handle(context, span);
+      for (FinishedSpanHandler handler : handlers) {
+        if (!handler.handle(context, span)) return false;
+      }
+      return true;
     }
 
     @Override public boolean alwaysSampleLocal() {
@@ -99,15 +93,7 @@ public final class FinishedSpanHandlers {
     }
 
     @Override public String toString() {
-      StringBuilder result = new StringBuilder();
-      CompositeFinishedSpanHandler sequential = this;
-      result.append(",").append(sequential.second);
-      while (sequential.first instanceof CompositeFinishedSpanHandler) {
-        sequential = (CompositeFinishedSpanHandler) sequential.first;
-        result.insert(0, ",").insert(1, sequential.second);
-      }
-      result.insert(0, sequential.first);
-      return result.insert(0, "CompositeFinishedSpanHandler(").append(")").toString();
+      return "CompositeFinishedSpanHandler(" + Arrays.toString(handlers) + ")";
     }
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/internal/handler/FinishedSpanHandlersBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/handler/FinishedSpanHandlersBenchmarks.java
@@ -16,6 +16,7 @@ package brave.internal.handler;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -74,7 +75,8 @@ public class FinishedSpanHandlersBenchmarks {
     }
   };
 
-  final FinishedSpanHandler composite = FinishedSpanHandlers.compose(asList(one, two, three));
+  final FinishedSpanHandler composite =
+    FinishedSpanHandlers.compose(new LinkedHashSet<>(asList(one, two, three)));
   final FinishedSpanHandler listIndexComposite = new FinishedSpanHandler() {
     List<FinishedSpanHandler> delegates = asList(one, two, three);
 

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -136,8 +136,8 @@ public class TracingFactoryBeanTest {
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
-      .extracting("tracer.finishedSpanHandler.delegate.first")
-      .isEqualTo(FIREHOSE_HANDLER);
+      .extracting("tracer.finishedSpanHandler.delegate.handlers")
+      .satisfies(a -> assertThat((FinishedSpanHandler[]) a).startsWith(FIREHOSE_HANDLER));
   }
 
   @Test public void clock() {


### PR DESCRIPTION
We will soon add features that use FinishedSpanHandler. This tightens up
code around it so that it is more stable when multiple handlers exist.