### PR TITLE
Log all exceptions when re-setting message props

### DIFF
--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -66,6 +66,12 @@
       <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -14,6 +14,8 @@
 package brave.jms;
 
 import brave.internal.Platform;
+import zipkin2.Call;
+
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -76,7 +78,8 @@ final class PropertyFilter {
       String name = out.get(i).toString();
       try {
         message.setObjectProperty(name, out.get(i + 1));
-      } catch (JMSException e) {
+      } catch (Throwable e) {
+        Call.propagateIfFatal(e);
         log(e, "error setting property {0} on message {1}", name, message);
         // continue on error when re-setting properties as it is better than not.
       }

--- a/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
@@ -22,8 +22,14 @@ import org.junit.After;
 import org.junit.Test;
 
 import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PropertyFilterTest {
 

--- a/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
@@ -15,13 +15,15 @@ package brave.jms;
 
 import java.util.Collections;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.TextMessage;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.junit.After;
 import org.junit.Test;
 
 import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class PropertyFilterTest {
 
@@ -42,6 +44,31 @@ public class PropertyFilterTest {
     PropertyFilter.filterProperties(message, Collections.singleton("b3"));
 
     assertThat(message).isEqualToIgnoringGivenFields(newMessageWithAllTypes(), "processAsExpired");
+  }
+
+  // When brave-instrumentation-jms is wrapped around an AWS SQSConnectionFactory, PropertyFilter.filterProperties()
+  // attempts to re-set properties on the received SQSMessage object. Doing so fails because SQSMessage throws an
+  // IllegalArgumentException if either the property name or value are empty. (Even though the properties came from
+  // SQSMessage to begin with.) Verify the IllegalArgumentException does not escape its try/catch block resulting in the
+  // message silently failing to process.
+  //
+  // https://github.com/awslabs/amazon-sqs-java-messaging-lib/blob/b462bdceac814c56e75ee0ba638b3928ce8adee1/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java#L904-L909
+  @Test public void filterProperties_message_handlesOnSetException() throws Exception {
+    Message message = mock(Message.class);
+    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.singletonList("JMS_SQS_DeduplicationId")));
+    when(message.getObjectProperty("JMS_SQS_DeduplicationId")).thenReturn("");
+    doThrow(new IllegalArgumentException()).when(message).setObjectProperty(anyString(), eq(""));
+
+    assertThatCode(() -> PropertyFilter.filterProperties(message, Collections.singleton("b3"))).doesNotThrowAnyException();
+  }
+
+  @Test public void filterProperties_message_passesFatalOnSetException() throws Exception {
+    Message message = mock(Message.class);
+    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.singletonList("JMS_SQS_DeduplicationId")));
+    when(message.getObjectProperty("JMS_SQS_DeduplicationId")).thenReturn("");
+    doThrow(new LinkageError()).when(message).setObjectProperty(anyString(), eq(""));
+
+    assertThatThrownBy(() -> PropertyFilter.filterProperties(message, Collections.singleton("b3"))).isInstanceOf(LinkageError.class);
   }
 
   static TextMessage newMessageWithAllTypes() throws Exception {


### PR DESCRIPTION
When receiving JMS messages from Amazon SQS, the message sometimes
has headers like JMSXGroupID and JMS_SQS_DeduplicationId added by
SQS with empty string values.

When brave-instrumentation-jms is wrapped around an SQSConnectionFactory,
PropertyFilter.filterProperties() attempts to re-set these properties
on the received SQSMessage object. Doing so fails becaus SQSMessage
throws an IllegalArgumentException if either the property name or
value are empty. (Even though the properties came from SQSMessage
to begin with.) The IllegalArgumentException escapes the
try/catch block only looking for JMSException, and results in the
message silently failing to process.

This change widens the scope of the catch block so that any failure
when attempting to re-set a message property is caught, preventing
an unexpected exception type from blowing up the entire message.