### PR TITLE
Supports external finish timestamp in HTTP client and server handling

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
@@ -13,11 +13,13 @@
  */
 package brave.http;
 
+import brave.Clock;
+import brave.Span;
 import brave.internal.Nullable;
+import brave.propagation.TraceContext;
 import java.net.URI;
 
 public abstract class HttpAdapter<Req, Resp> {
-
   /**
    * The HTTP method, or verb, such as "GET" or "POST" or null if unreadable.
    *
@@ -51,6 +53,28 @@ public abstract class HttpAdapter<Req, Resp> {
   @Nullable public abstract String requestHeader(Req request, String name);
 
   /**
+   * The timestamp in epoch microseconds of the beginning of this request or zero to take this
+   * implicitly from the current clock. Defaults to zero.
+   *
+   * <p>This is helpful in two scenarios: late parsing and avoiding redundant timestamp overhead.
+   * If a server span, this helps reach the "original" beginning of the request, which is always
+   * prior to parsing.
+   *
+   * <p>Note: Overriding has the same problems as using {@link brave.Span#start(long)}. For
+   * example, it can result in negative duration if the clock used is allowed to correct backwards.
+   * It can also result in misalignments in the trace, unless {@link brave.Tracing.Builder#clock(Clock)}
+   * uses the same implementation.
+   *
+   * @see #finishTimestamp(Object)
+   * @see brave.Span#start(long)
+   * @see brave.Tracing#clock(TraceContext)
+   * @since 5.7
+   */
+  public long startTimestamp(Req request) {
+    return 0L;
+  }
+
+  /**
    * Like {@link #method(Object)} except used in response parsing.
    *
    * <p>Notably, this is used to create a route-based span name.
@@ -82,17 +106,42 @@ public abstract class HttpAdapter<Req, Resp> {
    * <p>Conventionally associated with the key "http.status_code"
    *
    * @see #statusCodeAsInt(Object)
+   * @deprecated Since 5.7, use {@link #statusCodeAsInt(Object)} which prevents boxing.
    */
-  @Nullable public abstract Integer statusCode(Resp response);
+  @Deprecated @Nullable public abstract Integer statusCode(Resp response);
 
   /**
    * Like {@link #statusCode(Object)} except returns a primitive where zero implies absent.
    *
    * <p>Using this method usually avoids allocation, so is encouraged when parsing data.
+   *
+   * @since 4.16
    */
   public int statusCodeAsInt(Resp response) {
     Integer maybeStatus = statusCode(response);
     return maybeStatus != null ? maybeStatus : 0;
+  }
+
+  /**
+   * The timestamp in epoch microseconds of the end of this request or zero to take this implicitly
+   * from the current clock. Defaults to zero.
+   *
+   * <p>This is helpful in two scenarios: late parsing and avoiding redundant timestamp overhead.
+   * For example, you can asynchronously handle span completion without losing precision of the
+   * actual end.
+   *
+   * <p>Note: Overriding has the same problems as using {@link Span#finish(long)}. For
+   * example, it can result in negative duration if the clock used is allowed to correct backwards.
+   * It can also result in misalignments in the trace, unless {@link brave.Tracing.Builder#clock(Clock)}
+   * uses the same implementation.
+   *
+   * @see #startTimestamp(Object)
+   * @see brave.Span#finish(long)
+   * @see brave.Tracing#clock(TraceContext)
+   * @since 5.7
+   */
+  public long finishTimestamp(Resp response) {
+    return 0L;
   }
 
   HttpAdapter() {

--- a/instrumentation/http/src/main/java/brave/http/HttpClientAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientAdapter.java
@@ -45,6 +45,10 @@ public abstract class HttpClientAdapter<Req, Resp> extends HttpAdapter<Req, Resp
         return request.path();
       }
 
+      @Override public long startTimestamp(HttpClientRequest request) {
+        return request.startTimestamp();
+      }
+
       @Override public String methodFromResponse(HttpClientResponse response) {
         return response.method();
       }
@@ -60,6 +64,10 @@ public abstract class HttpClientAdapter<Req, Resp> extends HttpAdapter<Req, Resp
       @Override public Integer statusCode(HttpClientResponse response) {
         int result = response.statusCode();
         return result > 0 ? result : null;
+      }
+
+      @Override public long finishTimestamp(HttpClientResponse response) {
+        return response.finishTimestamp();
       }
 
       @Override public String toString() {

--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -55,6 +55,11 @@ public abstract class HttpClientRequest {
   /** @see HttpAdapter#requestHeader(Object, String) */
   @Nullable public abstract String header(String name);
 
+  /** @see HttpAdapter#startTimestamp(Object) */
+  public long startTimestamp() {
+    return 0L;
+  }
+
   /** @see #SETTER */
   @Nullable public abstract void header(String name, String value);
 

--- a/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
@@ -46,6 +46,11 @@ public abstract class HttpClientResponse {
   /** @see HttpAdapter#statusCodeAsInt(Object) */
   public abstract int statusCode();
 
+  /** @see HttpAdapter#finishTimestamp(Object) */
+  public long finishTimestamp() {
+    return 0L;
+  }
+
   @Override public String toString() {
     return unwrap().toString();
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpHandler.java
@@ -54,6 +54,7 @@ abstract class HttpHandler<Req, Resp, A extends HttpAdapter<Req, Resp>> {
 
   void handleFinish(@Nullable Resp response, @Nullable Throwable error, Span span) {
     if (span.isNoop()) return;
+    long finishTimestamp = response != null ? adapter.finishTimestamp(response) : 0L;
     try {
       Scope ws = currentTraceContext.maybeScope(span.context());
       try {
@@ -62,7 +63,7 @@ abstract class HttpHandler<Req, Resp, A extends HttpAdapter<Req, Resp>> {
         ws.close(); // close the scope before finishing the span
       }
     } finally {
-      finishInNullScope(span, adapter.finishTimestamp(response));
+      finishInNullScope(span, finishTimestamp);
     }
   }
 

--- a/instrumentation/http/src/main/java/brave/http/HttpParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpParser.java
@@ -57,7 +57,8 @@ public class HttpParser {
   // prevent basic HTTP info from being visible. A cost of this is another tag, but it is small with
   // very limited cardinality. Moreover, users who care strictly about size can override this.
   public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
-    customizer.name(spanName(adapter, req));
+    String name = spanName(adapter, req);
+    if (name != null) customizer.name(name);
     String method = adapter.method(req);
     if (method != null) customizer.tag("http.method", method);
     String path = adapter.path(req);

--- a/instrumentation/http/src/main/java/brave/http/HttpServerAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerAdapter.java
@@ -50,6 +50,10 @@ public abstract class HttpServerAdapter<Req, Resp> extends HttpAdapter<Req, Resp
         return request.path();
       }
 
+      @Override public long startTimestamp(HttpServerRequest request) {
+        return request.startTimestamp();
+      }
+
       @Override public String methodFromResponse(HttpServerResponse response) {
         return response.method();
       }
@@ -65,6 +69,10 @@ public abstract class HttpServerAdapter<Req, Resp> extends HttpAdapter<Req, Resp
       @Override public Integer statusCode(HttpServerResponse response) {
         int result = response.statusCode();
         return result > 0 ? result : null;
+      }
+
+      @Override public long finishTimestamp(HttpServerResponse response) {
+        return response.finishTimestamp();
       }
 
       @Override public String toString() {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
@@ -66,6 +66,11 @@ public abstract class HttpServerRequest {
     return false;
   }
 
+  /** @see HttpAdapter#startTimestamp(Object) */
+  public long startTimestamp() {
+    return 0L;
+  }
+
   @Override public String toString() {
     return unwrap().toString();
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerResponse.java
@@ -46,6 +46,11 @@ public abstract class HttpServerResponse {
   /** @see HttpAdapter#statusCodeAsInt(Object) */
   public abstract int statusCode();
 
+  /** @see HttpAdapter#finishTimestamp(Object) */
+  public long finishTimestamp() {
+    return 0L;
+  }
+
   @Override public String toString() {
     return unwrap().toString();
   }


### PR DESCRIPTION
Armeria supports `RequestLog.responseEndTimeNanos()` for more precise
timestamps, which line up with metrics. This punches a hole so that it
is possible to use this without copy/pasting most of the handler code.

cc @trustin @kojilin