### PR TITLE
Orphaned spans leak sensitive data

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -420,7 +420,7 @@ public abstract class Tracing implements Closeable {
         builder.clock,
         builder.propagationFactory,
         FinishedSpanHandlers.noopAware(finishedSpanHandler, noop),
-        new PendingSpans(clock, zipkinHandler, noop),
+        new PendingSpans(clock, finishedSpanHandler, noop),
         builder.sampler,
         builder.currentTraceContext,
         builder.traceId128Bit || propagationFactory.requires128BitTraceId(),


### PR DESCRIPTION
Found a bug where tags/annotations that are meant to be redacted could leak if the span is orphaned. I think the best way to fix this is to use the regular finishedSpanHandler when reporting orphaned spans. This pull request includes a unit test and the aforementioned fix.