### PR TITLE
Adds debug logging to JMS call-sites that can fail provider specifically

### DIFF
--- a/instrumentation/jms/README.md
+++ b/instrumentation/jms/README.md
@@ -6,7 +6,9 @@ factories.
 Under the scenes:
 * `TracingMessageProducer` - completes a producer span per message and propagates it via headers.
 * `TracingMessageConsumer` - completes a consumer span on `receive`, resuming a trace in headers if present.
+  * The message returned has the current span encoded as the property "b3".
 * `TracingMessageListener` - does the same as `TracingMessageConsumer`, and times the user-supplied listener.
+  * The message passed to the listener has no "b3" header. Similar to a server, use `Tracer.currentSpan()`.
 
 
 ## Setup

--- a/instrumentation/jms/README.md
+++ b/instrumentation/jms/README.md
@@ -72,6 +72,10 @@ void process(Message message) {
 }
 ```
 
+## Troubleshooting
+If you have problems with a JMS provider, such as broken traces, please capture the "FINE" output of
+the Java logger: `brave.jms.JmsTracing` and ask on [gitter](https://gitter.im/openzipkin/zipkin).
+
 ## Notes
 * This instrumentation library works with JMS 1.1 and 2.0
 * More information about "Message Tracing" [here](https://github.com/openzipkin/openzipkin.github.io/blob/master/pages/instrumenting.md#message-tracing)

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageConsumer.java
@@ -48,12 +48,7 @@ final class TracingMessageConsumer extends TracingConsumer<MessageConsumer>
   }
 
   @Override Destination destination(Message message) {
-    try {
-      return message.getJMSDestination();
-    } catch (JMSException ignored) {
-      // don't crash on wonky exceptions!
-    }
-    return null;
+    return JmsTracing.destination(message);
   }
 
   @Override public String getMessageSelector() throws JMSException {

--- a/instrumentation/jms/src/test/java/brave/jms/ArtemisJmsTestRule.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ArtemisJmsTestRule.java
@@ -17,8 +17,8 @@ import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.jms.Connection;
 import javax.jms.JMSContext;
+import javax.jms.Message;
 import javax.jms.QueueConnection;
-import javax.jms.TextMessage;
 import javax.jms.TopicConnection;
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
@@ -61,7 +61,7 @@ class ArtemisJmsTestRule extends JmsTestRule {
     return factory.createTopicConnection();
   }
 
-  @Override void setReadOnlyProperties(TextMessage message, boolean readOnlyProperties)
+  @Override void setReadOnlyProperties(Message message, boolean readOnlyProperties)
     throws Exception {
     Field propertiesReadOnly = ActiveMQMessage.class.getDeclaredField("propertiesReadOnly");
     propertiesReadOnly.setAccessible(true);

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTestRule.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTestRule.java
@@ -13,9 +13,11 @@
  */
 package brave.jms;
 
+import javax.jms.BytesMessage;
 import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.QueueConnection;
 import javax.jms.QueueSession;
@@ -25,7 +27,7 @@ import javax.jms.Topic;
 import javax.jms.TopicConnection;
 import javax.jms.TopicSession;
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.activemq.command.ActiveMQMessage;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestName;
 
@@ -54,8 +56,13 @@ public abstract class JmsTestRule extends ExternalResource {
     return queueSession.createTextMessage(text);
   }
 
-  abstract void setReadOnlyProperties(TextMessage message, boolean readOnlyProperties)
-    throws Exception;
+  BytesMessage newBytesMessage(String text) throws JMSException {
+    BytesMessage message = queueSession.createBytesMessage();
+    message.writeUTF(text);
+    return message;
+  }
+
+  abstract void setReadOnlyProperties(Message message, boolean readOnlyProperties) throws Exception;
 
   abstract Connection newConnection() throws Exception;
 
@@ -120,8 +127,8 @@ public abstract class JmsTestRule extends ExternalResource {
         .createTopicConnection();
     }
 
-    @Override void setReadOnlyProperties(TextMessage message, boolean readOnlyProperties) {
-      ((ActiveMQTextMessage) message).setReadOnlyProperties(readOnlyProperties);
+    @Override void setReadOnlyProperties(Message message, boolean readOnlyProperties) {
+      ((ActiveMQMessage) message).setReadOnlyProperties(readOnlyProperties);
     }
   }
 }

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
@@ -29,6 +29,7 @@ import javax.jms.XATopicConnection;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.junit.Test;
 
+import static brave.jms.JmsTracing.SETTER;
 import static java.util.Arrays.asList;
 import static org.apache.activemq.command.ActiveMQDestination.QUEUE_TYPE;
 import static org.apache.activemq.command.ActiveMQDestination.createDestination;
@@ -187,7 +188,7 @@ public class JmsTracingTest extends JmsTest {
   }
 
   @Test public void nextSpan_prefers_b3_header() throws Exception {
-    message.setStringProperty("b3", "0000000000000001-0000000000000002-1");
+    SETTER.put(message, "b3", "0000000000000001-0000000000000002-1");
 
     Span child;
     try (Scope ws = tracing.currentTraceContext()
@@ -209,7 +210,7 @@ public class JmsTracingTest extends JmsTest {
   }
 
   @Test public void nextSpan_should_use_span_from_headers_as_parent() throws Exception {
-    message.setStringProperty("b3", "0000000000000001-0000000000000002-1");
+    SETTER.put(message, "b3", "0000000000000001-0000000000000002-1");
     Span span = jmsTracing.nextSpan(message);
 
     assertThat(span.context().parentId()).isEqualTo(2L);
@@ -234,7 +235,7 @@ public class JmsTracingTest extends JmsTest {
    * now, or later when dynamic policy is added to JmsTracing
    */
   @Test public void nextSpan_shouldnt_tag_queue_when_incoming_context() throws Exception {
-    message.setStringProperty("b3", "0000000000000001-0000000000000002-1");
+    SETTER.put(message, "b3", "0000000000000001-0000000000000002-1");
     message.setDestination(createDestination("foo", QUEUE_TYPE));
     jmsTracing.nextSpan(message).start().finish();
 

--- a/instrumentation/jms/src/test/java/brave/jms/TracingMessageListenerTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/TracingMessageListenerTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Test;
 import zipkin2.Span;
 
+import static brave.jms.JmsTracing.SETTER;
 import static org.apache.activemq.command.ActiveMQDestination.QUEUE_TYPE;
 import static org.apache.activemq.command.ActiveMQDestination.createDestination;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -140,7 +141,7 @@ public class TracingMessageListenerTest {
       new TracingMessageListener(delegate, jmsTracing, false);
 
     ActiveMQTextMessage message = new ActiveMQTextMessage();
-    message.setStringProperty("b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
+    SETTER.put(message, "b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
     message.setDestination(createDestination("foo", QUEUE_TYPE));
     onMessageConsumed(message);
 
@@ -177,10 +178,10 @@ public class TracingMessageListenerTest {
 
   @Test public void continues_parent_trace() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
-    message.setStringProperty("X-B3-TraceId", TRACE_ID);
-    message.setStringProperty("X-B3-SpanId", SPAN_ID);
-    message.setStringProperty("X-B3-ParentSpanId", PARENT_ID);
-    message.setStringProperty("X-B3-Sampled", SAMPLED);
+    SETTER.put(message, "X-B3-TraceId", TRACE_ID);
+    SETTER.put(message, "X-B3-SpanId", SPAN_ID);
+    SETTER.put(message, "X-B3-ParentSpanId", PARENT_ID);
+    SETTER.put(message, "X-B3-Sampled", SAMPLED);
 
     onMessageConsumed(message);
 
@@ -198,10 +199,10 @@ public class TracingMessageListenerTest {
       new TracingMessageListener(delegate, jmsTracing, false);
 
     ActiveMQTextMessage message = new ActiveMQTextMessage();
-    message.setStringProperty("X-B3-TraceId", TRACE_ID);
-    message.setStringProperty("X-B3-SpanId", SPAN_ID);
-    message.setStringProperty("X-B3-ParentSpanId", PARENT_ID);
-    message.setStringProperty("X-B3-Sampled", SAMPLED);
+    SETTER.put(message, "X-B3-TraceId", TRACE_ID);
+    SETTER.put(message, "X-B3-SpanId", SPAN_ID);
+    SETTER.put(message, "X-B3-ParentSpanId", PARENT_ID);
+    SETTER.put(message, "X-B3-Sampled", SAMPLED);
 
     onMessageConsumed(message);
 
@@ -215,7 +216,7 @@ public class TracingMessageListenerTest {
 
   @Test public void continues_parent_trace_single_header() throws Exception {
     ActiveMQTextMessage message = new ActiveMQTextMessage();
-    message.setStringProperty("b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
+    SETTER.put(message, "b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
 
     onMessageConsumed(message);
 
@@ -233,7 +234,7 @@ public class TracingMessageListenerTest {
       new TracingMessageListener(delegate, jmsTracing, false);
 
     ActiveMQTextMessage message = new ActiveMQTextMessage();
-    message.setStringProperty("b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
+    SETTER.put(message, "b3", TRACE_ID + "-" + SPAN_ID + "-" + SAMPLED);
 
     onMessageConsumed(message);
 


### PR DESCRIPTION
This adds FINE messages on all call sites where we invoke JMS commands
implicitly, for reasons of parsing or propagation.

This is to investigate a few recent concerns, notably about bytes message mentioned by @Liodene 