### PR TITLE
Adds CurrentTraceContextCustomizer for flexible MDC integration

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -338,6 +338,7 @@ public abstract class Tracing implements Closeable {
      * overhead.
      *
      * @see TraceContext#sampledLocal()
+     * @since 5.4
      */
     public Builder addFinishedSpanHandler(FinishedSpanHandler finishedSpanHandler) {
       if (finishedSpanHandler == null) {

--- a/brave/src/main/java/brave/TracingCustomizer.java
+++ b/brave/src/main/java/brave/TracingCustomizer.java
@@ -14,6 +14,8 @@
 package brave;
 
 import brave.handler.FinishedSpanHandler;
+import brave.propagation.CurrentTraceContextCustomizer;
+import brave.propagation.ExtraFieldCustomizer;
 import zipkin2.reporter.Reporter;
 
 /**
@@ -36,6 +38,8 @@ import zipkin2.reporter.Reporter;
  *   <li><a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-autowired-annotation">Spring Autowired Collections</a></li>
  * </ul></pre>
  *
+ * @see CurrentTraceContextCustomizer
+ * @see ExtraFieldCustomizer
  * @since 5.7
  */
 public interface TracingCustomizer {

--- a/brave/src/main/java/brave/handler/FinishedSpanHandler.java
+++ b/brave/src/main/java/brave/handler/FinishedSpanHandler.java
@@ -28,6 +28,7 @@ import brave.propagation.TraceContext;
  * unsampled, this will still receive spans where {@link TraceContext#sampledLocal()} is true.
  *
  * @see #alwaysSampleLocal()
+ * @since 5.4
  */
 public abstract class FinishedSpanHandler {
   /** Use to avoid comparing against null references */
@@ -118,6 +119,8 @@ public abstract class FinishedSpanHandler {
    *
    * <p>The {@link MutableSpan} parameter {@link MutableSpan#containsAnnotation(String) includes
    * the annotation} "brave.flush", and whatever state was orphaned (ex a tag).
+   *
+   * @since 5.7
    */
   public boolean supportsOrphans() {
     return false;

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -46,7 +46,11 @@ public abstract class CurrentTraceContext {
   public abstract static class Builder {
     ArrayList<ScopeDecorator> scopeDecorators = new ArrayList<>();
 
-    /** Implementations call decorators in order to add features like log correlation to a scope. */
+    /**
+     * Implementations call decorators in order to add features like log correlation to a scope.
+     *
+     * @since 5.2
+     */
     public Builder addScopeDecorator(ScopeDecorator scopeDecorator) {
       if (scopeDecorator == null) throw new NullPointerException("scopeDecorator == null");
       this.scopeDecorators.add(scopeDecorator);
@@ -162,6 +166,8 @@ public abstract class CurrentTraceContext {
   /**
    * Use this to add features such as thread checks or log correlation fields when a scope is
    * created or closed.
+   *
+   * @since 5.2
    */
   public interface ScopeDecorator {
     Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope);

--- a/brave/src/main/java/brave/propagation/CurrentTraceContextCustomizer.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContextCustomizer.java
@@ -13,26 +13,25 @@
  */
 package brave.propagation;
 
-import brave.Tracing;
 import brave.TracingCustomizer;
 
 /**
  * This allows configuration plugins to collaborate on building an instance of {@link
- * ExtraFieldPropagation.Factory}.
+ * CurrentTraceContext}.
  *
- * <p>For example, a customizer can {@link ExtraFieldPropagation.FactoryBuilder#addField(String)
- * add an extra field field} without affecting the {@link ExtraFieldPropagation#newFactoryBuilder(Propagation.Factory)
- * trace propagation format}.
+ * <p>For example, a customizer can {@link CurrentTraceContext.Builder#addScopeDecorator(CurrentTraceContext.ScopeDecorator)
+ * add a scope decorator} without affecting the the implementation (like thread locals).
  *
- * <p>This also allows one object to customize both {@link Tracing}, via {@link TracingCustomizer},
- * and extra fields {@link ExtraFieldPropagation}, by implementing both customizer interfaces.
+ * <p>This also allows one object to customize both {@link ExtraFieldPropagation}, via {@link
+ * ExtraFieldCustomizer}, and integration like MDC (log) correlation, by implementing both
+ * customizer interfaces.
  *
  * <h3>Integration examples</h3>
  *
  * <p>In practice, a dependency injection tool applies a collection of these instances prior to
- * {@link ExtraFieldPropagation.FactoryBuilder#build() building the tracing instance}. For example,
- * an injected {@code List<ExtraFieldPropagationCustomizer>} parameter to a provider of {@link
- * Propagation.Factory}.
+ * {@link CurrentTraceContext.Builder#build() building the tracing instance}. For example, an
+ * injected {@code List<CurrentTraceContextCustomizer>} parameter to a provider of {@link
+ * CurrentTraceContext}.
  *
  * <p>Here are some examples, in alphabetical order:
  * <pre><ul>
@@ -41,20 +40,20 @@ import brave.TracingCustomizer;
  *   <li><a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-autowired-annotation">Spring Autowired Collections</a></li>
  * </ul></pre>
  *
- * @see CurrentTraceContextCustomizer
+ * @see ExtraFieldCustomizer
  * @see TracingCustomizer
  * @since 5.7
  */
-public interface ExtraFieldCustomizer {
+public interface CurrentTraceContextCustomizer {
   /** Use to avoid comparing against null references */
-  ExtraFieldCustomizer NOOP = new ExtraFieldCustomizer() {
-    @Override public void customize(ExtraFieldPropagation.FactoryBuilder builder) {
+  CurrentTraceContextCustomizer NOOP = new CurrentTraceContextCustomizer() {
+    @Override public void customize(CurrentTraceContext.Builder builder) {
     }
 
     @Override public String toString() {
-      return "NoopExtraFieldCustomizer{}";
+      return "NoopCurrentTraceContextCustomizer{}";
     }
   };
 
-  void customize(ExtraFieldPropagation.FactoryBuilder builder);
+  void customize(CurrentTraceContext.Builder builder);
 }

--- a/spring-beans/src/main/java/brave/spring/beans/CurrentTraceContextFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/CurrentTraceContextFactoryBean.java
@@ -15,6 +15,7 @@ package brave.spring.beans;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import brave.propagation.CurrentTraceContextCustomizer;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.List;
 import org.springframework.beans.factory.FactoryBean;
@@ -22,6 +23,7 @@ import org.springframework.beans.factory.FactoryBean;
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class CurrentTraceContextFactoryBean implements FactoryBean {
 
+  List<CurrentTraceContextCustomizer> customizers;
   List<ScopeDecorator> scopeDecorators;
 
   @Override public CurrentTraceContext getObject() {
@@ -30,6 +32,9 @@ public class CurrentTraceContextFactoryBean implements FactoryBean {
       for (ScopeDecorator scopeDecorator : scopeDecorators) {
         builder.addScopeDecorator(scopeDecorator);
       }
+    }
+    if (customizers != null) {
+      for (CurrentTraceContextCustomizer customizer : customizers) customizer.customize(builder);
     }
     return builder.build();
   }
@@ -44,5 +49,9 @@ public class CurrentTraceContextFactoryBean implements FactoryBean {
 
   public void setScopeDecorators(List<ScopeDecorator> scopeDecorators) {
     this.scopeDecorators = scopeDecorators;
+  }
+
+  public void setCustomizers(List<CurrentTraceContextCustomizer> customizers) {
+    this.customizers = customizers;
   }
 }

--- a/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
@@ -14,11 +14,15 @@
 package brave.spring.beans;
 
 import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContextCustomizer;
 import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class CurrentTraceContextFactoryBeanTest {
   XmlBeans context;
@@ -41,5 +45,27 @@ public class CurrentTraceContextFactoryBeanTest {
     assertThat(context.getBean("currentTraceContext", CurrentTraceContext.class))
       .extracting("scopeDecorators")
       .satisfies(e -> assertThat((List) e).isNotEmpty());
+  }
+
+  public static final CurrentTraceContextCustomizer
+    CUSTOMIZER_ONE = mock(CurrentTraceContextCustomizer.class),
+    CUSTOMIZER_TWO = mock(CurrentTraceContextCustomizer.class);
+
+  @Test public void customizers() {
+    context = new XmlBeans(""
+      + "<bean id=\"currentTraceContext\" class=\"brave.spring.beans.CurrentTraceContextFactoryBean\">\n"
+      + "  <property name=\"customizers\">\n"
+      + "    <list>\n"
+      + "      <util:constant static-field=\"" + getClass().getName() + ".CUSTOMIZER_ONE\"/>\n"
+      + "      <util:constant static-field=\"" + getClass().getName() + ".CUSTOMIZER_TWO\"/>\n"
+      + "    </list>\n"
+      + "  </property>"
+      + "</bean>"
+    );
+
+    context.getBean("currentTraceContext", CurrentTraceContext.class);
+
+    verify(CUSTOMIZER_ONE).customize(any(CurrentTraceContext.Builder.class));
+    verify(CUSTOMIZER_TWO).customize(any(CurrentTraceContext.Builder.class));
   }
 }


### PR DESCRIPTION
Currently, we have tools which simultaneously configure extra fields
and also integrate them with MDC (for example Sleuth does this). This
adds `CurrentTraceContextCustomizer` to allow integrations like this
to be self-contained.

See https://github.com/openzipkin/brave/pull/981#pullrequestreview-282036426