### PR TITLE
Enables maven-failsafe-plugin and fixes Dubbo tests

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -5,7 +5,8 @@ example, the directory "servlet" includes the artifact "brave-instrumentation-se
 
 Here's a brief overview of what's packaged here:
 
-* [dubbo-rpc](dubbo-rpc/README.md) - Tracing filter for RPC providers and consumers in [Dubbo](http://dubbo.io/books/dubbo-user-book-en/)
+* [dubbo](dubbo/README.md) - Tracing filter for RPC providers and consumers in [Apache Dubbo](http://dubbo.apache.org/en-us/)
+* [dubbo-rpc](dubbo-rpc/README.md) - Tracing filter for RPC providers and consumers in [Alibaba Dubbo](http://dubbo.io/books/dubbo-user-book-en/)
 * [grpc](grpc/README.md) - Tracing client and server interceptors for [grpc](github.com/grpc/grpc-java)
 * [httpasyncclient](httpasyncclient/README.md) - Tracing decorator for [Apache HttpClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+
 * [httpclient](httpclient/README.md) - Tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.3+

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -28,8 +28,7 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
-    <!-- TODO: not compile compatible with apache dubbo until 2.7.2
-         See https://github.com/apache/incubator-zipkin-brave/issues/867 -->
+    <!-- Use brave-instrumentation-dubbo for Apache Dubbo 2.7+, not this module. -->
     <dubbo.version>2.6.6</dubbo.version>
   </properties>
 
@@ -38,6 +37,15 @@
       <groupId>com.alibaba</groupId>
       <artifactId>dubbo</artifactId>
       <version>${dubbo.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Prevent classpath problems in IDE running tests -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>${netty.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -94,7 +94,7 @@ public final class TracingFilter implements Filter {
       }
       isOneway = RpcUtils.isOneway(invoker.getUrl(), invocation);
       Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
-      if (future instanceof FutureAdapter) {
+      if (!isOneway && future instanceof FutureAdapter) {
         deferFinish = true;
         ((FutureAdapter) future).getFuture().setCallback(new FinishSpanCallback(span));
       }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -27,12 +27,15 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITTracingFilter {
+  @Rule public Timeout globalTimeout = Timeout.seconds(5); // 5 seconds max per method
+
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 

--- a/instrumentation/dubbo-rpc/src/test/resources/log4j2.properties
+++ b/instrumentation/dubbo-rpc/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/dubbo-rpc/src/test/resources/log4j2.properties
+++ b/instrumentation/dubbo-rpc/src/test/resources/log4j2.properties
@@ -6,3 +6,23 @@ appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
 rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
+
+# mute logs that have to do with config re-loading, which is constant during tests
+logger.model.name=com.alibaba.dubbo.config.model.ApplicationModel
+logger.model.level=off
+logger.server.name=com.alibaba.dubbo.remoting.transport.AbstractServer
+logger.server.level=off
+logger.spring-extension.name=com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory
+logger.spring-extension.level=off
+
+# mute dispatcher error as we intentionally dispatch to an unknown route
+logger.dispatcher.name=com.alibaba.dubbo.remoting.transport.dispatcher
+logger.dispatcher.level=off
+
+# mute future error as we intentionally timeout a call
+logger.future.name=com.alibaba.dubbo.remoting.exchange.support.DefaultFuture
+logger.future.level=off
+
+# mute exception filter as we intentionally test exception paths
+logger.exception-filter.name=com.alibaba.dubbo.rpc.filter.ExceptionFilter
+logger.exception-filter.level=off

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -29,7 +29,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
 
-    <dubbo.version>2.7.2</dubbo.version>
+    <dubbo.version>2.7.3</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -37,6 +37,7 @@
       <groupId>org.apache.dubbo</groupId>
       <artifactId>dubbo</artifactId>
       <version>${dubbo.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
@@ -21,6 +21,9 @@ import brave.internal.Platform;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.Future;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.common.extension.ExtensionLoader;
@@ -33,9 +36,6 @@ import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.protocol.dubbo.FutureAdapter;
 import org.apache.dubbo.rpc.support.RpcUtils;
-import java.net.InetSocketAddress;
-import java.util.Map;
-import java.util.concurrent.Future;
 
 @Activate(group = {CommonConstants.PROVIDER, CommonConstants.CONSUMER}, value = "tracing")
 // http://dubbo.apache.org/en-us/docs/dev/impls/filter.html

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
@@ -61,7 +61,7 @@ public final class TracingFilter implements Filter {
 
   @Override
   public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-    if (isInit == false) return invoker.invoke(invocation);
+    if (!isInit) return invoker.invoke(invocation);
 
     RpcContext rpcContext = RpcContext.getContext();
     Kind kind = rpcContext.isProviderSide() ? Kind.SERVER : Kind.CLIENT;

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
@@ -96,13 +96,12 @@ public final class TracingFilter implements Filter {
       }
       isOneway = RpcUtils.isOneway(invoker.getUrl(), invocation);
       Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
-      if (future instanceof FutureAdapter) {
+      if (!isOneway && future instanceof FutureAdapter) {
         deferFinish = true;
         ((FutureAdapter<Object>)future).whenComplete((v, t) -> {
           if (t != null) {
             onError(t, span);
             span.finish();
-
           } else {
             span.finish();
           }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -21,6 +21,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.Filter;
@@ -45,7 +46,8 @@ public abstract class ITTracingFilter {
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
   Tracing tracing;
-  TestServer server = new TestServer();
+  ApplicationConfig application = new ApplicationConfig("brave");
+  TestServer server = new TestServer(application);
   ReferenceConfig<GreeterService> client;
 
   @After public void stop() {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -21,7 +21,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.Filter;
@@ -39,9 +38,6 @@ public abstract class ITTracingFilter {
   ITTracingFilter() {
     resetStaticState();
   }
-
-  // Dubbo is strict that there can be only one config.
-  static final ApplicationConfig APPLICATION_CONFIG = new ApplicationConfig("brave");
 
   @Rule public Timeout globalTimeout = Timeout.seconds(5); // 5 seconds max per method
 

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -14,16 +14,16 @@
 package brave.dubbo;
 
 import brave.Tracing;
-import brave.dubbo.TracingFilter;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
-import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.config.ReferenceConfig;
-import org.apache.dubbo.rpc.Filter;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.rpc.Filter;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -43,6 +43,7 @@ public abstract class ITTracingFilter {
 
   @After public void stop() {
     if (client != null) client.destroy();
+    ConfigManager.getInstance().clear();
     server.stop();
     Tracing current = Tracing.current();
     if (current != null) current.close();

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -21,6 +21,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.dubbo.common.extension.ExtensionLoader;
+import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.Filter;
@@ -28,12 +29,22 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITTracingFilter {
+  ITTracingFilter() {
+    resetStaticState();
+  }
+
+  // Dubbo is strict that there can be only one config.
+  static final ApplicationConfig APPLICATION_CONFIG = new ApplicationConfig("brave");
+
+  @Rule public Timeout globalTimeout = Timeout.seconds(5); // 5 seconds max per method
+
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
@@ -43,10 +54,8 @@ public abstract class ITTracingFilter {
 
   @After public void stop() {
     if (client != null) client.destroy();
-    ConfigManager.getInstance().clear();
     server.stop();
-    Tracing current = Tracing.current();
-    if (current != null) current.close();
+    resetStaticState();
   }
 
   // See brave.http.ITHttp for rationale on polling after tests complete
@@ -77,6 +86,13 @@ public abstract class ITTracingFilter {
       .getExtension("tracing"))
       .setTracing(tracing);
     this.tracing = tracing;
+  }
+
+  static void resetStaticState() {
+    ConfigManager.getInstance().clear();
+    ExtensionLoader.resetExtensionLoader(Filter.class);
+    Tracing current = Tracing.current();
+    if (current != null) current.close();
   }
 
   /** Call this to block until a span was reported */

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -34,9 +34,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 public class ITTracingFilter_Consumer extends ITTracingFilter {
   ReferenceConfig<GraterService> wrongClient;
 
-  @Before public void setup() {
-    setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
-
+  @Before public void setup() throws Exception {
     server.start();
 
     String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean";
@@ -51,6 +49,13 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     wrongClient.setFilter("tracing");
     wrongClient.setInterface(GraterService.class);
     wrongClient.setUrl(url);
+
+    setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+
+    // perform a warmup request to allow CI to fail quicker
+    client.get().sayHello("jorge");
+    server.takeRequest();
+    takeSpan();
   }
 
   @After public void stop() {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -17,12 +17,13 @@ import brave.ScopedSpan;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.Sampler;
-import org.apache.dubbo.config.ApplicationConfig;
-import org.apache.dubbo.config.ReferenceConfig;
-import org.apache.dubbo.rpc.RpcContext;
-import org.apache.dubbo.rpc.RpcException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Span;
@@ -31,11 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class ITTracingFilter_Consumer extends ITTracingFilter {
-
   @Before public void setup() {
     setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
     server.start();
 
+    ConfigManager.getInstance().clear();
     client = new ReferenceConfig<>();
     client.setApplication(new ApplicationConfig("bean-consumer"));
     client.setFilter("tracing");

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -19,9 +19,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.Sampler;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
-import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 import org.junit.After;
@@ -40,10 +38,6 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
 
     server.start();
-
-    // Avoid spurious error in CI:
-    // Duplicate Config found for ApplicationConfig, you should use only one unique ApplicationConfig for one application.
-    ConfigManager.getInstance().clear();
 
     String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean";
     client = new ReferenceConfig<>();

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -45,7 +45,6 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     // Duplicate Config found for ApplicationConfig, you should use only one unique ApplicationConfig for one application.
     ConfigManager.getInstance().clear();
 
-    ApplicationConfig application = new ApplicationConfig("brave-client");
     String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean";
     client = new ReferenceConfig<>();
     client.setApplication(application);

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -17,7 +17,6 @@ import brave.sampler.Sampler;
 import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
-import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.RpcContext;
 import org.junit.Before;
 import org.junit.Test;

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 public class ITTracingFilter_Provider extends ITTracingFilter {
 
   @Before public void setup() {
-    ConfigManager.getInstance().clear();
+    setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+
     server.service.setFilter("tracing");
     server.service.setRef((method, parameterTypes, args) -> {
       JavaBeanDescriptor arg = (JavaBeanDescriptor) args[0];
@@ -46,13 +47,10 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     });
     server.start();
 
-    ReferenceConfig<GreeterService> ref = new ReferenceConfig<>();
-    ref.setApplication(new ApplicationConfig("bean-consumer"));
-    ref.setInterface(GreeterService.class);
-    ref.setUrl("dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean");
-    client = ref;
-
-    setTracing(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
+    client = new ReferenceConfig<>();
+    client.setApplication(new ApplicationConfig("brave-client"));
+    client.setInterface(GreeterService.class);
+    client.setUrl("dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean");
   }
 
   @Test public void usesExistingTraceId() throws Exception {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -15,7 +15,6 @@ package brave.dubbo;
 
 import brave.sampler.Sampler;
 import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
-import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.rpc.RpcContext;
 import org.junit.Before;

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -47,7 +47,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     server.start();
 
     client = new ReferenceConfig<>();
-    client.setApplication(new ApplicationConfig("brave-client"));
+    client.setApplication(application);
     client.setInterface(GreeterService.class);
     client.setUrl("dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean");
   }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -17,6 +17,7 @@ import brave.sampler.Sampler;
 import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
+import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.RpcContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 public class ITTracingFilter_Provider extends ITTracingFilter {
 
   @Before public void setup() {
+    ConfigManager.getInstance().clear();
     server.service.setFilter("tracing");
     server.service.setRef((method, parameterTypes, args) -> {
       JavaBeanDescriptor arg = (JavaBeanDescriptor) args[0];

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -37,7 +37,7 @@ class TestServer {
   ServiceConfig<GenericService> service;
   String linkLocalIp;
 
-  TestServer() {
+  TestServer(ApplicationConfig application) {
     linkLocalIp = Platform.get().linkLocalIp();
     if (linkLocalIp != null) {
       // avoid dubbo's logic which might pick docker ip
@@ -45,7 +45,7 @@ class TestServer {
       System.setProperty(Constants.DUBBO_IP_TO_REGISTRY, linkLocalIp);
     }
     service = new ServiceConfig<>();
-    service.setApplication(new ApplicationConfig("brave-service"));
+    service.setApplication(application);
     service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
     service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
     service.setInterface(GreeterService.class.getName());

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -29,8 +29,6 @@ import org.apache.dubbo.config.ServiceConfig;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.service.GenericService;
 
-import static brave.dubbo.ITTracingFilter.APPLICATION_CONFIG;
-
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
   BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
@@ -75,13 +73,8 @@ class TestServer {
     service.export();
   }
 
-  void unexport() {
-    service.unexport();
-  }
-
   void stop() {
     service.unexport();
-    service.getProtocol().destroy();
   }
 
   int port() {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -13,23 +13,22 @@
  */
 package brave.dubbo;
 
-import brave.dubbo.TracingFilter;
 import brave.internal.Platform;
 import brave.propagation.B3Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
-import org.apache.dubbo.common.constants.CommonConstants;
-import org.apache.dubbo.config.ApplicationConfig;
-import org.apache.dubbo.config.ProtocolConfig;
-import org.apache.dubbo.config.RegistryConfig;
-import org.apache.dubbo.config.ServiceConfig;
-import org.apache.dubbo.rpc.RpcContext;
-import org.apache.dubbo.rpc.service.GenericService;
-import org.apache.dubbo.common.constants.RegistryConstants;
-import org.apache.dubbo.config.Constants;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.config.ApplicationConfig;
+import org.apache.dubbo.config.Constants;
+import org.apache.dubbo.config.ProtocolConfig;
+import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.config.ServiceConfig;
+import org.apache.dubbo.config.context.ConfigManager;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.service.GenericService;
 
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
@@ -46,6 +45,7 @@ class TestServer {
       System.setProperty(CommonConstants.DUBBO_IP_TO_BIND, linkLocalIp);
       System.setProperty(Constants.DUBBO_IP_TO_REGISTRY, linkLocalIp);
     }
+    ConfigManager.getInstance().clear();
     service = new ServiceConfig<>();
     service.setApplication(new ApplicationConfig("bean-provider"));
     service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -26,9 +26,10 @@ import org.apache.dubbo.config.Constants;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.ServiceConfig;
-import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.service.GenericService;
+
+import static brave.dubbo.ITTracingFilter.APPLICATION_CONFIG;
 
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
@@ -45,9 +46,8 @@ class TestServer {
       System.setProperty(CommonConstants.DUBBO_IP_TO_BIND, linkLocalIp);
       System.setProperty(Constants.DUBBO_IP_TO_REGISTRY, linkLocalIp);
     }
-    ConfigManager.getInstance().clear();
     service = new ServiceConfig<>();
-    service.setApplication(new ApplicationConfig("bean-provider"));
+    service.setApplication(new ApplicationConfig("brave-service"));
     service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
     service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
     service.setInterface(GreeterService.class.getName());
@@ -67,12 +67,21 @@ class TestServer {
     });
   }
 
+  ApplicationConfig application() {
+    return service.getApplication();
+  }
+
   void start() {
     service.export();
   }
 
+  void unexport() {
+    service.unexport();
+  }
+
   void stop() {
     service.unexport();
+    service.getProtocol().destroy();
   }
 
   int port() {

--- a/instrumentation/dubbo/src/test/resources/log4j2.properties
+++ b/instrumentation/dubbo/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/dubbo/src/test/resources/log4j2.properties
+++ b/instrumentation/dubbo/src/test/resources/log4j2.properties
@@ -6,3 +6,17 @@ appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
 rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
+
+# mute logs that have to do with config re-loading, which is constant during tests
+logger.model.name=org.apache.dubbo.rpc.model.ApplicationModel
+logger.model.level=off
+logger.config.name=org.apache.dubbo.config.AbstractConfig
+logger.config.level=off
+logger.server.name=org.apache.dubbo.remoting.transport.AbstractServer
+logger.server.level=off
+logger.spring-extension.name=org.apache.dubbo.config.spring.extension.SpringExtensionFactory
+logger.spring-extension.level=off
+
+# mute dispatcher error as we intentionally dispatch to an unknown route
+logger.dispatcher.name=org.apache.dubbo.remoting.transport.dispatcher
+logger.dispatcher.level=off

--- a/instrumentation/dubbo/src/test/resources/log4j2.properties
+++ b/instrumentation/dubbo/src/test/resources/log4j2.properties
@@ -20,3 +20,7 @@ logger.spring-extension.level=off
 # mute dispatcher error as we intentionally dispatch to an unknown route
 logger.dispatcher.name=org.apache.dubbo.remoting.transport.dispatcher
 logger.dispatcher.level=off
+
+# mute exception filter as we intentionally test exception paths
+logger.exception-filter.name=org.apache.dubbo.rpc.filter.ExceptionFilter
+logger.exception-filter.level=off

--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>brave-instrumentation-http</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -31,6 +31,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.http.HttpHeaders;
 import okio.Buffer;
+import org.eclipse.jetty.util.log.Log;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +44,7 @@ public abstract class ITHttpServer extends ITHttp {
   OkHttpClient client = new OkHttpClient();
 
   @Before public void setup() throws Exception {
+    Log.setLog(new Log4J2Log());
     httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
     init();
   }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/Log4J2Log.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/Log4J2Log.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test.http;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.util.log.AbstractLogger;
+
+final class Log4J2Log extends AbstractLogger {
+  final Logger logger;
+
+  Log4J2Log() {
+    this("org.eclipse.jetty.util.log");
+  }
+
+  Log4J2Log(String name) {
+    this.logger = LogManager.getLogger(name);
+  }
+
+  @Override public String getName() {
+    return logger.getName();
+  }
+
+  @Override public void warn(String msg, Object... args) {
+    logger.warn(msg, args);
+  }
+
+  @Override public void warn(Throwable thrown) {
+    warn("", thrown);
+  }
+
+  @Override public void warn(String msg, Throwable thrown) {
+    logger.warn(msg, thrown);
+  }
+
+  @Override public void info(String msg, Object... args) {
+    logger.info(msg, args);
+  }
+
+  @Override public void info(Throwable thrown) {
+    this.info("", thrown);
+  }
+
+  @Override public void info(String msg, Throwable thrown) {
+    logger.info(msg, thrown);
+  }
+
+  @Override public void debug(String msg, Object... args) {
+    logger.debug(msg, args);
+  }
+
+  @Override public void debug(Throwable thrown) {
+    this.debug("", thrown);
+  }
+
+  @Override public void debug(String msg, Throwable thrown) {
+    logger.debug(msg, thrown);
+  }
+
+  @Override public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  @Override public void setDebugEnabled(boolean enabled) {
+    this.warn("setDebugEnabled not implemented");
+  }
+
+  @Override protected org.eclipse.jetty.util.log.Logger newLogger(String fullname) {
+    return new Log4J2Log(fullname);
+  }
+
+  @Override public void ignore(Throwable ignored) {
+  }
+
+  @Override public String toString() {
+    return logger.toString();
+  }
+}

--- a/instrumentation/http-tests/src/main/resources/log4j2.properties
+++ b/instrumentation/http-tests/src/main/resources/log4j2.properties
@@ -3,6 +3,6 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/jms/src/test/resources/log4j2.properties
+++ b/instrumentation/jms/src/test/resources/log4j2.properties
@@ -7,3 +7,6 @@ rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT
 
+# don't log about missing DLQ config
+logger.artemis-server.name=org.apache.activemq.artemis.core.server
+logger.artemis-server.level=off

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -112,11 +112,13 @@ public final class KafkaTracing {
    * #nextSpan(ConsumerRecord)}.
    */
   public <K, V> Consumer<K, V> consumer(Consumer<K, V> consumer) {
+    if (consumer == null) throw new NullPointerException("consumer == null");
     return new TracingConsumer<>(consumer, this);
   }
 
   /** Starts and propagates {@link Span.Kind#PRODUCER} span for each message sent. */
   public <K, V> Producer<K, V> producer(Producer<K, V> producer) {
+    if (producer == null) throw new NullPointerException("producer == null");
     return new TracingProducer<>(producer, this);
   }
 

--- a/instrumentation/kafka-clients/src/test/resources/log4j2.properties
+++ b/instrumentation/kafka-clients/src/test/resources/log4j2.properties
@@ -10,6 +10,6 @@ rootLogger.appenderRef.stdout.ref=STDOUT
 #logger.kafka-clients.name=org.apache.kafka.clients
 #logger.kafka-clients.level=info
 logger.kafkaunit.name=com.github.charithe.kafka
-logger.kafkaunit.level=info
+logger.kafkaunit.level=off
 logger.kafka.name=zipkin2.collector.kafka
 logger.kafka.level=debug

--- a/instrumentation/kafka-streams/src/test/resources/log4j2.properties
+++ b/instrumentation/kafka-streams/src/test/resources/log4j2.properties
@@ -10,6 +10,6 @@ rootLogger.appenderRef.stdout.ref=STDOUT
 #logger.kafka-clients.name=org.apache.kafka.clients
 #logger.kafka-clients.level=info
 logger.kafkaunit.name=com.github.charithe.kafka
-logger.kafkaunit.level=info
+logger.kafkaunit.level=off
 logger.kafka.name=zipkin2.collector.kafka
 logger.kafka.level=debug

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -30,7 +30,7 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
 
-    <p6spy.version>3.8.2</p6spy.version>
+    <p6spy.version>3.8.5</p6spy.version>
     <derby.version>10.15.1.3</derby.version>
   </properties>
 
@@ -52,6 +52,13 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbyclient</artifactId>
+      <version>${derby.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- avoid CNFE in tests org.apache.derby.shared.common.security.SystemPermission -->
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbyshared</artifactId>
       <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -55,7 +55,7 @@ public class ITTracingP6Factory {
   @After
   public void close() throws Exception {
     Tracing.current().close();
-    connection.close();
+    if (connection != null) connection.close();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -567,6 +567,16 @@
             </java.util.logging.manager>
           </systemPropertyVariables>
         </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-eclipse-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <spring-rabbit.version>1.7.13.RELEASE</spring-rabbit.version>
 
     <finagle.version>19.6.0</finagle.version>
-    <log4j.version>2.12.0</log4j.version>
+    <log4j.version>2.12.1</log4j.version>
     <okhttp.version>4.0.0</okhttp.version>
     <httpclient.version>4.5.9</httpclient.version>
 

--- a/spring-beans/src/test/resources/log4j2.properties
+++ b/spring-beans/src/test/resources/log4j2.properties
@@ -3,6 +3,6 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
-rootLogger.level=info
+rootLogger.level=warn
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT


### PR DESCRIPTION
Before, we weren't actually running tests prefixed IT. Both of the Dubbo
implementations had test setup problems that weren't noticed.

cc @glmapper @icom2014 