### PR TITLE
Adds infrastructure to add secondary sampling data post extract

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -14,7 +14,6 @@
 package brave;
 
 import brave.handler.FinishedSpanHandler;
-import brave.internal.InternalPropagation;
 import brave.internal.IpLiteral;
 import brave.internal.Nullable;
 import brave.internal.Platform;

--- a/brave/src/main/java/brave/internal/MapPropagationFields.java
+++ b/brave/src/main/java/brave/internal/MapPropagationFields.java
@@ -17,51 +17,74 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Copy-on-write keeps propagation changes in a child context from affecting its parent */
-public class MapPropagationFields extends PropagationFields {
-
-  volatile Map<String, String> values; // guarded by this, copy on write
+/**
+ * Copy-on-write keeps propagation changes in a child context from affecting its parent.
+ *
+ * <p>Type parameters must be immutable to ensure copy-on-write branch safety. For example, if they
+ * weren't, modifications by a child span could effect its parent and siblings.
+ *
+ * @param <K> Must be immutable to ensure copy-on-write is effective.
+ * @param <V> Must be immutable to ensure copy-on-write is effective.
+ */
+public class MapPropagationFields<K, V> extends PropagationFields<K, V> {
+  volatile Map<K, V> values; // guarded by this, copy on write
 
   protected MapPropagationFields() {
   }
 
-  protected MapPropagationFields(Map<String, String> parent) {
+  protected MapPropagationFields(Map<K, V> parent) {
+    if (parent == null) throw new NullPointerException("parent == null");
     this.values = Collections.unmodifiableMap(parent);
   }
 
-  protected MapPropagationFields(MapPropagationFields parent) {
+  protected MapPropagationFields(MapPropagationFields<K, V> parent) {
     this.values = parent.values;
   }
 
-  @Override public String get(String name) {
-    Map<String, String> values;
-    synchronized (this) {
-      values = this.values;
-    }
-    return values != null ? values.get(name) : null;
+  @Override public V get(K key) {
+    Map<K, V> values = this.values;
+    return values != null ? values.get(key) : null;
   }
 
-  @Override public final void put(String name, String value) {
+  @Override public void forEach(FieldConsumer<K, V> fieldConsumer) {
     synchronized (this) {
-      Map<String, String> values = this.values;
+      Map<K, V> values = this.values;
+      if (values == null) return;
+
+      for (Map.Entry<K, V> entry : values.entrySet()) {
+        V value = entry.getValue();
+        if (value == null) continue;
+        fieldConsumer.accept(entry.getKey(), value);
+      }
+    }
+  }
+
+  @Override public final void put(K key, V value) {
+    synchronized (this) {
+      Map<K, V> values = this.values;
       if (values == null) {
         values = new LinkedHashMap<>();
-        values.put(name, value);
-      } else if (value.equals(values.get(name))) {
+        values.put(key, value);
+      } else if (value.equals(values.get(key))) {
         return;
       } else {
         // this is the copy-on-write part
         values = new LinkedHashMap<>(values);
-        values.put(name, value);
+        values.put(key, value);
       }
       this.values = Collections.unmodifiableMap(values);
     }
   }
 
+  @Override public boolean isEmpty() {
+    Map<K, V> values = this.values;
+    return values == null || values.isEmpty();
+  }
+
   @Override protected final void putAllIfAbsent(PropagationFields parent) {
     if (!(parent instanceof MapPropagationFields)) return;
-    MapPropagationFields mapParent = (MapPropagationFields) parent;
-    Map<String, String> parentValues = mapParent.values;
+    MapPropagationFields<K, V> mapParent = (MapPropagationFields<K, V>) parent;
+    Map<K, V> parentValues = mapParent.values;
     if (parentValues == null) return;
 
     synchronized (this) {
@@ -71,29 +94,28 @@ public class MapPropagationFields extends PropagationFields {
       }
     }
 
-    for (Map.Entry<String, String> entry : parentValues.entrySet()) {
+    for (Map.Entry<K, V> entry : parentValues.entrySet()) {
       if (values.containsKey(entry.getKey())) continue; // previous wins vs parent
       put(entry.getKey(), entry.getValue());
     }
   }
 
-  @Override public final Map<String, String> toMap() {
-    Map<String, String> values;
-    synchronized (this) {
-      values = this.values;
-    }
+  @Override public final Map<K, V> toMap() {
+    Map<K, V> values = this.values;
     if (values == null) return Collections.emptyMap();
     return values;
   }
 
   @Override public int hashCode() { // for unit tests
+    Map<K, V> values = this.values;
     return values == null ? 0 : values.hashCode();
   }
 
   @Override public boolean equals(Object o) { // for unit tests
     if (o == this) return true;
     if (!(o instanceof MapPropagationFields)) return false;
-    MapPropagationFields that = (MapPropagationFields) o;
-    return values == null ? that.values == null : values.equals(that.values);
+    MapPropagationFields<K, V> that = (MapPropagationFields) o;
+    Map<K, V> values = this.values, thatValues = that.values;
+    return values == null ? thatValues == null : values.equals(thatValues);
   }
 }

--- a/brave/src/main/java/brave/internal/PropagationFields.java
+++ b/brave/src/main/java/brave/internal/PropagationFields.java
@@ -24,19 +24,30 @@ import java.util.Map;
  * <p>Implementations of this type should use copy-on-write semantics to prevent changes in a child
  * context from affecting its parent.
  */
-public abstract class PropagationFields {
+public abstract class PropagationFields<K, V> {
+  public interface FieldConsumer<K, V> {
+    // BiConsumer is Java 1.8+
+    void accept(K key, V value);
+  }
+
   long traceId, spanId; // guarded by this
 
   /** Returns the value of the field with the specified key or null if not available */
-  public abstract String get(String name);
+  public abstract V get(K key);
 
   /** Replaces the value of the field with the specified key, ignoring if not a permitted field */
-  public abstract void put(String name, String value);
+  public abstract void put(K key, V value);
+
+  /** Invokes the consumer for every non-null field value */
+  public abstract void forEach(FieldConsumer<K, V> consumer);
+
+  public abstract boolean isEmpty();
 
   /** for each field in the input replace the value if the key doesn't already exist */
-  abstract void putAllIfAbsent(PropagationFields parent);
+  abstract void putAllIfAbsent(PropagationFields<K, V> parent);
 
-  public abstract Map<String, String> toMap();
+  /** for testing and default toString */
+  protected abstract Map<K, V> toMap();
 
   /** Fields are extracted before a context is created. We need to lazy set the context */
   final boolean tryToClaim(long traceId, long spanId) {
@@ -56,22 +67,22 @@ public abstract class PropagationFields {
   }
 
   /** Returns the value of the field with the specified key or null if not available */
-  public static String get(TraceContext context, String name,
-    Class<? extends PropagationFields> type) {
+  public static <K, V> V get(TraceContext context, K key,
+    Class<? extends PropagationFields<K, V>> type) {
     if (context == null) throw new NullPointerException("context == null");
-    if (name == null) throw new NullPointerException("name == null");
-    PropagationFields fields = context.findExtra(type);
-    return fields != null ? fields.get(name) : null;
+    if (key == null) throw new NullPointerException("key == null");
+    PropagationFields<K, V> fields = context.findExtra(type);
+    return fields != null ? fields.get(key) : null;
   }
 
   /** Replaces the value of the field with the specified key, ignoring if not a permitted field */
-  public static void put(TraceContext context, String name, String value,
-    Class<? extends PropagationFields> type) {
+  public static <K, V> void put(TraceContext context, K key, V value,
+    Class<? extends PropagationFields<K, V>> type) {
     if (context == null) throw new NullPointerException("context == null");
-    if (name == null) throw new NullPointerException("name == null");
+    if (key == null) throw new NullPointerException("key == null");
     if (value == null) throw new NullPointerException("value == null");
-    PropagationFields fields = context.findExtra(type);
+    PropagationFields<K, V> fields = context.findExtra(type);
     if (fields == null) return;
-    fields.put(name, value);
+    fields.put(key, value);
   }
 }

--- a/brave/src/main/java/brave/internal/PropagationFieldsFactory.java
+++ b/brave/src/main/java/brave/internal/PropagationFieldsFactory.java
@@ -16,7 +16,7 @@ package brave.internal;
 import brave.propagation.TraceContext;
 import java.util.List;
 
-public abstract class PropagationFieldsFactory<P extends PropagationFields> extends
+public abstract class PropagationFieldsFactory<K, V, P extends PropagationFields<K, V>> extends
   ExtraFactory<P> {
 
   @Override protected abstract P create();

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -246,14 +246,14 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     if (extracted == null) throw new NullPointerException("extracted == null");
     TraceContext extractedContext = extracted.context();
     if (extractedContext != null) return getAll(extractedContext);
-    PropagationFields fields = TraceContext.findExtra(Extra.class, extracted.extra());
+    Extra fields = TraceContext.findExtra(Extra.class, extracted.extra());
     return fields != null ? fields.toMap() : Collections.emptyMap();
   }
 
   /** Returns a mapping of any fields in the trace context. */
   public static Map<String, String> getAll(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
-    PropagationFields fields = context.findExtra(Extra.class);
+    Extra fields = context.findExtra(Extra.class);
     return fields != null ? fields.toMap() : Collections.emptyMap();
   }
 
@@ -435,7 +435,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     return result;
   }
 
-  static final class ExtraFactory extends PropagationFieldsFactory<Extra> {
+  static final class ExtraFactory extends PropagationFieldsFactory<String, String, Extra> {
     final String[] fieldNames;
 
     ExtraFactory(String[] fieldNames) {

--- a/brave/src/test/java/brave/internal/MapPropagationFieldsTest.java
+++ b/brave/src/test/java/brave/internal/MapPropagationFieldsTest.java
@@ -17,27 +17,31 @@ import java.util.Map;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class MapPropagationFieldsTest extends PropagationFieldsFactoryTest<MapPropagationFields> {
-  @Override protected PropagationFieldsFactory<MapPropagationFields> newFactory() {
-    return new PropagationFieldsFactory<MapPropagationFields>() {
-      @Override public Class<MapPropagationFields> type() {
-        return MapPropagationFields.class;
+public class MapPropagationFieldsTest extends PropagationFieldsFactoryTest<String, String, Extra> {
+  public MapPropagationFieldsTest() {
+    super("one", "two", "1", "2", "3");
+  }
+
+  @Override protected PropagationFieldsFactory<String, String, Extra> newFactory() {
+    return new PropagationFieldsFactory<String, String, Extra>() {
+      @Override public Class<Extra> type() {
+        return Extra.class;
       }
 
-      @Override public MapPropagationFields create() {
-        return new MapPropagationFields();
+      @Override public Extra create() {
+        return new Extra();
       }
 
-      @Override protected MapPropagationFields create(MapPropagationFields parent) {
-        return new MapPropagationFields(parent);
+      @Override protected Extra create(Extra parent) {
+        return new Extra(parent);
       }
     };
   }
 
   @Test public void put_allows_arbitrary_field() {
-    MapPropagationFields fields = factory.create();
+    MapPropagationFields<String, String> fields = factory.create();
 
     fields.put("balloon-color", "red");
 
@@ -46,7 +50,7 @@ public class MapPropagationFieldsTest extends PropagationFieldsFactoryTest<MapPr
   }
 
   @Test public void put_idempotent() {
-    MapPropagationFields fields = factory.create();
+    MapPropagationFields<String, String> fields = factory.create();
 
     fields.put("balloon-color", "red");
     Map<String, String> fieldsMap = fields.values;
@@ -61,14 +65,21 @@ public class MapPropagationFieldsTest extends PropagationFieldsFactoryTest<MapPr
   }
 
   @Test public void unmodifiable() {
-    MapPropagationFields fields = factory.create();
+    MapPropagationFields<String, String> fields = factory.create();
 
-    fields.put(FIELD1, "a");
+    fields.put(keyOne, "a");
 
-    try {
-      fields.values.put(FIELD1, "b");
-      failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-    } catch (UnsupportedOperationException e) {
-    }
+    assertThatThrownBy(() -> fields.values.put(keyOne, "b"))
+      .isInstanceOf(UnsupportedOperationException.class);
+  }
+}
+
+final class Extra extends MapPropagationFields<String, String> {
+  Extra() {
+    super();
+  }
+
+  Extra(Extra parent) {
+    super(parent);
   }
 }

--- a/brave/src/test/java/brave/internal/PredefinedPropagationFieldsTest.java
+++ b/brave/src/test/java/brave/internal/PredefinedPropagationFieldsTest.java
@@ -18,19 +18,24 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PredefinedPropagationFieldsTest
-  extends PropagationFieldsFactoryTest<PredefinedPropagationFields> {
-  @Override protected PropagationFieldsFactory<PredefinedPropagationFields> newFactory() {
-    return new PropagationFieldsFactory<PredefinedPropagationFields>() {
+  extends PropagationFieldsFactoryTest<String, String, PredefinedPropagationFields> {
+  public PredefinedPropagationFieldsTest() {
+    super("one", "two", "1", "2", "3");
+  }
+
+  @Override
+  protected PropagationFieldsFactory<String, String, PredefinedPropagationFields> newFactory() {
+    return new PropagationFieldsFactory<String, String, PredefinedPropagationFields>() {
       @Override public Class<PredefinedPropagationFields> type() {
         return PredefinedPropagationFields.class;
       }
 
       @Override public PredefinedPropagationFields create() {
-        return new PredefinedPropagationFields(FIELD1, FIELD2);
+        return new PredefinedPropagationFields(keyOne, keyTwo);
       }
 
       @Override protected PredefinedPropagationFields create(PredefinedPropagationFields parent) {
-        return new PredefinedPropagationFields(parent, FIELD1, FIELD2);
+        return new PredefinedPropagationFields(parent, keyOne, keyTwo);
       }
     };
   }
@@ -54,14 +59,14 @@ public class PredefinedPropagationFieldsTest
   @Test public void put_idempotent() {
     PredefinedPropagationFields fields = factory.create();
 
-    fields.put("foo", "red");
+    fields.put(keyOne, "red");
     String[] fieldsArray = fields.values;
 
-    fields.put("foo", "red");
+    fields.put(keyOne, "red");
     assertThat(fields.values)
       .isSameAs(fieldsArray);
 
-    fields.put("foo", "blue");
+    fields.put(keyOne, "blue");
     assertThat(fields.values)
       .isNotSameAs(fieldsArray);
   }
@@ -79,7 +84,7 @@ public class PredefinedPropagationFieldsTest
 
     assertThat(fields.toMap())
       .hasSize(1)
-      .containsEntry(FIELD2, "a");
+      .containsEntry(keyTwo, "a");
   }
 
   @Test public void toMap_two_index() {
@@ -89,7 +94,7 @@ public class PredefinedPropagationFieldsTest
 
     assertThat(fields.toMap())
       .hasSize(2)
-      .containsEntry(FIELD1, "1")
-      .containsEntry(FIELD2, "a");
+      .containsEntry(keyOne, "1")
+      .containsEntry(keyTwo, "a");
   }
 }

--- a/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
+++ b/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
@@ -24,16 +24,23 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
-  extends ExtraFactoryTest<P, PropagationFieldsFactory<P>> {
-  static final String FIELD1 = "foo";
-  static final String FIELD2 = "bar";
+public abstract class PropagationFieldsFactoryTest<K, V, P extends PropagationFields<K, V>>
+  extends ExtraFactoryTest<P, PropagationFieldsFactory<K, V, P>> {
+  protected final K keyOne, keyTwo;
+  protected final V valueOne, valueTwo, valueThree;
+
+  protected PropagationFieldsFactoryTest(K keyOne, K keyTwo, V valueOne, V valueTwo, V valueThree) {
+    this.keyOne = keyOne;
+    this.keyTwo = keyTwo;
+    this.valueOne = valueOne;
+    this.valueTwo = valueTwo;
+    this.valueThree = valueThree;
+  }
 
   @Test public void contextsAreIndependent() {
     try (Tracing tracing = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
-
       TraceContext context1 = tracing.tracer().nextSpan().context();
-      PropagationFields.put(context1, FIELD1, "1", factory.type());
+      PropagationFields.put(context1, keyOne, valueOne, factory.type());
       TraceContext context2 = tracing.tracer().newChild(context1).context();
 
       // Instances are not the same
@@ -43,18 +50,18 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
       // But have the same values
       assertThat(context1.findExtra(factory.type()).toMap())
         .isEqualTo(context2.findExtra(factory.type()).toMap());
-      assertThat(PropagationFields.get(context1, FIELD1, factory.type()))
-        .isEqualTo(PropagationFields.get(context2, FIELD1, factory.type()))
-        .isEqualTo("1");
+      assertThat(PropagationFields.get(context1, keyOne, factory.type()))
+        .isEqualTo(PropagationFields.get(context2, keyOne, factory.type()))
+        .isEqualTo(valueOne);
 
-      PropagationFields.put(context1, FIELD1, "2", factory.type());
-      PropagationFields.put(context2, FIELD1, "3", factory.type());
+      PropagationFields.put(context1, keyOne, valueTwo, factory.type());
+      PropagationFields.put(context2, keyOne, valueThree, factory.type());
 
       // Yet downstream changes don't affect eachother
-      assertThat(PropagationFields.get(context1, FIELD1, factory.type()))
-        .isEqualTo("2");
-      assertThat(PropagationFields.get(context2, FIELD1, factory.type()))
-        .isEqualTo("3");
+      assertThat(PropagationFields.get(context1, keyOne, factory.type()))
+        .isEqualTo(valueTwo);
+      assertThat(PropagationFields.get(context2, keyOne, factory.type()))
+        .isEqualTo(valueThree);
     }
   }
 
@@ -62,12 +69,12 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
     try (Tracing tracing = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
 
       TraceContext context1 = tracing.tracer().nextSpan().context();
-      PropagationFields.put(context1, FIELD1, "1", factory.type());
+      PropagationFields.put(context1, keyOne, valueOne, factory.type());
 
       TraceContext context2 =
         tracing.tracer().toSpan(context1.toBuilder().sampled(false).build()).context();
-      PropagationFields fields1 = (PropagationFields) context1.extra().get(0);
-      PropagationFields fields2 = (PropagationFields) context2.extra().get(0);
+      PropagationFields<K, V> fields1 = (PropagationFields<K, V>) context1.extra().get(0);
+      PropagationFields<K, V> fields2 = (PropagationFields<K, V>) context2.extra().get(0);
 
       // we have the same span ID, so we should couple our extra fields
       assertThat(fields1).isSameAs(fields2);
@@ -83,9 +90,9 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
       assertThat(fields1.toMap()).isEqualTo(fields3.toMap());
 
       // inside the span, the same change is present, but the other span has the old values
-      PropagationFields.put(context1, FIELD1, "2", factory.type());
+      PropagationFields.put(context1, keyOne, valueTwo, factory.type());
       assertThat(fields1).isEqualToComparingFieldByField(fields2);
-      assertThat(fields3.get(FIELD1)).isEqualTo("1");
+      assertThat(fields3.get(keyOne)).isEqualTo(valueOne);
     }
   }
 
@@ -102,11 +109,11 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
     try (Tracing tracing = Tracing.newBuilder().propagationFactory(propagationFactory).build()) {
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        PropagationFields.put(parent.context(), FIELD1, "1", factory.type());
+        PropagationFields.put(parent.context(), keyOne, valueOne, factory.type());
 
-        PropagationFields extractedPropagationFields = factory.create();
-        extractedPropagationFields.put(FIELD1, "2"); // extracted should win!
-        extractedPropagationFields.put(FIELD2, "a");
+        PropagationFields<K, V> extractedPropagationFields = factory.create();
+        extractedPropagationFields.put(keyOne, valueTwo); // extracted should win!
+        extractedPropagationFields.put(keyTwo, valueThree);
 
         TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
           .samplingFlags(SamplingFlags.EMPTY)
@@ -117,10 +124,10 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
 
         assertThat(context1.extra()) // merged
           .hasSize(1);
-        PropagationFields fields = ((PropagationFields) context1.extra().get(0));
+        PropagationFields<K, V> fields = ((PropagationFields<K, V>) context1.extra().get(0));
         assertThat(fields.toMap()).containsExactly(
-          entry(FIELD1, "2"),
-          entry(FIELD2, "a")
+          entry(keyOne, valueTwo),
+          entry(keyTwo, valueThree)
         );
         assertThat(fields).extracting("traceId", "spanId")
           .containsExactly(context1.traceId(), context1.spanId());
@@ -135,8 +142,8 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
 
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        PropagationFields extractedPropagationFields = factory.create();
-        extractedPropagationFields.put(FIELD2, "a");
+        PropagationFields<K, V> extractedPropagationFields = factory.create();
+        extractedPropagationFields.put(keyTwo, valueThree);
 
         TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
           .samplingFlags(SamplingFlags.EMPTY)
@@ -147,9 +154,9 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
 
         assertThat(context1.extra()).hasSize(1); // merged
 
-        PropagationFields fields = ((PropagationFields) context1.extra().get(0));
+        PropagationFields<K, V> fields = ((PropagationFields<K, V>) context1.extra().get(0));
         assertThat(fields.toMap())
-          .containsEntry(FIELD2, "a");
+          .containsEntry(keyTwo, valueThree);
         assertThat(fields).extracting("traceId", "spanId")
           .containsExactly(context1.traceId(), context1.spanId());
       } finally {
@@ -163,7 +170,7 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
 
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        PropagationFields.put(parent.context(), FIELD1, "1", factory.type());
+        PropagationFields.put(parent.context(), keyOne, valueOne, factory.type());
 
         TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
           .samplingFlags(SamplingFlags.EMPTY)
@@ -174,9 +181,9 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
 
         assertThat(context1.extra()).hasSize(1); // didn't duplicate
 
-        PropagationFields fields = ((PropagationFields) context1.extra().get(0));
+        PropagationFields<K, V> fields = ((PropagationFields<K, V>) context1.extra().get(0));
         assertThat(fields.toMap())
-          .containsEntry(FIELD1, "1");
+          .containsEntry(keyOne, valueOne);
         assertThat(fields).extracting("traceId", "spanId")
           .containsExactly(context1.traceId(), context1.spanId());
       } finally {
@@ -188,19 +195,19 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
   @Test public void get() {
     TraceContext context =
       propagationFactory.decorate(TraceContext.newBuilder().traceId(1).spanId(2).build());
-    PropagationFields.put(context, FIELD2, "a", factory.type());
+    PropagationFields.put(context, keyTwo, valueThree, factory.type());
 
-    assertThat(PropagationFields.get(context, FIELD2, factory.type()))
-      .isEqualTo("a");
+    assertThat(PropagationFields.get(context, keyTwo, factory.type()))
+      .isEqualTo(valueThree);
   }
 
   @Test public void get_null_if_not_set() {
-    assertThat(PropagationFields.get(context, FIELD2, factory.type()))
+    assertThat(PropagationFields.get(context, keyTwo, factory.type()))
       .isNull();
   }
 
   @Test public void get_ignore_if_not_defined() {
-    assertThat(PropagationFields.get(context, "balloon-color", factory.type()))
+    assertThat(PropagationFields.get(context, keyOne, factory.type()))
       .isNull();
   }
 
@@ -210,40 +217,48 @@ public abstract class PropagationFieldsFactoryTest<P extends PropagationFields>
     assertThat(extra.spanId).isEqualTo(spanId);
   }
 
+  @Test public void isEmpty() {
+    PropagationFields<K, V> fields = factory.create();
+    assertThat(fields.isEmpty()).isTrue();
+
+    fields.put(keyOne, valueOne);
+    assertThat(fields.isEmpty()).isFalse();
+  }
+
   @Test public void toMap_one() {
-    PropagationFields fields = factory.create();
-    fields.put(FIELD2, "a");
+    PropagationFields<K, V> fields = factory.create();
+    fields.put(keyTwo, valueThree);
 
     assertThat(fields.toMap())
       .hasSize(1)
-      .containsEntry(FIELD2, "a");
+      .containsEntry(keyTwo, valueThree);
   }
 
   @Test public void toMap_two() {
-    PropagationFields fields = factory.create();
-    fields.put(FIELD1, "1");
-    fields.put(FIELD2, "a");
+    PropagationFields<K, V> fields = factory.create();
+    fields.put(keyOne, valueOne);
+    fields.put(keyTwo, valueThree);
 
     assertThat(fields.toMap())
       .hasSize(2)
-      .containsEntry(FIELD1, "1")
-      .containsEntry(FIELD2, "a");
+      .containsEntry(keyOne, valueOne)
+      .containsEntry(keyTwo, valueThree);
   }
 
   @Test public void toString_one() {
-    PropagationFields fields = factory.create();
-    fields.put(FIELD2, "a");
+    PropagationFields<K, V> fields = factory.create();
+    fields.put(keyTwo, valueThree);
 
     assertThat(fields.toString())
-      .contains("{bar=a}");
+      .contains("{" + keyTwo + "=" + valueThree + "}");
   }
 
   @Test public void toString_two() {
-    PropagationFields fields = factory.create();
-    fields.put(FIELD1, "1");
-    fields.put(FIELD2, "a");
+    PropagationFields<K, V> fields = factory.create();
+    fields.put(keyOne, valueOne);
+    fields.put(keyTwo, valueThree);
 
     assertThat(fields.toString())
-      .contains("{foo=1, bar=a}");
+      .contains("{" + keyOne + "=" + valueOne + ", " + keyTwo + "=" + valueThree + "}");
   }
 }

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -14,7 +14,6 @@
 package brave.propagation;
 
 import brave.Tracing;
-import brave.internal.PropagationFields;
 import brave.propagation.ExtraFieldPropagation.Extra;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -145,8 +144,8 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void inject_extra() {
-    PropagationFields fields = context.findExtra(Extra.class);
-    fields.put("x-vcap-request-id", uuid);
+    Extra extra = context.findExtra(Extra.class);
+    extra.put("x-vcap-request-id", uuid);
 
     injector.inject(context, carrier);
 
@@ -154,9 +153,9 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void inject_two() {
-    PropagationFields fields = context.findExtra(Extra.class);
-    fields.put("x-vcap-request-id", uuid);
-    fields.put("x-amzn-trace-id", awsTraceId);
+    Extra extra = context.findExtra(Extra.class);
+    extra.put("x-vcap-request-id", uuid);
+    extra.put("x-amzn-trace-id", awsTraceId);
 
     injector.inject(context, carrier);
 
@@ -172,9 +171,9 @@ public class ExtraFieldPropagationTest {
       .build();
     initialize();
 
-    PropagationFields fields = context.findExtra(Extra.class);
-    fields.put("x-vcap-request-id", uuid);
-    fields.put("country-code", "FO");
+    Extra extra = context.findExtra(Extra.class);
+    extra.put("x-vcap-request-id", uuid);
+    extra.put("country-code", "FO");
 
     injector.inject(context, carrier);
 
@@ -193,8 +192,8 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().extra())
       .hasSize(1);
 
-    PropagationFields fields = (PropagationFields) extracted.context().extra().get(0);
-    assertThat(fields.toMap())
+    Extra extra = (Extra) extracted.context().extra().get(0);
+    assertThat(extra.toMap())
       .containsEntry("x-amzn-trace-id", awsTraceId);
   }
 
@@ -209,8 +208,8 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().extra())
       .hasSize(1);
 
-    PropagationFields fields = (PropagationFields) extracted.context().extra().get(0);
-    assertThat(fields.toMap())
+    Extra extra = (Extra) extracted.context().extra().get(0);
+    assertThat(extra.toMap())
       .containsEntry("x-amzn-trace-id", awsTraceId)
       .containsEntry("x-vcap-request-id", uuid);
   }
@@ -232,8 +231,8 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().extra())
       .hasSize(1);
 
-    PropagationFields fields = (PropagationFields) extracted.context().extra().get(0);
-    assertThat(fields.toMap())
+    Extra extra = (Extra) extracted.context().extra().get(0);
+    assertThat(extra.toMap())
       .containsEntry("country-code", "FO")
       .containsEntry("x-vcap-request-id", uuid);
   }

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
@@ -138,7 +138,7 @@ final class GrpcPropagation<K> implements Propagation<K> {
     }
   }
 
-  static final class TagsFactory extends PropagationFieldsFactory<Tags> {
+  static final class TagsFactory extends PropagationFieldsFactory<String, String, Tags> {
     @Override public Class<Tags> type() {
       return Tags.class;
     }
@@ -159,7 +159,7 @@ final class GrpcPropagation<K> implements Propagation<K> {
     return new Tags(extracted, parentMethod);
   }
 
-  static final class Tags extends MapPropagationFields {
+  static final class Tags extends MapPropagationFields<String, String> {
     final String parentMethod;
 
     Tags() {


### PR DESCRIPTION
https://github.com/openzipkin-contrib/zipkin-secondary-sampling tests
only have one client span per hop. Its internal "extra" carrier is not
safe for when one incoming request results in different downstream
sampling keys. This parameterizes infrastruture we use in the most
similar code (gRPC tags) so that we can re-use it for secondary sampling
entries.

Ex. while gRPC tags are string values, secondary sampling data can have
multiple options per key (such as ttl).