### PR TITLE
Switches HttpRuleSampler to directly use matchers

### DIFF
--- a/brave/src/main/java/brave/sampler/Matcher.java
+++ b/brave/src/main/java/brave/sampler/Matcher.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.sampler;
+
+/**
+ * Returns true if this rule matches the input parameters
+ *
+ * <p>Implement {@link #hashCode()} and {@link #equals(Object)} if you want to replace existing
+ * rules by something besides object identity.
+ *
+ * @see Matchers
+ * @since 5.8
+ */
+public interface Matcher<P> {
+  boolean matches(P parameters);
+}

--- a/brave/src/main/java/brave/sampler/Matchers.java
+++ b/brave/src/main/java/brave/sampler/Matchers.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.sampler;
+
+import java.util.Arrays;
+
+/**
+ * Convenience functions to compose matchers for {@link ParameterizedSampler}.
+ *
+ * @see Matcher
+ * @see ParameterizedSampler
+ * @since 5.8
+ */
+public final class Matchers {
+
+  /** @since 5.8 */
+  public static <P> Matcher<P> alwaysMatch() {
+    return (Matcher<P>) Constants.ALWAYS_MATCH;
+  }
+
+  /** @since 5.8 */
+  public static <P> Matcher<P> neverMatch() {
+    return (Matcher<P>) Constants.NEVER_MATCH;
+  }
+
+  enum Constants implements Matcher<Object> {
+    ALWAYS_MATCH {
+      @Override public boolean matches(Object parameters) {
+        return true;
+      }
+
+      @Override public String toString() {
+        return "matchAll()";
+      }
+    },
+    NEVER_MATCH {
+      @Override public boolean matches(Object parameters) {
+        return false;
+      }
+
+      @Override public String toString() {
+        return "neverMatch()";
+      }
+    }
+  }
+
+  /** @since 5.8 */
+  public static <P> Matcher<P> and(Matcher<P>... matchers) {
+    return composite(matchers, true);
+  }
+
+  /** @since 5.8 */
+  public static <P> Matcher<P> or(Matcher<P>... matchers) {
+    return composite(matchers, false);
+  }
+
+  static <P> Matcher<P> composite(Matcher<P>[] matchers, boolean and) {
+    if (matchers == null) throw new NullPointerException("matchers == null");
+    if (matchers.length == 0) throw new NullPointerException("matchers is empty");
+    for (int i = 0; i < matchers.length; i++) {
+      if (matchers[i] == null) throw new NullPointerException("matchers[" + i + "] == null");
+    }
+    if (matchers.length == 1) return matchers[0];
+    return new Composite<>(matchers, and);
+  }
+
+  static final class Composite<P> implements Matcher<P> {
+    final Matcher<P>[] matchers; // Array ensures no iterators are created at runtime
+    final boolean and;
+
+    Composite(Matcher<P>[] matchers, boolean and) {
+      this.matchers = Arrays.copyOf(matchers, matchers.length);
+      this.and = and;
+    }
+
+    @Override public boolean matches(P parameters) {
+      boolean or = false;
+      for (Matcher<P> matcher : matchers) {
+        boolean next = matcher.matches(parameters);
+        if (!next && and) return false;
+        if (next) or = true;
+      }
+      return or;
+    }
+
+    @Override public String toString() {
+      return (and ? "And" : "Or") + "(" + Arrays.toString(matchers) + ")";
+    }
+  }
+}

