### PR TITLE
Adds HttpRequestSampler and backports HttpSampler to use it

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -69,7 +69,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
   final Tracer tracer;
   @Nullable final HttpClientAdapter<Req, Resp> adapter; // null when using default types
   final Sampler sampler;
-  final HttpSampler httpSampler;
+  final HttpRequestSampler httpSampler;
   @Nullable final Tracer samplingTracer;
   @Nullable final String serverName;
   final Injector<HttpClientRequest> defaultInjector;
@@ -82,10 +82,10 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
     this.adapter = adapter;
     this.tracer = httpTracing.tracing().tracer();
     this.sampler = httpTracing.tracing().sampler();
-    this.httpSampler = httpTracing.clientSampler();
-    if (httpSampler == HttpSampler.TRACE_ID) {
+    this.httpSampler = httpTracing.clientRequestSampler();
+    if (httpSampler == HttpRequestSampler.TRACE_ID) {
       samplingTracer = tracer;
-    } else if (httpSampler == HttpSampler.NEVER_SAMPLE) {
+    } else if (httpSampler == HttpRequestSampler.NEVER_SAMPLE) {
       samplingTracer = sampler == NEVER_SAMPLE ? tracer : tracer.withSampler(NEVER_SAMPLE);
     } else {
       samplingTracer = null;
@@ -106,13 +106,8 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    * @since 5.7
    */
   public Span handleSend(HttpClientRequest request) {
-    HttpClientRequest.Adapter adapter = new HttpClientRequest.Adapter(request);
-    return handleSend(adapter, nextClientSpan(adapter, request.unwrap()));
-  }
-
-  Span handleSend(HttpClientRequest.Adapter adapter, Span span) {
-    defaultInjector.inject(span.context(), adapter.delegate);
-    return handleStart(adapter, adapter.unwrapped, span);
+    if (request == null) throw new NullPointerException("request == null");
+    return handleSend(request, nextClientSpan(request));
   }
 
   /**
@@ -122,8 +117,10 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    * @since 5.7
    */
   public Span handleSend(HttpClientRequest request, Span span) {
-    HttpClientRequest.Adapter adapter = new HttpClientRequest.Adapter(request);
-    return handleSend(adapter, span);
+    if (request == null) throw new NullPointerException("request == null");
+    if (span == null) throw new NullPointerException("span == null");
+    defaultInjector.inject(span.context(), request);
+    return handleStart(new HttpClientRequest.ToHttpAdapter(request), request.unwrap(), span);
   }
 
   /**
@@ -170,26 +167,33 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
   }
 
   /**
+   * @since 4.4
+   * @deprecated since 5.8 use {@link #nextClientSpan(HttpClientRequest)}
+   */
+  @Deprecated public Span nextSpan(Req request) {
+    // nextSpan can be called independently when interceptors control lifecycle directly. In these
+    // cases, it is possible to have HttpClientRequest as an argument.
+    HttpClientRequest clientRequest;
+    if (request instanceof HttpClientRequest) {
+      clientRequest = (HttpClientRequest) request;
+    } else {
+      clientRequest = new HttpClientRequest.FromHttpAdapter<>(adapter, request);
+    }
+    return nextClientSpan(clientRequest);
+  }
+
+  /**
    * Creates a potentially noop span representing this request. This is used when you need to
    * provision a span in a different scope than where the request is executed.
    *
-   * @since 4.4
+   * @since 5.8
    */
-  public Span nextSpan(Req request) {
+  // Renamed to avoid generics clash when <Req> is HttpClientRequest.
+  public Span nextClientSpan(HttpClientRequest request) {
     if (request == null) throw new NullPointerException("request == null");
-    // nextSpan can be called independently when interceptors control lifecycle directly. In these
-    // cases, it is possible to have HttpClientRequest as an argument.
-    if (request instanceof HttpClientRequest) {
-      HttpClientRequest clientRequest = (HttpClientRequest) request;
-      return nextClientSpan(new HttpClientRequest.Adapter(clientRequest), clientRequest.unwrap());
-    }
-    return nextClientSpan(adapter, request);
-  }
-
-  <Req1> Span nextClientSpan(HttpClientAdapter<Req1, ?> adapter, Req1 req1) {
     Tracer scoped = samplingTracer != null ? samplingTracer : tracer.withSampler(new Sampler() {
       @Override public boolean isSampled(long traceId) {
-        Boolean decision = httpSampler.trySample(adapter, req1);
+        Boolean decision = httpSampler.trySample(request);
         if (decision == null) return sampler.isSampled(traceId);
         return decision;
       }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -134,8 +134,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
 
   /**
    * @since 4.3
-   * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest)} to handle any difference
-   * between carrier and request via wrapping in {@link HttpClientRequest}.
+   * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest)}.
    */
   @Deprecated public <C> Span handleSend(Injector<C> injector, C carrier, Req request) {
     return handleSend(injector, carrier, request, nextSpan(request));
@@ -143,8 +142,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
 
   /**
    * @since 4.4
-   * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest, Span)}, as this allows more
-   * advanced samplers to be used.
+   * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest, Span)}.
    */
   @Deprecated public Span handleSend(Injector<Req> injector, Req request, Span span) {
     return handleSend(injector, request, request, span);
@@ -152,8 +150,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
 
   /**
    * @since 4.4
-   * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest)} to handle any difference
-   * between carrier and request via wrapping in {@link HttpClientRequest}.
+   * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest)}.
    */
   @Deprecated public <C> Span handleSend(Injector<C> injector, C carrier, Req request, Span span) {
     injector.inject(span.context(), carrier);

--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -15,6 +15,7 @@ package brave.http;
 
 import brave.internal.Nullable;
 import brave.propagation.Propagation.Setter;
+import brave.propagation.TraceContext;
 
 /**
  * Marks an interface for use in {@link HttpClientHandler#handleSend(HttpClientRequest)}. This gives
@@ -23,7 +24,7 @@ import brave.propagation.Propagation.Setter;
  * @see HttpClientResponse
  * @since 5.7
  */
-public abstract class HttpClientRequest {
+public abstract class HttpClientRequest extends HttpRequest {
   static final Setter<HttpClientRequest, String> SETTER = new Setter<HttpClientRequest, String>() {
     @Override public void put(HttpClientRequest carrier, String key, String value) {
       carrier.header(key, value);
@@ -35,58 +36,40 @@ public abstract class HttpClientRequest {
   };
 
   /**
-   * Returns the underlying http request object. Ex. {@code org.apache.http.HttpRequest}
+   * Sets a request header with the indicated name. Null values are unsupported.
    *
-   * <p>Note: Some implementations are composed of multiple types, such as a request and a socket
-   * address of the client. Moreover, an implementation may change the type returned due to
-   * refactoring. Unless you control the implementation, cast carefully (ex using {@code instance
-   * of}) instead of presuming a specific type will always be returned.
+   * This is only used when {@link TraceContext.Injector#inject(TraceContext, Object) injecting} a
+   * trace context as internally implemented by {link HttpClientHandler}. Calls during sampling or
+   * parsing are invalid.
+   *
+   * @see #SETTER
+   * @since 5.7
    */
-  public abstract Object unwrap();
-
-  /** @see HttpAdapter#method(Object) */
-  @Nullable public abstract String method();
-
-  /** @see HttpAdapter#path(Object) */
-  @Nullable public abstract String path();
-
-  /** @see HttpAdapter#url(Object) */
-  @Nullable public abstract String url();
-
-  /** @see HttpAdapter#requestHeader(Object, String) */
-  @Nullable public abstract String header(String name);
-
-  /** @see HttpAdapter#startTimestamp(Object) */
-  public long startTimestamp() {
-    return 0L;
-  }
-
-  /** @see #SETTER */
   @Nullable public abstract void header(String name, String value);
-
-  @Override public String toString() {
-    // unwrap() returning null is a bug, but don't NPE during toString()
-    return "HttpClientRequest{" + unwrap() + "}";
-  }
 
   /**
    * <h3>Why do we need an {@link HttpClientAdapter}?</h3>
    *
-   * <p>We'd normally expect {@link HttpClientRequest} and {@link HttpClientResponse} to be used
-   * directly, so not need an adapter. However, doing so would imply duplicating types that use
-   * adapters, including {@link HttpClientParser} and {@link HttpSampler}. An adapter allows this
-   * type to be used in existing parsers and samplers, avoiding code duplication.
+   * <p>We'd normally expect {@link HttpClientRequest} to be used directly, so not need an adapter.
+   * However, parsing hasn't yet been converted to this type. Even if it was, there are public apis
+   * that still accept instances of adapters. A bridge is needed until deprecated methods are
+   * removed.
    */
-  // Intentionally hidden; Void type used to force generics to fail handling the wrong side
-  static final class Adapter extends brave.http.HttpClientAdapter<Object, Void> {
+  // Intentionally hidden; Void type used to force generics to fail handling the wrong side.
+  @Deprecated static final class ToHttpAdapter extends brave.http.HttpClientAdapter<Object, Void> {
     final HttpClientRequest delegate;
     final Object unwrapped;
 
-    Adapter(HttpClientRequest delegate) {
+    ToHttpAdapter(HttpClientRequest delegate) {
       if (delegate == null) throw new NullPointerException("delegate == null");
       this.delegate = delegate;
       this.unwrapped = delegate.unwrap();
       if (unwrapped == null) throw new NullPointerException("delegate.unwrap() == null");
+    }
+
+    @Override public final long startTimestamp(Object request) {
+      if (request == unwrapped) return delegate.startTimestamp();
+      return 0L;
     }
 
     @Override public final String method(Object request) {
@@ -107,11 +90,6 @@ public abstract class HttpClientRequest {
     @Override public final String path(Object request) {
       if (request == unwrapped) return delegate.path();
       return null;
-    }
-
-    @Override public final long startTimestamp(Object request) {
-      if (request == unwrapped) return delegate.startTimestamp();
-      return 0L;
     }
 
     // Skip response adapter methods
@@ -136,19 +114,68 @@ public abstract class HttpClientRequest {
       return 0L;
     }
 
-    @Override public String toString() {
+    @Override public final String toString() {
       return delegate.toString();
     }
 
-    @Override public boolean equals(Object o) { // implemented to make testing easier
+    @Override public final boolean equals(Object o) { // implemented to make testing easier
       if (o == this) return true;
-      if (!(o instanceof Adapter)) return false;
-      Adapter that = (Adapter) o;
-      return delegate == that.delegate;
+      if (!(o instanceof HttpClientRequest.ToHttpAdapter)) return false;
+      return delegate.equals(((HttpClientRequest.ToHttpAdapter) o).delegate);
     }
 
-    @Override public int hashCode() {
+    @Override public final int hashCode() {
       return delegate.hashCode();
+    }
+  }
+
+  @Deprecated static final class FromHttpAdapter<Req> extends HttpClientRequest {
+    final HttpClientAdapter<Req, ?> adapter;
+    final Req request;
+
+    FromHttpAdapter(HttpClientAdapter<Req, ?> adapter, Req request) {
+      if (adapter == null) throw new NullPointerException("adapter == null");
+      this.adapter = adapter;
+      if (request == null) throw new NullPointerException("request == null");
+      this.request = request;
+    }
+
+    @Override public Object unwrap() {
+      return request;
+    }
+
+    @Override public String method() {
+      return adapter.method(request);
+    }
+
+    @Override public String path() {
+      return adapter.path(request);
+    }
+
+    @Override public String url() {
+      return adapter.url(request);
+    }
+
+    @Override public String header(String name) {
+      return adapter.requestHeader(request, name);
+    }
+
+    @Override public void header(String name, String value) {
+      throw new UnsupportedOperationException("immutable");
+    }
+
+    @Override public final String toString() {
+      return request.toString();
+    }
+
+    @Override public final boolean equals(Object o) { // implemented to make testing easier
+      if (o == this) return true;
+      if (!(o instanceof HttpClientRequest.FromHttpAdapter)) return false;
+      return request.equals(((HttpClientRequest.FromHttpAdapter) o).request);
+    }
+
+    @Override public final int hashCode() {
+      return request.hashCode();
     }
   }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -117,16 +117,6 @@ public abstract class HttpClientRequest extends HttpRequest {
     @Override public final String toString() {
       return delegate.toString();
     }
-
-    @Override public final boolean equals(Object o) { // implemented to make testing easier
-      if (o == this) return true;
-      if (!(o instanceof HttpClientRequest.ToHttpAdapter)) return false;
-      return delegate.equals(((HttpClientRequest.ToHttpAdapter) o).delegate);
-    }
-
-    @Override public final int hashCode() {
-      return delegate.hashCode();
-    }
   }
 
   @Deprecated static final class FromHttpAdapter<Req> extends HttpClientRequest {
@@ -142,6 +132,10 @@ public abstract class HttpClientRequest extends HttpRequest {
 
     @Override public Object unwrap() {
       return request;
+    }
+
+    @Override public long startTimestamp() {
+      return adapter.startTimestamp(request);
     }
 
     @Override public String method() {
@@ -166,16 +160,6 @@ public abstract class HttpClientRequest extends HttpRequest {
 
     @Override public final String toString() {
       return request.toString();
-    }
-
-    @Override public final boolean equals(Object o) { // implemented to make testing easier
-      if (o == this) return true;
-      if (!(o instanceof HttpClientRequest.FromHttpAdapter)) return false;
-      return request.equals(((HttpClientRequest.FromHttpAdapter) o).request);
-    }
-
-    @Override public final int hashCode() {
-      return request.hashCode();
     }
   }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.internal.Nullable;
+
+/**
+ * Abstract request type used for parsing and sampling of http clients and servers.
+ *
+ * @see HttpClientRequest
+ * @see HttpServerRequest
+ * @since 5.8
+ */
+public abstract class HttpRequest {
+  /**
+   * Returns the underlying http request object. Ex. {@code org.apache.http.HttpRequest}
+   *
+   * <p>Note: Some implementations are composed of multiple types, such as a request and a socket
+   * address of the client. Moreover, an implementation may change the type returned due to
+   * refactoring. Unless you control the implementation, cast carefully (ex using {@code instance
+   * of}) instead of presuming a specific type will always be returned.
+   */
+  public abstract Object unwrap();
+
+  /** @see HttpAdapter#startTimestamp(Object) */
+  public long startTimestamp() {
+    return 0L;
+  }
+
+  /** @see HttpAdapter#method(Object) */
+  @Nullable public abstract String method();
+
+  /** @see HttpAdapter#path(Object) */
+  @Nullable public abstract String path();
+
+  /** @see HttpAdapter#url(Object) */
+  @Nullable public abstract String url();
+
+  /** @see HttpAdapter#requestHeader(Object, String) */
+  @Nullable public abstract String header(String name);
+
+  @Override public String toString() {
+    Object unwrapped = unwrap();
+    // unwrap() returning null is a bug. It could also return this. don't NPE or stack overflow!
+    if (unwrapped == null || unwrapped == this) return getClass().getSimpleName();
+    return getClass().getSimpleName() + "{" + unwrapped + "}";
+  }
+
+  HttpRequest() { // sealed type: only client and server
+  }
+}

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestSampler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.internal.Nullable;
+
+/**
+ * Decides whether to start a new trace based on http request properties such as path.
+ *
+ * <p>Ex. Here's a sampler that only traces api requests
+ * <pre>{@code
+ * httpTracingBuilder.serverSampler(new HttpSampler() {
+ *   @Override public Boolean trySample(HttpRequest request) {
+ *     return request.path().startsWith("/api");
+ *   }
+ * });
+ * }</pre>
+ *
+ * @see HttpRuleSampler
+ * @since 5.8
+ */
+// interface, not abstract type, to allow backporting of HttpSampler.
+// This implies we cannot add new methods later, as the bytecode level of Brave core is 1.6
+public interface HttpRequestSampler {
+  /**
+   * Ignores the request and uses the {@link brave.sampler.Sampler trace ID instead}.
+   *
+   * @since 5.8
+   */
+  HttpRequestSampler TRACE_ID = new HttpRequestSampler() {
+    @Override @Nullable public Boolean trySample(HttpRequest request) {
+      return null;
+    }
+
+    @Override public String toString() {
+      return "DeferDecision";
+    }
+  };
+
+  /**
+   * Returns true to always start new traces for http requests.
+   *
+   * @since 5.8
+   */
+  HttpRequestSampler ALWAYS_SAMPLE = new HttpRequestSampler() {
+    @Override @Nullable public Boolean trySample(HttpRequest request) {
+      return true;
+    }
+
+    @Override public String toString() {
+      return "AlwaysSample";
+    }
+  };
+
+  /**
+   * Returns false to never start new traces for http requests. For example, you may wish to only
+   * capture traces if they originated from an inbound server request. Such a policy would filter
+   * out client requests made during bootstrap.
+   *
+   * @since 5.8
+   */
+  HttpRequestSampler NEVER_SAMPLE = new HttpRequestSampler() {
+    @Override @Nullable public Boolean trySample(HttpRequest request) {
+      return false;
+    }
+
+    @Override public String toString() {
+      return "NeverSample";
+    }
+  };
+
+  /**
+   * Returns an overriding sampling decision for a new trace. Return null ignore the request and use
+   * the {@link brave.sampler.Sampler trace ID sampler}.
+   *
+   * @since 5.8
+   */
+  @Nullable Boolean trySample(HttpRequest request);
+}

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -38,7 +38,7 @@ import brave.sampler.RateLimitingSampler;
  *
  * @since 4.4
  */
-public final class HttpRuleSampler extends HttpSampler {
+public final class HttpRuleSampler extends HttpSampler implements HttpRequestSampler {
   /** @since 4.4 */
   public static Builder newBuilder() {
     return new Builder();
@@ -95,6 +95,10 @@ public final class HttpRuleSampler extends HttpSampler {
 
   HttpRuleSampler(ParameterizedSampler<MethodAndPath> sampler) {
     this.sampler = sampler;
+  }
+
+  @Override public Boolean trySample(HttpRequest request) {
+    return trySample(request.method(), request.path());
   }
 
   @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -17,7 +17,7 @@ import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.internal.Nullable;
-import brave.propagation.TraceContext;
+import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContextOrSamplingFlags;
 
 /**
@@ -66,7 +66,7 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
   final Tracer tracer;
   final HttpRequestSampler sampler;
   @Nullable final HttpServerAdapter<Req, Resp> adapter; // null when using default types
-  final TraceContext.Extractor<HttpServerRequest> defaultExtractor;
+  final Extractor<HttpServerRequest> defaultExtractor;
 
   HttpServerHandler(HttpTracing httpTracing, HttpServerAdapter<Req, Resp> adapter) {
     super(
@@ -96,21 +96,17 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
 
   /**
    * @since 4.3
-   * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)}, as this allows more
-   * advanced samplers to be used.
+   * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)}
    */
-  @Deprecated
-  public Span handleReceive(TraceContext.Extractor<Req> extractor, Req request) {
+  @Deprecated public Span handleReceive(Extractor<Req> extractor, Req request) {
     return handleReceive(extractor, request, request);
   }
 
   /**
    * @since 4.3
-   * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)} to handle any difference
-   * between carrier and request via wrapping in {@link HttpServerRequest}.
+   * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)}
    */
-  @Deprecated
-  public <C> Span handleReceive(TraceContext.Extractor<C> extractor, C carrier, Req request) {
+  @Deprecated public <C> Span handleReceive(Extractor<C> extractor, C carrier, Req request) {
     HttpServerRequest serverRequest;
     if (request instanceof HttpServerRequest) {
       serverRequest = (HttpServerRequest) request;

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -41,6 +41,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
  *
  * @param <Req> the native http request type of the server.
  * @param <Resp> the native http response type of the server.
+ * @since 4.3
  */
 public final class HttpServerHandler<Req, Resp> extends HttpHandler {
   /** @since 5.7 */
@@ -50,7 +51,10 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
     return new HttpServerHandler<>(httpTracing, null);
   }
 
-  /** @deprecated Since 5.7, use {@link #create(HttpTracing)} as it is more portable. */
+  /**
+   * @since 4.3
+   * @deprecated Since 5.7, use {@link #create(HttpTracing)} as it is more portable.
+   */
   @Deprecated
   public static <Req, Resp> HttpServerHandler<Req, Resp> create(HttpTracing httpTracing,
     HttpServerAdapter<Req, Resp> adapter) {
@@ -60,7 +64,7 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
   }
 
   final Tracer tracer;
-  final HttpSampler sampler;
+  final HttpRequestSampler sampler;
   @Nullable final HttpServerAdapter<Req, Resp> adapter; // null when using default types
   final TraceContext.Extractor<HttpServerRequest> defaultExtractor;
 
@@ -71,7 +75,7 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
     );
     this.adapter = adapter;
     this.tracer = httpTracing.tracing().tracer();
-    this.sampler = httpTracing.serverSampler();
+    this.sampler = httpTracing.serverRequestSampler();
     // The following allows us to add the method: handleReceive(HttpServerRequest request) without
     // duplicating logic from the superclass or deprecated handleReceive methods.
     this.defaultExtractor = httpTracing.tracing().propagation().extractor(HttpServerRequest.GETTER);
@@ -86,17 +90,12 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
    * @since 5.7
    */
   public Span handleReceive(HttpServerRequest request) {
-    HttpServerRequest.Adapter adapter = new HttpServerRequest.Adapter(request);
-    Span span = nextSpan(adapter, defaultExtractor.extract(request), adapter.unwrapped);
-    return handleStart(adapter, adapter.unwrapped, span);
+    Span span = nextSpan(defaultExtractor.extract(request), request);
+    return handleStart(new HttpServerRequest.ToHttpAdapter(request), request.unwrap(), span);
   }
 
   /**
-   * Conditionally joins a span, or starts a new trace, depending on if a trace context was
-   * extracted from the request. Tags are added before the span is started.
-   *
-   * <p>This is typically called before the request is processed by the actual library.
-   *
+   * @since 4.3
    * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)}, as this allows more
    * advanced samplers to be used.
    */
@@ -106,18 +105,19 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
   }
 
   /**
-   * Like {@link #handleReceive(TraceContext.Extractor, Object)}, except for when the carrier of
-   * trace data is not the same as the request.
-   *
-   * <p>Request data is parsed before the span is started.
-   *
-   * @see HttpServerParser#request(HttpAdapter, Object, SpanCustomizer)
+   * @since 4.3
    * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)} to handle any difference
    * between carrier and request via wrapping in {@link HttpServerRequest}.
    */
   @Deprecated
   public <C> Span handleReceive(TraceContext.Extractor<C> extractor, C carrier, Req request) {
-    Span span = nextSpan(adapter, extractor.extract(carrier), request);
+    HttpServerRequest serverRequest;
+    if (request instanceof HttpServerRequest) {
+      serverRequest = (HttpServerRequest) request;
+    } else {
+      serverRequest = new HttpServerRequest.FromHttpAdapter<>(adapter, request);
+    }
+    Span span = nextSpan(extractor.extract(carrier), serverRequest);
     return handleStart(adapter, request, span);
   }
 
@@ -128,11 +128,10 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
   }
 
   /** Creates a potentially noop span representing this request */
-  <Req1> Span nextSpan(HttpAdapter<Req1, ?> adapter, TraceContextOrSamplingFlags extracted,
-    Req1 request) {
+  Span nextSpan(TraceContextOrSamplingFlags extracted, HttpServerRequest request) {
     Boolean sampled = extracted.sampled();
     // only recreate the context if the http sampler made a decision
-    if (sampled == null && (sampled = sampler.trySample(adapter, request)) != null) {
+    if (sampled == null && (sampled = sampler.trySample(request)) != null) {
       extracted = extracted.sampled(sampled.booleanValue());
     }
     return extracted.context() != null
@@ -147,6 +146,7 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
    * brave.Tracer.SpanInScope#close() no longer in scope}.
    *
    * @see HttpServerParser#response(HttpAdapter, Object, Throwable, SpanCustomizer)
+   * @since 4.3
    */
   public void handleSend(@Nullable Resp response, @Nullable Throwable error, Span span) {
     if (response instanceof HttpServerResponse) {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
@@ -14,7 +14,6 @@
 package brave.http;
 
 import brave.Span;
-import brave.internal.Nullable;
 import brave.propagation.Propagation.Getter;
 
 /**
@@ -24,7 +23,7 @@ import brave.propagation.Propagation.Getter;
  * @see HttpServerResponse
  * @since 5.7
  */
-public abstract class HttpServerRequest {
+public abstract class HttpServerRequest extends HttpRequest {
   static final Getter<HttpServerRequest, String> GETTER = new Getter<HttpServerRequest, String>() {
     @Override public String get(HttpServerRequest carrier, String key) {
       return carrier.header(key);
@@ -36,28 +35,6 @@ public abstract class HttpServerRequest {
   };
 
   /**
-   * Returns the underlying http request object. Ex. {@code javax.servlet.http.HttpServletRequest}
-   *
-   * <p>Note: Some implementations are composed of multiple types, such as a request and a socket
-   * address of the client. Moreover, an implementation may change the type returned due to
-   * refactoring. Unless you control the implementation, cast carefully (ex using {@code instance
-   * of}) instead of presuming a specific type will always be returned.
-   */
-  public abstract Object unwrap();
-
-  /** @see HttpAdapter#method(Object) */
-  @Nullable public abstract String method();
-
-  /** @see HttpAdapter#path(Object) */
-  @Nullable public abstract String path();
-
-  /** @see HttpAdapter#url(Object) */
-  @Nullable public abstract String url();
-
-  /** @see HttpAdapter#requestHeader(Object, String) */
-  @Nullable public abstract String header(String name);
-
-  /**
    * Override and return true when it is possible to parse the {@link Span#remoteIpAndPort(String,
    * int) remote IP and port} from the {@link #unwrap() delegate}. Defaults to false.
    *
@@ -67,30 +44,20 @@ public abstract class HttpServerRequest {
     return false;
   }
 
-  /** @see HttpAdapter#startTimestamp(Object) */
-  public long startTimestamp() {
-    return 0L;
-  }
-
-  @Override public String toString() {
-    // unwrap() returning null is a bug, but don't NPE during toString()
-    return "HttpServerRequest{" + unwrap() + "}";
-  }
-
   /**
    * <h3>Why do we need an {@link HttpServerAdapter}?</h3>
    *
-   * <p>We'd normally expect {@link HttpServerRequest} and {@link HttpServerResponse} to be used
-   * directly, so not need an adapter. However, doing so would imply duplicating types that use
-   * adapters, including {@link HttpServerParser} and {@link HttpSampler}. An adapter allows this
-   * type to be used in existing parsers and samplers, avoiding code duplication.
+   * <p>We'd normally expect {@link HttpServerRequest} to be used directly, so not need an adapter.
+   * However, parsing hasn't yet been converted to this type. Even if it was, there are public apis
+   * that still accept instances of adapters. A bridge is needed until deprecated methods are
+   * removed.
    */
-  // Intentionally hidden; Void type used to force generics to fail handling the wrong side
-  static final class Adapter extends brave.http.HttpServerAdapter<Object, Void> {
+  // Intentionally hidden; Void type used to force generics to fail handling the wrong side.
+  @Deprecated static final class ToHttpAdapter extends brave.http.HttpServerAdapter<Object, Void> {
     final HttpServerRequest delegate;
     final Object unwrapped;
 
-    Adapter(HttpServerRequest delegate) {
+    ToHttpAdapter(HttpServerRequest delegate) {
       if (delegate == null) throw new NullPointerException("delegate == null");
       this.delegate = delegate;
       this.unwrapped = delegate.unwrap();
@@ -103,6 +70,11 @@ public abstract class HttpServerRequest {
         return delegate.parseClientIpAndPort(span);
       }
       return false;
+    }
+
+    @Override public final long startTimestamp(Object request) {
+      if (request == unwrapped) return delegate.startTimestamp();
+      return 0L;
     }
 
     @Override public final String method(Object request) {
@@ -123,11 +95,6 @@ public abstract class HttpServerRequest {
     @Override public final String path(Object request) {
       if (request == unwrapped) return delegate.path();
       return null;
-    }
-
-    @Override public final long startTimestamp(Object request) {
-      if (request == unwrapped) return delegate.startTimestamp();
-      return 0L;
     }
 
     // Skip response adapter methods
@@ -152,19 +119,68 @@ public abstract class HttpServerRequest {
       return 0L;
     }
 
-    @Override public String toString() {
+    @Override public final String toString() {
       return delegate.toString();
     }
 
-    @Override public boolean equals(Object o) { // implemented to make testing easier
+    @Override public final boolean equals(Object o) { // implemented to make testing easier
       if (o == this) return true;
-      if (!(o instanceof Adapter)) return false;
-      Adapter that = (Adapter) o;
-      return delegate == that.delegate;
+      if (!(o instanceof ToHttpAdapter)) return false;
+      return delegate.equals(((ToHttpAdapter) o).delegate);
     }
 
-    @Override public int hashCode() {
+    @Override public final int hashCode() {
       return delegate.hashCode();
+    }
+  }
+
+  @Deprecated static final class FromHttpAdapter<Req> extends HttpServerRequest {
+    final HttpServerAdapter<Req, ?> adapter;
+    final Req request;
+
+    FromHttpAdapter(HttpServerAdapter<Req, ?> adapter, Req request) {
+      if (adapter == null) throw new NullPointerException("adapter == null");
+      this.adapter = adapter;
+      if (request == null) throw new NullPointerException("request == null");
+      this.request = request;
+    }
+
+    @Override public Object unwrap() {
+      return request;
+    }
+
+    @Override public String method() {
+      return adapter.method(request);
+    }
+
+    @Override public String path() {
+      return adapter.path(request);
+    }
+
+    @Override public String url() {
+      return adapter.url(request);
+    }
+
+    @Override public String header(String name) {
+      return adapter.requestHeader(request, name);
+    }
+
+    @Override public boolean parseClientIpAndPort(Span span) {
+      return adapter.parseClientIpAndPort(request, span);
+    }
+
+    @Override public final String toString() {
+      return request.toString();
+    }
+
+    @Override public final boolean equals(Object o) { // implemented to make testing easier
+      if (o == this) return true;
+      if (!(o instanceof HttpServerRequest.FromHttpAdapter)) return false;
+      return request.equals(((HttpServerRequest.FromHttpAdapter) o).request);
+    }
+
+    @Override public final int hashCode() {
+      return request.hashCode();
     }
   }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
@@ -122,16 +122,6 @@ public abstract class HttpServerRequest extends HttpRequest {
     @Override public final String toString() {
       return delegate.toString();
     }
-
-    @Override public final boolean equals(Object o) { // implemented to make testing easier
-      if (o == this) return true;
-      if (!(o instanceof ToHttpAdapter)) return false;
-      return delegate.equals(((ToHttpAdapter) o).delegate);
-    }
-
-    @Override public final int hashCode() {
-      return delegate.hashCode();
-    }
   }
 
   @Deprecated static final class FromHttpAdapter<Req> extends HttpServerRequest {
@@ -147,6 +137,10 @@ public abstract class HttpServerRequest extends HttpRequest {
 
     @Override public Object unwrap() {
       return request;
+    }
+
+    @Override public long startTimestamp() {
+      return adapter.startTimestamp(request);
     }
 
     @Override public String method() {
@@ -171,16 +165,6 @@ public abstract class HttpServerRequest extends HttpRequest {
 
     @Override public final String toString() {
       return request.toString();
-    }
-
-    @Override public final boolean equals(Object o) { // implemented to make testing easier
-      if (o == this) return true;
-      if (!(o instanceof HttpServerRequest.FromHttpAdapter)) return false;
-      return request.equals(((HttpServerRequest.FromHttpAdapter) o).request);
-    }
-
-    @Override public final int hashCode() {
-      return request.hashCode();
     }
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpClientRequestTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientRequestTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.Span;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpClientRequestTest {
+  @Mock HttpClientRequest clientRequest;
+  @Mock HttpClientAdapter<Object, Object> adapter;
+  Object request = new Object();
+  @Mock Span span;
+
+  HttpClientRequest.ToHttpAdapter toAdapter;
+  HttpClientRequest.FromHttpAdapter<Object> fromAdapter;
+
+  @Before public void callRealMethod() {
+    when(clientRequest.unwrap()).thenReturn(request);
+    toAdapter = new HttpClientRequest.ToHttpAdapter(clientRequest);
+    fromAdapter = new HttpClientRequest.FromHttpAdapter<>(adapter, request);
+  }
+
+  @Test public void toAdapter_startTimestamp_zeroOnNoMatch() {
+    assertThat(toAdapter.startTimestamp(request)).isZero();
+  }
+
+  @Test public void toAdapter_startTimestamp_zeroOnWrongRequest() {
+    assertThat(toAdapter.startTimestamp(null)).isZero();
+    assertThat(toAdapter.startTimestamp(clientRequest)).isZero();
+  }
+
+  @Test public void toAdapter_startTimestamp_delegatesToClientRequest() {
+    when(clientRequest.startTimestamp()).thenReturn(1L);
+
+    assertThat(toAdapter.startTimestamp(request)).isEqualTo(1L);
+
+    verify(clientRequest).startTimestamp();
+  }
+
+  @Test public void toAdapter_method_nullOnNoMatch() {
+    assertThat(toAdapter.method(request)).isNull();
+  }
+
+  @Test public void toAdapter_method_nullOnWrongRequest() {
+    assertThat(toAdapter.method(null)).isNull();
+    assertThat(toAdapter.method(clientRequest)).isNull();
+  }
+
+  @Test public void toAdapter_method_delegatesToClientRequest() {
+    when(clientRequest.method()).thenReturn("GET");
+
+    assertThat(toAdapter.method(request)).isEqualTo("GET");
+
+    verify(clientRequest).method();
+  }
+
+  @Test public void toAdapter_url_nullOnNoMatch() {
+    assertThat(toAdapter.url(request)).isNull();
+  }
+
+  @Test public void toAdapter_url_nullOnWrongRequest() {
+    assertThat(toAdapter.url(null)).isNull();
+    assertThat(toAdapter.url(clientRequest)).isNull();
+  }
+
+  @Test public void toAdapter_url_delegatesToClientRequest() {
+    when(clientRequest.url()).thenReturn("https://zipkin.io");
+
+    assertThat(toAdapter.url(request)).isEqualTo("https://zipkin.io");
+
+    verify(clientRequest).url();
+  }
+
+  @Test public void toAdapter_requestHeader_nullOnNoMatch() {
+    assertThat(toAdapter.requestHeader(request, "Content-Type")).isNull();
+  }
+
+  @Test public void toAdapter_requestHeader_nullOnWrongRequest() {
+    assertThat(toAdapter.requestHeader(null, "Content-Type")).isNull();
+    assertThat(toAdapter.requestHeader(clientRequest, "Content-Type")).isNull();
+  }
+
+  @Test public void toAdapter_requestHeader_delegatesToClientRequest() {
+    when(clientRequest.header("Content-Type")).thenReturn("text/plain");
+
+    assertThat(toAdapter.requestHeader(request, "Content-Type")).isEqualTo("text/plain");
+
+    verify(clientRequest).header("Content-Type");
+  }
+
+  @Test public void toAdapter_path_nullOnNoMatch() {
+    assertThat(toAdapter.path(request)).isNull();
+  }
+
+  @Test public void toAdapter_path_nullOnWrongRequest() {
+    assertThat(toAdapter.path(null)).isNull();
+    assertThat(toAdapter.path(clientRequest)).isNull();
+  }
+
+  @Test public void toAdapter_path_delegatesToClientRequest() {
+    when(clientRequest.path()).thenReturn("/api/v2/traces");
+
+    assertThat(toAdapter.path(request)).isEqualTo("/api/v2/traces");
+
+    verify(clientRequest).path();
+  }
+
+  @Test public void fromAdapter_startTimestamp_zeroOnNoMatch() {
+    assertThat(fromAdapter.startTimestamp()).isZero();
+  }
+
+  @Test public void fromAdapter_startTimestamp_delegatesToAdapter() {
+    when(adapter.startTimestamp(request)).thenReturn(1L);
+
+    assertThat(fromAdapter.startTimestamp()).isEqualTo(1L);
+
+    verify(adapter).startTimestamp(request);
+  }
+
+  @Test public void fromAdapter_method_nullOnNoMatch() {
+    assertThat(fromAdapter.method()).isNull();
+  }
+
+  @Test public void fromAdapter_method_delegatesToAdapter() {
+    when(adapter.method(request)).thenReturn("GET");
+
+    assertThat(fromAdapter.method()).isEqualTo("GET");
+
+    verify(adapter).method(request);
+  }
+
+  @Test public void fromAdapter_url_nullOnNoMatch() {
+    assertThat(fromAdapter.url()).isNull();
+  }
+
+  @Test public void fromAdapter_url_delegatesToAdapter() {
+    when(adapter.url(request)).thenReturn("https://zipkin.io");
+
+    assertThat(fromAdapter.url()).isEqualTo("https://zipkin.io");
+
+    verify(adapter).url(request);
+  }
+
+  @Test public void fromAdapter_header_nullOnNoMatch() {
+    assertThat(fromAdapter.header("Content-Type")).isNull();
+  }
+
+  @Test public void fromAdapter_header_delegatesToAdapter() {
+    when(adapter.requestHeader(request, "Content-Type")).thenReturn("text/plain");
+
+    assertThat(fromAdapter.header("Content-Type")).isEqualTo("text/plain");
+
+    verify(adapter).requestHeader(request, "Content-Type");
+  }
+
+  @Test public void fromAdapter_path_nullOnNoMatch() {
+    assertThat(fromAdapter.path()).isNull();
+  }
+
+  @Test public void fromAdapter_path_delegatesToAdapter() {
+    when(adapter.path(request)).thenReturn("/api/v2/traces");
+
+    assertThat(fromAdapter.path()).isEqualTo("/api/v2/traces");
+
+    verify(adapter).path(request);
+  }
+}

--- a/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -140,11 +140,9 @@ public class HttpHandlerTest {
   @Test public void handleFinish_finishedEvenIfAdapterThrows() {
     when(adapter.statusCodeAsInt(response)).thenThrow(new RuntimeException());
 
-    try {
-      handler.handleFinish(adapter, response, null, span);
-      failBecauseExceptionWasNotThrown(RuntimeException.class);
-    } catch (RuntimeException e) {
-      verify(span).finish();
-    }
+    assertThatThrownBy(() -> handler.handleFinish(adapter, response, null, span))
+      .isInstanceOf(RuntimeException.class);
+
+    verify(span).finish();
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpRequestTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRequestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpRequestTest {
+  @Test public void toString_mentionsDelegate() {
+    class IceCreamRequest extends HttpRequest {
+      @Override public Object unwrap() {
+        return "chocolate";
+      }
+
+      @Override public String method() {
+        return null;
+      }
+
+      @Override public String path() {
+        return null;
+      }
+
+      @Override public String url() {
+        return null;
+      }
+
+      @Override public String header(String name) {
+        return null;
+      }
+    }
+    assertThat(new IceCreamRequest())
+      .hasToString("IceCreamRequest{chocolate}");
+  }
+
+  @Test public void toString_doesntStackoverflowWhenUnwrapIsNull() {
+    class BuggyRequest extends HttpRequest {
+      @Override public Object unwrap() {
+        return null;
+      }
+
+      @Override public String method() {
+        return null;
+      }
+
+      @Override public String path() {
+        return null;
+      }
+
+      @Override public String url() {
+        return null;
+      }
+
+      @Override public String header(String name) {
+        return null;
+      }
+    }
+    assertThat(new BuggyRequest())
+      .hasToString("BuggyRequest");
+  }
+}

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -26,6 +26,9 @@ public class HttpRuleSamplerTest {
   @Mock HttpClientAdapter<Object, Object> adapter;
   Object request = new Object();
 
+  @Mock HttpClientRequest httpClientRequest;
+  @Mock HttpServerRequest httpServerRequest;
+
   @Test public void onPath() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
       .addRuleWithProbability(null, "/foo", 1.0f)
@@ -35,6 +38,18 @@ public class HttpRuleSamplerTest {
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
+      .isTrue();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isTrue();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpServerRequest))
       .isTrue();
   }
 
@@ -72,6 +87,18 @@ public class HttpRuleSamplerTest {
 
     assertThat(sampler.trySample(adapter, request))
       .isFalse();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isFalse();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpServerRequest))
+      .isFalse();
   }
 
   @Test public void onPath_sampled_prefix() {
@@ -83,6 +110,18 @@ public class HttpRuleSamplerTest {
     when(adapter.path(request)).thenReturn("/foo/abcd");
 
     assertThat(sampler.trySample(adapter, request))
+      .isFalse();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/foo/abcd");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isFalse();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo/abcd");
+
+    assertThat(sampler.trySample(httpServerRequest))
       .isFalse();
   }
 
@@ -96,6 +135,18 @@ public class HttpRuleSamplerTest {
 
     assertThat(sampler.trySample(adapter, request))
       .isNull();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/bar");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isNull();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/bar");
+
+    assertThat(sampler.trySample(httpServerRequest))
+      .isNull();
   }
 
   @Test public void onMethodAndPath_sampled() {
@@ -107,6 +158,18 @@ public class HttpRuleSamplerTest {
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
+      .isTrue();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isTrue();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpServerRequest))
       .isTrue();
   }
 
@@ -120,6 +183,18 @@ public class HttpRuleSamplerTest {
 
     assertThat(sampler.trySample(adapter, request))
       .isTrue();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/foo/abcd");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isTrue();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo/abcd");
+
+    assertThat(sampler.trySample(httpServerRequest))
+      .isTrue();
   }
 
   @Test public void onMethodAndPath_unsampled() {
@@ -131,6 +206,18 @@ public class HttpRuleSamplerTest {
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
+      .isFalse();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isFalse();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpServerRequest))
       .isFalse();
   }
 
@@ -144,6 +231,18 @@ public class HttpRuleSamplerTest {
 
     assertThat(sampler.trySample(adapter, request))
       .isNull();
+
+    when(httpClientRequest.method()).thenReturn("POST");
+    when(httpClientRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isNull();
+
+    when(httpServerRequest.method()).thenReturn("POST");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(sampler.trySample(httpServerRequest))
+      .isNull();
   }
 
   @Test public void onMethodAndPath_doesntMatch_path() {
@@ -156,6 +255,18 @@ public class HttpRuleSamplerTest {
 
     assertThat(sampler.trySample(adapter, request))
       .isNull();
+
+    when(httpClientRequest.method()).thenReturn("GET");
+    when(httpClientRequest.path()).thenReturn("/bar");
+
+    assertThat(sampler.trySample(httpClientRequest))
+      .isNull();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/bar");
+
+    assertThat(sampler.trySample(httpServerRequest))
+      .isNull();
   }
 
   @Test public void nullOnParseFailure() {
@@ -165,6 +276,10 @@ public class HttpRuleSamplerTest {
 
     // not setting up mocks means they return null which is like a parse fail
     assertThat(sampler.trySample(adapter, request))
+      .isNull();
+    assertThat(sampler.trySample(httpClientRequest))
+      .isNull();
+    assertThat(sampler.trySample(httpServerRequest))
       .isNull();
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -18,7 +18,6 @@ import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.Tracing;
 import brave.propagation.SamplingFlags;
-import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.ArrayList;
@@ -46,35 +45,38 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class HttpServerHandlerTest {
   List<zipkin2.Span> spans = new ArrayList<>();
-  Tracer tracer;
   @Mock HttpSampler sampler;
+  HttpTracing httpTracing;
+  HttpServerHandler<Object, Object> handler;
+
   @Spy HttpServerParser parser = new HttpServerParser();
   @Mock HttpServerAdapter<Object, Object> adapter;
   @Mock TraceContext.Extractor<Object> extractor;
   @Mock Object request;
   @Mock Object response;
-  HttpServerHandler<Object, Object> handler;
+
+  @Mock HttpRequestSampler requestSampler;
+  HttpTracing defaultHttpTracing;
+  HttpServerHandler<HttpServerRequest, HttpServerResponse> defaultHandler;
 
   @Mock(answer = CALLS_REAL_METHODS) HttpServerRequest defaultRequest;
   @Mock(answer = CALLS_REAL_METHODS) HttpServerResponse defaultResponse;
-  HttpServerHandler<HttpServerRequest, HttpServerResponse> defaultHandler;
 
   @Before public void init() {
-    HttpTracing httpTracing = HttpTracing.newBuilder(
-      Tracing.newBuilder()
-        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
-        .spanReporter(spans::add)
-        .build()
-    ).serverSampler(sampler).serverParser(parser).build();
-    tracer = httpTracing.tracing().tracer();
+    httpTracing = HttpTracing.newBuilder(Tracing.newBuilder().spanReporter(spans::add).build())
+      .serverSampler(sampler).serverParser(parser).build();
     handler = HttpServerHandler.create(httpTracing, adapter);
 
-    when(adapter.method(request)).thenReturn("GET");
-    doCallRealMethod().when(adapter).parseClientIpAndPort(eq(request), isA(brave.Span.class));
+    defaultHttpTracing =
+      HttpTracing.newBuilder(Tracing.newBuilder().spanReporter(spans::add).build())
+        .serverSampler(requestSampler).serverParser(parser).build();
+    defaultHandler = HttpServerHandler.create(defaultHttpTracing);
 
     when(defaultRequest.unwrap()).thenReturn(request);
     when(defaultResponse.unwrap()).thenReturn(response);
-    defaultHandler = HttpServerHandler.create(httpTracing);
+
+    when(adapter.method(request)).thenReturn("GET");
+    doCallRealMethod().when(adapter).parseClientIpAndPort(eq(request), isA(brave.Span.class));
   }
 
   @After public void close() {
@@ -95,6 +97,15 @@ public class HttpServerHandlerTest {
     verifyNoMoreInteractions(spanCustomizer);
   }
 
+  @Test public void handleReceive_defaultRequest() {
+    // request sampler abstains (trace ID sampler will say true)
+    when(requestSampler.trySample(defaultRequest)).thenReturn(null);
+
+    Span newSpan = defaultHandler.handleReceive(defaultRequest);
+    assertThat(newSpan.isNoop()).isFalse();
+    assertThat(newSpan.context().shared()).isFalse();
+  }
+
   @Test public void handleReceive_defaultsToMakeNewTrace() {
     when(extractor.extract(request))
       .thenReturn(TraceContextOrSamplingFlags.create(SamplingFlags.EMPTY));
@@ -109,20 +120,16 @@ public class HttpServerHandlerTest {
   }
 
   @Test public void handleReceive_reusesTraceId() {
-    HttpTracing httpTracing = HttpTracing.create(
-      Tracing.newBuilder()
-        .currentTraceContext(ThreadLocalCurrentTraceContext.create())
-        .supportsJoin(false)
-        .spanReporter(spans::add)
-        .build()
-    );
+    httpTracing = HttpTracing.newBuilder(
+      Tracing.newBuilder().supportsJoin(false).spanReporter(spans::add).build())
+      .serverSampler(sampler).serverParser(parser).build();
 
-    tracer = httpTracing.tracing().tracer();
+    Tracer tracer = httpTracing.tracing().tracer();
     handler = HttpServerHandler.create(httpTracing, adapter);
 
     TraceContext incomingContext = tracer.nextSpan().context();
-    when(extractor.extract(request))
-      .thenReturn(TraceContextOrSamplingFlags.create(incomingContext));
+    when(extractor.extract(request)).thenReturn(
+      TraceContextOrSamplingFlags.create(incomingContext));
 
     assertThat(handler.handleReceive(extractor, request).context())
       .extracting(TraceContext::traceId, TraceContext::parentId, TraceContext::shared)
@@ -130,7 +137,7 @@ public class HttpServerHandlerTest {
   }
 
   @Test public void handleReceive_reusesSpanIds() {
-    TraceContext incomingContext = tracer.nextSpan().context();
+    TraceContext incomingContext = httpTracing.tracing().tracer().nextSpan().context();
     when(extractor.extract(request))
       .thenReturn(TraceContextOrSamplingFlags.create(incomingContext));
 
@@ -159,6 +166,7 @@ public class HttpServerHandlerTest {
   }
 
   @Test public void handleReceive_makesRequestBasedSamplingDecision_context() {
+    Tracer tracer = httpTracing.tracing().tracer();
     TraceContext incomingContext = tracer.nextSpan().context().toBuilder().sampled(null).build();
     when(extractor.extract(request))
       .thenReturn(TraceContextOrSamplingFlags.create(incomingContext));
@@ -183,16 +191,14 @@ public class HttpServerHandlerTest {
     assertThat(spans.get(0).durationAsLong()).isEqualTo(1000L);
   }
 
-  @Test public void handleReceive_samplerSeesUnwrappedType() {
-    when(sampler.trySample(defaultRequest)).thenReturn(null);
-
+  @Test public void handleReceive_samplerSeesHttpRequest() {
     defaultHandler.handleReceive(defaultRequest);
 
-    verify(sampler).trySample(defaultRequest);
+    verify(requestSampler).trySample(defaultRequest);
   }
 
   @Test public void handleReceive_parserSeesUnwrappedType() {
-    when(sampler.trySample(defaultRequest)).thenReturn(null);
+    when(requestSampler.trySample(defaultRequest)).thenReturn(null);
 
     defaultHandler.handleReceive(defaultRequest);
 
@@ -200,8 +206,20 @@ public class HttpServerHandlerTest {
     verify(parser).request(eq(adapter), eq(request), any(SpanCustomizer.class));
   }
 
-  @Test public void handleSend_parserSeesUnwrappedType() {
-    when(sampler.trySample(defaultRequest)).thenReturn(null);
+  @Test public void handleSend_oldHandler() {
+    when(extractor.extract(request)).thenReturn(TraceContextOrSamplingFlags.EMPTY);
+    // request sampler abstains (trace ID sampler will say true)
+    when(sampler.trySample(new HttpServerRequest.FromHttpAdapter<>(adapter, request)))
+      .thenReturn(null);
+
+    brave.Span span = handler.handleReceive(extractor, request);
+    handler.handleSend(response, null, span);
+
+    verify(parser).response(eq(adapter), eq(response), isNull(), any(SpanCustomizer.class));
+  }
+
+  @Test public void handleSend_parserSeesHttpRequest() {
+    when(requestSampler.trySample(defaultRequest)).thenReturn(null);
 
     brave.Span span = defaultHandler.handleReceive(defaultRequest);
     defaultHandler.handleSend(defaultResponse, null, span);
@@ -210,10 +228,11 @@ public class HttpServerHandlerTest {
     verify(parser).response(eq(adapter), eq(response), isNull(), any(SpanCustomizer.class));
   }
 
-  @Test public void handleSend_parserSeesUnwrappedType_oldHandler() {
+  @Test public void handleSend_parserSeesHttpRequest_oldHandler() {
+    when(extractor.extract(defaultRequest)).thenReturn(TraceContextOrSamplingFlags.EMPTY);
     when(sampler.trySample(defaultRequest)).thenReturn(null);
 
-    brave.Span span = handler.handleReceive(defaultRequest);
+    brave.Span span = handler.handleReceive(extractor, defaultRequest);
     handler.handleSend(defaultResponse, null, span);
 
     HttpServerResponse.Adapter adapter = new HttpServerResponse.Adapter(defaultResponse);

--- a/instrumentation/http/src/test/java/brave/http/HttpServerRequestTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerRequestTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.Span;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpServerRequestTest {
+  @Mock HttpServerRequest serverRequest;
+  @Mock HttpServerAdapter<Object, Object> adapter;
+  Object request = new Object();
+  @Mock Span span;
+
+  HttpServerRequest.ToHttpAdapter toAdapter;
+  HttpServerRequest.FromHttpAdapter<Object> fromAdapter;
+
+  @Before public void callRealMethod() {
+    when(serverRequest.unwrap()).thenReturn(request);
+    toAdapter = new HttpServerRequest.ToHttpAdapter(serverRequest);
+    fromAdapter = new HttpServerRequest.FromHttpAdapter<>(adapter, request);
+  }
+
+  @Test public void toAdapter_parseClientIpAndPort_falseOnNoMatch() {
+    assertThat(toAdapter.parseClientIpAndPort(request, span)).isFalse();
+  }
+
+  @Test public void toAdapter_parseClientIpAndPort_falseOnWrongRequest() {
+    assertThat(toAdapter.parseClientIpAndPort(null, span)).isFalse();
+    assertThat(toAdapter.parseClientIpAndPort(serverRequest, span)).isFalse();
+  }
+
+  @Test public void toAdapter_parseClientIpAndPort_prioritizesXForwardedFor() {
+    when(serverRequest.header("X-Forwarded-For")).thenReturn("1.2.3.4");
+    when(span.remoteIpAndPort("1.2.3.4", 0)).thenReturn(true);
+
+    assertThat(toAdapter.parseClientIpAndPort(request, span)).isTrue();
+  }
+
+  @Test public void toAdapter_parseClientIpAndPort_delegatesToServerRequest() {
+    when(serverRequest.parseClientIpAndPort(span)).thenReturn(true);
+
+    assertThat(toAdapter.parseClientIpAndPort(request, span)).isTrue();
+
+    verify(serverRequest).parseClientIpAndPort(span);
+  }
+
+  @Test public void toAdapter_startTimestamp_zeroOnNoMatch() {
+    assertThat(toAdapter.startTimestamp(request)).isZero();
+  }
+
+  @Test public void toAdapter_startTimestamp_zeroOnWrongRequest() {
+    assertThat(toAdapter.startTimestamp(null)).isZero();
+    assertThat(toAdapter.startTimestamp(serverRequest)).isZero();
+  }
+
+  @Test public void toAdapter_startTimestamp_delegatesToServerRequest() {
+    when(serverRequest.startTimestamp()).thenReturn(1L);
+
+    assertThat(toAdapter.startTimestamp(request)).isEqualTo(1L);
+
+    verify(serverRequest).startTimestamp();
+  }
+
+  @Test public void toAdapter_method_nullOnNoMatch() {
+    assertThat(toAdapter.method(request)).isNull();
+  }
+
+  @Test public void toAdapter_method_nullOnWrongRequest() {
+    assertThat(toAdapter.method(null)).isNull();
+    assertThat(toAdapter.method(serverRequest)).isNull();
+  }
+
+  @Test public void toAdapter_method_delegatesToServerRequest() {
+    when(serverRequest.method()).thenReturn("GET");
+
+    assertThat(toAdapter.method(request)).isEqualTo("GET");
+
+    verify(serverRequest).method();
+  }
+
+  @Test public void toAdapter_url_nullOnNoMatch() {
+    assertThat(toAdapter.url(request)).isNull();
+  }
+
+  @Test public void toAdapter_url_nullOnWrongRequest() {
+    assertThat(toAdapter.url(null)).isNull();
+    assertThat(toAdapter.url(serverRequest)).isNull();
+  }
+
+  @Test public void toAdapter_url_delegatesToServerRequest() {
+    when(serverRequest.url()).thenReturn("https://zipkin.io");
+
+    assertThat(toAdapter.url(request)).isEqualTo("https://zipkin.io");
+
+    verify(serverRequest).url();
+  }
+
+  @Test public void toAdapter_requestHeader_nullOnNoMatch() {
+    assertThat(toAdapter.requestHeader(request, "Content-Type")).isNull();
+  }
+
+  @Test public void toAdapter_requestHeader_nullOnWrongRequest() {
+    assertThat(toAdapter.requestHeader(null, "Content-Type")).isNull();
+    assertThat(toAdapter.requestHeader(serverRequest, "Content-Type")).isNull();
+  }
+
+  @Test public void toAdapter_requestHeader_delegatesToServerRequest() {
+    when(serverRequest.header("Content-Type")).thenReturn("text/plain");
+
+    assertThat(toAdapter.requestHeader(request, "Content-Type")).isEqualTo("text/plain");
+
+    verify(serverRequest).header("Content-Type");
+  }
+
+  @Test public void toAdapter_path_nullOnNoMatch() {
+    assertThat(toAdapter.path(request)).isNull();
+  }
+
+  @Test public void toAdapter_path_nullOnWrongRequest() {
+    assertThat(toAdapter.path(null)).isNull();
+    assertThat(toAdapter.path(serverRequest)).isNull();
+  }
+
+  @Test public void toAdapter_path_delegatesToServerRequest() {
+    when(serverRequest.path()).thenReturn("/api/v2/traces");
+
+    assertThat(toAdapter.path(request)).isEqualTo("/api/v2/traces");
+
+    verify(serverRequest).path();
+  }
+
+  @Test public void fromAdapter_parseClientIpAndPort_falseOnNoMatch() {
+    assertThat(fromAdapter.parseClientIpAndPort(span)).isFalse();
+  }
+
+  @Test public void fromAdapter_parseClientIpAndPort_delegatesToAdapter() {
+    when(adapter.parseClientIpAndPort(eq(request), isA(Span.class))).thenReturn(true);
+
+    assertThat(fromAdapter.parseClientIpAndPort(span)).isTrue();
+  }
+
+  @Test public void fromAdapter_startTimestamp_zeroOnNoMatch() {
+    assertThat(fromAdapter.startTimestamp()).isZero();
+  }
+
+  @Test public void fromAdapter_startTimestamp_delegatesToAdapter() {
+    when(adapter.startTimestamp(request)).thenReturn(1L);
+
+    assertThat(fromAdapter.startTimestamp()).isEqualTo(1L);
+
+    verify(adapter).startTimestamp(request);
+  }
+
+  @Test public void fromAdapter_method_nullOnNoMatch() {
+    assertThat(fromAdapter.method()).isNull();
+  }
+
+  @Test public void fromAdapter_method_delegatesToAdapter() {
+    when(adapter.method(request)).thenReturn("GET");
+
+    assertThat(fromAdapter.method()).isEqualTo("GET");
+
+    verify(adapter).method(request);
+  }
+
+  @Test public void fromAdapter_url_nullOnNoMatch() {
+    assertThat(fromAdapter.url()).isNull();
+  }
+
+  @Test public void fromAdapter_url_delegatesToAdapter() {
+    when(adapter.url(request)).thenReturn("https://zipkin.io");
+
+    assertThat(fromAdapter.url()).isEqualTo("https://zipkin.io");
+
+    verify(adapter).url(request);
+  }
+
+  @Test public void fromAdapter_header_nullOnNoMatch() {
+    assertThat(fromAdapter.header("Content-Type")).isNull();
+  }
+
+  @Test public void fromAdapter_header_delegatesToAdapter() {
+    when(adapter.requestHeader(request, "Content-Type")).thenReturn("text/plain");
+
+    assertThat(fromAdapter.header("Content-Type")).isEqualTo("text/plain");
+
+    verify(adapter).requestHeader(request, "Content-Type");
+  }
+
+  @Test public void fromAdapter_path_nullOnNoMatch() {
+    assertThat(fromAdapter.path()).isNull();
+  }
+
+  @Test public void fromAdapter_path_delegatesToAdapter() {
+    when(adapter.path(request)).thenReturn("/api/v2/traces");
+
+    assertThat(fromAdapter.path()).isEqualTo("/api/v2/traces");
+
+    verify(adapter).path(request);
+  }
+}

--- a/spring-beans/src/main/java/brave/spring/beans/HttpTracingFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/HttpTracingFactoryBean.java
@@ -15,7 +15,7 @@ package brave.spring.beans;
 
 import brave.Tracing;
 import brave.http.HttpClientParser;
-import brave.http.HttpSampler;
+import brave.http.HttpRequestSampler;
 import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
 import brave.http.HttpTracingCustomizer;
@@ -28,8 +28,7 @@ public class HttpTracingFactoryBean implements FactoryBean {
   Tracing tracing;
   HttpClientParser clientParser;
   HttpServerParser serverParser;
-  HttpSampler clientSampler;
-  HttpSampler serverSampler;
+  HttpRequestSampler clientSampler, serverSampler;
   List<HttpTracingCustomizer> customizers;
 
   @Override public HttpTracing getObject() {
@@ -64,11 +63,11 @@ public class HttpTracingFactoryBean implements FactoryBean {
     this.serverParser = serverParser;
   }
 
-  public void setClientSampler(HttpSampler clientSampler) {
+  public void setClientSampler(HttpRequestSampler clientSampler) {
     this.clientSampler = clientSampler;
   }
 
-  public void setServerSampler(HttpSampler serverSampler) {
+  public void setServerSampler(HttpRequestSampler serverSampler) {
     this.serverSampler = serverSampler;
   }
 

--- a/spring-beans/src/test/java/brave/spring/beans/HttpTracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/HttpTracingFactoryBeanTest.java
@@ -14,8 +14,8 @@
 package brave.spring.beans;
 
 import brave.Tracing;
-import brave.TracingCustomizer;
 import brave.http.HttpClientParser;
+import brave.http.HttpRequestSampler;
 import brave.http.HttpSampler;
 import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
@@ -105,6 +105,22 @@ public class HttpTracingFactoryBeanTest {
       .isEqualTo(HttpSampler.NEVER_SAMPLE);
   }
 
+  @Test public void clientRequestSampler() {
+    context = new XmlBeans(""
+      + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+      + "  <property name=\"tracing\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"clientSampler\">\n"
+      + "    <util:constant static-field=\"brave.http.HttpRequestSampler.NEVER_SAMPLE\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("httpTracing", HttpTracing.class).clientRequestSampler())
+      .isEqualTo(HttpRequestSampler.NEVER_SAMPLE);
+  }
+
   @Test public void serverSampler() {
     context = new XmlBeans(""
       + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
@@ -120,6 +136,22 @@ public class HttpTracingFactoryBeanTest {
     assertThat(context.getBean("httpTracing", HttpTracing.class))
       .extracting("serverSampler")
       .isEqualTo(HttpSampler.NEVER_SAMPLE);
+  }
+
+  @Test public void serverRequestSampler() {
+    context = new XmlBeans(""
+      + "<bean id=\"httpTracing\" class=\"brave.spring.beans.HttpTracingFactoryBean\">\n"
+      + "  <property name=\"tracing\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"serverSampler\">\n"
+      + "    <util:constant static-field=\"brave.http.HttpRequestSampler.NEVER_SAMPLE\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("httpTracing", HttpTracing.class).serverRequestSampler())
+      .isEqualTo(HttpRequestSampler.NEVER_SAMPLE);
   }
 
   public static final HttpTracingCustomizer CUSTOMIZER_ONE = mock(HttpTracingCustomizer.class);


### PR DESCRIPTION
We recently introduced the `HttpClientRequest` and `HttpServerRequest` 
types. These are used during propagation extraction, for example as a 
parameter to `Extractor.extract(request)`. This was to facilitate
secondary sampling, which occurs just prior to the primary sampling as
performed by `HttpSampler`.

One feedback was that it is intuitive to use types like 
`HttpRuleSampler` uniformly across primary and secondary sampling.

This change introduces `HttpRequestSampler` which aligns types so that
rules can be defined with similar code regardless of primary or 
secondary decision. This also takes care to not break api. In order to
reduce complexity around starting a span with old or new types, this
pushes some logic to adapters. Rationale is adapters are straightforward
to test and easier to reason with than other logic.

See https://github.com/openzipkin-contrib/zipkin-secondary-sampling/issues/8