### PR TITLE
Refines test to show only one use-case fails with ActiveMQ BytesMessage

### DIFF
--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageProducer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageProducer.java
@@ -58,6 +58,9 @@ public class ITJms_1_1_TracingMessageProducer extends JmsTest {
   TopicPublisher topicPublisher;
   TopicSubscriber topicSubscriber;
 
+  TextMessage message;
+  BytesMessage bytesMessage;
+
   Map<String, String> existingProperties = Collections.singletonMap("tx", "1");
 
   JmsTestRule newJmsTestRule(TestName testName) {

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageConsumer.java
@@ -13,11 +13,17 @@
  */
 package brave.jms;
 
+import org.junit.Test;
 import org.junit.rules.TestName;
 
 /** When adding tests here, also add to {@linkplain brave.jms.ITTracingJMSConsumer} */
 public class ITJms_2_0_TracingMessageConsumer extends ITJms_1_1_TracingMessageConsumer {
   @Override JmsTestRule newJmsTestRule(TestName testName) {
     return new ArtemisJmsTestRule(testName);
+  }
+
+  // Inability to encode "b3" on a received BytesMessage only applies to ActiveMQ 5.x
+  @Test public void receive_resumesTrace_bytes() throws Exception {
+    receive_resumesTrace(() -> messageProducer.send(bytesMessage), messageConsumer);
   }
 }

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTest.java
@@ -23,10 +23,8 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.Message;
-import javax.jms.TextMessage;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -34,7 +32,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import zipkin2.Span;
 
-import static brave.jms.JmsTracing.SETTER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class JmsTest {
@@ -79,18 +76,6 @@ public abstract class JmsTest {
     .build();
   CurrentTraceContext current = tracing.currentTraceContext();
   JmsTracing jmsTracing = JmsTracing.create(tracing);
-  TextMessage message;
-  BytesMessage bytesMessage;
-
-  String resetMessageToHaveParentId(JmsTestRule jms) throws Exception {
-    String parentId = "463ac35c9f6413ad";
-    jms.setReadOnlyProperties(message, false);
-    jms.setReadOnlyProperties(bytesMessage, true);
-    SETTER.put(message, "b3", parentId + "-" + parentId + "-1");
-    SETTER.put(bytesMessage, "b3", parentId + "-" + parentId + "-1");
-    bytesMessage.reset();
-    return parentId;
-  }
 
   static Map<String, String> propertiesToMap(Message headers) throws Exception {
     Map<String, String> result = new LinkedHashMap<>();


### PR DESCRIPTION
MessageListener doesn't fail. What fails is receive. We want `receive()`
to return a message which includes a "b3" header for later processing.
When ActiveMQ 5.x BytesMessage, this fails due to a guard on writing a
message when in read-only mode.

See #967