### PR TITLE
Removes obviated nextClientSpan as no longer needed

### DIFF
--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -209,7 +209,7 @@ public class HttpClientHandlerTest {
   @Test public void nextSpan_samplerSeesUnwrappedType_oldHandler() {
     when(sampler.trySample(defaultRequest)).thenReturn(null);
 
-    handler.nextClientSpan(defaultRequest);
+    handler.nextSpan(defaultRequest);
 
     verify(sampler).trySample(defaultRequest);
   }


### PR DESCRIPTION
paring down prior to release of 5.8