### PR TITLE
fix dubbo async invoke has no correct trace data

### DIFF
--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -18,6 +18,7 @@ import brave.Span.Kind;
 import brave.Tracer;
 import brave.Tracing;
 import brave.internal.Platform;
+import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -45,6 +46,7 @@ import java.util.concurrent.Future;
 // public constructor permitted to allow dubbo to instantiate this
 public final class TracingFilter implements Filter {
 
+  CurrentTraceContext current;
   Tracer tracer;
   TraceContext.Extractor<Map<String, String>> extractor;
   TraceContext.Injector<Map<String, String>> injector;
@@ -56,14 +58,14 @@ public final class TracingFilter implements Filter {
    * injected.
    */
   public void setTracing(Tracing tracing) {
+    current = tracing.currentTraceContext();
     tracer = tracing.tracer();
     extractor = tracing.propagation().extractor(GETTER);
     injector = tracing.propagation().injector(SETTER);
     isInit = true;
   }
 
-  @Override
-  public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+  @Override public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
     if (isInit == false) return invoker.invoke(invocation);
 
     RpcContext rpcContext = RpcContext.getContext();
@@ -89,18 +91,11 @@ public final class TracingFilter implements Filter {
     }
 
     boolean isOneway = false, deferFinish = false;
-    try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
+    try (CurrentTraceContext.Scope scope = current.newScope(span.context())) {
       Result result = invoker.invoke(invocation);
-      if (result.hasException()) {
-        onError(result.getException(), span);
-      }
       isOneway = RpcUtils.isOneway(invoker.getUrl(), invocation);
-      Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
-      if (!isOneway && future instanceof FutureAdapter) {
-        deferFinish = true;
-        ResponseFuture responseFuture = ((FutureAdapter<Object>) future).getFuture();
-        ResponseFuture responseFutureDelegate = new AsyncResponseFutureDelegate(span, responseFuture);
-        RpcContext.getContext().setFuture(new FutureAdapter<>(responseFutureDelegate));
+      if (!span.isNoop()) {
+        deferFinish = ensureSpanFinishes(rpcContext, span, result);
       }
       return result;
     } catch (Error | RuntimeException e) {
@@ -115,40 +110,19 @@ public final class TracingFilter implements Filter {
     }
   }
 
-
-  /**
-   * ResponseFuture Delegate Class to Resolve ResponseCallBack are covered
-   */
-  static class AsyncResponseFutureDelegate implements ResponseFuture {
-
-    private final ResponseFuture responseFuture;
-    private final Span     span;
-
-    public AsyncResponseFutureDelegate(Span span,
-                                       ResponseFuture responseFuture) {
-      this.responseFuture = responseFuture;
-      this.span = span;
+  boolean ensureSpanFinishes(RpcContext rpcContext, Span span, Result result) {
+    boolean deferFinish = false;
+    if (result.hasException()) onError(result.getException(), span);
+    Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
+    if (future instanceof FutureAdapter) {
+      deferFinish = true;
+      ResponseFuture original = ((FutureAdapter<Object>) future).getFuture();
+      ResponseFuture wrapped = new FinishSpanResponseFuture(original, span, current);
+      // Ensures even if no callback added later, for example when a consumer, we finish the span
+      wrapped.setCallback(null);
+      RpcContext.getContext().setFuture(new FutureAdapter<>(wrapped));
     }
-
-    @Override
-    public Object get() throws RemotingException {
-      return responseFuture.get();
-    }
-
-    @Override
-    public Object get(int timeoutInMillis) throws RemotingException {
-      return responseFuture.get(timeoutInMillis);
-    }
-
-    @Override
-    public void setCallback(ResponseCallback callback) {
-      responseFuture.setCallback(new FinishSpanCallback(span, callback));
-    }
-
-    @Override
-    public boolean isDone() {
-      return responseFuture.isDone();
-    }
+    return deferFinish;
   }
 
   static void parseRemoteAddress(RpcContext rpcContext, Span span) {
@@ -190,26 +164,32 @@ public final class TracingFilter implements Filter {
       }
     };
 
-  static final class FinishSpanCallback implements ResponseCallback {
+  /** Ensures any callbacks finish the span. */
+  static final class FinishSpanResponseFuture implements ResponseFuture {
+    final ResponseFuture delegate;
     final Span span;
+    final CurrentTraceContext current;
 
-    final ResponseCallback        responseCallback;
-
-    FinishSpanCallback(Span span,ResponseCallback responseCallback) {
+    FinishSpanResponseFuture(ResponseFuture delegate, Span span, CurrentTraceContext current) {
+      this.delegate = delegate;
       this.span = span;
-      this.responseCallback = responseCallback;
+      this.current = current;
     }
 
-    @Override public void done(Object response) {
-      span.finish();
-      responseCallback.done(response);
+    @Override public Object get() throws RemotingException {
+      return delegate.get();
     }
 
-    @Override public void caught(Throwable exception) {
-      onError(exception, span);
-      span.finish();
-      responseCallback.caught(exception);
+    @Override public Object get(int timeoutInMillis) throws RemotingException {
+      return delegate.get(timeoutInMillis);
+    }
+
+    @Override public void setCallback(ResponseCallback callback) {
+      delegate.setCallback(TracingResponseCallback.create(callback, span, current));
+    }
+
+    @Override public boolean isDone() {
+      return delegate.isDone();
     }
   }
-
 }

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -115,27 +115,6 @@ public final class TracingFilter implements Filter {
     }
   }
 
-  static class FinishSpanCallback implements ResponseCallback {
-
-    private final Span              span;
-    private final ResponseCallback        responseCallback;
-
-    FinishSpanCallback(Span span,ResponseCallback responseCallback) {
-      this.span = span;
-      this.responseCallback = responseCallback;
-    }
-
-    @Override public void done(Object response) {
-      span.finish();
-      responseCallback.done(response);
-    }
-
-    @Override public void caught(Throwable exception) {
-      onError(exception, span);
-      span.finish();
-      responseCallback.caught(exception);
-    }
-  }
 
   /**
    * ResponseFuture Delegate Class to Resolve ResponseCallBack are covered
@@ -210,4 +189,27 @@ public final class TracingFilter implements Filter {
         return "Map::set";
       }
     };
+
+  static final class FinishSpanCallback implements ResponseCallback {
+    final Span span;
+
+    final ResponseCallback        responseCallback;
+
+    FinishSpanCallback(Span span,ResponseCallback responseCallback) {
+      this.span = span;
+      this.responseCallback = responseCallback;
+    }
+
+    @Override public void done(Object response) {
+      span.finish();
+      responseCallback.done(response);
+    }
+
+    @Override public void caught(Throwable exception) {
+      onError(exception, span);
+      span.finish();
+      responseCallback.caught(exception);
+    }
+  }
+
 }

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingResponseCallback.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingResponseCallback.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.Span;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+
+import static brave.dubbo.rpc.TracingFilter.onError;
+
+/**
+ * Ensures deferred async calls complete a span upon success or failure callback.
+ *
+ * <p>This is an exact design copy of {@code brave.kafka.clients.TracingCallback}.
+ */
+final class TracingResponseCallback {
+  static ResponseCallback create(@Nullable ResponseCallback delegate, Span span,
+    CurrentTraceContext current) {
+    if (delegate == null) return new FinishSpan(span);
+    return new DelegateAndFinishSpan(delegate, span, current);
+  }
+
+  static class FinishSpan implements ResponseCallback {
+    final Span span;
+
+    FinishSpan(Span span) {
+      this.span = span;
+    }
+
+    @Override public void done(Object response) {
+      span.finish();
+    }
+
+    @Override public void caught(Throwable exception) {
+      onError(exception, span);
+      span.finish();
+    }
+  }
+
+  static final class DelegateAndFinishSpan extends FinishSpan {
+    final ResponseCallback delegate;
+    final CurrentTraceContext current;
+
+    DelegateAndFinishSpan(ResponseCallback delegate, Span span, CurrentTraceContext current) {
+      super(span);
+      this.delegate = delegate;
+      this.current = current;
+    }
+
+    @Override public void done(Object response) {
+      try (CurrentTraceContext.Scope ws = current.maybeScope(span.context())) {
+        delegate.done(response);
+      } finally {
+        super.done(response);
+      }
+    }
+
+    @Override public void caught(Throwable exception) {
+      try (CurrentTraceContext.Scope ws = current.maybeScope(span.context())) {
+        delegate.caught(exception);
+      } finally {
+        super.caught(exception);
+      }
+    }
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
@@ -189,17 +189,14 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
       .contains("Not found exported service");
   }
 
-
-  /**
-   * It will not be throws `Span was not reported` message, But before that, it will be
-   * @throws Exception
-   */
+  /** Ensures the span completes on asynchronous invocation. */
   @Test public void test_async_invoke() throws Exception {
     client.setAsync(true);
     String jorge = client.get().sayHello("jorge");
-    Assert.assertTrue(jorge == null);
+    assertThat(jorge).isNull();
     Object o = RpcContext.getContext().getFuture().get();
-    Assert.assertTrue(o != null);
+    assertThat(o).isNotNull();
+
     Span span = takeSpan();
     assertThat(span.kind())
       .isEqualTo(Span.Kind.CLIENT);

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
@@ -23,6 +23,8 @@ import com.alibaba.dubbo.rpc.RpcContext;
 import com.alibaba.dubbo.rpc.RpcException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Span;
@@ -185,5 +187,21 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
       .isEqualTo("1");
     assertThat(span.tags().get("error"))
       .contains("Not found exported service");
+  }
+
+
+  /**
+   * It will not be throws `Span was not reported` message, But before that, it will be
+   * @throws Exception
+   */
+  @Test public void test_async_invoke() throws Exception {
+    client.setAsync(true);
+    String jorge = client.get().sayHello("jorge");
+    Assert.assertTrue(jorge == null);
+    Object o = RpcContext.getContext().getFuture().get();
+    Assert.assertTrue(o != null);
+    Span span = takeSpan();
+    assertThat(span.kind())
+      .isEqualTo(Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TracingResponseCallbackTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TracingResponseCallbackTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.Span;
+import brave.sampler.Sampler;
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TracingResponseCallbackTest extends ITTracingFilter {
+  @Before public void setup() {
+    setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+  }
+
+  @Test public void done_should_finish_span() throws Exception {
+    Span span = tracing.tracer().nextSpan().start();
+
+    ResponseCallback tracingResponseCallback =
+      TracingResponseCallback.create(null, span, tracing.currentTraceContext());
+    tracingResponseCallback.done(null);
+
+    assertThat(spans.take()).isNotNull();
+  }
+
+  @Test public void caught_should_tag() throws Exception {
+    Span span = tracing.tracer().nextSpan().start();
+
+    ResponseCallback tracingResponseCallback =
+      TracingResponseCallback.create(null, span, tracing.currentTraceContext());
+    tracingResponseCallback.caught(new Exception("Test exception"));
+
+    assertThat(spans.take().tags())
+      .containsEntry("error", "Test exception");
+  }
+
+  @Test public void done_should_forward_then_finish_span() throws Exception {
+    Span span = tracing.tracer().nextSpan().start();
+
+    ResponseCallback delegate = mock(ResponseCallback.class);
+    ResponseCallback tracingResponseCallback =
+      TracingResponseCallback.create(delegate, span, tracing.currentTraceContext());
+
+    Object result = new Object();
+    tracingResponseCallback.done(result);
+
+    verify(delegate).done(result);
+    assertThat(spans.take()).isNotNull();
+  }
+
+  @Test public void done_should_have_span_in_scope() throws Exception {
+    Span span = tracing.tracer().nextSpan().start();
+
+    ResponseCallback delegate = new ResponseCallback() {
+      @Override public void done(Object response) {
+        assertThat(tracing.currentTraceContext().get()).isSameAs(span.context());
+      }
+
+      @Override public void caught(Throwable exception) {
+        throw new AssertionError();
+      }
+    };
+
+    TracingResponseCallback.create(delegate, span, tracing.currentTraceContext())
+      .done(new Object());
+
+    assertThat(spans.take()).isNotNull();
+  }
+
+  @Test public void caught_should_forward_then_tag() throws Exception {
+    Span span = tracing.tracer().nextSpan().start();
+
+    ResponseCallback delegate = new ResponseCallback() {
+      @Override public void done(Object response) {
+        throw new AssertionError();
+      }
+
+      @Override public void caught(Throwable exception) {
+        assertThat(tracing.currentTraceContext().get()).isSameAs(span.context());
+      }
+    };
+
+    TracingResponseCallback.create(delegate, span, tracing.currentTraceContext())
+      .caught(new Exception("Test exception"));
+
+    assertThat(spans.take().tags())
+      .containsEntry("error", "Test exception");
+  }
+}

--- a/instrumentation/jms/src/main/java/brave/jms/TracingCompletionListener.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingCompletionListener.java
@@ -49,10 +49,10 @@ import javax.jms.Message;
   }
 
   @Override public void onException(Message message, Exception exception) {
-    try {
+    try (Scope ws = current.maybeScope(span.context())) {
       delegate.onException(message, exception);
-      span.error(exception);
     } finally {
+      span.error(exception);
       span.finish();
     }
   }


### PR DESCRIPTION
In the Dubbo 2.6.x release series, when ResponseCallBack is used, ResponseCallBack in Brave may be overwritten。[Why doesn't ResponseCallback support multiple?](https://github.com/apache/dubbo/issues/4968)

So, When Dubbo is temporarily unable to provide an onResponse similar to the 2.7.x series, I am trying to provide a new solution.