### PR TITLE
Update TracingFilter.java to solve a thread-safe problem

### DIFF
--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -46,6 +46,7 @@ public final class TracingFilter implements Filter {
   Tracer tracer;
   TraceContext.Extractor<Map<String, String>> extractor;
   TraceContext.Injector<Map<String, String>> injector;
+  volatile boolean isInit = false;
 
   /**
    * {@link ExtensionLoader} supplies the tracing implementation which must be named "tracing". For
@@ -56,11 +57,12 @@ public final class TracingFilter implements Filter {
     tracer = tracing.tracer();
     extractor = tracing.propagation().extractor(GETTER);
     injector = tracing.propagation().injector(SETTER);
+    isInit = true;
   }
 
   @Override
   public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-    if (tracer == null) return invoker.invoke(invocation);
+    if (isInit == false) return invoker.invoke(invocation);
 
     RpcContext rpcContext = RpcContext.getContext();
     Kind kind = rpcContext.isProviderSide() ? Kind.SERVER : Kind.CLIENT;


### PR DESCRIPTION
the code is not safe when executed in several threads simultaneously.for example, if "tracer" is null, now threadA execute "setTracing" method, and tracer is not null. but "extractor" and "injector" has not been initialized, just at that moment threadB come, threadB try to execute "invoke" method,because tracer is not null,threadB will go to 72 line or 74 line.because injector and extractor is null,the code will throw NullPointerException,and the code didn't return "invoker.invoke(invocation)".this will cause dubbo service not invoked.
so i use a volatile flag to solve this problem,and make the code thread-safe.