### PR TITLE
Ensures we use the name probability and rate accurately

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -260,7 +260,7 @@ policy. Here's how they might work internally.
 
 ```java
 // derives a sample rate from an annotation on a java method
-DeclarativeSampler<Traced> sampler = DeclarativeSampler.create(Traced::sampleRate);
+DeclarativeSampler<Traced> sampler = DeclarativeSampler.createWithRate(Traced::sampleRate);
 
 @Around("@annotation(traced)")
 public Object traceThing(ProceedingJoinPoint pjp, Traced traced) throws Throwable {

--- a/brave/src/main/java/brave/SpanCustomizerShield.java
+++ b/brave/src/main/java/brave/SpanCustomizerShield.java
@@ -15,7 +15,6 @@ package brave;
 
 /** This reduces exposure of methods on {@link Span} to those exposed on {@link SpanCustomizer}. */
 final class SpanCustomizerShield implements SpanCustomizer {
-
   final Span delegate;
 
   SpanCustomizerShield(Span delegate) {
@@ -37,8 +36,7 @@ final class SpanCustomizerShield implements SpanCustomizer {
     return this;
   }
 
-  @Override
-  public String toString() {
-    return "SpanCustomizer(" + delegate.toString() + ")";
+  @Override public String toString() {
+    return "SpanCustomizer(" + delegate + ")";
   }
 }

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -356,10 +356,10 @@ public abstract class Tracing implements Closeable {
      * {@link #spanReporter(Reporter) span reporter}, even if they aren't sampled remotely. Defaults
      * to false.
      *
-     * <p>The primary use case is to implement a sampling overlay, such as boosting the sample rate
-     * for a subset of the network depending on the value of an {@link ExtraFieldPropagation extra
-     * field}. This means that data will report when either the trace is normally sampled, or
-     * secondarily sampled via a custom header.
+     * <p>The primary use case is to implement a <a href="https://github.com/openzipkin-contrib/zipkin-secondary-sampling">sampling
+     * overlay</a>, such as boosting the sample rate for a subset of the network depending on the
+     * value of an {@link ExtraFieldPropagation extra field}. This means that data will report when
+     * either the trace is normally sampled, or secondarily sampled via a custom header.
      *
      * <p>This is simpler than {@link #addFinishedSpanHandler(FinishedSpanHandler)}, because you
      * don't have to duplicate transport mechanics already implemented in the {@link

--- a/brave/src/main/java/brave/sampler/BoundarySampler.java
+++ b/brave/src/main/java/brave/sampler/BoundarySampler.java
@@ -22,7 +22,7 @@ import java.util.Random;
  *
  * <h3>Implementation</h3>
  *
- * <p>This uses modulo 10000 arithmetic, which allows a minimum sample rate of 0.01%. Trace id
+ * <p>This uses modulo 10000 arithmetic, which allows a minimum probability of 0.01%. Trace id
  * collision was noticed in practice in the Twitter front-end cluster. A random salt is here to
  * defend against nodes in the same cluster sampling exactly the same subset of trace ids. The goal
  * was full 64-bit coverage of trace IDs on multi-host deployments.
@@ -33,16 +33,17 @@ public final class BoundarySampler extends Sampler {
   static final long SALT = new Random().nextLong();
 
   /**
-   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is
-   * 0.0001, or 0.01% of traces
+   * @param probability 0 means never sample, 1 means always sample. Otherwise minimum probability
+   * is 0.0001, or 0.01% of traces
    */
-  public static Sampler create(float rate) {
-    if (rate == 0) return Sampler.NEVER_SAMPLE;
-    if (rate == 1.0) return ALWAYS_SAMPLE;
-    if (rate < 0.0001f || rate > 1) {
-      throw new IllegalArgumentException("rate should be between 0.0001 and 1: was " + rate);
+  public static Sampler create(float probability) {
+    if (probability == 0) return Sampler.NEVER_SAMPLE;
+    if (probability == 1.0) return ALWAYS_SAMPLE;
+    if (probability < 0.0001f || probability > 1) {
+      throw new IllegalArgumentException(
+        "probability should be between 0.0001 and 1: was " + probability);
     }
-    final long boundary = (long) (rate * 10000); // safe cast as less <= 1
+    final long boundary = (long) (probability * 10000); // safe cast as less <= 1
     return new BoundarySampler(boundary);
   }
 

--- a/brave/src/main/java/brave/sampler/CountingSampler.java
+++ b/brave/src/main/java/brave/sampler/CountingSampler.java
@@ -31,32 +31,33 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class CountingSampler extends Sampler {
 
   /**
-   * @param rate 0 means never sample, 1 means always sample. Otherwise minimum sample rate is 0.01,
-   * or 1% of traces
+   * @param probability probability a request will result in a new trace. 0 means never sample, 1
+   * means always sample. Minimum probability is 0.01, or 1% of traces
    */
-  public static Sampler create(final float rate) {
-    if (rate == 0) return NEVER_SAMPLE;
-    if (rate == 1.0) return ALWAYS_SAMPLE;
-    if (rate < 0.01f || rate > 1) {
-      throw new IllegalArgumentException("rate should be between 0.01 and 1: was " + rate);
+  public static Sampler create(final float probability) {
+    if (probability == 0) return NEVER_SAMPLE;
+    if (probability == 1.0) return ALWAYS_SAMPLE;
+    if (probability < 0.01f || probability > 1) {
+      throw new IllegalArgumentException(
+        "probability should be between 0.01 and 1: was " + probability);
     }
-    return new CountingSampler(rate);
+    return new CountingSampler(probability);
   }
 
   private final AtomicInteger counter;
   private final BitSet sampleDecisions;
 
-  /** Fills a bitset with decisions according to the supplied rate. */
-  CountingSampler(float rate) {
-    this(rate, new Random());
+  /** Fills a bitset with decisions according to the supplied probability. */
+  CountingSampler(float probability) {
+    this(probability, new Random());
   }
 
   /**
-   * Fills a bitset with decisions according to the supplied rate with the supplied {@link Random}.
+   * Fills a bitset with decisions according to the probability using the supplied {@link Random}.
    */
-  CountingSampler(float rate, Random random) {
+  CountingSampler(float probability, Random random) {
     counter = new AtomicInteger();
-    int outOf100 = (int) (rate * 100.0f);
+    int outOf100 = (int) (probability * 100.0f);
     this.sampleDecisions = randomBitSet(100, outOf100, random);
   }
 

--- a/brave/src/main/java/brave/sampler/Sampler.java
+++ b/brave/src/main/java/brave/sampler/Sampler.java
@@ -55,14 +55,14 @@ public abstract class Sampler {
   public abstract boolean isSampled(long traceId);
 
   /**
-   * Returns a sampler, given a rate expressed as a percentage.
+   * Returns a sampler, given a probability expressed as a percentage.
    *
    * <p>The sampler returned is good for low volumes of traffic (<100K requests), as it is precise.
    * If you have high volumes of traffic, consider {@link BoundarySampler}.
    *
-   * @param rate minimum sample rate is 0.01, or 1% of traces
+   * @param probability probability a trace will be sampled. minimum is 0.01, or 1% of traces
    */
-  public static Sampler create(float rate) {
-    return CountingSampler.create(rate);
+  public static Sampler create(float probability) {
+    return CountingSampler.create(probability);
   }
 }

--- a/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
+++ b/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
@@ -54,7 +54,6 @@ public class AspectJSamplerTest {
 
   @Before public void clear() {
     tracing.set(Tracing.newBuilder()
-      .currentTraceContext(ThreadLocalCurrentTraceContext.create())
       .spanReporter(spans::add)
       .sampler(new Sampler() {
         @Override public boolean isSampled(long traceId) {
@@ -87,10 +86,9 @@ public class AspectJSamplerTest {
   static class Config {
   }
 
-  @Component
-  @Aspect
-  static class TracingAspect {
-    DeclarativeSampler<Traced> declarativeSampler = DeclarativeSampler.create(Traced::sampleRate);
+  @Component @Aspect static class TracingAspect {
+    DeclarativeSampler<Traced> declarativeSampler =
+      DeclarativeSampler.createWithRate(Traced::sampleRate);
 
     @Around("@annotation(traced)")
     public Object traceThing(ProceedingJoinPoint pjp, Traced traced) throws Throwable {
@@ -117,11 +115,11 @@ public class AspectJSamplerTest {
     @Traced public void traced() {
     }
 
-    @Traced(sampleRate = 0.0f) public void notTraced() {
+    @Traced(sampleRate = 0) public void notTraced() {
     }
   }
 
   @Retention(RetentionPolicy.RUNTIME) public @interface Traced {
-    float sampleRate() default 1.0f;
+    int sampleRate() default 10;
   }
 }

--- a/brave/src/test/java/brave/sampler/BoundarySamplerTest.java
+++ b/brave/src/test/java/brave/sampler/BoundarySamplerTest.java
@@ -19,16 +19,15 @@ import org.junit.Test;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 public class BoundarySamplerTest extends SamplerTest {
-  @Override Sampler newSampler(float rate) {
-    return BoundarySampler.create(rate);
+  @Override Sampler newSampler(float probability) {
+    return BoundarySampler.create(probability);
   }
 
-  @Override Percentage expectedErrorRate() {
+  @Override Percentage expectedErrorProbability() {
     return withPercentage(10);
   }
 
-  @Test
-  public void acceptsOneInTenThousandSampleRate() {
+  @Test public void acceptsOneInTenThousandProbability() {
     newSampler(0.0001f);
   }
 }

--- a/brave/src/test/java/brave/sampler/CountingSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/CountingSamplerTest.java
@@ -19,16 +19,15 @@ import org.junit.Test;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 public class CountingSamplerTest extends SamplerTest {
-  @Override Sampler newSampler(float rate) {
-    return CountingSampler.create(rate);
+  @Override Sampler newSampler(float probability) {
+    return CountingSampler.create(probability);
   }
 
-  @Override Percentage expectedErrorRate() {
+  @Override Percentage expectedErrorProbability() {
     return withPercentage(0);
   }
 
-  @Test
-  public void sampleRateMinimumOnePercent() throws Exception {
+  @Test public void probabilityMinimumOnePercent() {
     thrown.expect(IllegalArgumentException.class);
     newSampler(0.0001f);
   }

--- a/brave/src/test/java/brave/sampler/RateLimitingSamplerSoakTest.java
+++ b/brave/src/test/java/brave/sampler/RateLimitingSamplerSoakTest.java
@@ -34,11 +34,11 @@ import static org.assertj.core.data.Percentage.withPercentage;
 @RunWith(Theories.class)
 public class RateLimitingSamplerSoakTest {
 
-  @DataPoints public static final int[] SAMPLE_RESERVOIRS = {1, 11, 101, 1001, 1_000_001};
+  @DataPoints public static final int[] SAMPLE_RATE = {1, 11, 101, 1001, 1_000_001};
 
-  /** This test will take a little over a second per reservoir */
-  @Theory public void retainsPerSampleRate(int reservoir) throws Exception {
-    Sampler sampler = RateLimitingSampler.create(reservoir);
+  /** This test will take a little over a second */
+  @Theory public void retainsPerSampleRate(int rate) throws Exception {
+    Sampler sampler = RateLimitingSampler.create(rate);
 
     // We want to make sure we fill up the entire second, so
     long startTick = System.nanoTime();
@@ -59,8 +59,8 @@ public class RateLimitingSamplerSoakTest {
 
     Runnable loopAndSample = () -> {
       do {
-        if (reservoir > 10) {  // execute one tenth of our reservoir
-          for (int j = 0; j < reservoir / 10; j++) sample.run();
+        if (rate > 10) {  // execute one tenth of our rate
+          for (int j = 0; j < rate / 10; j++) sample.run();
         } else {// don't divide by 10!
           sample.run();
         }
@@ -79,7 +79,7 @@ public class RateLimitingSamplerSoakTest {
     service.awaitTermination(1, TimeUnit.SECONDS);
 
     assertThat(passed.get())
-      .isCloseTo(reservoir, withPercentage(0.01)); // accomodates flakes in CI
+      .isCloseTo(rate, withPercentage(0.01)); // accomodates flakes in CI
     assumeThat(hitLastDecisecond.get())
       .withFailMessage("ran out of samples before the end of the second")
       .isTrue();

--- a/brave/src/test/java/brave/sampler/SamplerTest.java
+++ b/brave/src/test/java/brave/sampler/SamplerTest.java
@@ -33,25 +33,25 @@ public abstract class SamplerTest {
    */
   static final int INPUT_SIZE = 100000;
 
-  abstract Sampler newSampler(float rate);
+  abstract Sampler newSampler(float probability);
 
-  abstract Percentage expectedErrorRate();
+  abstract Percentage expectedErrorProbability();
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
   @DataPoints
-  public static final float[] SAMPLE_RATES = {0.01f, 0.5f, 0.9f};
+  public static final float[] SAMPLE_PROBABILITIES = {0.01f, 0.5f, 0.9f};
 
   @Theory
-  public void retainsPerSampleRate(float sampleRate) {
-    final Sampler sampler = newSampler(sampleRate);
+  public void retainsPerSampleProbability(float sampleProbability) {
+    final Sampler sampler = newSampler(sampleProbability);
 
     // parallel to ensure there aren't any unsynchronized race conditions
     long passed = new Random().longs(INPUT_SIZE).parallel().filter(sampler::isSampled).count();
 
     assertThat(passed)
-      .isCloseTo((long) (INPUT_SIZE * sampleRate), expectedErrorRate());
+      .isCloseTo((long) (INPUT_SIZE * sampleProbability), expectedErrorProbability());
   }
 
   @Test
@@ -70,14 +70,14 @@ public abstract class SamplerTest {
   }
 
   @Test
-  public void rateCantBeNegative() {
+  public void probabilityCantBeNegative() {
     thrown.expect(IllegalArgumentException.class);
 
     newSampler(-1.0f);
   }
 
   @Test
-  public void rateCantBeOverOne() {
+  public void probabilityCantBeOverOne() {
     thrown.expect(IllegalArgumentException.class);
 
     newSampler(1.1f);

--- a/instrumentation/benchmarks/src/main/java/brave/sampler/SamplerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/sampler/SamplerBenchmarks.java
@@ -55,10 +55,10 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 public class SamplerBenchmarks {
 
   /**
-   * Sample rate is a percentage expressed as a float. So, 0.001 is 0.1% (let one in a 1000nd pass).
+   * Probability is a percentage expressed as a float. So, 0.001 is 0.1% (let one in a 1000nd pass).
    * Zero effectively disables tracing.
    *
-   * <p>Here are default sample rates from actual implementations:
+   * <p>Here are default sample probabilities from actual implementations:
    * <pre>
    * <ul>
    *   <li>Finagle Scala Tracer: 0.001</li>
@@ -68,10 +68,10 @@ public class SamplerBenchmarks {
    * </ul>
    * </pre>
    */
-  static final float SAMPLE_RATE = 0.01f;
+  static final float SAMPLE_PROBABILITY = 0.01f;
 
   /**
-   * The reservior is a measure of how many traces per second.
+   * The rate is a measure of how many traces per second.
    *
    * <p>Here are default sample rates from actual implementations:
    * <pre>
@@ -81,7 +81,7 @@ public class SamplerBenchmarks {
    * </ul>
    * </pre>
    */
-  static final int SAMPLE_RESERVOIR = 1;
+  static final int SAMPLE_RATE = 1;
 
   @State(Scope.Benchmark)
   public static class Args {
@@ -98,20 +98,20 @@ public class SamplerBenchmarks {
     return SAMPLER_BOUNDARY.isSampled(args.traceId);
   }
 
-  static final Sampler SAMPLER_BOUNDARY = BoundarySampler.create(SAMPLE_RATE);
+  static final Sampler SAMPLER_BOUNDARY = BoundarySampler.create(SAMPLE_PROBABILITY);
 
   @Benchmark public boolean sampler_counting(Args args) {
     return SAMPLER_RATE.isSampled(args.traceId);
   }
 
   // Use fixed-seed Random so performance of runs can be compared.
-  static final Sampler SAMPLER_RATE = new CountingSampler(SAMPLE_RATE, new Random(1000));
+  static final Sampler SAMPLER_RATE = new CountingSampler(SAMPLE_PROBABILITY, new Random(1000));
 
   @Benchmark public boolean sampler_rateLimited_1(Args args) {
     return SAMPLER_RATE_LIMITED.isSampled(args.traceId);
   }
 
-  static final Sampler SAMPLER_RATE_LIMITED = RateLimitingSampler.create(SAMPLE_RESERVOIR);
+  static final Sampler SAMPLER_RATE_LIMITED = RateLimitingSampler.create(SAMPLE_RATE);
 
   @Benchmark public boolean sampler_rateLimited_100(Args args) {
     return SAMPLER_RATE_LIMITED_100.isSampled(args.traceId);
@@ -123,7 +123,7 @@ public class SamplerBenchmarks {
     return RESERVOIR_RATE_LIMITED.take();
   }
 
-  static final Reservoir RESERVOIR_RATE_LIMITED = new Reservoir(SAMPLE_RESERVOIR);
+  static final Reservoir RESERVOIR_RATE_LIMITED = new Reservoir(SAMPLE_RATE);
 
   @Benchmark public boolean sampler_rateLimited_100_xray(Args args) {
     return RESERVOIR_RATE_LIMITED_100.take();
@@ -135,7 +135,7 @@ public class SamplerBenchmarks {
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
       .addProfiler("gc")
-      .include(".*" + SamplerBenchmarks.class.getSimpleName() + ".*rate.*")
+      .include(".*" + SamplerBenchmarks.class.getSimpleName())
       .build();
 
     new Runner(opt).run();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -151,7 +151,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
   @Test public void customSampler() throws Exception {
     close();
     httpTracing = httpTracing.toBuilder().clientSampler(HttpRuleSampler.newBuilder()
-      .addRule(null, "/foo", 0.0f)
+      .addRuleWithProbability(null, "/foo", 0.0f)
       .build()).build();
     client = newClient(server.getPort());
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -133,7 +133,7 @@ public abstract class ITHttpServer extends ITHttp {
     String path = "/foo";
 
     httpTracing = httpTracing.toBuilder().serverSampler(HttpRuleSampler.newBuilder()
-      .addRule(null, path, 0.0f)
+      .addRuleWithProbability(null, path, 0.0f)
       .build()).build();
     init();
 

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -86,16 +86,16 @@ You can change the sampling policy by specifying it in the `HttpTracing`
 component. The default implementation is `HttpRuleSampler`, which allows
 you to declare rules based on http patterns.
 
-Ex. Here's a sampler that traces 80% requests to /foo and 10% of POST
-requests to /bar. This doesn't start new traces for requests to favicon
-(which many browsers automatically fetch). Other requests will use a
-global rate provided by the tracing component.
+Ex. Here's a sampler that traces 100 requests per second to /foo and 10
+POST requests to /bar per second. This doesn't start new traces for
+requests to favicon (which many browsers automatically fetch). Other
+requests will use a global rate provided by the tracing component.
 
 ```java
 httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