--- a/brave/src/main/java/brave/sampler/Matchers.java
+++ b/brave/src/main/java/brave/sampler/Matchers.java
@@ -67,7 +67,7 @@ public final class Matchers {
 
   static <P> Matcher<P> composite(Matcher<P>[] matchers, boolean and) {
     if (matchers == null) throw new NullPointerException("matchers == null");
-    if (matchers.length == 0) throw new NullPointerException("matchers is empty");
+    if (matchers.length == 0) return neverMatch();
     for (int i = 0; i < matchers.length; i++) {
       if (matchers[i] == null) throw new NullPointerException("matchers[" + i + "] == null");
     }

--- a/brave/src/main/java/brave/sampler/ParameterizedSampler.java
+++ b/brave/src/main/java/brave/sampler/ParameterizedSampler.java
@@ -30,21 +30,10 @@ import java.util.Map;
  *
  * @param <P> The type that encloses parameters associated with a sample rate. For example, this
  * could be a pair of http and method.
+ * @see Matcher
  * @since 4.4
  */
 public final class ParameterizedSampler<P> {
-  /**
-   * Returns true if this rule matches the input parameters
-   *
-   * <p>Implement {@link #hashCode()} and {@link #equals(Object)} if you want to replace existing
-   * rules by something besides object identity.
-   *
-   * @since 5.8
-   */
-  public interface Matcher<P> {
-    boolean matches(P parameters);
-  }
-
   /** @since 5.8 */
   public static <P> Builder<P> newBuilder() {
     return new Builder<>();
@@ -53,13 +42,6 @@ public final class ParameterizedSampler<P> {
   /** @since 5.8 */
   public static final class Builder<P> {
     final Map<Matcher<P>, Sampler> rules = new LinkedHashMap<>();
-
-    /** @since 5.8 */
-    public Builder<P> removeRule(Matcher<P> matcher) {
-      if (matcher == null) throw new NullPointerException("matcher == null");
-      rules.remove(matcher);
-      return this;
-    }
 
     /**
      * Adds or replaces all rules in this sampler with those of the input.

--- a/brave/src/test/java/brave/sampler/MatchersTest.java
+++ b/brave/src/test/java/brave/sampler/MatchersTest.java
@@ -21,6 +21,7 @@ import static brave.sampler.Matchers.alwaysMatch;
 import static brave.sampler.Matchers.and;
 import static brave.sampler.Matchers.neverMatch;
 import static brave.sampler.Matchers.or;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -77,5 +78,22 @@ public class MatchersTest {
     Matcher<Void> two = b -> false;
     Matcher<Void> three = b -> false;
     assertThat(or(one, two, three).matches(null)).isFalse();
+  }
+
+  @Test public void toArray_list() {
+    Matcher<Void> one = b -> true;
+    Matcher<Void> two = b -> false;
+    Matcher<Void> three = b -> true;
+    assertThat(Matchers.toArray(asList(one, two, three)))
+      .containsExactly(one, two, three);
+  }
+
+  @Test public void toArray_iterable() {
+    Matcher<Void> one = b -> true;
+    Matcher<Void> two = b -> false;
+    Matcher<Void> three = b -> true;
+
+    assertThat(Matchers.toArray(() -> asList(one, two, three).iterator()))
+      .containsExactly(one, two, three);
   }
 }

--- a/brave/src/test/java/brave/sampler/MatchersTest.java
+++ b/brave/src/test/java/brave/sampler/MatchersTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.sampler;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static brave.sampler.Matchers.alwaysMatch;
+import static brave.sampler.Matchers.and;
+import static brave.sampler.Matchers.neverMatch;
+import static brave.sampler.Matchers.or;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MatchersTest {
+  @Test public void alwaysMatch_matched() {
+    assertThat(alwaysMatch().matches(null)).isTrue();
+  }
+
+  @Test public void neverMatch_unmatched() {
+    assertThat(neverMatch().matches(null)).isFalse();
+  }
+
+  @Test public void and_empty() {
+    assertThat(and()).isSameAs(neverMatch());
+  }
+
+  @Test public void and_single() {
+    Matcher<Boolean> one = Boolean::booleanValue;
+    assertThat(and(one)).isSameAs(one);
+  }
+
+  @Test public void and_multiple_matched() {
+    Matcher<Void> one = b -> true;
+    Matcher<Void> two = b -> true;
+    Matcher<Void> three = b -> true;
+    assertThat(and(one, two, three).matches(null)).isTrue();
+  }
+
+  @Test public void and_multiple_unmatched() {
+    Matcher<Void> one = b -> true;
+    Matcher<Void> two = b -> false;
+    Matcher<Void> three = b -> true;
+    assertThat(and(one, two, three).matches(null)).isFalse();
+  }
+
+  @Test public void or_empty() {
+    assertThat(or()).isSameAs(neverMatch());
+  }
+
+  @Test public void or_single() {
+    Matcher<Boolean> one = Boolean::booleanValue;
+    assertThat(or(one)).isSameAs(one);
+  }
+
+  @Test public void or_multiple_matched() {
+    Matcher<Void> one = b -> true;
+    Matcher<Void> two = b -> false;
+    Matcher<Void> three = b -> true;
+    assertThat(or(one, two, three).matches(null)).isTrue();
+  }
+
+  @Test public void or_multiple_unmatched() {
+    Matcher<Void> one = b -> false;
+    Matcher<Void> two = b -> false;
+    Matcher<Void> three = b -> false;
+    assertThat(or(one, two, three).matches(null)).isFalse();
+  }
+}

--- a/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/ParameterizedSamplerTest.java
@@ -14,7 +14,6 @@
 package brave.sampler;
 
 import brave.propagation.SamplingFlags;
-import brave.sampler.ParameterizedSampler.Matcher;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 
+import static brave.http.HttpRequestMatchers.pathStartsWith;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -149,14 +150,16 @@ public abstract class ITHttpClient<C> extends ITHttp {
   }
 
   @Test public void customSampler() throws Exception {
+    String path = "/foo";
+
     close();
     httpTracing = httpTracing.toBuilder().clientSampler(HttpRuleSampler.newBuilder()
-      .putRuleWithProbability(null, "/foo", 0.0f)
+      .putRule(pathStartsWith(path), Sampler.NEVER_SAMPLE)
       .build()).build();
     client = newClient(server.getPort());
 
     server.enqueue(new MockResponse());
-    get(client, "/foo");
+    get(client, path);
 
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeaders().toMultimap())

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 
+import static brave.http.HttpRequestMatchers.pathStartsWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITHttpServer extends ITHttp {
@@ -133,7 +134,7 @@ public abstract class ITHttpServer extends ITHttp {
     String path = "/foo";
 
     httpTracing = httpTracing.toBuilder().serverSampler(HttpRuleSampler.newBuilder()
-      .putRuleWithProbability(null, path, 0.0f)
+      .putRule(pathStartsWith(path), Sampler.NEVER_SAMPLE)
       .build()).build();
     init();
 

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -92,8 +92,6 @@ requests to favicon (which many browsers automatically fetch). Other
 requests will use a global rate provided by the tracing component.
 
 ```java
-
-
 httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
   .putRule(pathStartsWith("/favicon"), Sampler.NEVER_SAMPLE)
   .putRule(pathStartsWith("/foo"), RateLimitingSampler.create(100))

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -92,10 +92,12 @@ requests to favicon (which many browsers automatically fetch). Other
 requests will use a global rate provided by the tracing component.
 
 ```java
+
+
 httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
-  .putRuleWithRate(null, "/favicon", 0)
-  .putRuleWithRate(null, "/foo", 100)
-  .putRuleWithRate("POST", "/bar", 10)
+  .putRule(pathStartsWith("/favicon"), Sampler.NEVER_SAMPLE)
+  .putRule(pathStartsWith("/foo"), RateLimitingSampler.create(100))
+  .putRule(and(methodIsEqualTo("POST"), pathStartsWith("/bar")), RateLimitingSampler.create(10))
   .build());
 ```
 

--- a/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
@@ -24,6 +24,11 @@ public abstract class HttpAdapter<Req, Resp> {
    * The HTTP method, or verb, such as "GET" or "POST" or null if unreadable.
    *
    * <p>Conventionally associated with the key "http.method"
+   *
+   * <h3>Note</h3>
+   * <p>It is part of the <a href="https://tools.ietf.org/html/rfc7231#section-4.1">HTTP RFC</a>
+   * that an HTTP method is case-sensitive. Do not downcase results. If you do, not only will
+   * integration tests fail, but you will surprise any consumers who expect compliant results.
    */
   @Nullable public abstract String method(Req request);
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestMatchers.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestMatchers.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.sampler.Matcher;
+import brave.sampler.Matchers;
+
+/**
+ * Null safe matchers for use in {@link HttpRequestSampler}.
+ *
+ * @see Matchers
+ * @since 5.8
+ */
+public final class HttpRequestMatchers {
+  public static Matcher<HttpRequest> methodEquals(String method) {
+    if (method == null) throw new NullPointerException("method == null");
+    if (method.isEmpty()) throw new NullPointerException("method is empty");
+    return new MethodIsEqualTo(method);
+  }
+
+  static final class MethodIsEqualTo implements Matcher<HttpRequest> {
+    final String method;
+
+    MethodIsEqualTo(String method) {
+      this.method = method;
+    }
+
+    @Override public boolean matches(HttpRequest request) {
+      return method.equals(request.method());
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) return true;
+      if (!(o instanceof MethodIsEqualTo)) return false;
+      MethodIsEqualTo that = (MethodIsEqualTo) o;
+      return method.equals(that.method);
+    }
+
+    @Override public int hashCode() {
+      return method.hashCode();
+    }
+
+    @Override public String toString() {
+      return "Method(" + method + ")";
+    }
+  }
+
+  public static Matcher<HttpRequest> pathStartsWith(String pathPrefix) {
+    if (pathPrefix == null) throw new NullPointerException("pathPrefix == null");
+    if (pathPrefix.isEmpty()) throw new NullPointerException("pathPrefix is empty");
+    return new PathStartsWith(pathPrefix);
+  }
+
+  static final class PathStartsWith implements Matcher<HttpRequest> {
+    final String pathPrefix;
+
+    PathStartsWith(String pathPrefix) {
+      this.pathPrefix = pathPrefix;
+    }
+
+    @Override public boolean matches(HttpRequest request) {
+      String requestPath = request.path();
+      return requestPath != null && requestPath.startsWith(pathPrefix);
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) return true;
+      if (!(o instanceof PathStartsWith)) return false;
+      PathStartsWith that = (PathStartsWith) o;
+      return pathPrefix.equals(that.pathPrefix);
+    }
+
+    @Override public int hashCode() {
+      return pathPrefix.hashCode();
+    }
+
+    @Override public String toString() {
+      return "PathStartsWith(" + pathPrefix + ")";
+    }
+  }
+}

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestMatchers.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestMatchers.java
@@ -23,16 +23,18 @@ import brave.sampler.Matchers;
  * @since 5.8
  */
 public final class HttpRequestMatchers {
+
+  /** Matcher for case-sensitive HTTP methods, such as "GET" and "POST" */
   public static Matcher<HttpRequest> methodEquals(String method) {
     if (method == null) throw new NullPointerException("method == null");
     if (method.isEmpty()) throw new NullPointerException("method is empty");
-    return new MethodIsEqualTo(method);
+    return new MethodEquals(method);
   }
 
-  static final class MethodIsEqualTo implements Matcher<HttpRequest> {
+  static final class MethodEquals implements Matcher<HttpRequest> {
     final String method;
 
-    MethodIsEqualTo(String method) {
+    MethodEquals(String method) {
       this.method = method;
     }
 
@@ -42,8 +44,8 @@ public final class HttpRequestMatchers {
 
     @Override public boolean equals(Object o) {
       if (o == this) return true;
-      if (!(o instanceof MethodIsEqualTo)) return false;
-      MethodIsEqualTo that = (MethodIsEqualTo) o;
+      if (!(o instanceof MethodEquals)) return false;
+      MethodEquals that = (MethodEquals) o;
       return method.equals(that.method);
     }
 
@@ -52,7 +54,7 @@ public final class HttpRequestMatchers {
     }
 
     @Override public String toString() {
-      return "Method(" + method + ")";
+      return "MethodEquals(" + method + ")";
     }
   }
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestSampler.java
@@ -49,21 +49,6 @@ public interface HttpRequestSampler {
   };
 
   /**
-   * Returns true to always start new traces for http requests.
-   *
-   * @since 5.8
-   */
-  HttpRequestSampler ALWAYS_SAMPLE = new HttpRequestSampler() {
-    @Override @Nullable public Boolean trySample(HttpRequest request) {
-      return true;
-    }
-
-    @Override public String toString() {
-      return "AlwaysSample";
-    }
-  };
-
-  /**
    * Returns false to never start new traces for http requests. For example, you may wish to only
    * capture traces if they originated from an inbound server request. Such a policy would filter
    * out client requests made during bootstrap.

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -16,8 +16,14 @@ package brave.http;
 import brave.Tracing;
 import brave.internal.Nullable;
 import brave.sampler.CountingSampler;
+import brave.sampler.Matcher;
 import brave.sampler.ParameterizedSampler;
 import brave.sampler.RateLimitingSampler;
+import brave.sampler.Sampler;
+
+import static brave.http.HttpRequestMatchers.methodEquals;
+import static brave.http.HttpRequestMatchers.pathStartsWith;
+import static brave.sampler.Matchers.and;
 
 /**
  * Assigns sample rates to http routes.
@@ -26,15 +32,26 @@ import brave.sampler.RateLimitingSampler;
  * per second. This doesn't start new traces for requests to favicon (which many browsers
  * automatically fetch). Other requests will use a global rate provided by the {@link Tracing
  * tracing component}.
- * <pre>{@code
+ *
+ * <p><pre>{@code
+ * import static brave.http.HttpRequestMatchers.methodIsEqualTo;
+ * import static brave.http.HttpRequestMatchers.pathStartsWith;
+ * import static brave.sampler.Matchers.and;
+ *
  * httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
- *   .putRuleWithRate(null, "/favicon", 0)
- *   .putRuleWithRate(null, "/foo", 100)
- *   .putRuleWithRate("POST", "/bar", 10)
+ *   .putRule(pathStartsWith("/favicon"), Sampler.NEVER_SAMPLE)
+ *   .putRule(pathStartsWith("/foo"), RateLimitingSampler.create(100))
+ *   .putRule(and(methodIsEqualTo("POST"), pathStartsWith("/bar")), RateLimitingSampler.create(10))
  *   .build());
+ * }</pre>
+ * <pre>{@code
+ *
  * }</pre>
  *
  * <p>Note that the path is a prefix, so "/foo" will match "/foo/abcd".
+ *
+ * <h3>Implementation notes</h3>
+ * Be careful when implementing matchers as {@link HttpRequest} methods can return null.
  *
  * @since 4.4
  */
@@ -50,22 +67,16 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
 
     /**
      * @since 4.4
-     * @deprecated Since 5.8, use {@link #putRuleWithProbability(String, String, float)}
+     * @deprecated Since 5.8, use {@link #putRule(Matcher, Sampler)}
      */
-    // overload was considered and dismissed as it could result in those who used the integer 1 to
-    // express 1.0, as in 100% probability, to accidentally match a rate of 1 request per second.
     @Deprecated public Builder addRule(@Nullable String method, String path, float probability) {
-      return putRuleWithProbability(method, path, probability);
-    }
-
-    /**
-     * Removes any rule associated with the method and path.
-     *
-     * @param method if null, any method is accepted
-     * @param path all paths starting with this string are accepted
-     */
-    public Builder removeRule(@Nullable String method, String path) {
-      delegate.removeRule(new HttpRequestMatcher(method, path));
+      if (path == null) throw new NullPointerException("path == null");
+      Sampler sampler = CountingSampler.create(probability);
+      if (method == null) {
+        delegate.putRule(pathStartsWith(path), RateLimitingSampler.create(10));
+        return this;
+      }
+      delegate.putRule(and(methodEquals(method), pathStartsWith(path)), sampler);
       return this;
     }
 
@@ -81,27 +92,19 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
     }
 
     /**
-     * Replaces any rule matching the method and path with a sample probability.
+     * Adds or replaces the sampler for the matcher.
      *
-     * @param method if null, any method is accepted
-     * @param path all paths starting with this string are accepted
-     * @param probability probability that requests that match the method and path will be sampled.
-     * Expressed as a percentage. Ex 1.0 is 100%.
-     */
-    public Builder putRuleWithProbability(@Nullable String method, String path, float probability) {
-      delegate.putRule(new HttpRequestMatcher(method, path), CountingSampler.create(probability));
-      return this;
-    }
-
-    /**
-     * Replaces any rule matching the method and path with a sample rate.
+     * <p>Ex.
+     * <pre>{@code
+     * import static brave.http.HttpRequestMatchers.pathStartsWith;
      *
-     * @param method if null, any method is accepted
-     * @param path all paths starting with this string are accepted
-     * @param rate max traces per second for requests that match the method and path.
+     * builder.putRule(pathStartsWith("/api"), RateLimitingSampler.create(10));
+     * }</pre>
+     *
+     * @since 5.8
      */
-    public Builder putRuleWithRate(@Nullable String method, String path, int rate) {
-      delegate.putRule(new HttpRequestMatcher(method, path), RateLimitingSampler.create(rate));
+    public Builder putRule(Matcher<HttpRequest> matcher, Sampler sampler) {
+      delegate.putRule(matcher, sampler);
       return this;
     }
 
@@ -125,37 +128,5 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
 
   @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {
     return trySample(new FromHttpAdapter<>(adapter, request));
-  }
-
-  static final class HttpRequestMatcher implements ParameterizedSampler.Matcher<HttpRequest> {
-    @Nullable final String method;
-    final String path;
-
-    HttpRequestMatcher(@Nullable String method, String path) {
-      this.method = method;
-      this.path = path;
-    }
-
-    @Override public boolean matches(HttpRequest request) {
-      if (method != null && !method.equals(request.method())) return false;
-      String requestPath = request.path();
-      return requestPath != null && requestPath.startsWith(path);
-    }
-
-    @Override public boolean equals(Object o) {
-      if (o == this) return true;
-      if (!(o instanceof HttpRequestMatcher)) return false;
-      HttpRequestMatcher that = (HttpRequestMatcher) o;
-      return (method == null ? that.method == null : method.equals(that.method))
-        && path.equals(that.path);
-    }
-
-    @Override public int hashCode() {
-      int h = 1;
-      h ^= (method == null) ? 0 : method.hashCode();
-      h *= 1000003;
-      h ^= path.hashCode();
-      return h;
-    }
   }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -44,11 +44,18 @@ import static brave.sampler.Matchers.and;
  *   .putRule(and(methodIsEqualTo("POST"), pathStartsWith("/bar")), RateLimitingSampler.create(10))
  *   .build());
  * }</pre>
- * <pre>{@code
  *
+ * <p>Ex. Here's a custom matcher for the endpoint "/play&country=US"
+ *
+ * <p><pre>{@code
+ * Matcher<HttpRequest> playInTheUSA = request -> {
+ *   if (!"/play".equals(request.path())) return false;
+ *   String url = request.url();
+ *   if (url == null) return false;
+ *   String query = URI.create(url).getQuery();
+ *   return query != null && query.contains("country=US");
+ * };
  * }</pre>
- *
- * <p>Note that the path is a prefix, so "/foo" will match "/foo/abcd".
  *
  * <h3>Implementation notes</h3>
  * Be careful when implementing matchers as {@link HttpRequest} methods can return null.

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -130,7 +130,7 @@ public final class HttpRuleSampler extends HttpSampler implements HttpRequestSam
   }
 
   @Override public Boolean trySample(HttpRequest request) {
-    return delegate.sample(request).sampled();
+    return delegate.trySample(request);
   }
 
   @Override public <Req> Boolean trySample(HttpAdapter<Req, ?> adapter, Req request) {

--- a/instrumentation/http/src/test/java/brave/http/HttpRequestMatchersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRequestMatchersTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static brave.http.HttpRequestMatchers.methodEquals;
+import static brave.http.HttpRequestMatchers.pathStartsWith;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpRequestMatchersTest {
+  @Mock HttpRequest httpRequest;
+
+  @Test public void methodEquals_matched() {
+    when(httpRequest.method()).thenReturn("GET");
+
+    assertThat(methodEquals("GET").matches(httpRequest)).isTrue();
+  }
+
+  @Test public void methodEquals_unmatched() {
+    when(httpRequest.method()).thenReturn("POST");
+
+    assertThat(methodEquals("GET").matches(httpRequest)).isFalse();
+  }
+
+  @Test public void methodEquals_unmatched_null() {
+    assertThat(methodEquals("GET").matches(httpRequest)).isFalse();
+  }
+
+  @Test public void pathStartsWith_matched_exact() {
+    when(httpRequest.path()).thenReturn("/foo");
+
+    assertThat(pathStartsWith("/foo").matches(httpRequest)).isTrue();
+  }
+
+  @Test public void pathStartsWith_matched_prefix() {
+    when(httpRequest.path()).thenReturn("/foo/bar");
+
+    assertThat(pathStartsWith("/foo").matches(httpRequest)).isTrue();
+  }
+
+  @Test public void pathStartsWith_unmatched() {
+    when(httpRequest.path()).thenReturn("/fo");
+
+    assertThat(pathStartsWith("/foo").matches(httpRequest)).isFalse();
+  }
+
+  @Test public void pathStartsWith_unmatched_null() {
+    assertThat(pathStartsWith("/foo").matches(httpRequest)).isFalse();
+  }
+}

--- a/instrumentation/http/src/test/java/brave/http/HttpRequestMatchersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRequestMatchersTest.java
@@ -33,6 +33,13 @@ public class HttpRequestMatchersTest {
     assertThat(methodEquals("GET").matches(httpRequest)).isTrue();
   }
 
+  /** Emphasize that this is pre-baked for RFC complaint requests. */
+  @Test public void methodEquals_unmatched_mixedCase() {
+    when(httpRequest.method()).thenReturn("PoSt");
+
+    assertThat(methodEquals("POST").matches(httpRequest)).isFalse();
+  }
+
   @Test public void methodEquals_unmatched() {
     when(httpRequest.method()).thenReturn("POST");
 

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -30,23 +30,20 @@ public class HttpRuleSamplerTest {
   @Mock HttpServerRequest httpServerRequest;
 
   @Test public void onPath() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability(null, "/foo", 1.0f)
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
       .isTrue();
 
-    when(httpClientRequest.method()).thenReturn("GET");
     when(httpClientRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpClientRequest))
       .isTrue();
 
-    when(httpServerRequest.method()).thenReturn("GET");
     when(httpServerRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpServerRequest))
@@ -54,11 +51,10 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onPath_rate() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithRate(null, "/foo", 1)
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
@@ -66,11 +62,10 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onPath_unsampled() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
@@ -78,23 +73,20 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onPath_unsampled_rate() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithRate(null, "/foo", 0)
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
     when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
       .isFalse();
 
-    when(httpClientRequest.method()).thenReturn("GET");
     when(httpClientRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpClientRequest))
       .isFalse();
 
-    when(httpServerRequest.method()).thenReturn("GET");
     when(httpServerRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpServerRequest))
@@ -102,23 +94,20 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onPath_sampled_prefix() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
     when(adapter.path(request)).thenReturn("/foo/abcd");
 
     assertThat(sampler.trySample(adapter, request))
       .isFalse();
 
-    when(httpClientRequest.method()).thenReturn("GET");
     when(httpClientRequest.path()).thenReturn("/foo/abcd");
 
     assertThat(sampler.trySample(httpClientRequest))
       .isFalse();
 
-    when(httpServerRequest.method()).thenReturn("GET");
     when(httpServerRequest.path()).thenReturn("/foo/abcd");
 
     assertThat(sampler.trySample(httpServerRequest))
@@ -126,23 +115,20 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onPath_doesntMatch() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability(null, "/foo", 0.0f)
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
     when(adapter.path(request)).thenReturn("/bar");
 
     assertThat(sampler.trySample(adapter, request))
       .isNull();
 
-    when(httpClientRequest.method()).thenReturn("GET");
     when(httpClientRequest.path()).thenReturn("/bar");
 
     assertThat(sampler.trySample(httpClientRequest))
       .isNull();
 
-    when(httpServerRequest.method()).thenReturn("GET");
     when(httpServerRequest.path()).thenReturn("/bar");
 
     assertThat(sampler.trySample(httpServerRequest))
@@ -150,7 +136,7 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onMethodAndPath_sampled() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability("GET", "/foo", 1.0f)
       .build();
 
@@ -174,7 +160,7 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onMethodAndPath_sampled_prefix() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability("GET", "/foo", 1.0f)
       .build();
 
@@ -198,7 +184,7 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onMethodAndPath_unsampled() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
@@ -222,31 +208,28 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void onMethodAndPath_doesntMatch_method() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
     when(adapter.method(request)).thenReturn("POST");
-    when(adapter.path(request)).thenReturn("/foo");
 
     assertThat(sampler.trySample(adapter, request))
       .isNull();
 
     when(httpClientRequest.method()).thenReturn("POST");
-    when(httpClientRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpClientRequest))
       .isNull();
 
     when(httpServerRequest.method()).thenReturn("POST");
-    when(httpServerRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpServerRequest))
       .isNull();
   }
 
   @Test public void onMethodAndPath_doesntMatch_path() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
@@ -270,7 +253,7 @@ public class HttpRuleSamplerTest {
   }
 
   @Test public void nullOnParseFailure() {
-    HttpSampler sampler = HttpRuleSampler.newBuilder()
+    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
       .putRuleWithProbability("GET", "/foo", 0.0f)
       .build();
 
@@ -293,10 +276,15 @@ public class HttpRuleSamplerTest {
       .build();
 
     when(httpServerRequest.method()).thenReturn("POST");
-    when(httpServerRequest.path()).thenReturn("/foo");
 
     assertThat(extended.trySample(httpServerRequest))
       .isNull();
+
+    when(httpServerRequest.method()).thenReturn("GET");
+    when(httpServerRequest.path()).thenReturn("/foo");
+
+    assertThat(extended.trySample(httpServerRequest))
+      .isFalse();
   }
 
   // empty may sound unintuitive, but it allows use of the same type when always deferring

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -13,7 +13,12 @@
  */
 package brave.http;
 
+import brave.sampler.Matcher;
+import brave.sampler.RateLimitingSampler;
 import brave.sampler.Sampler;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -33,209 +38,100 @@ public class HttpRuleSamplerTest {
   @Mock HttpClientRequest httpClientRequest;
   @Mock HttpServerRequest httpServerRequest;
 
-  @Test public void onPath() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(pathStartsWith("/foo"), Sampler.ALWAYS_SAMPLE)
+  @Test public void matches() {
+    Map<Sampler, Boolean> samplerToAnswer = new LinkedHashMap<>();
+    samplerToAnswer.put(Sampler.ALWAYS_SAMPLE, true);
+    samplerToAnswer.put(Sampler.NEVER_SAMPLE, false);
+
+    samplerToAnswer.forEach((sampler, answer) -> {
+      HttpRuleSampler ruleSampler = HttpRuleSampler.newBuilder()
+        .putRule(pathStartsWith("/foo"), sampler)
+        .build();
+
+      when(adapter.path(request)).thenReturn("/foo");
+
+      assertThat(ruleSampler.trySample(adapter, request))
+        .isEqualTo(answer);
+
+      when(httpClientRequest.path()).thenReturn("/foo");
+
+      assertThat(ruleSampler.trySample(httpClientRequest))
+        .isEqualTo(answer);
+
+      when(httpServerRequest.path()).thenReturn("/foo");
+
+      // consistent answer
+      assertThat(ruleSampler.trySample(httpServerRequest))
+        .isEqualTo(answer);
+    });
+  }
+
+  @Test public void unmatched() {
+    HttpRuleSampler ruleSampler = HttpRuleSampler.newBuilder()
+      .putRule(pathStartsWith("/bar"), Sampler.ALWAYS_SAMPLE)
       .build();
 
     when(adapter.path(request)).thenReturn("/foo");
 
-    assertThat(sampler.trySample(adapter, request))
-      .isTrue();
+    assertThat(ruleSampler.trySample(adapter, request))
+      .isNull();
 
     when(httpClientRequest.path()).thenReturn("/foo");
 
-    assertThat(sampler.trySample(httpClientRequest))
-      .isTrue();
+    assertThat(ruleSampler.trySample(httpClientRequest))
+      .isNull();
 
     when(httpServerRequest.path()).thenReturn("/foo");
 
-    assertThat(sampler.trySample(httpServerRequest))
-      .isTrue();
-  }
-
-  @Test public void onPath_unsampled() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(pathStartsWith("/foo"), Sampler.NEVER_SAMPLE)
-      .build();
-
-    when(adapter.path(request)).thenReturn("/foo");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isFalse();
-  }
-
-  @Test public void onPath_sampled_prefix() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(pathStartsWith("/foo"), Sampler.NEVER_SAMPLE)
-      .build();
-
-    when(adapter.path(request)).thenReturn("/foo/abcd");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isFalse();
-
-    when(httpClientRequest.path()).thenReturn("/foo/abcd");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isFalse();
-
-    when(httpServerRequest.path()).thenReturn("/foo/abcd");
-
-    assertThat(sampler.trySample(httpServerRequest))
-      .isFalse();
-  }
-
-  @Test public void onPath_doesntMatch() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(pathStartsWith("/foo"), Sampler.NEVER_SAMPLE)
-      .build();
-
-    when(adapter.path(request)).thenReturn("/bar");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isNull();
-
-    when(httpClientRequest.path()).thenReturn("/bar");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isNull();
-
-    when(httpServerRequest.path()).thenReturn("/bar");
-
-    assertThat(sampler.trySample(httpServerRequest))
+    // consistent answer
+    assertThat(ruleSampler.trySample(httpServerRequest))
       .isNull();
   }
 
-  @Test public void onMethodAndPath_sampled() {
+  @Test public void exampleCustomMatcher() {
+    Matcher<HttpRequest> playInTheUSA = request -> {
+      if (!"/play".equals(request.path())) return false;
+      String url = request.url();
+      if (url == null) return false;
+      String query = URI.create(url).getQuery();
+      return query != null && query.contains("country=US");
+    };
+
     HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(and(methodEquals("GET"), pathStartsWith("/foo")), Sampler.ALWAYS_SAMPLE)
+      .putRule(playInTheUSA, RateLimitingSampler.create(100))
       .build();
 
-    when(adapter.method(request)).thenReturn("GET");
-    when(adapter.path(request)).thenReturn("/foo");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isTrue();
-
-    when(httpClientRequest.method()).thenReturn("GET");
-    when(httpClientRequest.path()).thenReturn("/foo");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isTrue();
-
-    when(httpServerRequest.method()).thenReturn("GET");
-    when(httpServerRequest.path()).thenReturn("/foo");
+    when(httpServerRequest.path()).thenReturn("/play");
+    when(httpServerRequest.url())
+      .thenReturn("https://movies/play?user=gumby&country=US&device=iphone");
 
     assertThat(sampler.trySample(httpServerRequest))
       .isTrue();
-  }
 
-  @Test public void onMethodAndPath_sampled_prefix() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(and(methodEquals("GET"), pathStartsWith("/foo")), Sampler.ALWAYS_SAMPLE)
-      .build();
-
-    when(adapter.method(request)).thenReturn("GET");
-    when(adapter.path(request)).thenReturn("/foo/abcd");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isTrue();
-
-    when(httpClientRequest.method()).thenReturn("GET");
-    when(httpClientRequest.path()).thenReturn("/foo/abcd");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isTrue();
-
-    when(httpServerRequest.method()).thenReturn("GET");
-    when(httpServerRequest.path()).thenReturn("/foo/abcd");
+    when(httpServerRequest.path()).thenReturn("/play");
+    when(httpServerRequest.url())
+      .thenReturn("https://movies/play?user=gumby&country=ES&device=iphone");
 
     assertThat(sampler.trySample(httpServerRequest))
-      .isTrue();
+      .isNull(); // unmatched because country isn't ES
   }
 
-  @Test public void onMethodAndPath_unsampled() {
+  /** Tests deprecated method */
+  @Test public void addRule() {
     HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(and(methodEquals("GET"), pathStartsWith("/foo")), Sampler.NEVER_SAMPLE)
+      .addRule("GET", "/foo", 0.0f)
       .build();
-
-    when(adapter.method(request)).thenReturn("GET");
-    when(adapter.path(request)).thenReturn("/foo");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isFalse();
-
-    when(httpClientRequest.method()).thenReturn("GET");
-    when(httpClientRequest.path()).thenReturn("/foo");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isFalse();
-
-    when(httpServerRequest.method()).thenReturn("GET");
-    when(httpServerRequest.path()).thenReturn("/foo");
-
-    assertThat(sampler.trySample(httpServerRequest))
-      .isFalse();
-  }
-
-  @Test public void onMethodAndPath_doesntMatch_method() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(and(methodEquals("GET"), pathStartsWith("/foo")), Sampler.NEVER_SAMPLE)
-      .build();
-
-    when(adapter.method(request)).thenReturn("POST");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isNull();
-
-    when(httpClientRequest.method()).thenReturn("POST");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isNull();
 
     when(httpServerRequest.method()).thenReturn("POST");
 
     assertThat(sampler.trySample(httpServerRequest))
       .isNull();
-  }
-
-  @Test public void onMethodAndPath_doesntMatch_path() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(and(methodEquals("GET"), pathStartsWith("/foo")), Sampler.NEVER_SAMPLE)
-      .build();
-
-    when(adapter.method(request)).thenReturn("GET");
-    when(adapter.path(request)).thenReturn("/bar");
-
-    assertThat(sampler.trySample(adapter, request))
-      .isNull();
-
-    when(httpClientRequest.method()).thenReturn("GET");
-    when(httpClientRequest.path()).thenReturn("/bar");
-
-    assertThat(sampler.trySample(httpClientRequest))
-      .isNull();
 
     when(httpServerRequest.method()).thenReturn("GET");
-    when(httpServerRequest.path()).thenReturn("/bar");
+    when(httpServerRequest.path()).thenReturn("/foo");
 
     assertThat(sampler.trySample(httpServerRequest))
-      .isNull();
-  }
-
-  @Test public void nullOnParseFailure() {
-    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
-      .putRule(and(methodEquals("GET"), pathStartsWith("/foo")), Sampler.NEVER_SAMPLE)
-      .build();
-
-    // not setting up mocks means they return null which is like a parse fail
-    assertThat(sampler.trySample(adapter, request))
-      .isNull();
-    assertThat(sampler.trySample(httpClientRequest))
-      .isNull();
-    assertThat(sampler.trySample(httpServerRequest))
-      .isNull();
+      .isFalse();
   }
 
   @Test public void putAllRules() {


### PR DESCRIPTION
This switches the rule sampler to use more flexible matchers instead of pre-canned method signatures:

```java
httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
  .putRule(pathStartsWith("/favicon"), Sampler.NEVER_SAMPLE)
  .putRule(pathStartsWith("/foo"), RateLimitingSampler.create(100))
  .putRule(and(methodIsEqualTo("POST"), pathStartsWith("/bar")), RateLimitingSampler.create(10))
  .build());
```

This allows one use case @narayaruna asked for, which is a query-based rule.

Ex. 100 requests per second that match /play&country=US

```java
    Matcher<HttpRequest> playInTheUSA = request -> {
      if (!"/play".equals(request.path())) return false;
      String url = request.url();
      if (url == null) return false;
      String query = URI.create(url).getQuery();
      return query != null && query.contains("country=US");
    };

    HttpRuleSampler sampler = HttpRuleSampler.newBuilder()
      .putRule(playInTheUSA, RateLimitingSampler.create(100))
      .build();
```