### PR TITLE
Adds basic infrastructure for RPC request sampling

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -144,6 +144,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>brave-instrumentation-rpc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-instrumentation-dubbo-rpc</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -29,7 +29,8 @@ Here's a brief overview of what's packaged here:
 * [vertx-web](vertx-web/README.md) - Tracing routing context handler for [Vert.x Web](http://vertx.io/docs/vertx-web/js/)
 
 Here are other tools we provide for configuring or testing instrumentation:
-* [http](http/README.md) - `HttpTracing` that allows portable configuration of http instrumentation
+* [rpc](rpc/README.md) - `RpcTracing` that allows portable configuration of RPC instrumentation
+* [http](http/README.md) - `HttpTracing` that allows portable configuration of HTTP instrumentation
 * [http-tests](http-tests/README.md) - Interop test suit that all http client and server instrumentation must pass
 * [spring-beans](../spring-beans/README.md) - This allows you to setup tracing with XML instead of custom code.
 * [benchmarks](benchmarks/README.md) - JMH microbenchmarks that measure instrumentation overhead

--- a/instrumentation/benchmarks/src/main/java/brave/grpc/GrpcPropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/grpc/GrpcPropagationBenchmarks.java
@@ -23,6 +23,9 @@ import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -42,15 +45,23 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class GrpcPropagationBenchmarks {
+  static final MethodDescriptor<Void, Void> methodDescriptor =
+    MethodDescriptor.<Void, Void>newBuilder()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName("helloworld.Greeter/SayHello")
+      .setRequestMarshaller(VoidMarshaller.INSTANCE)
+      .setResponseMarshaller(VoidMarshaller.INSTANCE)
+      .build();
+
   static final Propagation<Metadata.Key<String>> b3 =
     B3Propagation.FACTORY.create(AsciiMetadataKeyFactory.INSTANCE);
-  static final Injector<Metadata> b3Injector = b3.injector(TracingClientInterceptor.SETTER);
+  static final Injector<GrpcClientRequest> b3Injector = b3.injector(GrpcClientRequest.SETTER);
   static final Extractor<GrpcServerRequest> b3Extractor = b3.extractor(GrpcServerRequest.GETTER);
 
   static final Propagation.Factory bothFactory = GrpcPropagation.newFactory(B3Propagation.FACTORY);
   static final Propagation<Metadata.Key<String>> both =
     bothFactory.create(AsciiMetadataKeyFactory.INSTANCE);
-  static final Injector<Metadata> bothInjector = both.injector(TracingClientInterceptor.SETTER);
+  static final Injector<GrpcClientRequest> bothInjector = both.injector(GrpcClientRequest.SETTER);
   static final Extractor<GrpcServerRequest> bothExtractor =
     both.extractor(GrpcServerRequest.GETTER);
 
@@ -62,23 +73,25 @@ public class GrpcPropagationBenchmarks {
     .build();
   static final TraceContext contextWithTags = bothFactory.decorate(context);
 
-  static final String fullMethodName = "helloworld.Greeter/SayHello";
   static final GrpcServerRequest
-    incomingB3 = new GrpcServerRequest(fullMethodName, new Metadata()),
-    incomingBoth = new GrpcServerRequest(fullMethodName, new Metadata()),
-    incomingBothNoTags = new GrpcServerRequest(fullMethodName, new Metadata()),
-    nothingIncoming = new GrpcServerRequest(fullMethodName, new Metadata());
+    incomingB3 = new GrpcServerRequest(methodDescriptor, new Metadata()),
+    incomingBoth = new GrpcServerRequest(methodDescriptor, new Metadata()),
+    incomingBothNoTags = new GrpcServerRequest(methodDescriptor, new Metadata()),
+    nothingIncoming = new GrpcServerRequest(methodDescriptor, new Metadata());
 
   static {
     PropagationFields.put(contextWithTags, "method", "helloworld.Greeter/SayHello", Tags.class);
-    b3Injector.inject(context, incomingB3.metadata);
-    bothInjector.inject(contextWithTags, incomingBoth.metadata);
-    bothInjector.inject(context, incomingBothNoTags.metadata);
+    b3Injector.inject(context,
+      new GrpcClientRequest(methodDescriptor).metadata(incomingB3.metadata));
+    bothInjector.inject(contextWithTags,
+      new GrpcClientRequest(methodDescriptor).metadata(incomingBoth.metadata));
+    bothInjector.inject(context,
+      new GrpcClientRequest(methodDescriptor).metadata(incomingBothNoTags.metadata));
   }
 
   @Benchmark public void inject_b3() {
-    Metadata carrier = new Metadata();
-    b3Injector.inject(context, carrier);
+    GrpcClientRequest request = new GrpcClientRequest(methodDescriptor).metadata(new Metadata());
+    b3Injector.inject(context, request);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract_b3() {
@@ -90,13 +103,13 @@ public class GrpcPropagationBenchmarks {
   }
 
   @Benchmark public void inject_both() {
-    Metadata carrier = new Metadata();
-    bothInjector.inject(contextWithTags, carrier);
+    GrpcClientRequest request = new GrpcClientRequest(methodDescriptor).metadata(new Metadata());
+    bothInjector.inject(contextWithTags, request);
   }
 
   @Benchmark public void inject_both_no_tags() {
-    Metadata carrier = new Metadata();
-    bothInjector.inject(context, carrier);
+    GrpcClientRequest request = new GrpcClientRequest(methodDescriptor).metadata(new Metadata());
+    bothInjector.inject(context, request);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract_both() {
@@ -119,5 +132,17 @@ public class GrpcPropagationBenchmarks {
       .build();
 
     new Runner(opt).run();
+  }
+
+  enum VoidMarshaller implements MethodDescriptor.Marshaller<Void> {
+    INSTANCE;
+
+    @Override public InputStream stream(Void value) {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override public Void parse(InputStream stream) {
+      return null;
+    }
   }
 }

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboClientRequest.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboClientRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.propagation.Propagation.Setter;
+import brave.rpc.RpcClientRequest;
+import com.alibaba.dubbo.rpc.Invocation;
+import java.util.Map;
+
+// intentionally not yet public until we add tag parsing functionality
+final class DubboClientRequest extends RpcClientRequest {
+  static final Setter<DubboClientRequest, String> SETTER =
+    new Setter<DubboClientRequest, String>() {
+      @Override public void put(DubboClientRequest request, String key, String value) {
+        request.putAttachment(key, value);
+      }
+
+      @Override public String toString() {
+        return "DubboClientRequest::putAttachment";
+      }
+    };
+
+  final Invocation invocation;
+  final Map<String, String> attachments;
+
+  DubboClientRequest(Invocation invocation, Map<String, String> attachments) {
+    if (invocation == null) throw new NullPointerException("invocation == null");
+    this.invocation = invocation;
+    if (attachments == null) throw new NullPointerException("attachments == null");
+    this.attachments = attachments;
+  }
+
+  @Override public Object unwrap() {
+    return this;
+  }
+
+  @Override public String method() {
+    return DubboParser.method(invocation);
+  }
+
+  @Override public String service() {
+    return DubboParser.service(invocation);
+  }
+
+  String putAttachment(String key, String value) {
+    return attachments.put(key, value);
+  }
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboParser.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboParser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.internal.Nullable;
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.support.RpcUtils;
+
+final class DubboParser {
+  /**
+   * Returns the method name of the invocation or the first string arg of an "$invoke" method.
+   *
+   * <p>Like {@link RpcUtils#getMethodName(Invocation)}, except without re-reading fields or
+   * returning an unhelpful "$invoke" method name.
+   */
+  static @Nullable String method(Invocation invocation) {
+    String methodName = invocation.getMethodName();
+    if ("$invoke".equals(methodName)) {
+      Object[] arguments = invocation.getArguments();
+      if (arguments != null && arguments.length > 0 && arguments[0] instanceof String) {
+        methodName = (String) arguments[0];
+      } else {
+        methodName = null;
+      }
+    }
+    return methodName != null && !methodName.isEmpty() ? methodName : null;
+  }
+
+  /**
+   * Returns the {@link URL#getServiceInterface() service interface} of the invocation.
+   *
+   * <p>This was chosen as the {@link URL#getServiceName() service name} is deprecated for it.
+   */
+  static @Nullable String service(Invocation invocation) {
+    Invoker<?> invoker = invocation.getInvoker();
+    if (invoker == null) return null;
+    URL url = invoker.getUrl();
+    if (url == null) return null;
+    String service = url.getServiceInterface();
+    return service != null && !service.isEmpty() ? service : null;
+  }
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboServerRequest.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboServerRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.internal.Nullable;
+import brave.propagation.Propagation.Getter;
+import brave.rpc.RpcServerRequest;
+import com.alibaba.dubbo.rpc.Invocation;
+import java.util.Map;
+
+// intentionally not yet public until we add tag parsing functionality
+final class DubboServerRequest extends RpcServerRequest {
+  static final Getter<DubboServerRequest, String> GETTER =
+    new Getter<DubboServerRequest, String>() {
+      @Override public String get(DubboServerRequest request, String key) {
+        return request.getAttachment(key);
+      }
+
+      @Override public String toString() {
+        return "DubboServerRequest::getAttachment";
+      }
+    };
+
+  final Invocation invocation;
+  final Map<String, String> attachments;
+
+  DubboServerRequest(Invocation invocation, Map<String, String> attachments) {
+    if (invocation == null) throw new NullPointerException("invocation == null");
+    this.invocation = invocation;
+    if (attachments == null) throw new NullPointerException("attachments == null");
+    this.attachments = attachments;
+  }
+
+  @Override public Object unwrap() {
+    return this;
+  }
+
+  @Override public String method() {
+    return DubboParser.method(invocation);
+  }
+
+  @Override public String service() {
+    return DubboParser.service(invocation);
+  }
+
+  @Nullable String getAttachment(String key) {
+    return attachments.get(key);
+  }
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -19,9 +19,11 @@ import brave.Tracer;
 import brave.Tracing;
 import brave.internal.Platform;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
+import brave.rpc.RpcRequest;
+import brave.rpc.RpcTracing;
+import brave.sampler.SamplerFunction;
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.common.extension.Activate;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
@@ -41,6 +43,10 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+import static brave.dubbo.rpc.DubboClientRequest.SETTER;
+import static brave.dubbo.rpc.DubboServerRequest.GETTER;
+import static brave.sampler.SamplerFunctions.deferDecision;
+
 @Activate(group = {Constants.PROVIDER, Constants.CONSUMER}, value = "tracing")
 // http://dubbo.apache.org/en-us/docs/dev/impls/filter.html
 // public constructor permitted to allow dubbo to instantiate this
@@ -48,8 +54,9 @@ public final class TracingFilter implements Filter {
 
   CurrentTraceContext current;
   Tracer tracer;
-  TraceContext.Extractor<Map<String, String>> extractor;
-  TraceContext.Injector<Map<String, String>> injector;
+  TraceContext.Extractor<DubboServerRequest> extractor;
+  TraceContext.Injector<DubboClientRequest> injector;
+  SamplerFunction<RpcRequest> clientSampler = deferDecision(), serverSampler = deferDecision();
   volatile boolean isInit = false;
 
   /**
@@ -65,22 +72,41 @@ public final class TracingFilter implements Filter {
     isInit = true;
   }
 
+  /**
+   * {@link ExtensionLoader} supplies the tracing implementation which must be named "rpcTracing".
+   * For example, if using the {@link SpringExtensionFactory}, only a bean named "rpcTracing" will
+   * be injected.
+   */
+  public void setRpcTracing(RpcTracing rpcTracing) {
+    if (rpcTracing == null) throw new NullPointerException("rpcTracing == null");
+    tracer = rpcTracing.tracing().tracer();
+    extractor = rpcTracing.tracing().propagation().extractor(GETTER);
+    injector = rpcTracing.tracing().propagation().injector(SETTER);
+    clientSampler = rpcTracing.clientSampler();
+    serverSampler = rpcTracing.serverSampler();
+    isInit = true;
+  }
+
   @Override public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-    if (isInit == false) return invoker.invoke(invocation);
+    if (!isInit) return invoker.invoke(invocation);
 
     RpcContext rpcContext = RpcContext.getContext();
     Kind kind = rpcContext.isProviderSide() ? Kind.SERVER : Kind.CLIENT;
     final Span span;
     if (kind.equals(Kind.CLIENT)) {
-      span = tracer.nextSpan();
-      injector.inject(span.context(), invocation.getAttachments());
+      // When A service invoke B service, then B service then invoke C service, the parentId of the
+      // C service span is A when read from invocation.getAttachments(). This is because
+      // AbstractInvoker adds attachments via RpcContext.getContext(), not the invocation.
+      // See com.alibaba.dubbo.rpc.protocol.AbstractInvoker(line 138) from v2.6.7
+      Map<String, String> attachments = RpcContext.getContext().getAttachments();
+      DubboClientRequest request = new DubboClientRequest(invocation, attachments);
+      span = tracer.nextSpan(clientSampler, request);
+      injector.inject(span.context(), request);
     } else {
-      TraceContextOrSamplingFlags extracted = extractor.extract(invocation.getAttachments());
-      span = extracted.context() != null
-        ? tracer.joinSpan(extracted.context())
-        : tracer.nextSpan(extracted);
+      DubboServerRequest request = new DubboServerRequest(invocation, invocation.getAttachments());
+      TraceContextOrSamplingFlags extracted = extractor.extract(request);
+      span = nextSpan(extracted, request);
     }
-
     if (!span.isNoop()) {
       span.kind(kind);
       String service = invoker.getInterface().getSimpleName();
@@ -110,6 +136,20 @@ public final class TracingFilter implements Filter {
     }
   }
 
+  /** Creates a potentially noop span representing this request */
+  // This is the same code as HttpServerHandler.nextSpan
+  // TODO: pull this into RpcServerHandler when stable https://github.com/openzipkin/brave/pull/999
+  Span nextSpan(TraceContextOrSamplingFlags extracted, DubboServerRequest request) {
+    Boolean sampled = extracted.sampled();
+    // only recreate the context if the sampler made a decision
+    if (sampled == null && (sampled = serverSampler.trySample(request)) != null) {
+      extracted = extracted.sampled(sampled.booleanValue());
+    }
+    return extracted.context() != null
+      ? tracer.joinSpan(extracted.context())
+      : tracer.nextSpan(extracted);
+  }
+
   boolean ensureSpanFinishes(RpcContext rpcContext, Span span, Result result) {
     boolean deferFinish = false;
     if (result.hasException()) onError(result.getException(), span);
@@ -137,32 +177,6 @@ public final class TracingFilter implements Filter {
       span.tag("dubbo.error_code", Integer.toString(((RpcException) error).getCode()));
     }
   }
-
-  static final Propagation.Getter<Map<String, String>, String> GETTER =
-    new Propagation.Getter<Map<String, String>, String>() {
-      @Override
-      public String get(Map<String, String> carrier, String key) {
-        return carrier.get(key);
-      }
-
-      @Override
-      public String toString() {
-        return "Map::get";
-      }
-    };
-
-  static final Propagation.Setter<Map<String, String>, String> SETTER =
-    new Propagation.Setter<Map<String, String>, String>() {
-      @Override
-      public void put(Map<String, String> carrier, String key, String value) {
-        carrier.put(key, value);
-      }
-
-      @Override
-      public String toString() {
-        return "Map::set";
-      }
-    };
 
   /** Ensures any callbacks finish the span. */
   static final class FinishSpanResponseFuture implements ResponseFuture {

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboParserTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboParserTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DubboParserTest {
+  @Mock Invocation invocation;
+  @Mock Invoker invoker;
+
+  @Test public void method() {
+    when(invocation.getMethodName()).thenReturn("sayHello");
+
+    assertThat(DubboParser.method(invocation))
+      .isEqualTo("sayHello");
+  }
+
+  @Test public void method_malformed() {
+    when(invocation.getMethodName()).thenReturn("");
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void method_invoke() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+    when(invocation.getArguments()).thenReturn(new Object[] {"sayHello"});
+
+    assertThat(DubboParser.method(invocation))
+      .isEqualTo("sayHello");
+  }
+
+  @Test public void method_invoke_nullArgs() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void method_invoke_emptyArgs() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+    when(invocation.getArguments()).thenReturn(new Object[0]);
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void method_invoke_nonStringArg() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+    when(invocation.getArguments()).thenReturn(new Object[] {new Object()});
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void service() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    URL url = URL.valueOf("http://localhost:9000?interface=brave.dubbo.GreeterService");
+    when(invoker.getUrl()).thenReturn(url);
+
+    assertThat(DubboParser.service(invocation))
+      .isEqualTo("brave.dubbo.GreeterService");
+  }
+
+  @Test public void service_nullInvoker() {
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+
+  @Test public void service_nullUrl() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+
+  @Test public void service_nullServiceInterface() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    URL url = URL.valueOf("http://localhost:9000");
+    when(invoker.getUrl()).thenReturn(url);
+
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+
+  @Test public void service_malformed() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    URL url = URL.valueOf("http://localhost:9000?interface=");
+    when(invoker.getUrl()).thenReturn(url);
+
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/GreeterService.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/GreeterService.java
@@ -15,4 +15,6 @@ package brave.dubbo.rpc;
 
 public interface GreeterService {
   String sayHello(String name);
+
+  String sayGoodbye(String name);
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -16,6 +16,7 @@ package brave.dubbo.rpc;
 import brave.Tracing;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.rpc.RpcTracing;
 import brave.sampler.Sampler;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
 import com.alibaba.dubbo.config.ReferenceConfig;
@@ -40,6 +41,7 @@ public abstract class ITTracingFilter {
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
   Tracing tracing;
+  RpcTracing rpcTracing;
   TestServer server = new TestServer();
   ReferenceConfig<GreeterService> client;
 
@@ -78,6 +80,14 @@ public abstract class ITTracingFilter {
       .getExtension("tracing"))
       .setTracing(tracing);
     this.tracing = tracing;
+  }
+
+  void setRpcTracing(RpcTracing rpcTracing) {
+    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+      .getExtension("tracing"))
+      .setRpcTracing(rpcTracing);
+    this.tracing = rpcTracing.tracing();
+    this.rpcTracing = rpcTracing;
   }
 
   /** Call this to block until a span was reported */

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
@@ -24,15 +24,14 @@ import com.alibaba.dubbo.config.RegistryConfig;
 import com.alibaba.dubbo.config.ServiceConfig;
 import com.alibaba.dubbo.rpc.RpcContext;
 import com.alibaba.dubbo.rpc.service.GenericService;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
   BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
-  TraceContext.Extractor<Map<String, String>> extractor =
-    B3Propagation.B3_STRING.extractor(TracingFilter.GETTER);
+  TraceContext.Extractor<DubboServerRequest> extractor =
+    B3Propagation.B3_STRING.extractor(DubboServerRequest.GETTER);
   ServiceConfig<GenericService> service;
   String linkLocalIp;
 
@@ -47,7 +46,7 @@ class TestServer {
     service.setApplication(new ApplicationConfig("bean-provider"));
     service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
     service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
-    service.setInterface(GreeterService.class.getName());
+    service.setInterface(GreeterService.class);
     service.setRef((method, parameterTypes, args) -> {
       Long delay = delayQueue.poll();
       if (delay != null) {
@@ -58,7 +57,11 @@ class TestServer {
           throw new AssertionError("interrupted sleeping " + delay);
         }
       }
-      requestQueue.add(extractor.extract(RpcContext.getContext().getAttachments()));
+
+      RpcContext context = RpcContext.getContext();
+      DubboServerRequest request =
+        new DubboServerRequest(context.getInvocation(), context.getAttachments());
+      requestQueue.add(extractor.extract(request));
 
       return args[0];
     });

--- a/instrumentation/dubbo/README.md
+++ b/instrumentation/dubbo/README.md
@@ -27,34 +27,52 @@ dubbo.provider.filter=tracing
 dubbo.consumer.filter=tracing
 ```
 
-### Registering the `brave.Tracing` extension with Spring
-Most typically, the `brave.Tracing` extension is provided by Spring, so
-have this in place before proceeding. The bean must be named "tracing"
+### Registering the `brave.rpc.RpcTracing` extension with Spring
+Most typically, the `brave.rpc.RpcTracing` extension is provided by Spring, so
+have this in place before proceeding. The bean must be named "rpcTracing"
 
 Here's an example in [XML](../../spring-beans/README.md).
 
-### Registering the `brave.Tracing` extension with Java
+### Registering the `brave.rpc.RpcTracing` extension with Java
 Dubbo supports custom extensions. You can supply your own instance of
 tracing by creating and registering an extension factory:
 
-#### create an extension factory that returns `brave.Tracing`
+#### create an extension factory that returns `brave.rpc.RpcTracing`
 
 ```java
 package com.yourcompany.dubbo;
 
 import brave.Tracing;
+import brave.rpc.RpcTracing;
+import brave.rpc.RpcRuleSampler;
 import org.apache.dubbo.common.extension.ExtensionFactory;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.Span;
 
+import static brave.rpc.RpcRequestMatchers.methodEquals;
+import static brave.sampler.Matchers.and;
+
 public class TracingExtensionFactory implements ExtensionFactory {
 
   @Override public <T> T getExtension(Class<T> type, String name) {
-    if (type != Tracing.class) return null;
-    return (T) Tracing.newBuilder()
-                      .localServiceName("my-service")
-                      .spanReporter(spanReporter())
-                      .build();
+    if (type != RpcTracing.class) return null;
+
+    return (T) RpcTracing.newBuilder(tracing())
+                         .serverSampler(serverSampler())
+                         .build();
+  }
+
+  RpcRuleSampler serverSampler() {
+    return RpcRuleSampler.newBuilder()
+      .putRule(methodEquals("sayHello"), Sampler.NEVER_SAMPLE)
+      .build();
+  }
+
+  Tracing tracing() {
+    return Tracing.newBuilder()
+                  .localServiceName("my-service")
+                  .spanReporter(spanReporter())
+                  .build();
   }
 
   // NOTE: The reporter should be closed with a shutdown hook

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -37,6 +37,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-rpc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.dubbo</groupId>
       <artifactId>dubbo</artifactId>
       <version>${dubbo.version}</version>

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboClientRequest.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboClientRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.propagation.Propagation.Setter;
+import brave.rpc.RpcClientRequest;
+import java.util.Map;
+import org.apache.dubbo.rpc.Invocation;
+
+// intentionally not yet public until we add tag parsing functionality
+final class DubboClientRequest extends RpcClientRequest {
+  static final Setter<DubboClientRequest, String> SETTER =
+    new Setter<DubboClientRequest, String>() {
+      @Override public void put(DubboClientRequest request, String key, String value) {
+        request.putAttachment(key, value);
+      }
+
+      @Override public String toString() {
+        return "DubboClientRequest::putAttachment";
+      }
+    };
+
+  final Invocation invocation;
+  final Map<String, String> attachments;
+
+  DubboClientRequest(Invocation invocation, Map<String, String> attachments) {
+    if (invocation == null) throw new NullPointerException("invocation == null");
+    this.invocation = invocation;
+    if (attachments == null) throw new NullPointerException("attachments == null");
+    this.attachments = attachments;
+  }
+
+  @Override public Object unwrap() {
+    return this;
+  }
+
+  @Override public String method() {
+    return DubboParser.method(invocation);
+  }
+
+  @Override public String service() {
+    return DubboParser.service(invocation);
+  }
+
+  String putAttachment(String key, String value) {
+    return attachments.put(key, value);
+  }
+}

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboParser.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.internal.Nullable;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.support.RpcUtils;
+
+import static org.apache.dubbo.rpc.Constants.$INVOKE;
+import static org.apache.dubbo.rpc.Constants.$INVOKE_ASYNC;
+
+final class DubboParser {
+  /**
+   * Returns the method name of the invocation or the first string arg of an "$invoke" or
+   * "$invokeAsync" method.
+   *
+   * <p>Like {@link RpcUtils#getMethodName(Invocation)}, except without re-reading fields or
+   * returning an unhelpful "$invoke" method name.
+   */
+  static @Nullable String method(Invocation invocation) {
+    String methodName = invocation.getMethodName();
+    if ($INVOKE.equals(methodName) || $INVOKE_ASYNC.equals(methodName)) {
+      Object[] arguments = invocation.getArguments();
+      if (arguments != null && arguments.length > 0 && arguments[0] instanceof String) {
+        methodName = (String) arguments[0];
+      } else {
+        methodName = null;
+      }
+    }
+    return methodName != null && !methodName.isEmpty() ? methodName : null;
+  }
+
+  /**
+   * Returns the {@link URL#getServiceInterface() service interface} of the invocation.
+   *
+   * <p>This was chosen as the {@link URL#getServiceName() service name} is deprecated for it.
+   */
+  static @Nullable String service(Invocation invocation) {
+    Invoker<?> invoker = invocation.getInvoker();
+    if (invoker == null) return null;
+    URL url = invoker.getUrl();
+    if (url == null) return null;
+    String service = url.getServiceInterface();
+    return service != null && !service.isEmpty() ? service : null;
+  }
+}

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboServerRequest.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboServerRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.internal.Nullable;
+import brave.propagation.Propagation.Getter;
+import brave.rpc.RpcServerRequest;
+import java.util.Map;
+import org.apache.dubbo.rpc.Invocation;
+
+// intentionally not yet public until we add tag parsing functionality
+final class DubboServerRequest extends RpcServerRequest {
+  static final Getter<DubboServerRequest, String> GETTER =
+    new Getter<DubboServerRequest, String>() {
+      @Override public String get(DubboServerRequest request, String key) {
+        return request.getAttachment(key);
+      }
+
+      @Override public String toString() {
+        return "DubboServerRequest::getAttachment";
+      }
+    };
+
+  final Invocation invocation;
+  final Map<String, String> attachments;
+
+  DubboServerRequest(Invocation invocation, Map<String, String> attachments) {
+    if (invocation == null) throw new NullPointerException("invocation == null");
+    this.invocation = invocation;
+    if (attachments == null) throw new NullPointerException("attachments == null");
+    this.attachments = attachments;
+  }
+
+  @Override public Object unwrap() {
+    return this;
+  }
+
+  @Override public String method() {
+    return DubboParser.method(invocation);
+  }
+
+  @Override public String service() {
+    return DubboParser.service(invocation);
+  }
+
+  @Nullable String getAttachment(String key) {
+    return attachments.get(key);
+  }
+}

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
@@ -18,9 +18,11 @@ import brave.Span.Kind;
 import brave.Tracer;
 import brave.Tracing;
 import brave.internal.Platform;
-import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
+import brave.rpc.RpcRequest;
+import brave.rpc.RpcTracing;
+import brave.sampler.SamplerFunction;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -37,14 +39,19 @@ import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.protocol.dubbo.FutureAdapter;
 import org.apache.dubbo.rpc.support.RpcUtils;
 
+import static brave.dubbo.DubboClientRequest.SETTER;
+import static brave.dubbo.DubboServerRequest.GETTER;
+import static brave.sampler.SamplerFunctions.deferDecision;
+
 @Activate(group = {CommonConstants.PROVIDER, CommonConstants.CONSUMER}, value = "tracing")
 // http://dubbo.apache.org/en-us/docs/dev/impls/filter.html
 // public constructor permitted to allow dubbo to instantiate this
 public final class TracingFilter implements Filter {
 
   Tracer tracer;
-  TraceContext.Extractor<Map<String, String>> extractor;
-  TraceContext.Injector<Map<String, String>> injector;
+  TraceContext.Extractor<DubboServerRequest> extractor;
+  TraceContext.Injector<DubboClientRequest> injector;
+  SamplerFunction<RpcRequest> clientSampler = deferDecision(), serverSampler = deferDecision();
   volatile boolean isInit = false;
 
   /**
@@ -52,10 +59,26 @@ public final class TracingFilter implements Filter {
    * example, if using the {@link SpringExtensionFactory}, only a bean named "tracing" will be
    * injected.
    */
-  public void setTracing(Tracing tracing) {
+  public synchronized void setTracing(Tracing tracing) {
+    if (tracing == null) throw new NullPointerException("rpcTracing == null");
     tracer = tracing.tracer();
     extractor = tracing.propagation().extractor(GETTER);
     injector = tracing.propagation().injector(SETTER);
+    isInit = true;
+  }
+
+  /**
+   * {@link ExtensionLoader} supplies the tracing implementation which must be named "rpcTracing".
+   * For example, if using the {@link SpringExtensionFactory}, only a bean named "rpcTracing" will
+   * be injected.
+   */
+  public synchronized void setRpcTracing(RpcTracing rpcTracing) {
+    if (rpcTracing == null) throw new NullPointerException("rpcTracing == null");
+    tracer = rpcTracing.tracing().tracer();
+    extractor = rpcTracing.tracing().propagation().extractor(GETTER);
+    injector = rpcTracing.tracing().propagation().injector(SETTER);
+    clientSampler = rpcTracing.clientSampler();
+    serverSampler = rpcTracing.serverSampler();
     isInit = true;
   }
 
@@ -67,16 +90,16 @@ public final class TracingFilter implements Filter {
     Kind kind = rpcContext.isProviderSide() ? Kind.SERVER : Kind.CLIENT;
     final Span span;
     if (kind.equals(Kind.CLIENT)) {
-      span = tracer.nextSpan();
       // if use  invocation.getAttachments(),when A service invoke B service,B service then invoke C service,the parentId  of C service span  is A
       // because   invocation add attachments from rpcContext in org.apache.dubbo.rpc.protocol.AbstractInvoker(line 141),so what we do will be override
-      //injector.inject(span.context(), invocation.getAttachments());
-      injector.inject(span.context(),  RpcContext.getContext().getAttachments());
+      Map<String, String> attachments = RpcContext.getContext().getAttachments();
+      DubboClientRequest request = new DubboClientRequest(invocation, attachments);
+      span = tracer.nextSpan(clientSampler, request);
+      injector.inject(span.context(), request);
     } else {
-      TraceContextOrSamplingFlags extracted = extractor.extract(invocation.getAttachments());
-      span = extracted.context() != null
-        ? tracer.joinSpan(extracted.context())
-        : tracer.nextSpan(extracted);
+      DubboServerRequest request = new DubboServerRequest(invocation, invocation.getAttachments());
+      TraceContextOrSamplingFlags extracted = extractor.extract(request);
+      span = nextSpan(extracted, request);
     }
 
     if (!span.isNoop()) {
@@ -98,7 +121,7 @@ public final class TracingFilter implements Filter {
       Future<Object> future = rpcContext.getFuture(); // the case on async client invocation
       if (!isOneway && future instanceof FutureAdapter) {
         deferFinish = true;
-        ((FutureAdapter<Object>)future).whenComplete((v, t) -> {
+        ((FutureAdapter<Object>) future).whenComplete((v, t) -> {
           if (t != null) {
             onError(t, span);
             span.finish();
@@ -120,6 +143,20 @@ public final class TracingFilter implements Filter {
     }
   }
 
+  /** Creates a potentially noop span representing this request */
+  // This is the same code as HttpServerHandler.nextSpan
+  // TODO: pull this into RpcServerHandler when stable https://github.com/openzipkin/brave/pull/999
+  Span nextSpan(TraceContextOrSamplingFlags extracted, DubboServerRequest request) {
+    Boolean sampled = extracted.sampled();
+    // only recreate the context if the sampler made a decision
+    if (sampled == null && (sampled = serverSampler.trySample(request)) != null) {
+      extracted = extracted.sampled(sampled.booleanValue());
+    }
+    return extracted.context() != null
+      ? tracer.joinSpan(extracted.context())
+      : tracer.nextSpan(extracted);
+  }
+
   static void parseRemoteAddress(RpcContext rpcContext, Span span) {
     InetSocketAddress remoteAddress = rpcContext.getRemoteAddress();
     if (remoteAddress == null) return;
@@ -132,32 +169,4 @@ public final class TracingFilter implements Filter {
       span.tag("dubbo.error_code", Integer.toString(((RpcException) error).getCode()));
     }
   }
-
-  static final Propagation.Getter<Map<String, String>, String> GETTER =
-    new Propagation.Getter<Map<String, String>, String>() {
-      @Override
-      public String get(Map<String, String> carrier, String key) {
-        return carrier.get(key);
-      }
-
-      @Override
-      public String toString() {
-        return "Map::get";
-      }
-    };
-
-  static final Propagation.Setter<Map<String, String>, String> SETTER =
-    new Propagation.Setter<Map<String, String>, String>() {
-      @Override
-      public void put(Map<String, String> carrier, String key, String value) {
-        carrier.put(key, value);
-      }
-
-      @Override
-      public String toString() {
-        return "Map::set";
-      }
-    };
-
-
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DubboParserTest {
+  @Mock Invocation invocation;
+  @Mock Invoker invoker;
+  @Mock URL url;
+
+  @Test public void method() {
+    when(invocation.getMethodName()).thenReturn("sayHello");
+
+    assertThat(DubboParser.method(invocation))
+      .isEqualTo("sayHello");
+  }
+
+  @Test public void method_malformed() {
+    when(invocation.getMethodName()).thenReturn("");
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void method_invoke() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+    when(invocation.getArguments()).thenReturn(new Object[] {"sayHello"});
+
+    assertThat(DubboParser.method(invocation))
+      .isEqualTo("sayHello");
+  }
+
+  @Test public void method_invoke_nullArgs() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void method_invoke_emptyArgs() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+    when(invocation.getArguments()).thenReturn(new Object[0]);
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void method_invoke_nonStringArg() {
+    when(invocation.getMethodName()).thenReturn("$invoke");
+    when(invocation.getArguments()).thenReturn(new Object[] {new Object()});
+
+    assertThat(DubboParser.method(invocation)).isNull();
+  }
+
+  @Test public void service() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+    when(url.getServiceInterface()).thenReturn("brave.dubbo.GreeterService");
+
+    assertThat(DubboParser.service(invocation))
+      .isEqualTo("brave.dubbo.GreeterService");
+  }
+
+  @Test public void service_nullInvoker() {
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+
+  @Test public void service_nullUrl() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+
+  @Test public void service_nullServiceInterface() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+
+  @Test public void service_malformed() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+    when(url.getServiceInterface()).thenReturn("");
+
+    assertThat(DubboParser.service(invocation)).isNull();
+  }
+}

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/GreeterService.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/GreeterService.java
@@ -15,4 +15,6 @@ package brave.dubbo;
 
 public interface GreeterService {
   String sayHello(String name);
+
+  String sayGoodbye(String name);
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -16,6 +16,7 @@ package brave.dubbo;
 import brave.Tracing;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.rpc.RpcTracing;
 import brave.sampler.Sampler;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -41,6 +42,7 @@ public abstract class ITTracingFilter {
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
   Tracing tracing;
+  RpcTracing rpcTracing;
   ApplicationConfig application = new ApplicationConfig("brave");
   TestServer server = new TestServer(application);
   ReferenceConfig<GreeterService> client;
@@ -80,6 +82,14 @@ public abstract class ITTracingFilter {
       .getExtension("tracing"))
       .setTracing(tracing);
     this.tracing = tracing;
+  }
+
+  void setRpcTracing(RpcTracing rpcTracing) {
+    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+      .getExtension("tracing"))
+      .setRpcTracing(rpcTracing);
+    this.tracing = rpcTracing.tracing();
+    this.rpcTracing = rpcTracing;
   }
 
   /** Call this to block until a span was reported */

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -17,7 +17,6 @@ import brave.internal.Platform;
 import brave.propagation.B3Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.dubbo.common.constants.CommonConstants;
@@ -59,6 +58,7 @@ class TestServer {
           throw new AssertionError("interrupted sleeping " + delay);
         }
       }
+
       RpcContext context = RpcContext.getContext();
       DubboServerRequest request =
         new DubboServerRequest(context.getInvocation(), context.getAttachments());

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -32,8 +32,8 @@ import org.apache.dubbo.rpc.service.GenericService;
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
   BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
-  TraceContext.Extractor<Map<String, String>> extractor =
-    B3Propagation.B3_STRING.extractor(TracingFilter.GETTER);
+  TraceContext.Extractor<DubboServerRequest> extractor =
+    B3Propagation.B3_STRING.extractor(DubboServerRequest.GETTER);
   ServiceConfig<GenericService> service;
   String linkLocalIp;
 
@@ -48,7 +48,7 @@ class TestServer {
     service.setApplication(application);
     service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
     service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
-    service.setInterface(GreeterService.class.getName());
+    service.setInterface(GreeterService.class);
     service.setRef((method, parameterTypes, args) -> {
       Long delay = delayQueue.poll();
       if (delay != null) {
@@ -59,7 +59,10 @@ class TestServer {
           throw new AssertionError("interrupted sleeping " + delay);
         }
       }
-      requestQueue.add(extractor.extract(RpcContext.getContext().getAttachments()));
+      RpcContext context = RpcContext.getContext();
+      DubboServerRequest request =
+        new DubboServerRequest(context.getInvocation(), context.getAttachments());
+      requestQueue.add(extractor.extract(request));
 
       return args[0];
     });

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -72,11 +72,13 @@ doesn't start new traces for requests to the health check service. Other
 requests will use a global rate provided by the tracing component.
 
 ```java
-import static brave.rpc.RpcRequestMatchers.*;
+import static brave.rpc.RpcRequestMatchers.methodEquals;
+import static brave.rpc.RpcRequestMatchers.serviceEquals;
+import static brave.sampler.Matchers.and;
 
 rpcTracing = rpcTracingBuilder.serverSampler(RpcRuleSampler.newBuilder()
   .putRule(serviceEquals("grpc.health.v1.Health"), Sampler.NEVER_SAMPLE)
-  .putRule(methodEquals("GetUserToken"), RateLimitingSampler.create(100))
+  .putRule(and(serviceEquals("users.UserService"), methodEquals("GetUserToken")), RateLimitingSampler.create(100))
   .build()).build();
 
 grpcTracing = GrpcTracing.create(rpcTracing);

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -60,6 +60,28 @@ overrideSpanName = new GrpcClientParser() {
 };
 ```
 
+## Sampling Policy
+The default sampling policy is to use the default (trace ID) sampler for
+server and client requests.
+
+You can use an [RpcRuleSampler](../rpc/README.md) to override this based on
+gRPC service or method names.
+
+Ex. Here's a sampler that traces 100 "GetUserToken" requests per second. This
+doesn't start new traces for requests to the health check service. Other
+requests will use a global rate provided by the tracing component.
+
+```java
+import static brave.rpc.RpcRequestMatchers.*;
+
+rpcTracing = rpcTracingBuilder.serverSampler(RpcRuleSampler.newBuilder()
+  .putRule(serviceEquals("grpc.health.v1.Health"), Sampler.NEVER_SAMPLE)
+  .putRule(methodEquals("GetUserToken"), RateLimitingSampler.create(100))
+  .build()).build();
+
+grpcTracing = GrpcTracing.create(rpcTracing);
+```
+
 ## gRPC Propagation Format (Census interop)
 
 gRPC defines a [binary encoded propagation format](https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md) which is implemented

--- a/instrumentation/grpc/README.md
+++ b/instrumentation/grpc/README.md
@@ -14,7 +14,7 @@ To enable tracing for a gRPC application, add the interceptors when
 constructing the client and server bindings:
 
 ```java
-grpcTracing = GrpcTracing.create(tracing);
+grpcTracing = GrpcTracing.create(rpcTracing);
 
 Server server = ServerBuilder.forPort(serverPort)
     .addService(ServerInterceptors.intercept(

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -13,7 +13,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
@@ -40,6 +42,10 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-rpc</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-all</artifactId>

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.grpc;
+
+import brave.rpc.RpcClientRequest;
+
+// intentionally not yet public until we add tag parsing functionality
+final class GrpcClientRequest extends RpcClientRequest {
+  final String fullMethodName;
+
+  GrpcClientRequest(String fullMethodName) {
+    if (fullMethodName == null) throw new NullPointerException("fullMethodName == null");
+    this.fullMethodName = fullMethodName;
+  }
+
+  @Override public Object unwrap() {
+    return this;
+  }
+
+  @Override public String method() {
+    int index = fullMethodName.lastIndexOf('/');
+    if (index == -1) return null;
+    return fullMethodName.substring(index);
+  }
+
+  @Override public String service() {
+    int index = fullMethodName.lastIndexOf('/');
+    if (index == -1) return null;
+    return fullMethodName.substring(0, index);
+  }
+}

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientRequest.java
@@ -25,7 +25,7 @@ final class GrpcClientRequest extends RpcClientRequest {
   static final Setter<GrpcClientRequest, Metadata.Key<String>> SETTER =
     new Setter<GrpcClientRequest, Metadata.Key<String>>() { // retrolambda no like
       @Override public void put(GrpcClientRequest request, Metadata.Key<String> key, String value) {
-        request.metadata(key, value);
+        request.setMetadata(key, value);
       }
 
       @Override public String toString() {
@@ -59,7 +59,7 @@ final class GrpcClientRequest extends RpcClientRequest {
     return this;
   }
 
-  <T> void metadata(Metadata.Key<T> key, T value) {
+  <T> void setMetadata(Metadata.Key<T> key, T value) {
     Metadata metadata = this.metadata;
     if (metadata == null) {
       assert false : "This code should never be called when null";

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientRequest.java
@@ -29,7 +29,7 @@ final class GrpcClientRequest extends RpcClientRequest {
       }
 
       @Override public String toString() {
-        return "GrpcClientRequest::metadata";
+        return "GrpcClientRequest::setMetadata";
       }
     };
 

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcParser.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcParser.java
@@ -16,6 +16,7 @@ package brave.grpc;
 import brave.ErrorParser;
 import brave.SpanCustomizer;
 import brave.Tracing;
+import brave.internal.Nullable;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
@@ -67,5 +68,17 @@ public class GrpcParser {
       span.tag("grpc.status_code", code);
       span.tag("error", code);
     }
+  }
+
+  static @Nullable String method(String fullMethodName) {
+    int index = fullMethodName.lastIndexOf('/');
+    if (index == -1 || index == 0) return null;
+    return fullMethodName.substring(index + 1);
+  }
+
+  static @Nullable String service(String fullMethodName) {
+    int index = fullMethodName.lastIndexOf('/');
+    if (index == -1 || index == 0) return null;
+    return fullMethodName.substring(0, index);
   }
 }

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
@@ -124,9 +124,9 @@ final class GrpcPropagation<K> implements Propagation<K> {
 
     @Override public TraceContextOrSamplingFlags extract(C carrier) {
       Tags tags = null;
-      if (carrier instanceof Metadata) {
-        tags = extractTags(((Metadata) carrier).get(GRPC_TAGS_BIN));
-        byte[] bytes = ((Metadata) carrier).get(GRPC_TRACE_BIN);
+      if (carrier instanceof GrpcServerRequest) {
+        tags = extractTags(((GrpcServerRequest) carrier).metadata(GRPC_TAGS_BIN));
+        byte[] bytes = ((GrpcServerRequest) carrier).metadata(GRPC_TRACE_BIN);
         if (bytes != null) {
           TraceContext maybeContext = TraceContextBinaryFormat.parseBytes(bytes, tags);
           if (maybeContext != null) return TraceContextOrSamplingFlags.create(maybeContext);

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
@@ -125,8 +125,8 @@ final class GrpcPropagation<K> implements Propagation<K> {
     @Override public TraceContextOrSamplingFlags extract(C carrier) {
       Tags tags = null;
       if (carrier instanceof GrpcServerRequest) {
-        tags = extractTags(((GrpcServerRequest) carrier).metadata(GRPC_TAGS_BIN));
-        byte[] bytes = ((GrpcServerRequest) carrier).metadata(GRPC_TRACE_BIN);
+        tags = extractTags(((GrpcServerRequest) carrier).getMetadata(GRPC_TAGS_BIN));
+        byte[] bytes = ((GrpcServerRequest) carrier).getMetadata(GRPC_TRACE_BIN);
         if (bytes != null) {
           TraceContext maybeContext = TraceContextBinaryFormat.parseBytes(bytes, tags);
           if (maybeContext != null) return TraceContextOrSamplingFlags.create(maybeContext);

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
@@ -103,11 +103,11 @@ final class GrpcPropagation<K> implements Propagation<K> {
     }
 
     @Override public void inject(TraceContext traceContext, C carrier) {
-      if (carrier instanceof Metadata) {
+      if (carrier instanceof GrpcClientRequest) {
         byte[] serialized = TraceContextBinaryFormat.toBytes(traceContext);
-        ((Metadata) carrier).put(GRPC_TRACE_BIN, serialized);
+        ((GrpcClientRequest) carrier).metadata(GRPC_TRACE_BIN, serialized);
         Tags tags = traceContext.findExtra(Tags.class);
-        if (tags != null) ((Metadata) carrier).put(GRPC_TAGS_BIN, tags.toMap());
+        if (tags != null) ((GrpcClientRequest) carrier).metadata(GRPC_TAGS_BIN, tags.toMap());
       }
       delegate.inject(traceContext, carrier);
     }

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
@@ -105,9 +105,9 @@ final class GrpcPropagation<K> implements Propagation<K> {
     @Override public void inject(TraceContext traceContext, C carrier) {
       if (carrier instanceof GrpcClientRequest) {
         byte[] serialized = TraceContextBinaryFormat.toBytes(traceContext);
-        ((GrpcClientRequest) carrier).metadata(GRPC_TRACE_BIN, serialized);
+        ((GrpcClientRequest) carrier).setMetadata(GRPC_TRACE_BIN, serialized);
         Tags tags = traceContext.findExtra(Tags.class);
-        if (tags != null) ((GrpcClientRequest) carrier).metadata(GRPC_TAGS_BIN, tags.toMap());
+        if (tags != null) ((GrpcClientRequest) carrier).setMetadata(GRPC_TAGS_BIN, tags.toMap());
       }
       delegate.inject(traceContext, carrier);
     }

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
@@ -17,6 +17,7 @@ import brave.internal.Nullable;
 import brave.propagation.Propagation.Getter;
 import brave.rpc.RpcServerRequest;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 
 // intentionally not yet public until we add tag parsing functionality
 final class GrpcServerRequest extends RpcServerRequest {
@@ -27,16 +28,16 @@ final class GrpcServerRequest extends RpcServerRequest {
       }
 
       @Override public String toString() {
-        return "Metadata::get";
+        return "GrpcServerRequest::metadata";
       }
     };
 
   final String fullMethodName;
   final Metadata metadata;
 
-  GrpcServerRequest(String fullMethodName, Metadata metadata) {
-    if (fullMethodName == null) throw new NullPointerException("fullMethodName == null");
-    this.fullMethodName = fullMethodName;
+  GrpcServerRequest(MethodDescriptor<?, ?> methodDescriptor, Metadata metadata) {
+    if (methodDescriptor == null) throw new NullPointerException("methodDescriptor == null");
+    this.fullMethodName = methodDescriptor.getFullMethodName();
     if (metadata == null) throw new NullPointerException("metadata == null");
     this.metadata = metadata;
   }
@@ -46,15 +47,11 @@ final class GrpcServerRequest extends RpcServerRequest {
   }
 
   @Override public String method() {
-    int index = fullMethodName.lastIndexOf('/');
-    if (index == -1) return null;
-    return fullMethodName.substring(index);
+    return GrpcParser.method(fullMethodName);
   }
 
   @Override public String service() {
-    int index = fullMethodName.lastIndexOf('/');
-    if (index == -1) return null;
-    return fullMethodName.substring(0, index);
+    return GrpcParser.service(fullMethodName);
   }
 
   @Nullable <T> T metadata(Metadata.Key<T> key) {

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
@@ -24,11 +24,11 @@ final class GrpcServerRequest extends RpcServerRequest {
   static final Getter<GrpcServerRequest, Metadata.Key<String>> GETTER =
     new Getter<GrpcServerRequest, Metadata.Key<String>>() { // retrolambda no like
       @Override public String get(GrpcServerRequest request, Metadata.Key<String> key) {
-        return request.metadata(key);
+        return request.getMetadata(key);
       }
 
       @Override public String toString() {
-        return "GrpcServerRequest::metadata";
+        return "GrpcServerRequest::getMetadata";
       }
     };
 
@@ -54,7 +54,7 @@ final class GrpcServerRequest extends RpcServerRequest {
     return GrpcParser.service(fullMethodName);
   }
 
-  @Nullable <T> T metadata(Metadata.Key<T> key) {
+  @Nullable <T> T getMetadata(Metadata.Key<T> key) {
     return metadata.get(key);
   }
 }

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.grpc;
+
+import brave.internal.Nullable;
+import brave.propagation.Propagation.Getter;
+import brave.rpc.RpcServerRequest;
+import io.grpc.Metadata;
+
+// intentionally not yet public until we add tag parsing functionality
+final class GrpcServerRequest extends RpcServerRequest {
+  static final Getter<GrpcServerRequest, Metadata.Key<String>> GETTER =
+    new Getter<GrpcServerRequest, Metadata.Key<String>>() { // retrolambda no like
+      @Override public String get(GrpcServerRequest request, Metadata.Key<String> key) {
+        return request.metadata(key);
+      }
+
+      @Override public String toString() {
+        return "Metadata::get";
+      }
+    };
+
+  final String fullMethodName;
+  final Metadata metadata;
+
+  GrpcServerRequest(String fullMethodName, Metadata metadata) {
+    if (fullMethodName == null) throw new NullPointerException("fullMethodName == null");
+    this.fullMethodName = fullMethodName;
+    if (metadata == null) throw new NullPointerException("metadata == null");
+    this.metadata = metadata;
+  }
+
+  @Override public Object unwrap() {
+    return this;
+  }
+
+  @Override public String method() {
+    int index = fullMethodName.lastIndexOf('/');
+    if (index == -1) return null;
+    return fullMethodName.substring(index);
+  }
+
+  @Override public String service() {
+    int index = fullMethodName.lastIndexOf('/');
+    if (index == -1) return null;
+    return fullMethodName.substring(0, index);
+  }
+
+  @Nullable String metadata(Metadata.Key<String> key) {
+    return metadata.get(key);
+  }
+}

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerRequest.java
@@ -57,7 +57,7 @@ final class GrpcServerRequest extends RpcServerRequest {
     return fullMethodName.substring(0, index);
   }
 
-  @Nullable String metadata(Metadata.Key<String> key) {
+  @Nullable <T> T metadata(Metadata.Key<T> key) {
     return metadata.get(key);
   }
 }

--- a/instrumentation/grpc/src/main/java/brave/grpc/TracingClientInterceptor.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TracingClientInterceptor.java
@@ -16,9 +16,7 @@ package brave.grpc;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
-import brave.propagation.Propagation.Setter;
 import brave.propagation.TraceContext.Injector;
-import brave.rpc.RpcClientRequest;
 import brave.rpc.RpcRequest;
 import brave.sampler.SamplerFunction;
 import io.grpc.CallOptions;
@@ -31,23 +29,13 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
+import static brave.grpc.GrpcClientRequest.SETTER;
+
 // not exposed directly as implementation notably changes between versions 1.2 and 1.3
 final class TracingClientInterceptor implements ClientInterceptor {
-  static final Setter<Metadata, Metadata.Key<String>> SETTER =
-    new Setter<Metadata, Metadata.Key<String>>() { // retrolambda no like
-      @Override public void put(Metadata metadata, Metadata.Key<String> key, String value) {
-        metadata.removeAll(key);
-        metadata.put(key, value);
-      }
-
-      @Override public String toString() {
-        return "Metadata::put";
-      }
-    };
-
   final Tracer tracer;
   final SamplerFunction<RpcRequest> sampler;
-  final Injector<Metadata> injector;
+  final Injector<GrpcClientRequest> injector;
   final GrpcClientParser parser;
 
   TracingClientInterceptor(GrpcTracing grpcTracing) {
@@ -64,16 +52,17 @@ final class TracingClientInterceptor implements ClientInterceptor {
    * to wrap the executor with one that's aware of the current context.
    */
   @Override
-  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-    final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions,
-    final Channel next) {
-    Span span = tracer.nextSpan(sampler, new GrpcClientRequest(method.getFullMethodName()));
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+    CallOptions callOptions, Channel next) {
+    GrpcClientRequest request = new GrpcClientRequest(method);
+    Span span = tracer.nextSpan(sampler, request);
+
     SpanInScope scope = tracer.withSpanInScope(span);
     try {
       return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-        @Override
-        public void start(Listener<RespT> responseListener, Metadata headers) {
-          injector.inject(span.context(), headers);
+        @Override public void start(Listener<RespT> responseListener, Metadata headers) {
+          request.metadata = headers;
+          injector.inject(span.context(), request);
           span.kind(Span.Kind.CLIENT).start();
           SpanInScope scope = tracer.withSpanInScope(span);
           try { // retrolambda can't resolve this try/finally

--- a/instrumentation/grpc/src/test/java/brave/grpc/GreeterImpl.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GreeterImpl.java
@@ -32,7 +32,7 @@ class GreeterImpl extends GreeterGrpc.GreeterImplBase {
   final SpanCustomizer spanCustomizer;
 
   GreeterImpl(@Nullable GrpcTracing grpcTracing) {
-    tracing = grpcTracing != null ? grpcTracing.tracing : null;
+    tracing = grpcTracing != null ? grpcTracing.rpcTracing.tracing() : null;
     spanCustomizer =
       tracing != null ? CurrentSpanCustomizer.create(tracing) : NoopSpanCustomizer.INSTANCE;
   }

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestSetterTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestSetterTest.java
@@ -18,25 +18,27 @@ import brave.test.propagation.PropagationSetterTest;
 import io.grpc.Metadata;
 import java.util.Collections;
 
-import static brave.grpc.TracingClientInterceptor.SETTER;
+import static brave.grpc.GrpcClientRequest.SETTER;
+import static brave.grpc.TestObjects.METHOD_DESCRIPTOR;
 
-public class MetadataSetterTest extends PropagationSetterTest<Metadata, Metadata.Key<String>> {
-  Metadata carrier = new Metadata();
+public class GrpcClientRequestSetterTest
+  extends PropagationSetterTest<GrpcClientRequest, Metadata.Key<String>> {
+  GrpcClientRequest request = new GrpcClientRequest(METHOD_DESCRIPTOR).metadata(new Metadata());
 
   @Override public AsciiMetadataKeyFactory keyFactory() {
     return AsciiMetadataKeyFactory.INSTANCE;
   }
 
-  @Override protected Metadata carrier() {
-    return carrier;
+  @Override protected GrpcClientRequest carrier() {
+    return request;
   }
 
-  @Override protected Propagation.Setter<Metadata, Metadata.Key<String>> setter() {
+  @Override protected Propagation.Setter<GrpcClientRequest, Metadata.Key<String>> setter() {
     return SETTER;
   }
 
-  @Override protected Iterable<String> read(Metadata carrier, Metadata.Key<String> key) {
-    Iterable<String> result = carrier.getAll(key);
+  @Override protected Iterable<String> read(GrpcClientRequest request, Metadata.Key<String> key) {
+    Iterable<String> result = request.metadata.getAll(key);
     return result != null ? result : Collections.emptyList();
   }
 }

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.grpc;
+
+import io.grpc.Metadata;
+import org.junit.Test;
+
+import static brave.grpc.TestObjects.METHOD_DESCRIPTOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class GrpcClientRequestTest {
+  Metadata metadata = new Metadata();
+  GrpcClientRequest request = new GrpcClientRequest(METHOD_DESCRIPTOR);
+  Metadata.Key<String> b3Key = AsciiMetadataKeyFactory.INSTANCE.create("b3");
+
+  @Test public void metadata() {
+    request.metadata(metadata).metadata(b3Key, "1");
+
+    assertThat(metadata.get(b3Key))
+      .isEqualTo("1");
+  }
+
+  @Test public void metadata_replace() {
+    metadata.put(b3Key, "0");
+
+    request.metadata(metadata).metadata(b3Key, "1");
+
+    assertThat(request.metadata.get(b3Key))
+      .isEqualTo("1");
+  }
+
+  @Test public void metadata_null() {
+    assertThatThrownBy(() -> request.metadata(b3Key, "1")) // doesn't NPE
+      .hasMessage("This code should never be called when null");
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestTest.java
@@ -26,7 +26,7 @@ public class GrpcClientRequestTest {
   Metadata.Key<String> b3Key = AsciiMetadataKeyFactory.INSTANCE.create("b3");
 
   @Test public void metadata() {
-    request.metadata(metadata).metadata(b3Key, "1");
+    request.metadata(metadata).setMetadata(b3Key, "1");
 
     assertThat(metadata.get(b3Key))
       .isEqualTo("1");
@@ -35,14 +35,15 @@ public class GrpcClientRequestTest {
   @Test public void metadata_replace() {
     metadata.put(b3Key, "0");
 
-    request.metadata(metadata).metadata(b3Key, "1");
+    request.metadata(metadata).setMetadata(b3Key, "1");
 
     assertThat(request.metadata.get(b3Key))
       .isEqualTo("1");
   }
 
   @Test public void metadata_null() {
-    assertThatThrownBy(() -> request.metadata(b3Key, "1")) // doesn't NPE
+    assertThatThrownBy(() -> request.setMetadata(b3Key, "1"))
+      .isNotInstanceOf(NullPointerException.class)
       .hasMessage("This code should never be called when null");
   }
 }

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcParserTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcParserTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.grpc;
+
+import org.junit.Test;
+
+import static brave.grpc.TestObjects.METHOD_DESCRIPTOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcParserTest {
+  @Test public void method() {
+    assertThat(GrpcParser.method(METHOD_DESCRIPTOR.getFullMethodName()))
+      .isEqualTo("SayHello");
+  }
+
+  @Test public void method_malformed() {
+    assertThat(GrpcParser.method("/")).isNull();
+  }
+
+  @Test public void service() {
+    assertThat(GrpcParser.service(METHOD_DESCRIPTOR.getFullMethodName()))
+      .isEqualTo("helloworld.Greeter");
+  }
+
+  @Test public void service_malformed() {
+    assertThat(GrpcParser.service("/")).isNull();
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcServerRequestTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcServerRequestTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.grpc;
+
+import io.grpc.Metadata;
+import org.junit.Test;
+
+import static brave.grpc.TestObjects.METHOD_DESCRIPTOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcServerRequestTest {
+  GrpcServerRequest request = new GrpcServerRequest(METHOD_DESCRIPTOR, new Metadata());
+  Metadata.Key<String> b3Key = AsciiMetadataKeyFactory.INSTANCE.create("b3");
+
+  @Test public void metadata() {
+    request.metadata.put(b3Key, "1");
+
+    assertThat(request.metadata(b3Key))
+      .isEqualTo("1");
+  }
+
+  @Test public void metadata_null() {
+    assertThat(request.metadata(b3Key)).isNull();
+  }
+}

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcServerRequestTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcServerRequestTest.java
@@ -26,11 +26,11 @@ public class GrpcServerRequestTest {
   @Test public void metadata() {
     request.metadata.put(b3Key, "1");
 
-    assertThat(request.metadata(b3Key))
+    assertThat(request.getMetadata(b3Key))
       .isEqualTo("1");
   }
 
   @Test public void metadata_null() {
-    assertThat(request.metadata(b3Key)).isNull();
+    assertThat(request.getMetadata(b3Key)).isNull();
   }
 }

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingClientInterceptor.java
@@ -358,7 +358,8 @@ public class ITTracingClientInterceptor {
     client = newClient();
 
     // unsampled
-    GreeterGrpc.newBlockingStub(client).sayHelloWithManyReplies(HELLO_REQUEST);
+    assertThat(GreeterGrpc.newBlockingStub(client).sayHelloWithManyReplies(HELLO_REQUEST))
+      .hasNext(); // Request is lazy, so you must invoke the iterator
 
     // sampled
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);

--- a/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/ITTracingServerInterceptor.java
@@ -14,12 +14,15 @@
 package brave.grpc;
 
 import brave.SpanCustomizer;
+import brave.Tracer;
 import brave.Tracing;
 import brave.context.log4j2.ThreadContextScopeDecorator;
 import brave.internal.Nullable;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
+import brave.rpc.RpcRuleSampler;
+import brave.rpc.RpcTracing;
 import brave.sampler.Sampler;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -60,6 +63,7 @@ import org.junit.runner.Description;
 import zipkin2.Span;
 
 import static brave.grpc.GreeterImpl.HELLO_REQUEST;
+import static brave.rpc.RpcRequestMatchers.methodEquals;
 import static brave.sampler.Sampler.NEVER_SAMPLE;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,13 +77,13 @@ public class ITTracingServerInterceptor {
 
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+  Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
 
-  GrpcTracing grpcTracing;
+  GrpcTracing grpcTracing = GrpcTracing.create(tracing);
   Server server;
   ManagedChannel client;
 
   @Before public void setup() throws Exception {
-    grpcTracing = GrpcTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
     init();
   }
 
@@ -218,7 +222,7 @@ public class ITTracingServerInterceptor {
       public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
         Metadata headers, ServerCallHandler<ReqT, RespT> next) {
         testLogger.info("in span!");
-        fromUserInterceptor.set(grpcTracing.tracing.currentTraceContext().get());
+        fromUserInterceptor.set(tracing.currentTraceContext().get());
         return next.startCall(call, headers);
       }
     });
@@ -286,14 +290,14 @@ public class ITTracingServerInterceptor {
     grpcTracing = grpcTracing.toBuilder().serverParser(new GrpcServerParser() {
       @Override protected <M> void onMessageSent(M message, SpanCustomizer span) {
         span.tag("grpc.message_sent", message.toString());
-        if (grpcTracing.tracing.currentTraceContext().get() != null) {
+        if (tracing.currentTraceContext().get() != null) {
           span.tag("grpc.message_sent.visible", "true");
         }
       }
 
       @Override protected <M> void onMessageReceived(M message, SpanCustomizer span) {
         span.tag("grpc.message_received", message.toString());
-        if (grpcTracing.tracing.currentTraceContext().get() != null) {
+        if (tracing.currentTraceContext().get() != null) {
           span.tag("grpc.message_received.visible", "true");
         }
       }
@@ -331,6 +335,23 @@ public class ITTracingServerInterceptor {
     // all response messages are tagged to the same span
     Span span = takeSpan();
     assertThat(span.tags()).hasSize(10);
+  }
+
+  @Test public void customSampler() throws Exception {
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing).clientSampler(RpcRuleSampler.newBuilder()
+      .putRule(methodEquals("SayHelloWithManyReplies"), Sampler.NEVER_SAMPLE)
+      .build()).build();
+    grpcTracing = GrpcTracing.create(rpcTracing);
+    init();
+
+    // unsampled
+    GreeterGrpc.newBlockingStub(client).sayHelloWithManyReplies(HELLO_REQUEST);
+
+    // sampled
+    GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
+
+    assertThat(takeSpan().name()).isEqualTo("helloworld.greeter/sayhello");
+    // @After will also check that sayHelloWithManyReplies was not sampled
   }
 
   Tracing.Builder tracingBuilder(Sampler sampler) {

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestObjects.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestObjects.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.grpc;
+
+import io.grpc.MethodDescriptor;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+final class TestObjects {
+  // Allows invoker tests to run without needing to compile protos
+  static final MethodDescriptor<Void, Void> METHOD_DESCRIPTOR =
+    MethodDescriptor.<Void, Void>newBuilder()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName("helloworld.Greeter/SayHello")
+      .setRequestMarshaller(VoidMarshaller.INSTANCE)
+      .setResponseMarshaller(VoidMarshaller.INSTANCE)
+      .build();
+
+  enum VoidMarshaller implements MethodDescriptor.Marshaller<Void> {
+    INSTANCE;
+
+    @Override public InputStream stream(Void value) {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override public Void parse(InputStream stream) {
+      return null;
+    }
+  }
+}

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -48,6 +48,7 @@
     <module>mysql8</module>
     <module>okhttp3</module>
     <module>p6spy</module>
+    <module>rpc</module>
     <module>servlet</module>
     <module>sparkjava</module>
     <module>spring-rabbit</module>

--- a/instrumentation/rpc/RATIONALE.md
+++ b/instrumentation/rpc/RATIONALE.md
@@ -1,0 +1,61 @@
+# brave-instrumentation-rpc rationale
+
+## `RpcRequest` initially with `method()` and `service()` properties
+
+### Why in general?
+In order to lower initial effort, we decided to scope the initial
+implementation of RPC to just things needed by samplers, injection and
+extraction. Among these were the desire to create a sampling rule to match
+requests to an "auth service" or a "play" method.
+
+## Examples please?
+`rpc.method` - The unqualified, case-sensitive method name, defined in IDL or
+the corresponding protocol.
+
+Examples
+* gRPC - full method "grpc.health.v1.Health/Check" returns "Check"
+* Apache Thrift - full method "scribe.Log" returns "Log"
+* Redis - "EXISTS" command returns "EXISTS"
+
+`rpc.service` - The fully-qualified, case-sensitive service path as defined in IDL.
+
+Examples
+* gRPC - full method "grpc.health.v1.Health/Check" returns "grpc.health.v1.Health"
+* Apache Thrift - full method "scribe.Log" returns "scribe"
+* Redis - "EXISTS" command returns null
+
+### Why not parameters?
+It was easier to start with these because the `method` and `service` properties
+of RPC are quite explored and also easy compared to other attributes such as
+request parameters. For example, unlike HTTP, where parameters are strings, RPC
+parameters can be encoded in binary types, such as protobuf. Not only does this
+present abstraction concerns, such as where in the code these types are
+unmarshalled, but also serialization issues, when we consider most policy will
+be defined declaratively.
+
+### Why use `rpc.method` and `rpc.service`?
+To reduce friction, we wanted to use names already in practice. For example,
+`method` and `service` are fairly common in IDL such as Apache Thrift and gRPC.
+Moreover, there are established practice of `method` and `service` in tools
+such as [Prometheus gRPC monitoring](https://github.com/grpc-ecosystem/go-grpc-prometheus#labels).
+
+While there could be confusion around `rpc.method` vs Java method, that exists
+anyway and is easy to explain. `rpc.service` unfortunately conflicts with our
+term `Endpoint.serviceName`, but only if you ignore the `Endpoint` prefix.
+Given this, we feel it is conventional, fits in with existing practice and
+doesn't add enough confusion to create new terms.
+
+### Wait.. not everything has a `service` namespace?
+
+Not all RPC implementation has a service/namespace. For example, Redis commands
+have a flat namespace. In our model, not applicable properties are represented
+as null. The important part is decoupling `service` from `method` allows one
+property, `method`, to be extractable more frequently vs if we forced
+concatenation through a `full method name` as exists in gRPC.
+
+### But what if I want a `full method name` as exists in gRPC?
+
+We can have the talk about what an idiomatic term could be for a fully
+qualified method name. Only gRPC uses the term `full method name`, so it isn't
+as clean to lift that term up, vs other names such as `service` than exist in
+multiple tools such as Apache Thrift. For now, concat on your own.

--- a/instrumentation/rpc/RATIONALE.md
+++ b/instrumentation/rpc/RATIONALE.md
@@ -18,7 +18,7 @@ requests to an "auth service" or a "play" method.
 
 ## Examples please?
 `rpc.method` - The unqualified, case-sensitive method name. Prefer the name
-defined in IDL or to any mapped Java method name.
+defined in IDL to any mapped Java method name.
 
 Examples
 * gRPC - full method "grpc.health.v1.Health/Check" returns "Check"
@@ -26,7 +26,7 @@ Examples
 * Apache Thrift - full method "scribe.Log" returns "Log"
 
 `rpc.service` - The fully-qualified, case-sensitive service path. Prefer the
-name defined in IDL or to any mapped Java package name.
+name defined in IDL to any mapped Java package name.
 
 Examples
 * gRPC - full method "grpc.health.v1.Health/Check" returns "grpc.health.v1.Health"

--- a/instrumentation/rpc/RATIONALE.md
+++ b/instrumentation/rpc/RATIONALE.md
@@ -17,20 +17,21 @@ extraction. Among these were the desire to create a sampling rule to match
 requests to an "auth service" or a "play" method.
 
 ## Examples please?
-`rpc.method` - The unqualified, case-sensitive method name, defined in IDL or
-the corresponding protocol.
+`rpc.method` - The unqualified, case-sensitive method name. Prefer the name
+defined in IDL or to any mapped Java method name.
 
 Examples
 * gRPC - full method "grpc.health.v1.Health/Check" returns "Check"
+* Apache Dubbo - "demo.service.DemoService#sayHello()" command returns "demo.service.DemoService"
 * Apache Thrift - full method "scribe.Log" returns "Log"
-* Redis - "EXISTS" command returns "EXISTS"
 
-`rpc.service` - The fully-qualified, case-sensitive service path as defined in IDL.
+`rpc.service` - The fully-qualified, case-sensitive service path. Prefer the
+name defined in IDL or to any mapped Java package name.
 
 Examples
 * gRPC - full method "grpc.health.v1.Health/Check" returns "grpc.health.v1.Health"
+* Apache Dubbo - "demo.service.DemoService#sayHello()" command returns "demo.service.DemoService"
 * Apache Thrift - full method "scribe.Log" returns "scribe"
-* Redis - "EXISTS" command returns null
 
 ### Why not parameters?
 It was easier to start with these because the `method` and `service` properties
@@ -44,14 +45,17 @@ be defined declaratively.
 ### Why use `rpc.method` and `rpc.service`?
 To reduce friction, we wanted to use names already in practice. For example,
 `method` and `service` are fairly common in IDL such as Apache Thrift and gRPC.
-Moreover, there are established practice of `method` and `service` in tools
-such as [Prometheus gRPC monitoring](https://github.com/grpc-ecosystem/go-grpc-prometheus#labels).
+These names are also used in non-IDL based RPC, such as Apache Dubbo. Moreover,
+there are established practice of `method` and `service` in tools such as
+[Prometheus gRPC monitoring](https://github.com/grpc-ecosystem/go-grpc-prometheus#labels).
 
 While there could be confusion around `rpc.method` vs Java method, that exists
-anyway and is easy to explain. `rpc.service` unfortunately conflicts with our
-term `Endpoint.serviceName`, but only if you ignore the `Endpoint` prefix.
-Given this, we feel it is conventional, fits in with existing practice and
-doesn't add enough confusion to create new terms.
+anyway and is easy to explain: When IDL exists, prefer its service and method
+name to any matched Java names. 
+
+`rpc.service` unfortunately conflicts with our term `Endpoint.serviceName`, but
+only if you ignore the `Endpoint` prefix. Given this, we feel it fits in with
+existing practice and doesn't add enough confusion to create new terms.
 
 ### Wait.. not everything has a `service` namespace?
 

--- a/instrumentation/rpc/README.md
+++ b/instrumentation/rpc/README.md
@@ -1,0 +1,50 @@
+# brave-instrumentation-rpc
+
+Most instrumentation are based on RPC communication. For this reason,
+we have specialized handlers for RPC clients and servers. All of these
+are configured with `RpcTracing`.
+
+The `RpcTracing` class holds a reference to a tracing component and
+sampling policy.
+
+## Sampling Policy
+The default sampling policy is to use the default (trace ID) sampler for
+server and client requests.
+
+For example, if there's a incoming request that has no trace IDs in its
+headers, the sampler indicated by `Tracing.Builder.sampler` decides whether
+or not to start a new trace. Once a trace is in progress, it is used for
+any outgoing rpc client requests.
+
+On the other hand, you may have rpc client requests that didn't originate
+from a server. For example, you may be bootstrapping your application,
+and that makes an RPC call to a system service. The default policy will
+start a trace for any RPC call, even ones that didn't come from a server
+request.
+
+This allows you to declare rules based on RPC patterns. These decide
+which sample rate to apply.
+
+You can change the sampling policy by specifying it in the `RpcTracing`
+component. The default implementation is `RpcRuleSampler`, which allows
+you to declare rules based on rpc patterns.
+
+Ex. Here's a sampler that traces 100 "Report" requests per second. This
+doesn't start new traces for requests to the scribe service. Other
+requests will use a global rate provided by the tracing component.
+
+```java
+import static brave.rpc.RpcRequestMatchers.*;
+
+rpcTracingBuilder.serverSampler(RpcRuleSampler.newBuilder()
+  .putRule(serviceEquals("scribe"), Sampler.NEVER_SAMPLE)
+  .putRule(methodEquals("Report"), RateLimitingSampler.create(100))
+  .build());
+```
+
+# Developing new instrumentation
+
+Check for [instrumentation written here](../) and [Zipkin's list](https://zipkin.io/pages/existing_instrumentations.html)
+before rolling your own Rpc instrumentation! Besides documentation here,
+you should look at the [core library documentation](../../brave/README.md) as it
+covers topics including propagation. You may find our [feature tests](src/test/java/brave/rpc/features) helpful, too.

--- a/instrumentation/rpc/README.md
+++ b/instrumentation/rpc/README.md
@@ -44,7 +44,7 @@ rpcTracingBuilder.serverSampler(RpcRuleSampler.newBuilder()
 
 # Developing new instrumentation
 
-Check for [instrumentation written here](../) and [Zipkin's list](https://zipkin.io/pages/existing_instrumentations.html)
+Check for [instrumentation written here](../) and [Zipkin's list](https://zipkin.io/pages/tracers_instrumentation.html)
 before rolling your own Rpc instrumentation! Besides documentation here,
 you should look at the [core library documentation](../../brave/README.md) as it
 covers topics including propagation. You may find our [feature tests](src/test/java/brave/rpc/features) helpful, too.

--- a/instrumentation/rpc/bnd.bnd
+++ b/instrumentation/rpc/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.rpc

--- a/instrumentation/rpc/pom.xml
+++ b/instrumentation/rpc/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright 2013-2019 The OpenZipkin Authors
@@ -21,36 +22,16 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>brave-instrumentation-dubbo-rpc</artifactId>
-  <name>Brave Instrumentation: Alibaba Dubbo</name>
+  <artifactId>brave-instrumentation-rpc</artifactId>
+  <name>Brave Instrumentation: Rpc Adapters</name>
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
-    <!-- Use brave-instrumentation-dubbo for Apache Dubbo 2.7+, not this module. -->
-    <dubbo.version>2.6.7</dubbo.version>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>brave-instrumentation-rpc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.alibaba</groupId>
-      <artifactId>dubbo</artifactId>
-      <version>${dubbo.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- Prevent classpath problems in IDE running tests -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>${netty.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
@@ -61,14 +42,27 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.dubbo.rpc</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.rpc</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcClientRequest.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcClientRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+/**
+ * Marks an interface for use in injection and {@link RpcRuleSampler}. This gives a standard type
+ * to consider when parsing an outgoing context.
+ *
+ * @since 5.8
+ */
+public abstract class RpcClientRequest extends RpcRequest {
+}

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcRequest.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcRequest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.Span;
+import brave.internal.Nullable;
+import java.lang.reflect.Method;
+
+/**
+ * Abstract request type used for parsing and sampling of rpc clients and servers.
+ *
+ * @see RpcClientRequest
+ * @see RpcServerRequest
+ * @since 5.8
+ */
+public abstract class RpcRequest {
+  /**
+   * Returns the underlying rpc request object. Ex. {@code org.apache.rpc.RpcRequest}
+   *
+   * <p>Note: Some implementations are composed of multiple types, such as a request and a socket
+   * address of the client. Moreover, an implementation may change the type returned due to
+   * refactoring. Unless you control the implementation, cast carefully (ex using {@code instance
+   * of}) instead of presuming a specific type will always be returned.
+   *
+   * @since 5.8
+   */
+  public abstract Object unwrap();
+
+  /**
+   * The unqualified, case-sensitive method name, defined in IDL or the corresponding protocol.
+   *
+   * <p>Examples
+   * <pre><ul>
+   *   <li>gRPC - full method "grpc.health.v1.Health/Check" returns "Check"</li>
+   *   <li>Apache Thrift - full method "scribe.Log" returns "Log"</li>
+   *   <li>Redis - "EXISTS" command returns "EXISTS"</li>
+   * </ul></pre>
+   *
+   * <p>Note: This is not the same as the {@link Method#getName() Java method name}.
+   *
+   * @return the RPC method name or null if unreadable.
+   */
+  @Nullable public abstract String method();
+
+  /**
+   * The fully-qualified, case-sensitive service path as defined in IDL.
+   *
+   * <p>Examples
+   * <pre><ul>
+   *   <li>gRPC - full method "grpc.health.v1.Health/Check" returns "grpc.health.v1.Health"</li>
+   *   <li>Apache Thrift - full method "scribe.Log" returns "scribe"</li>
+   *   <li>Redis - "EXISTS" command returns null</li>
+   * </ul></pre>
+   *
+   * <p>Note: This is not the deployment {@link Span#remoteServiceName(String) service name}.
+   *
+   * @return the RPC namespace or null if unreadable.
+   */
+  @Nullable public abstract String service();
+
+  @Override public String toString() {
+    Object unwrapped = unwrap();
+    // unwrap() returning null is a bug. It could also return this. don't NPE or stack overflow!
+    if (unwrapped == null || unwrapped == this) return getClass().getSimpleName();
+    return getClass().getSimpleName() + "{" + unwrapped + "}";
+  }
+
+  RpcRequest() { // sealed type: only client and server
+  }
+}

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcRequest.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcRequest.java
@@ -38,7 +38,7 @@ public abstract class RpcRequest {
   public abstract Object unwrap();
 
   /**
-   * The unqualified, case-sensitive method name. Prefer the name defined in IDL or to any mapped
+   * The unqualified, case-sensitive method name. Prefer the name defined in IDL to any mapped
    * {@link Method#getName() Java method name}.
    *
    * <p>Examples
@@ -56,8 +56,8 @@ public abstract class RpcRequest {
   @Nullable public abstract String method();
 
   /**
-   * The fully-qualified, case-sensitive service path. Prefer the name defined in IDL or to any
-   * mapped {@link Package#getName() Java package name}.
+   * The fully-qualified, case-sensitive service path. Prefer the name defined in IDL to any mapped
+   * {@link Package#getName() Java package name}.
    *
    * <p>Examples
    * <pre><ul>

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcRequest.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcRequest.java
@@ -38,32 +38,38 @@ public abstract class RpcRequest {
   public abstract Object unwrap();
 
   /**
-   * The unqualified, case-sensitive method name, defined in IDL or the corresponding protocol.
+   * The unqualified, case-sensitive method name. Prefer the name defined in IDL or to any mapped
+   * {@link Method#getName() Java method name}.
    *
    * <p>Examples
    * <pre><ul>
    *   <li>gRPC - full method "grpc.health.v1.Health/Check" returns "Check"</li>
+   *   <li>Apache Dubbo - "demo.service.DemoService#sayHello()" command returns "sayHello"</li>
    *   <li>Apache Thrift - full method "scribe.Log" returns "Log"</li>
-   *   <li>Redis - "EXISTS" command returns "EXISTS"</li>
    * </ul></pre>
    *
-   * <p>Note: This is not the same as the {@link Method#getName() Java method name}.
+   * <p>Note: For IDL based services, such as Protocol Buffers, this may be different than the
+   * {@link Method#getName() Java method name}, or in a different case format.
    *
    * @return the RPC method name or null if unreadable.
    */
   @Nullable public abstract String method();
 
   /**
-   * The fully-qualified, case-sensitive service path as defined in IDL.
+   * The fully-qualified, case-sensitive service path. Prefer the name defined in IDL or to any
+   * mapped {@link Package#getName() Java package name}.
    *
    * <p>Examples
    * <pre><ul>
    *   <li>gRPC - full method "grpc.health.v1.Health/Check" returns "grpc.health.v1.Health"</li>
+   *   <li>Apache Dubbo - "demo.service.DemoService#sayHello()" command returns "demo.service.DemoService"</li>
    *   <li>Apache Thrift - full method "scribe.Log" returns "scribe"</li>
-   *   <li>Redis - "EXISTS" command returns null</li>
    * </ul></pre>
    *
-   * <p>Note: This is not the deployment {@link Span#remoteServiceName(String) service name}.
+   * <p>Note: For IDL based services, such as Protocol Buffers, this may be different than the
+   * {@link Package#getName() Java package name}, or in a different case format. Also, this is the
+   * definition of the service, not its deployment {@link Span#remoteServiceName(String) service
+   * name}.
    *
    * @return the RPC namespace or null if unreadable.
    */

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcRequestMatchers.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcRequestMatchers.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.sampler.Matcher;
+import brave.sampler.Matchers;
+
+/**
+ * Null safe matchers for use in {@link RpcRuleSampler}.
+ *
+ * @see Matchers
+ * @since 5.8
+ */
+public final class RpcRequestMatchers {
+
+  /**
+   * Matcher for case-sensitive RPC method names, such as "Report" or "EXISTS"
+   *
+   * @see RpcRequest#method()
+   * @since 5.8
+   */
+  public static <Req extends RpcRequest> Matcher<Req> methodEquals(String method) {
+    if (method == null) throw new NullPointerException("method == null");
+    if (method.isEmpty()) throw new NullPointerException("method is empty");
+    return new RpcMethodEquals<>(method);
+  }
+
+  static final class RpcMethodEquals<Req extends RpcRequest> implements Matcher<Req> {
+    final String method;
+
+    RpcMethodEquals(String method) {
+      this.method = method;
+    }
+
+    @Override public boolean matches(Req request) {
+      return method.equals(request.method());
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) return true;
+      if (!(o instanceof RpcMethodEquals)) return false;
+      RpcMethodEquals that = (RpcMethodEquals) o;
+      return method.equals(that.method);
+    }
+
+    @Override public int hashCode() {
+      return method.hashCode();
+    }
+
+    @Override public String toString() {
+      return "RpcMethodEquals(" + method + ")";
+    }
+  }
+
+  /**
+   * Matcher for case-sensitive RPC service names, such as "grpc.health.v1.Health" or "scribe"
+   *
+   * @see RpcRequest#service()
+   * @since 5.8
+   */
+  public static <Req extends RpcRequest> Matcher<Req> serviceEquals(String service) {
+    if (service == null) throw new NullPointerException("service == null");
+    if (service.isEmpty()) throw new NullPointerException("service is empty");
+    return new RpcServiceEquals<>(service);
+  }
+
+  static final class RpcServiceEquals<Req extends RpcRequest> implements Matcher<Req> {
+    final String service;
+
+    RpcServiceEquals(String service) {
+      this.service = service;
+    }
+
+    @Override public boolean matches(Req request) {
+      return service.equals(request.service());
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) return true;
+      if (!(o instanceof RpcServiceEquals)) return false;
+      RpcServiceEquals that = (RpcServiceEquals) o;
+      return service.equals(that.service);
+    }
+
+    @Override public int hashCode() {
+      return service.hashCode();
+    }
+
+    @Override public String toString() {
+      return "RpcServiceEquals(" + service + ")";
+    }
+  }
+}

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcRuleSampler.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcRuleSampler.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.Tracing;
+import brave.sampler.Matcher;
+import brave.sampler.ParameterizedSampler;
+import brave.sampler.Sampler;
+import brave.sampler.SamplerFunction;
+
+/**
+ * Assigns sample rates to rpc requests.
+ *
+ * <p>Ex. Here's a sampler that traces 100 "Report" requests per second. This doesn't start new
+ * traces for requests to the scribe service. Other requests will use a global rate provided by the
+ * {@link Tracing tracing component}.
+ *
+ * <p><pre>{@code
+ * import static brave.rpc.RpcRequestMatchers.*;
+ *
+ * rpcTracingBuilder.serverSampler(RpcRuleSampler.newBuilder()
+ *   .putRule(serviceEquals("scribe"), Sampler.NEVER_SAMPLE)
+ *   .putRule(methodEquals("Report"), RateLimitingSampler.create(100))
+ *   .build());
+ * }</pre>
+ *
+ * <h3>Implementation notes</h3>
+ * Be careful when implementing matchers as {@link RpcRequest} methods can return null.
+ *
+ * @see RpcRequestMatchers
+ * @since 5.8
+ */
+// Not parameterized for client-server types as the generic complexity isn't worth it and properties
+// specific to client and server side are not used in sampling.
+public final class RpcRuleSampler implements SamplerFunction<RpcRequest> {
+  /** @since 5.8 */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /** @since 5.8 */
+  public static final class Builder {
+    final ParameterizedSampler.Builder<RpcRequest> delegate = ParameterizedSampler.newBuilder();
+
+    /**
+     * Adds or replaces all rules in this sampler with those of the input.
+     *
+     * @since 5.8
+     */
+    public Builder putAllRules(RpcRuleSampler sampler) {
+      if (sampler == null) throw new NullPointerException("sampler == null");
+      delegate.putAllRules(sampler.delegate);
+      return this;
+    }
+
+    /**
+     * Adds or replaces the sampler for the matcher.
+     *
+     * <p>Ex.
+     * <pre>{@code
+     * import static brave.rpc.RpcRequestMatchers.methodEquals;
+     *
+     * builder.putRule(methodEquals("Report"), RateLimitingSampler.create(10));
+     * }</pre>
+     *
+     * @since 5.8
+     */
+    public Builder putRule(Matcher matcher, Sampler sampler) {
+      delegate.putRule(matcher, sampler);
+      return this;
+    }
+
+    public RpcRuleSampler build() {
+      return new RpcRuleSampler(delegate.build());
+    }
+
+    Builder() {
+    }
+  }
+
+  final ParameterizedSampler<RpcRequest> delegate;
+
+  RpcRuleSampler(ParameterizedSampler delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public Boolean trySample(RpcRequest request) {
+    return delegate.trySample(request);
+  }
+}

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcServerRequest.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcServerRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+/**
+ * Marks an interface for use in extraction and {@link RpcRuleSampler}. This gives a standard type
+ * to consider when parsing an incoming context.
+ *
+ * @since 5.8
+ */
+public abstract class RpcServerRequest extends RpcRequest {
+}

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.Tracing;
+import brave.sampler.SamplerFunction;
+import brave.sampler.SamplerFunctions;
+
+/** @since 5.8 */
+public class RpcTracing {
+  /** @since 5.8 */
+  public static RpcTracing create(Tracing tracing) {
+    return newBuilder(tracing).build();
+  }
+
+  /** @since 5.8 */
+  public static Builder newBuilder(Tracing tracing) {
+    return new Builder(tracing);
+  }
+
+  /** @since 5.8 */
+  public Tracing tracing() {
+    return tracing;
+  }
+
+  /**
+   * Returns an overriding sampling decision for a new trace. Defaults to ignore the request and use
+   * the {@link SamplerFunctions#deferDecision() trace ID instead}.
+   *
+   * <p>This decision happens when a trace was not yet started in process. For example, you may be
+   * making an rpc request as a part of booting your application. You may want to opt-out of tracing
+   * client requests that did not originate from a server request.
+   *
+   * @see SamplerFunctions
+   * @see RpcRuleSampler
+   * @since 5.8
+   */
+  public SamplerFunction<RpcRequest> clientSampler() {
+    return clientSampler;
+  }
+
+  /**
+   * Returns an overriding sampling decision for a new trace. Defaults to ignore the request and use
+   * the {@link SamplerFunctions#deferDecision() trace ID instead}.
+   *
+   * <p>This decision happens when trace IDs were not in headers, or a sampling decision has not
+   * yet been made. For example, if a trace is already in progress, this function is not called. You
+   * can implement this to skip paths that you never want to trace.
+   *
+   * @see SamplerFunctions
+   * @see RpcRuleSampler
+   * @since 5.8
+   */
+  public SamplerFunction<RpcRequest> serverSampler() {
+    return serverSampler;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  final Tracing tracing;
+  final SamplerFunction<RpcRequest> clientSampler;
+  final SamplerFunction<RpcRequest> serverSampler;
+
+  RpcTracing(Builder builder) {
+    this.tracing = builder.tracing;
+    this.clientSampler = builder.clientSampler;
+    this.serverSampler = builder.serverSampler;
+  }
+
+  public static final class Builder {
+    Tracing tracing;
+    SamplerFunction<RpcRequest> clientSampler;
+    SamplerFunction<RpcRequest> serverSampler;
+
+    Builder(Tracing tracing) {
+      if (tracing == null) throw new NullPointerException("tracing == null");
+      this.tracing = tracing;
+      this.clientSampler = SamplerFunctions.deferDecision();
+      this.serverSampler = SamplerFunctions.deferDecision();
+    }
+
+    Builder(RpcTracing source) {
+      this.tracing = source.tracing;
+      this.clientSampler = source.clientSampler;
+      this.serverSampler = source.serverSampler;
+    }
+
+    /** @see RpcTracing#tracing() */
+    public Builder tracing(Tracing tracing) {
+      if (tracing == null) throw new NullPointerException("tracing == null");
+      this.tracing = tracing;
+      return this;
+    }
+
+    /** @see RpcTracing#clientSampler() */
+    public Builder clientSampler(SamplerFunction<RpcRequest> clientSampler) {
+      if (clientSampler == null) throw new NullPointerException("clientSampler == null");
+      this.clientSampler = clientSampler;
+      return this;
+    }
+
+    /** @see RpcTracing#serverSampler() */
+    public Builder serverSampler(SamplerFunction<RpcRequest> serverSampler) {
+      if (serverSampler == null) throw new NullPointerException("serverSampler == null");
+      this.serverSampler = serverSampler;
+      return this;
+    }
+
+    public RpcTracing build() {
+      return new RpcTracing(this);
+    }
+  }
+}

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcTracingCustomizer.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcTracingCustomizer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.Tracing;
+import brave.TracingCustomizer;
+import brave.sampler.SamplerFunction;
+
+/**
+ * This allows configuration plugins to collaborate on building an instance of {@link RpcTracing}.
+ *
+ * <p>For example, a customizer can setup {@link RpcTracing.Builder#serverSampler(SamplerFunction)}
+ * samplers} without a reference to the {@link RpcTracing.Builder#Builder(Tracing) tracing
+ * component}.
+ *
+ * <p>This also allows one object to customize both {@link Tracing}, via {@link TracingCustomizer},
+ * and the rpc layer {@link RpcTracing}, by implementing both customizer interfaces.
+ *
+ * <h3>Integration examples</h3>
+ *
+ * <p>In practice, a dependency injection tool applies a collection of these instances prior to
+ * {@link RpcTracing.Builder#build() building the tracing instance}. For example, an injected {@code
+ * List<RpcTracingCustomizer>} parameter to a provider of {@link RpcTracing}.
+ *
+ * <p>Here are some examples, in alphabetical order:
+ * <pre><ul>
+ *   <li><a href="https://dagger.dev/multibindings.html">Dagger Set Multibindings</a></li>
+ *   <li><a href="http://google.github.io/guice/api-docs/latest/javadoc/com/google/inject/multibindings/Multibinder.html">Guice Set Multibinder</a></li>
+ *   <li><a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-autowired-annotation">Spring Autowired Collections</a></li>
+ * </ul></pre>
+ *
+ * @see TracingCustomizer
+ * @since 5.8
+ */
+public interface RpcTracingCustomizer {
+  /** Use to avoid comparing against null references */
+  RpcTracingCustomizer NOOP = new RpcTracingCustomizer() {
+    @Override public void customize(RpcTracing.Builder builder) {
+    }
+
+    @Override public String toString() {
+      return "NoopRpcTracingCustomizer{}";
+    }
+  };
+
+  void customize(RpcTracing.Builder builder);
+}

--- a/instrumentation/rpc/src/test/java/brave/rpc/RpcRequestMatchersTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/RpcRequestMatchersTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static brave.rpc.RpcRequestMatchers.methodEquals;
+import static brave.rpc.RpcRequestMatchers.serviceEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RpcRequestMatchersTest {
+  @Mock RpcRequest request;
+
+  @Test public void methodEquals_matched() {
+    when(request.method()).thenReturn("Check");
+
+    assertThat(methodEquals("Check").matches(request)).isTrue();
+  }
+
+  @Test public void methodEquals_unmatched_mixedCase() {
+    when(request.method()).thenReturn("Check");
+
+    assertThat(methodEquals("check").matches(request)).isFalse();
+  }
+
+  @Test public void methodEquals_unmatched() {
+    when(request.method()).thenReturn("Log");
+
+    assertThat(methodEquals("Check").matches(request)).isFalse();
+  }
+
+  @Test public void methodEquals_unmatched_null() {
+    assertThat(methodEquals("Check").matches(request)).isFalse();
+  }
+
+  @Test public void serviceEquals_matched() {
+    when(request.service()).thenReturn("grpc.health.v1.Health");
+
+    assertThat(serviceEquals("grpc.health.v1.Health").matches(request)).isTrue();
+  }
+
+  @Test public void serviceEquals_unmatched_mixedCase() {
+    when(request.service()).thenReturn("grpc.health.v1.Health");
+
+    assertThat(serviceEquals("grpc.health.v1.Health").matches(request)).isFalse();
+  }
+
+  @Test public void serviceEquals_unmatched() {
+    when(request.service()).thenReturn("scribe");
+
+    assertThat(serviceEquals("grpc.health.v1.Health").matches(request)).isFalse();
+  }
+
+  @Test public void serviceEquals_unmatched_null() {
+    assertThat(serviceEquals("grpc.health.v1.Health").matches(request)).isFalse();
+  }
+}

--- a/instrumentation/rpc/src/test/java/brave/rpc/RpcRequestMatchersTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/RpcRequestMatchersTest.java
@@ -58,7 +58,7 @@ public class RpcRequestMatchersTest {
   @Test public void serviceEquals_unmatched_mixedCase() {
     when(request.service()).thenReturn("grpc.health.v1.Health");
 
-    assertThat(serviceEquals("grpc.health.v1.Health").matches(request)).isFalse();
+    assertThat(serviceEquals("grpc.health.v1.health").matches(request)).isFalse();
   }
 
   @Test public void serviceEquals_unmatched() {

--- a/instrumentation/rpc/src/test/java/brave/rpc/RpcRequestTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/RpcRequestTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RpcRequestTest {
+  @Test public void toString_mentionsDelegate() {
+    class IceCreamRequest extends RpcRequest {
+      @Override public Object unwrap() {
+        return "chocolate";
+      }
+
+      @Override public String method() {
+        return null;
+      }
+
+      @Override public String service() {
+        return null;
+      }
+    }
+    assertThat(new IceCreamRequest())
+      .hasToString("IceCreamRequest{chocolate}");
+  }
+
+  @Test public void toString_doesntStackoverflowWhenUnwrapIsNull() {
+    class BuggyRequest extends RpcRequest {
+      @Override public Object unwrap() {
+        return null;
+      }
+
+      @Override public String method() {
+        return null;
+      }
+
+      @Override public String service() {
+        return null;
+      }
+    }
+    assertThat(new BuggyRequest())
+      .hasToString("BuggyRequest");
+  }
+}

--- a/instrumentation/rpc/src/test/java/brave/rpc/RpcRuleSamplerTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/RpcRuleSamplerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.sampler.Matcher;
+import brave.sampler.RateLimitingSampler;
+import brave.sampler.Sampler;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static brave.rpc.RpcRequestMatchers.methodEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RpcRuleSamplerTest {
+
+  @Mock RpcServerRequest request;
+  RpcRuleSampler sampler = RpcRuleSampler.newBuilder()
+    .putRule(methodEquals("health"), Sampler.ALWAYS_SAMPLE)
+    .build();
+
+  @Test public void matches() {
+    Map<Sampler, Boolean> samplerToAnswer = new LinkedHashMap<>();
+    samplerToAnswer.put(Sampler.ALWAYS_SAMPLE, true);
+    samplerToAnswer.put(Sampler.NEVER_SAMPLE, false);
+
+    samplerToAnswer.forEach((sampler, answer) -> {
+      this.sampler = RpcRuleSampler.newBuilder()
+        .putRule(methodEquals("health"), sampler)
+        .build();
+
+      when(request.method()).thenReturn("health");
+
+      assertThat(this.sampler.trySample(request))
+        .isEqualTo(answer);
+
+      // consistent answer
+      assertThat(this.sampler.trySample(request))
+        .isEqualTo(answer);
+    });
+  }
+
+  @Test public void nullOnNull() {
+    assertThat(sampler.trySample(null))
+      .isNull();
+  }
+
+  @Test public void unmatched() {
+    sampler = RpcRuleSampler.newBuilder()
+      .putRule(methodEquals("log"), Sampler.ALWAYS_SAMPLE)
+      .build();
+
+    assertThat(sampler.trySample(request))
+      .isNull();
+
+    when(request.method()).thenReturn("health");
+
+    // consistent answer
+    assertThat(sampler.trySample(request))
+      .isNull();
+  }
+
+  @Test public void exampleCustomMatcher() {
+    Matcher<RpcRequest> playInTheUSA = request -> (!"health".equals(request.method()));
+
+    sampler = RpcRuleSampler.newBuilder()
+      .putRule(playInTheUSA, RateLimitingSampler.create(100))
+      .build();
+
+    when(request.method()).thenReturn("log");
+
+    assertThat(sampler.trySample(request))
+      .isTrue();
+
+    when(request.method()).thenReturn("health");
+
+    assertThat(sampler.trySample(request))
+      .isNull(); // unmatched because country is health
+  }
+
+  @Test public void putAllRules() {
+    RpcRuleSampler base = RpcRuleSampler.newBuilder()
+      .putRule(methodEquals("health"), Sampler.NEVER_SAMPLE)
+      .build();
+
+    sampler = RpcRuleSampler.newBuilder()
+      .putAllRules(base)
+      .build();
+
+    when(request.method()).thenReturn("log");
+
+    assertThat(sampler.trySample(request))
+      .isNull();
+  }
+
+  // empty may sound unintuitive, but it allows use of the same type when always deferring
+  @Test public void noRulesOk() {
+    RpcRuleSampler.newBuilder().build();
+  }
+}

--- a/instrumentation/rpc/src/test/java/brave/rpc/RpcTracingTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/RpcTracingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc;
+
+import brave.Tracing;
+import org.junit.Test;
+
+import static brave.sampler.SamplerFunctions.deferDecision;
+import static brave.sampler.SamplerFunctions.neverSample;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class RpcTracingTest {
+  Tracing tracing = mock(Tracing.class);
+
+  @Test public void defaultSamplersDefer() {
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing).build();
+
+    assertThat(rpcTracing.clientSampler())
+      .isSameAs(deferDecision());
+    assertThat(rpcTracing.serverSampler())
+      .isSameAs(deferDecision());
+  }
+
+  @Test public void toBuilder() {
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing).build();
+
+    assertThat(rpcTracing.toBuilder().build())
+      .usingRecursiveComparison()
+      .isEqualTo(rpcTracing);
+
+    assertThat(rpcTracing.toBuilder().clientSampler(neverSample()).build())
+      .usingRecursiveComparison()
+      .isEqualTo(RpcTracing.newBuilder(tracing).clientSampler(neverSample()).build());
+  }
+}

--- a/instrumentation/rpc/src/test/java/brave/rpc/features/ExampleTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/features/ExampleTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.rpc.features;
+
+import brave.Tracing;
+import brave.rpc.RpcRuleSampler;
+import brave.rpc.RpcServerRequest;
+import brave.rpc.RpcTracing;
+import brave.sampler.RateLimitingSampler;
+import brave.sampler.Sampler;
+import brave.sampler.SamplerFunctions;
+import org.junit.Test;
+
+import static brave.rpc.RpcRequestMatchers.methodEquals;
+import static brave.rpc.RpcRequestMatchers.serviceEquals;
+import static org.mockito.Mockito.mock;
+
+public class ExampleTest {
+  Tracing tracing = mock(Tracing.class);
+  RpcTracing rpcTracing;
+
+  // This mainly shows that we don't accidentally rely on package-private access
+  @Test public void showConstruction() {
+    rpcTracing = RpcTracing.newBuilder(tracing)
+      .serverSampler(RpcRuleSampler.newBuilder()
+        .putRule(serviceEquals("scribe"), Sampler.NEVER_SAMPLE)
+        .putRule(methodEquals("Report"), RateLimitingSampler.create(100))
+        .build())
+      .clientSampler(SamplerFunctions.neverSample())
+      .build();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>brave-instrumentation-rpc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>brave-instrumentation-http</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -6,7 +6,8 @@ tracing with only XML
 Bean Factories exist for the following types:
 * EndpointFactoryBean - for configuring the service name, IP etc representing this host
 * TracingFactoryBean - wires most together, like reporter and log integration
-* HttpTracingFactoryBean - for http tagging and sampling policy
+* RpcTracingFactoryBean - for RPC tagging and sampling policy
+* HttpTracingFactoryBean - for HTTP tagging and sampling policy
 * CurrentTraceContextFactoryBean - for scope decorations such as MDC (logging) field correlation
 * ExtraFieldPropagationFactoryBean - for propagating extra fields over headers, like "customer-id"
 

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -35,6 +35,10 @@ Here are some example beans using the factories in this module:
     </property>
   </bean>
 
+  <bean id="rpcTracing" class="brave.spring.beans.RpcTracingFactoryBean">
+    <property name="rpcTracing" ref="tracing"/>
+  </bean>
+
   <bean id="httpTracing" class="brave.spring.beans.HttpTracingFactoryBean">
     <property name="tracing" ref="tracing"/>
   </bean>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -39,6 +39,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-rpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/spring-beans/src/main/java/brave/spring/beans/RpcTracingFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/RpcTracingFactoryBean.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.spring.beans;
+
+import brave.Tracing;
+import brave.rpc.RpcRequest;
+import brave.rpc.RpcTracing;
+import brave.rpc.RpcTracingCustomizer;
+import brave.sampler.SamplerFunction;
+import java.util.List;
+import org.springframework.beans.factory.FactoryBean;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class RpcTracingFactoryBean implements FactoryBean {
+
+  Tracing tracing;
+  SamplerFunction<RpcRequest> clientSampler, serverSampler;
+  List<RpcTracingCustomizer> customizers;
+
+  @Override public RpcTracing getObject() {
+    RpcTracing.Builder builder = RpcTracing.newBuilder(tracing);
+    if (clientSampler != null) builder.clientSampler(clientSampler);
+    if (serverSampler != null) builder.serverSampler(serverSampler);
+    if (customizers != null) {
+      for (RpcTracingCustomizer customizer : customizers) customizer.customize(builder);
+    }
+    return builder.build();
+  }
+
+  @Override public Class<? extends RpcTracing> getObjectType() {
+    return RpcTracing.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setTracing(Tracing tracing) {
+    this.tracing = tracing;
+  }
+
+  public void setClientSampler(SamplerFunction<RpcRequest> clientSampler) {
+    this.clientSampler = clientSampler;
+  }
+
+  public void setServerSampler(SamplerFunction<RpcRequest> serverSampler) {
+    this.serverSampler = serverSampler;
+  }
+
+  public void setCustomizers(List<RpcTracingCustomizer> customizers) {
+    this.customizers = customizers;
+  }
+}

--- a/spring-beans/src/test/java/brave/spring/beans/RpcTracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/RpcTracingFactoryBeanTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.spring.beans;
+
+import brave.Tracing;
+import brave.rpc.RpcTracing;
+import brave.rpc.RpcTracingCustomizer;
+import brave.sampler.SamplerFunctions;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class RpcTracingFactoryBeanTest {
+
+  public static Tracing TRACING = mock(Tracing.class);
+
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void tracing() {
+    context = new XmlBeans(""
+      + "<bean id=\"rpcTracing\" class=\"brave.spring.beans.RpcTracingFactoryBean\">\n"
+      + "  <property name=\"tracing\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("rpcTracing", RpcTracing.class))
+      .extracting("tracing")
+      .isEqualTo(TRACING);
+  }
+
+  @Test public void clientSampler() {
+    context = new XmlBeans(""
+      + "<bean id=\"rpcTracing\" class=\"brave.spring.beans.RpcTracingFactoryBean\">\n"
+      + "  <property name=\"tracing\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"clientSampler\">\n"
+      + "    <bean class=\"brave.sampler.SamplerFunctions\" factory-method=\"neverSample\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("rpcTracing", RpcTracing.class).clientSampler())
+      .isEqualTo(SamplerFunctions.neverSample());
+  }
+
+  @Test public void serverSampler() {
+    context = new XmlBeans(""
+      + "<bean id=\"rpcTracing\" class=\"brave.spring.beans.RpcTracingFactoryBean\">\n"
+      + "  <property name=\"tracing\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"serverSampler\">\n"
+      + "    <bean class=\"brave.sampler.SamplerFunctions\" factory-method=\"neverSample\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("rpcTracing", RpcTracing.class).serverSampler())
+      .isEqualTo(SamplerFunctions.neverSample());
+  }
+
+  public static final RpcTracingCustomizer CUSTOMIZER_ONE = mock(RpcTracingCustomizer.class);
+  public static final RpcTracingCustomizer CUSTOMIZER_TWO = mock(RpcTracingCustomizer.class);
+
+  @Test public void customizers() {
+    context = new XmlBeans(""
+      + "<bean id=\"rpcTracing\" class=\"brave.spring.beans.RpcTracingFactoryBean\">\n"
+      + "  <property name=\"tracing\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".TRACING\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"customizers\">\n"
+      + "    <list>\n"
+      + "      <util:constant static-field=\"" + getClass().getName() + ".CUSTOMIZER_ONE\"/>\n"
+      + "      <util:constant static-field=\"" + getClass().getName() + ".CUSTOMIZER_TWO\"/>\n"
+      + "    </list>\n"
+      + "  </property>"
+      + "</bean>"
+    );
+
+    context.getBean("rpcTracing", RpcTracing.class);
+
+    verify(CUSTOMIZER_ONE).customize(any(RpcTracing.Builder.class));
+    verify(CUSTOMIZER_TWO).customize(any(RpcTracing.Builder.class));
+  }
+}


### PR DESCRIPTION
This adds an abstraction layer for RPC, based on non-deprecated code in
brave-instrumentation-http. It will be a work in progress until at least
Dubbo and gRPC are integrated (ideally also Armeria even though in
another repo.

This is limited to sampling logic to make it easy to integrate and also
as that's the more in-demand functionality. Most notably, we only need
two properties: RPC service and method, to satisfy the first use cases
of RPC sampling.

Ex. Here's a sampler that traces 100 "GetUserToken" requests per second. This
doesn't start new traces for requests to the health check service. Other
requests will use a global rate provided by the tracing component.

```java
import static brave.rpc.RpcRequestMatchers.*;

rpcTracing = rpcTracingBuilder.serverSampler(RpcRuleSampler.newBuilder()
  .putRule(serviceEquals("grpc.health.v1.Health"), Sampler.NEVER_SAMPLE)
  .putRule(methodEquals("GetUserToken"), RateLimitingSampler.create(100))
  .build()).build();

grpcTracing = GrpcTracing.create(rpcTracing);
```

Thanks @trustin for helping me think through namings and such