-  .addRule(null, "/favicon", 0.0f)
-  .addRule(null, "/foo", 0.8f)
-  .addRule("POST", "/bar", 0.1f)
+  .addRuleWithRate(null, "/favicon", 0)
+  .addRuleWithRate(null, "/foo", 100)
+  .addRuleWithRate("POST", "/bar", 10)
   .build());
 ```
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -15,47 +15,76 @@ package brave.http;
 
 import brave.Tracing;
 import brave.internal.Nullable;
+import brave.sampler.CountingSampler;
 import brave.sampler.ParameterizedSampler;
-import java.util.ArrayList;
-import java.util.List;
+import brave.sampler.RateLimitingSampler;
 
 /**
  * Assigns sample rates to http routes.
  *
- * <p>Ex. Here's a sampler that traces 80% requests to /foo and 10% of POST requests to /bar. Other
- * requests will use a global rate provided by the {@link Tracing tracing component}.
+ * <p>Ex. Here's a sampler that traces 100 requests per second to /foo and 10 POST requests to /bar
+ * per second. This doesn't start new traces for requests to favicon (which many browsers
+ * automatically fetch). Other requests will use a global rate provided by the {@link Tracing
+ * tracing component}.
  * <pre>{@code
  * httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
- *   .addRule(null, "/foo", 0.8f)
- *   .addRule("POST", "/bar", 0.1f)
+ *   .addRuleWithRate(null, "/favicon", 0)
+ *   .addRuleWithRate(null, "/foo", 100)
+ *   .addRuleWithRate("POST", "/bar", 10)
  *   .build());
  * }</pre>
  *
  * <p>Note that the path is a prefix, so "/foo" will match "/foo/abcd".
+ *
+ * @since 4.4
  */
 public final class HttpRuleSampler extends HttpSampler {
-
+  /** @since 4.4 */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /** @since 4.4 */
   public static final class Builder {
-    final List<MethodAndPathRule> rules = new ArrayList<>();
+    ParameterizedSampler.Builder<MethodAndPath> delegate = ParameterizedSampler.newBuilder();
+
+    /**
+     * @since 4.4
+     * @deprecated Since 5.8, use {@link #addRuleWithProbability(String, String, float)}
+     */
+    // overload was considered and dismissed as it could result in those who used the integer 1 to
+    // express 1.0, as in 100% probability, to accidentally match a rate of 1 request per second.
+    @Deprecated public Builder addRule(@Nullable String method, String path, float probability) {
+      return addRuleWithProbability(method, path, probability);
+    }
+
+    /**
+     * Assigns a probability to all requests that match the input.
+     *
+     * @param method if null, any method is accepted
+     * @param path all paths starting with this string are accepted
+     * @param probability probability that requests that match the method and path will be sampled.
+     * Expressed as a percentage. Ex 1.0 is 100%.
+     */
+    public Builder addRuleWithProbability(@Nullable String method, String path, float probability) {
+      delegate.addRule(new MethodAndPathMatcher(method, path), CountingSampler.create(probability));
+      return this;
+    }
 
     /**
      * Assigns a sample rate to all requests that match the input.
      *
      * @param method if null, any method is accepted
      * @param path all paths starting with this string are accepted
-     * @param rate percentage of requests to start traces for. 1.0 is 100%
+     * @param rate max traces per second for requests that match the method and path.
      */
-    public Builder addRule(@Nullable String method, String path, float rate) {
-      rules.add(new MethodAndPathRule(method, path, rate));
+    public Builder addRuleWithRate(@Nullable String method, String path, int rate) {
+      delegate.addRule(new MethodAndPathMatcher(method, path), RateLimitingSampler.create(rate));
       return this;
     }
 
-    public HttpSampler build() {
-      return new HttpRuleSampler(rules);
+    public HttpRuleSampler build() {
+      return new HttpRuleSampler(delegate.build());
     }
 
     Builder() {
@@ -64,19 +93,20 @@ public final class HttpRuleSampler extends HttpSampler {
 
   final ParameterizedSampler<MethodAndPath> sampler;
 
-  HttpRuleSampler(List<MethodAndPathRule> rules) {
-    this.sampler = ParameterizedSampler.create(rules);
+  HttpRuleSampler(ParameterizedSampler<MethodAndPath> sampler) {
+    this.sampler = sampler;
   }
 
   @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
-    String method = adapter.method(request);
-    String path = adapter.path(request);
+    return trySample(adapter.method(request), adapter.path(request));
+  }
+
+  @Nullable Boolean trySample(@Nullable String method, @Nullable String path) {
     if (method == null || path == null) return null; // use default if we couldn't parse
     return sampler.sample(new MethodAndPath(method, path)).sampled();
   }
 
   static final class MethodAndPath {
-
     final String method;
     final String path;
 
@@ -84,30 +114,13 @@ public final class HttpRuleSampler extends HttpSampler {
       this.method = method;
       this.path = path;
     }
-
-    @Override public boolean equals(Object o) {
-      if (o == this) return true;
-      if (!(o instanceof MethodAndPath)) return false;
-      MethodAndPath that = (MethodAndPath) o;
-      return method.equals(that.method) && path.equals(that.path);
-    }
-
-    @Override public int hashCode() {
-      int h = 1;
-      h *= 1000003;
-      h ^= method.hashCode();
-      h *= 1000003;
-      h ^= path.hashCode();
-      return h;
-    }
   }
 
-  static final class MethodAndPathRule extends ParameterizedSampler.Rule<MethodAndPath> {
+  static final class MethodAndPathMatcher implements ParameterizedSampler.Matcher<MethodAndPath> {
     @Nullable final String method;
     final String path;
 
-    MethodAndPathRule(@Nullable String method, String path, float rate) {
-      super(rate);
+    MethodAndPathMatcher(@Nullable String method, String path) {
       this.method = method;
       this.path = path;
     }

--- a/instrumentation/http/src/main/java/brave/http/HttpSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpSampler.java
@@ -14,7 +14,6 @@
 package brave.http;
 
 import brave.internal.Nullable;
-import brave.sampler.Sampler;
 
 /**
  * Decides whether to start a new trace based on http request properties such as path.
@@ -63,20 +62,4 @@ public abstract class HttpSampler {
    * the {@link brave.sampler.Sampler trace ID sampler}.
    */
   @Nullable public abstract <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request);
-
-  /**
-   * Used internally by {@link HttpClientHandler} to override the default sampling decision when
-   * starting a new trace for an http client request.
-   */
-  <Req> Sampler toSampler(HttpAdapter<Req, ?> adapter, Req request, Sampler delegate) {
-    if (this == TRACE_ID) return delegate;
-    if (this == NEVER_SAMPLE) return Sampler.NEVER_SAMPLE;
-    return new Sampler() {
-      @Override public boolean isSampled(long traceId) {
-        Boolean decision = trySample(adapter, request);
-        if (decision == null) return delegate.isSampled(traceId);
-        return decision;
-      }
-    };
-  }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpTracing.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpTracing.java
@@ -15,7 +15,6 @@ package brave.http;
 
 import brave.ErrorParser;
 import brave.Tracing;
-import zipkin2.Endpoint;
 
 public class HttpTracing { // Not final as it previously was not. This allows mocks and similar.
   public static HttpTracing create(Tracing tracing) {
@@ -50,8 +49,8 @@ public class HttpTracing { // Not final as it previously was not. This allows mo
    * github = TracingHttpClientBuilder.create(httpTracing.serverName("github"));
    * }</pre>
    *
-   * @see HttpClientAdapter#parseServerIpAndPort(Object, Endpoint.Builder)
-   * @see brave.Span#remoteEndpoint(Endpoint)
+   * @see HttpClientHandler
+   * @see brave.Span#remoteServiceName(String)
    */
   public String serverName() {
     return serverName;
@@ -137,7 +136,7 @@ public class HttpTracing { // Not final as it previously was not. This allows mo
         }
       };
       this.clientSampler = HttpSampler.TRACE_ID;
-      this.serverSampler(HttpSampler.TRACE_ID);
+      this.serverSampler = HttpSampler.TRACE_ID;
     }
 
     Builder(HttpTracing source) {
@@ -189,7 +188,6 @@ public class HttpTracing { // Not final as it previously was not. This allows mo
     /** @see HttpTracing#clientSampler() */
     public Builder clientSampler(HttpSampler clientSampler) {
       if (clientSampler == null) throw new NullPointerException("clientSampler == null");
-
       this.clientSampler = clientSampler;
       return this;
     }

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -28,7 +28,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule(null, "/foo", 1.0f)
+      .addRuleWithProbability(null, "/foo", 1.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -38,9 +38,33 @@ public class HttpRuleSamplerTest {
       .isTrue();
   }
 
-  @Test public void onPath_sampled() {
+  @Test public void onPath_rate() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule(null, "/foo", 0.0f)
+      .addRuleWithRate(null, "/foo", 1)
+      .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+      .isTrue();
+  }
+
+  @Test public void onPath_unsampled() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+      .addRuleWithProbability(null, "/foo", 0.0f)
+      .build();
+
+    when(adapter.method(request)).thenReturn("GET");
+    when(adapter.path(request)).thenReturn("/foo");
+
+    assertThat(sampler.trySample(adapter, request))
+      .isFalse();
+  }
+
+  @Test public void onPath_unsampled_rate() {
+    HttpSampler sampler = HttpRuleSampler.newBuilder()
+      .addRuleWithRate(null, "/foo", 0)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -52,7 +76,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_sampled_prefix() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule(null, "/foo", 0.0f)
+      .addRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -64,7 +88,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_doesntMatch() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule(null, "/foo", 0.0f)
+      .addRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -76,7 +100,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_sampled() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule("GET", "/foo", 1.0f)
+      .addRuleWithProbability("GET", "/foo", 1.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -88,7 +112,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_sampled_prefix() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule("GET", "/foo", 1.0f)
+      .addRuleWithProbability("GET", "/foo", 1.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -100,7 +124,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_unsampled() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule("GET", "/foo", 0.0f)
+      .addRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -112,7 +136,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_doesntMatch_method() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule("GET", "/foo", 0.0f)
+      .addRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("POST");
@@ -124,7 +148,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_doesntMatch_path() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule("GET", "/foo", 0.0f)
+      .addRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -136,7 +160,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void nullOnParseFailure() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRule("GET", "/foo", 0.0f)
+      .addRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     // not setting up mocks means they return null which is like a parse fail


### PR DESCRIPTION
In the past, we've had problems where people confuse a rate per second
with a probability (percentage). This eventually led to Sleuth changing
the property name. This change ensures that probability and rate are
used consistently. It also backfills logic where formerly only
probability was a choice.