### PR TITLE
Adds putAllRules to parameterized sampling to allow composition

### DIFF
--- a/brave/src/main/java/brave/sampler/ParameterizedSampler.java
+++ b/brave/src/main/java/brave/sampler/ParameterizedSampler.java
@@ -83,7 +83,6 @@ public final class ParameterizedSampler<P> {
     }
 
     public ParameterizedSampler<P> build() {
-      if (rules.isEmpty()) throw new IllegalArgumentException("no rules");
       return new ParameterizedSampler<>(this);
     }
 

--- a/brave/src/main/java/brave/sampler/ParameterizedSampler.java
+++ b/brave/src/main/java/brave/sampler/ParameterizedSampler.java
@@ -15,8 +15,9 @@ package brave.sampler;
 
 import brave.internal.Nullable;
 import brave.propagation.SamplingFlags;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This is an implementation of how to decide whether to trace a request using ordered rules. For
@@ -32,9 +33,15 @@ import java.util.List;
  * @since 4.4
  */
 public final class ParameterizedSampler<P> {
-  /** @since 5.8 */
+  /**
+   * Returns true if this rule matches the input parameters
+   *
+   * <p>Implement {@link #hashCode()} and {@link #equals(Object)} if you want to replace existing
+   * rules by something besides object identity.
+   *
+   * @since 5.8
+   */
   public interface Matcher<P> {
-    /** Returns true if this rule matches the input parameters */
     boolean matches(P parameters);
   }
 
@@ -44,19 +51,40 @@ public final class ParameterizedSampler<P> {
   }
 
   /** @since 5.8 */
+  public Builder<P> toBuilder() {
+    Builder<P> builder = newBuilder();
+    for (R<P> rule : rules) {
+      builder.putRule(rule.matcher, rule.sampler);
+    }
+    return builder;
+  }
+
+  /** @since 5.8 */
   public static final class Builder<P> {
-    final List<R<P>> rules = new ArrayList<>();
+    final Map<Matcher<P>, Sampler> rules = new LinkedHashMap<>();
 
     /** @since 5.8 */
-    public Builder<P> addRule(Matcher<P> matcher, Sampler sampler) {
+    public Builder<P> removeRule(Matcher<P> matcher) {
+      if (matcher == null) throw new NullPointerException("matcher == null");
+      rules.remove(matcher);
+      return this;
+    }
+
+    /**
+     * Adds or replaces the sampler of the input matcher.
+     *
+     * @since 5.8
+     */
+    public Builder<P> putRule(Matcher<P> matcher, Sampler sampler) {
       if (matcher == null) throw new NullPointerException("matcher == null");
       if (sampler == null) throw new NullPointerException("sampler == null");
-      rules.add(new R<>(matcher, sampler));
+      rules.put(matcher, sampler);
       return this;
     }
 
     public ParameterizedSampler<P> build() {
-      return new ParameterizedSampler<>(rules);
+      if (rules.isEmpty()) throw new IllegalArgumentException("no rules");
+      return new ParameterizedSampler<>(this);
     }
 
     Builder() {
@@ -71,28 +99,26 @@ public final class ParameterizedSampler<P> {
       this.matcher = matcher;
       this.sampler = sampler;
     }
-
-    boolean matches(P parameters) {
-      return matcher.matches(parameters);
-    }
-
-    SamplingFlags isSampled() {
-      return sampler.isSampled(0L) // counting sampler ignores the input
-        ? SamplingFlags.SAMPLED
-        : SamplingFlags.NOT_SAMPLED;
-    }
   }
 
-  final List<? extends R<P>> rules;
+  final R<P>[] rules; // array avoids Map overhead at runtime
 
-  ParameterizedSampler(List<? extends R<P>> rules) {
-    this.rules = rules;
+  ParameterizedSampler(Builder<P> builder) {
+    this.rules = new R[builder.rules.size()];
+    int i = 0;
+    for (Map.Entry<Matcher<P>, Sampler> rule : builder.rules.entrySet()) {
+      rules[i++] = new R<>(rule.getKey(), rule.getValue());
+    }
   }
 
   public SamplingFlags sample(@Nullable P parameters) {
     if (parameters == null) return SamplingFlags.EMPTY;
     for (R<P> rule : rules) {
-      if (rule.matches(parameters)) return rule.isSampled();
+      if (rule.matcher.matches(parameters)) {
+        return rule.sampler.isSampled(0L) // counting sampler ignores the input
+          ? SamplingFlags.SAMPLED
+          : SamplingFlags.NOT_SAMPLED;
+      }
     }
     return SamplingFlags.EMPTY;
   }
@@ -103,12 +129,16 @@ public final class ParameterizedSampler<P> {
    */
   public static <P> ParameterizedSampler<P> create(List<? extends Rule<P>> rules) {
     if (rules == null) throw new NullPointerException("rules == null");
-    return new ParameterizedSampler<>(rules);
+    Builder<P> builder = newBuilder();
+    for (Rule<P> rule : rules) {
+      builder.putRule(rule.matcher, rule.sampler);
+    }
+    return builder.build();
   }
 
   /**
    * @since 4.4
-   * @deprecated Since 5.8, use {@link Builder#addRule(Matcher, Sampler)}
+   * @deprecated Since 5.8, use {@link Builder#putRule(Matcher, Sampler)}
    */
   @Deprecated public static abstract class Rule<P> extends R<P> implements Matcher<P> {
     protected Rule(float probability) {

--- a/brave/src/main/java/brave/sampler/ParameterizedSampler.java
+++ b/brave/src/main/java/brave/sampler/ParameterizedSampler.java
@@ -51,15 +51,6 @@ public final class ParameterizedSampler<P> {
   }
 
   /** @since 5.8 */
-  public Builder<P> toBuilder() {
-    Builder<P> builder = newBuilder();
-    for (R<P> rule : rules) {
-      builder.putRule(rule.matcher, rule.sampler);
-    }
-    return builder;
-  }
-
-  /** @since 5.8 */
   public static final class Builder<P> {
     final Map<Matcher<P>, Sampler> rules = new LinkedHashMap<>();
 
@@ -67,6 +58,17 @@ public final class ParameterizedSampler<P> {
     public Builder<P> removeRule(Matcher<P> matcher) {
       if (matcher == null) throw new NullPointerException("matcher == null");
       rules.remove(matcher);
+      return this;
+    }
+
+    /**
+     * Adds or replaces all rules in this sampler with those of the input.
+     *
+     * @since 5.8
+     */
+    public Builder<P> putAllRules(ParameterizedSampler<P> sampler) {
+      if (sampler == null) throw new NullPointerException("sampler == null");
+      for (R<P> rule : sampler.rules) putRule(rule.matcher, rule.sampler);
       return this;
     }
 

--- a/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
@@ -80,4 +80,9 @@ public class ParameterizedSamplerTest {
       .build()
     );
   }
+
+  // empty may sound unintuitive, but it allows use of the same type when always deferring
+  @Test public void noRulesOk() {
+    ParameterizedSampler.<Boolean>newBuilder().build();
+  }
 }

--- a/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
@@ -58,27 +58,31 @@ public class ParameterizedSamplerTest {
       .isEqualTo(SamplingFlags.NOT_SAMPLED);
   }
 
-  @Test public void toBuilder_composes() {
+  @Test public void putAllRules() {
     Matcher<Void> one = v -> false;
     Matcher<Void> two = v -> true;
     Matcher<Void> three = v -> Boolean.FALSE;
     Matcher<Void> four = v -> Boolean.TRUE;
-    ParameterizedSampler<Void> sampler = ParameterizedSampler.<Void>newBuilder()
+    ParameterizedSampler<Void> base = ParameterizedSampler.<Void>newBuilder()
       .putRule(one, Sampler.ALWAYS_SAMPLE)
       .putRule(two, Sampler.NEVER_SAMPLE)
       .putRule(three, Sampler.ALWAYS_SAMPLE)
-      .build().toBuilder()
-      .removeRule(two)
+      .build();
+
+    ParameterizedSampler<Void> extended = ParameterizedSampler.<Void>newBuilder()
+      .putAllRules(base)
       .putRule(one, Sampler.NEVER_SAMPLE)
       .putRule(four, Sampler.ALWAYS_SAMPLE)
       .build();
 
-    assertThat(sampler).usingRecursiveComparison().isEqualTo(ParameterizedSampler.<Void>newBuilder()
-      .putRule(one, Sampler.NEVER_SAMPLE)
-      .putRule(three, Sampler.ALWAYS_SAMPLE)
-      .putRule(four, Sampler.ALWAYS_SAMPLE)
-      .build()
-    );
+    assertThat(extended).usingRecursiveComparison()
+      .isEqualTo(ParameterizedSampler.<Void>newBuilder()
+        .putRule(one, Sampler.NEVER_SAMPLE)
+        .putRule(two, Sampler.NEVER_SAMPLE)
+        .putRule(three, Sampler.ALWAYS_SAMPLE)
+        .putRule(four, Sampler.ALWAYS_SAMPLE)
+        .build()
+      );
   }
 
   // empty may sound unintuitive, but it allows use of the same type when always deferring

--- a/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
@@ -14,6 +14,7 @@
 package brave.sampler;
 
 import brave.propagation.SamplingFlags;
+import brave.sampler.ParameterizedSampler.Matcher;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +23,7 @@ public class ParameterizedSamplerTest {
 
   @Test public void matchesParameters() {
     ParameterizedSampler<Boolean> sampler = ParameterizedSampler.<Boolean>newBuilder()
-      .addRule(Boolean::booleanValue, Sampler.ALWAYS_SAMPLE)
+      .putRule(Boolean::booleanValue, Sampler.ALWAYS_SAMPLE)
       .build();
 
     assertThat(sampler.sample(true))
@@ -31,7 +32,7 @@ public class ParameterizedSamplerTest {
 
   @Test public void emptyOnNoMatch() {
     ParameterizedSampler<Boolean> sampler = ParameterizedSampler.<Boolean>newBuilder()
-      .addRule(Boolean::booleanValue, Sampler.ALWAYS_SAMPLE)
+      .putRule(Boolean::booleanValue, Sampler.ALWAYS_SAMPLE)
       .build();
 
     assertThat(sampler.sample(false))
@@ -40,7 +41,7 @@ public class ParameterizedSamplerTest {
 
   @Test public void emptyOnNull() {
     ParameterizedSampler<Void> sampler = ParameterizedSampler.<Void>newBuilder()
-      .addRule(v -> true, Sampler.ALWAYS_SAMPLE)
+      .putRule(v -> true, Sampler.ALWAYS_SAMPLE)
       .build();
 
     assertThat(sampler.sample(null))
@@ -49,11 +50,34 @@ public class ParameterizedSamplerTest {
 
   @Test public void multipleRules() {
     ParameterizedSampler<Boolean> sampler = ParameterizedSampler.<Boolean>newBuilder()
-      .addRule(v -> false, Sampler.ALWAYS_SAMPLE) // doesn't match
-      .addRule(v -> true, Sampler.NEVER_SAMPLE) // match
+      .putRule(v -> false, Sampler.ALWAYS_SAMPLE) // doesn't match
+      .putRule(v -> true, Sampler.NEVER_SAMPLE) // match
       .build();
 
     assertThat(sampler.sample(true))
       .isEqualTo(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Test public void toBuilder_composes() {
+    Matcher<Void> one = v -> false;
+    Matcher<Void> two = v -> true;
+    Matcher<Void> three = v -> Boolean.FALSE;
+    Matcher<Void> four = v -> Boolean.TRUE;
+    ParameterizedSampler<Void> sampler = ParameterizedSampler.<Void>newBuilder()
+      .putRule(one, Sampler.ALWAYS_SAMPLE)
+      .putRule(two, Sampler.NEVER_SAMPLE)
+      .putRule(three, Sampler.ALWAYS_SAMPLE)
+      .build().toBuilder()
+      .removeRule(two)
+      .putRule(one, Sampler.NEVER_SAMPLE)
+      .putRule(four, Sampler.ALWAYS_SAMPLE)
+      .build();
+
+    assertThat(sampler).usingRecursiveComparison().isEqualTo(ParameterizedSampler.<Void>newBuilder()
+      .putRule(one, Sampler.NEVER_SAMPLE)
+      .putRule(three, Sampler.ALWAYS_SAMPLE)
+      .putRule(four, Sampler.ALWAYS_SAMPLE)
+      .build()
+    );
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -151,7 +151,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
   @Test public void customSampler() throws Exception {
     close();
     httpTracing = httpTracing.toBuilder().clientSampler(HttpRuleSampler.newBuilder()
-      .addRuleWithProbability(null, "/foo", 0.0f)
+      .putRuleWithProbability(null, "/foo", 0.0f)
       .build()).build();
     client = newClient(server.getPort());
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -133,7 +133,7 @@ public abstract class ITHttpServer extends ITHttp {
     String path = "/foo";
 
     httpTracing = httpTracing.toBuilder().serverSampler(HttpRuleSampler.newBuilder()
-      .addRuleWithProbability(null, path, 0.0f)
+      .putRuleWithProbability(null, path, 0.0f)
       .build()).build();
     init();
 

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -93,9 +93,9 @@ requests will use a global rate provided by the tracing component.
 
 ```java
 httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
-  .addRuleWithRate(null, "/favicon", 0)
-  .addRuleWithRate(null, "/foo", 100)
-  .addRuleWithRate("POST", "/bar", 10)
+  .putRuleWithRate(null, "/favicon", 0)
+  .putRuleWithRate(null, "/foo", 100)
+  .putRuleWithRate("POST", "/bar", 10)
   .build());
 ```
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -44,22 +44,9 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
     return new Builder();
   }
 
-  /** @since 5.8 */
-  public Builder toBuilder() {
-    return new Builder(this);
-  }
-
   /** @since 4.4 */
   public static final class Builder {
-    final ParameterizedSampler.Builder<MethodAndPath> delegate;
-
-    Builder() {
-      delegate = ParameterizedSampler.newBuilder();
-    }
-
-    Builder(HttpRuleSampler sampler) {
-      delegate = sampler.delegate.toBuilder();
-    }
+    final ParameterizedSampler.Builder<MethodAndPath> delegate = ParameterizedSampler.newBuilder();
 
     /**
      * @since 4.4
@@ -79,6 +66,17 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
      */
     public Builder removeRule(@Nullable String method, String path) {
       delegate.removeRule(new MethodAndPathMatcher(method, path));
+      return this;
+    }
+
+    /**
+     * Adds or replaces all rules in this sampler with those of the input.
+     *
+     * @since 5.8
+     */
+    public Builder putAllRules(HttpRuleSampler sampler) {
+      if (sampler == null) throw new NullPointerException("sampler == null");
+      delegate.putAllRules(sampler.delegate);
       return this;
     }
 
@@ -109,6 +107,9 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
 
     public HttpRuleSampler build() {
       return new HttpRuleSampler(delegate.build());
+    }
+
+    Builder() {
     }
   }
 

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -31,7 +31,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability(null, "/foo", 1.0f)
+      .putRuleWithProbability(null, "/foo", 1.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -55,7 +55,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_rate() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithRate(null, "/foo", 1)
+      .putRuleWithRate(null, "/foo", 1)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -67,7 +67,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_unsampled() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability(null, "/foo", 0.0f)
+      .putRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -79,7 +79,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_unsampled_rate() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithRate(null, "/foo", 0)
+      .putRuleWithRate(null, "/foo", 0)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -103,7 +103,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_sampled_prefix() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability(null, "/foo", 0.0f)
+      .putRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -127,7 +127,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onPath_doesntMatch() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability(null, "/foo", 0.0f)
+      .putRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -151,7 +151,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_sampled() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability("GET", "/foo", 1.0f)
+      .putRuleWithProbability("GET", "/foo", 1.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -175,7 +175,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_sampled_prefix() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability("GET", "/foo", 1.0f)
+      .putRuleWithProbability("GET", "/foo", 1.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -199,7 +199,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_unsampled() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability("GET", "/foo", 0.0f)
+      .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -223,7 +223,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_doesntMatch_method() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability("GET", "/foo", 0.0f)
+      .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("POST");
@@ -247,7 +247,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void onMethodAndPath_doesntMatch_path() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability("GET", "/foo", 0.0f)
+      .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("GET");
@@ -271,7 +271,7 @@ public class HttpRuleSamplerTest {
 
   @Test public void nullOnParseFailure() {
     HttpSampler sampler = HttpRuleSampler.newBuilder()
-      .addRuleWithProbability("GET", "/foo", 0.0f)
+      .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     // not setting up mocks means they return null which is like a parse fail

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -282,4 +282,9 @@ public class HttpRuleSamplerTest {
     assertThat(sampler.trySample(httpServerRequest))
       .isNull();
   }
+
+  // empty may sound unintuitive, but it allows use of the same type when always deferring
+  @Test public void noRulesOk() {
+    HttpRuleSampler.<Boolean>newBuilder().build();
+  }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -283,6 +283,22 @@ public class HttpRuleSamplerTest {
       .isNull();
   }
 
+  @Test public void putAllRules() {
+    HttpRuleSampler base = HttpRuleSampler.newBuilder()
+      .putRuleWithProbability("GET", "/foo", 0.0f)
+      .build();
+
+    HttpRuleSampler extended = HttpRuleSampler.newBuilder()
+      .putAllRules(base)
+      .build();
+
+    when(httpServerRequest.method()).thenReturn("POST");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(extended.trySample(httpServerRequest))
+      .isNull();
+  }
+
   // empty may sound unintuitive, but it allows use of the same type when always deferring
   @Test public void noRulesOk() {
     HttpRuleSampler.<Boolean>newBuilder().build();


### PR DESCRIPTION
In order to ease api, this adds `HttpRuleSampler.Builder.putAllRules()`, which
allows you to compose rules without knowing what the former ones were.

This also adds `removeRule` and renames the prefix `addRule` to
`putRule` in order to emphasize replacement based on the match
expression.