### PR TITLE
Adds OSGi manifests to all non-test jars

### DIFF
--- a/brave/bnd.bnd
+++ b/brave/bnd.bnd
@@ -1,8 +1,8 @@
 Import-Package: \
   *
 Export-Package: \
-	brave,\
+  brave,\
   brave.handler,\
-	brave.propagation,\
-	brave.sampler,\
-	brave.internal;braveinternal=true;mandatory:=braveinternal
+  brave.propagation,\
+  brave.sampler,\
+  brave.internal;braveinternal=true;mandatory:=braveinternal

--- a/brave/bnd.bnd
+++ b/brave/bnd.bnd
@@ -1,5 +1,4 @@
 Import-Package: \
-  !zipkin2.internal,\
   *
 Export-Package: \
 	brave,\

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -27,6 +27,9 @@
   <description>Brave: Core Libary</description>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave</module.name>
+
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -113,37 +116,12 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-      </plugin>
-
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -116,12 +116,14 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
@@ -130,6 +132,7 @@
             <id>default-jar</id>
             <configuration>
               <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                 <manifestEntries>
                   <Automatic-Module-Name>brave</Automatic-Module-Name>

--- a/context/jfr/bnd.bnd
+++ b/context/jfr/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.context.jfr

--- a/context/jfr/bnd.bnd
+++ b/context/jfr/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.context.jfr
+  brave.context.jfr

--- a/context/jfr/pom.xml
+++ b/context/jfr/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
@@ -42,16 +44,33 @@
           </compilerArgs>
         </configuration>
       </plugin>
+
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.context.jfr</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.context.jfr</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
+
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/context/jfr/pom.xml
+++ b/context/jfr/pom.xml
@@ -28,6 +28,9 @@
   <name>Brave Context: JDK Flight Recorder</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.context.jfr</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>11</main.java.version>
   </properties>
@@ -44,33 +47,6 @@
           </compilerArgs>
         </configuration>
       </plugin>
-
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.context.jfr</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/context/log4j12/bnd.bnd
+++ b/context/log4j12/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.propagation.CorrelationFieldScopeDecorator
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.context.log4j12

--- a/context/log4j12/bnd.bnd
+++ b/context/log4j12/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.context.log4j12
+  brave.context.log4j12

--- a/context/log4j12/pom.xml
+++ b/context/log4j12/pom.xml
@@ -42,15 +42,30 @@
 
   <build>
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.context.log4j12</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.context.log4j12</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/context/log4j12/pom.xml
+++ b/context/log4j12/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Context: Log4J 1.2</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.context.log4j12</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -39,34 +42,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.context.log4j12</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/context/log4j2/bnd.bnd
+++ b/context/log4j2/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.propagation.CorrelationFieldScopeDecorator
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.context.log4j2

--- a/context/log4j2/bnd.bnd
+++ b/context/log4j2/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.context.log4j2
+  brave.context.log4j2

--- a/context/log4j2/pom.xml
+++ b/context/log4j2/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Context: Log4J 2</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.context.log4j2</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -39,34 +42,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.context.log4j2</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/context/log4j2/pom.xml
+++ b/context/log4j2/pom.xml
@@ -42,15 +42,30 @@
 
   <build>
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.context.log4j2</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.context.log4j2</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/context/rxjava2/bnd.bnd
+++ b/context/rxjava2/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.context.rxjava2
+  brave.context.rxjava2

--- a/context/rxjava2/bnd.bnd
+++ b/context/rxjava2/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.context.rxjava2

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
@@ -58,18 +60,32 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
   <build>
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.context.rxjava2</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.context.rxjava2</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -28,6 +28,9 @@
   <name>Brave Context: RxJava 2</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.context.rxjava2</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- RxJava 2.x continues support for Java 1.6 and Android 2.3+ -->
     <main.java.version>1.6</main.java.version>
@@ -60,33 +63,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.context.rxjava2</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/context/slf4j/bnd.bnd
+++ b/context/slf4j/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.context.slf4j
+  brave.context.slf4j

--- a/context/slf4j/bnd.bnd
+++ b/context/slf4j/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.propagation.CorrelationFieldScopeDecorator
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.context.slf4j

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -41,15 +41,30 @@
 
   <build>
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.context.slf4j</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.context.slf4j</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Context: SLF4J</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.context.slf4j</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -38,34 +41,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.context.slf4j</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/dubbo-rpc/bnd.bnd
+++ b/instrumentation/dubbo-rpc/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.dubbo.rpc
+  brave.dubbo.rpc

--- a/instrumentation/dubbo-rpc/bnd.bnd
+++ b/instrumentation/dubbo-rpc/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.Platform
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.dubbo.rpc

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -60,15 +60,30 @@
 
   <build>
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.dubbo.rpc</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.dubbo.rpc</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -25,6 +25,9 @@
   <name>Brave Instrumentation: Alibaba Dubbo</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.dubbo.rpc</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -57,34 +60,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.dubbo.rpc</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/dubbo/bnd.bnd
+++ b/instrumentation/dubbo/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.Platform
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.dubbo

--- a/instrumentation/dubbo/bnd.bnd
+++ b/instrumentation/dubbo/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.dubbo
+  brave.dubbo

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -25,6 +25,9 @@
   <name>Brave Instrumentation: Apache Dubbo</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.dubbo</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
@@ -50,34 +53,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.dubbo</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -53,15 +53,30 @@
 
   <build>
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.dubbo</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.dubbo</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/grpc/bnd.bnd
+++ b/instrumentation/grpc/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable,Platform,MapPropagationFields,PropagationFieldsFactory
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.grpc

--- a/instrumentation/grpc/bnd.bnd
+++ b/instrumentation/grpc/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.grpc
+  brave.grpc

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -13,7 +13,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
@@ -89,17 +91,35 @@
         <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
+
     <plugins>
+      <!-- OSGi and Java Modules configuration -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.grpc</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.dubbo.grpc</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
+
+      <!-- Integration test old gRPC version -->
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -27,6 +27,9 @@
   <name>Brave Instrumentation: gRPC</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.grpc</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- grpc < 1.15 supports java 6 https://github.com/grpc/grpc-java/issues/3961 -->
     <main.java.version>1.6</main.java.version>
@@ -93,32 +96,6 @@
     </extensions>
 
     <plugins>
-      <!-- OSGi and Java Modules configuration -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.dubbo.grpc</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- Integration test old gRPC version -->
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>

--- a/instrumentation/http/bnd.bnd
+++ b/instrumentation/http/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.http
+  brave.http

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -40,6 +40,7 @@
   </dependencies>
 
   <build>
+    <!-- OSGi and Java Modules configuration -->
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -52,6 +53,7 @@
             <id>default-jar</id>
             <configuration>
               <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                 <manifestEntries>
                   <Automatic-Module-Name>brave.http</Automatic-Module-Name>

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Http Adapters</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.http</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -38,34 +41,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <!-- OSGi and Java Modules configuration -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.http</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/httpasyncclient/bnd.bnd
+++ b/instrumentation/httpasyncclient/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.httpasyncclient
+  brave.httpasyncclient

--- a/instrumentation/httpasyncclient/bnd.bnd
+++ b/instrumentation/httpasyncclient/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.httpasyncclient

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Apache HttpAsyncClient v4.0+</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.httpasyncclient</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -53,34 +56,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <!-- OSGi and Java Modules configuration -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.httpasyncclient</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -55,16 +55,31 @@
   </dependencies>
 
   <build>
+    <!-- OSGi and Java Modules configuration -->
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.httpasyncclient</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.httpasyncclient</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/httpclient/bnd.bnd
+++ b/instrumentation/httpclient/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.httpclient
+  brave.httpclient

--- a/instrumentation/httpclient/bnd.bnd
+++ b/instrumentation/httpclient/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.httpclient

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Apache HttpClient v4.4+</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.httpclient</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -58,34 +61,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <!-- OSGi and Java Modules configuration -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.httpclient</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -60,16 +60,31 @@
   </dependencies>
 
   <build>
+    <!-- OSGi and Java Modules configuration -->
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.httpclient</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.httpclient</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/jaxrs2/bnd.bnd
+++ b/instrumentation/jaxrs2/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.jaxrs2
+  brave.jaxrs2

--- a/instrumentation/jaxrs2/bnd.bnd
+++ b/instrumentation/jaxrs2/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.jaxrs2

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -92,16 +92,31 @@
   </dependencies>
 
   <build>
+    <!-- OSGi and Java Modules configuration -->
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.jaxrs2</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.jaxrs2</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: JAX-RS v2</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.jaxrs2</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -90,34 +93,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <!-- OSGi and Java Modules configuration -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.jaxrs2</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/jersey-server/bnd.bnd
+++ b/instrumentation/jersey-server/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.jersey.server
+  brave.jersey.server

--- a/instrumentation/jersey-server/bnd.bnd
+++ b/instrumentation/jersey-server/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.jersey.server

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Jersey Server 2.x</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.jersey.server</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- Jersey 2.7 -> 2.25 are Java 7. We don't currently compile against Jersey 2.26+
          https://jersey.github.io/documentation/latest/modules-and-dependencies.html#d0e560
@@ -83,34 +86,4 @@
       <version>1.1.1</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <!-- OSGi and Java Modules configuration -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.jersey.server</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -85,16 +85,31 @@
   </dependencies>
 
   <build>
+    <!-- OSGi and Java Modules configuration -->
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.jersey.server</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <manifestEntries>
+                  <Automatic-Module-Name>brave.jersey.server</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/instrumentation/jms/bnd.bnd
+++ b/instrumentation/jms/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.jms
+  brave.jms

--- a/instrumentation/jms/bnd.bnd
+++ b/instrumentation/jms/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.Throwables
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.jms

--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: JMS</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.jms</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -76,16 +79,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.jms</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/instrumentation/kafka-clients/bnd.bnd
+++ b/instrumentation/kafka-clients/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.kafka.clients
+  brave.kafka.clients

--- a/instrumentation/kafka-clients/bnd.bnd
+++ b/instrumentation/kafka-clients/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.kafka.clients

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Kafka Clients</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.kafka.clients</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
@@ -80,16 +83,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.kafka.clients</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/instrumentation/kafka-streams/bnd.bnd
+++ b/instrumentation/kafka-streams/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.kafka.streams
+  brave.kafka.streams

--- a/instrumentation/kafka-streams/bnd.bnd
+++ b/instrumentation/kafka-streams/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.kafka.streams

--- a/instrumentation/kafka-streams/pom.xml
+++ b/instrumentation/kafka-streams/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Kafka Streams</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.kafka.streams</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
@@ -71,16 +74,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.kafka.streams</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/instrumentation/mysql/bnd.bnd
+++ b/instrumentation/mysql/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.mysql

--- a/instrumentation/mysql/bnd.bnd
+++ b/instrumentation/mysql/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.mysql
+  brave.mysql

--- a/instrumentation/mysql/pom.xml
+++ b/instrumentation/mysql/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: MySQL</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.mysql</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- mysql-connector-java < v6 requires Java 6 -->
     <main.java.version>1.6</main.java.version>
@@ -40,19 +43,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.mysql</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/mysql6/bnd.bnd
+++ b/instrumentation/mysql6/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.mysql6

--- a/instrumentation/mysql6/bnd.bnd
+++ b/instrumentation/mysql6/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.mysql6
+  brave.mysql6

--- a/instrumentation/mysql6/pom.xml
+++ b/instrumentation/mysql6/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: MySQL6</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.mysql6</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- mysql-connector-java 6+ requires Java 8 -->
     <main.java.version>1.8</main.java.version>
@@ -40,19 +43,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.mysql6</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/mysql8/bnd.bnd
+++ b/instrumentation/mysql8/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.mysql8
+  brave.mysql8

--- a/instrumentation/mysql8/bnd.bnd
+++ b/instrumentation/mysql8/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.mysql8

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: MySQL8</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.mysql8</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- mysql-connector-java 8+ requires Java 8 -->
     <main.java.version>1.8</main.java.version>
@@ -43,19 +46,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.mysql8</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/netty-codec-http/bnd.bnd
+++ b/instrumentation/netty-codec-http/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.Platform
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.netty.http

--- a/instrumentation/netty-codec-http/bnd.bnd
+++ b/instrumentation/netty-codec-http/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.netty.http
+  brave.netty.http

--- a/instrumentation/netty-codec-http/pom.xml
+++ b/instrumentation/netty-codec-http/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Netty Http Codec</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.netty.http</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- Netty 4.x requires Java 6+ https://netty.io/wiki/requirements-for-4.x.html -->
     <main.java.version>1.6</main.java.version>
@@ -51,19 +54,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.netty.http</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/okhttp3/bnd.bnd
+++ b/instrumentation/okhttp3/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.okhttp3
+  brave.okhttp3

--- a/instrumentation/okhttp3/bnd.bnd
+++ b/instrumentation/okhttp3/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.okhttp3

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: OkHttp v3.x</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.okhttp3</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
   </properties>
 
@@ -51,19 +54,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.okhttp3</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/p6spy/bnd.bnd
+++ b/instrumentation/p6spy/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.p6spy
+  brave.p6spy

--- a/instrumentation/p6spy/bnd.bnd
+++ b/instrumentation/p6spy/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.p6spy

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: P6Spy (JDBC)</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.p6spy</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -63,19 +66,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.p6spy</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/rpc/bnd.bnd
+++ b/instrumentation/rpc/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.rpc
+  brave.rpc

--- a/instrumentation/rpc/pom.xml
+++ b/instrumentation/rpc/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Rpc Adapters</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.rpc</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -38,32 +41,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <configuration>
-              <archive>
-                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                <manifestEntries>
-                  <Automatic-Module-Name>brave.rpc</Automatic-Module-Name>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/servlet/bnd.bnd
+++ b/instrumentation/servlet/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable and brave.internal.Throwables
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.servlet

--- a/instrumentation/servlet/bnd.bnd
+++ b/instrumentation/servlet/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.servlet
+  brave.servlet

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Servlet</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.servlet</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -53,16 +56,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.servlet</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
       </plugin>

--- a/instrumentation/sparkjava/bnd.bnd
+++ b/instrumentation/sparkjava/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.sparkjava

--- a/instrumentation/sparkjava/bnd.bnd
+++ b/instrumentation/sparkjava/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.sparkjava
+  brave.sparkjava

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Spark Framework</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.sparkjava</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
@@ -57,19 +60,8 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.sparkjava</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/instrumentation/spring-rabbit/bnd.bnd
+++ b/instrumentation/spring-rabbit/bnd.bnd
@@ -3,4 +3,4 @@ Import-Package: \
   !brave.internal*,\
   *
 Export-Package: \
-	brave.spring.rabbit
+  brave.spring.rabbit

--- a/instrumentation/spring-rabbit/bnd.bnd
+++ b/instrumentation/spring-rabbit/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but nothing else internal.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+	brave.spring.rabbit

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Spring RabbitMQ</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.spring.rabbit</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -65,19 +68,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.spring.rabbit</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/instrumentation/spring-web/bnd.bnd
+++ b/instrumentation/spring-web/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.spring.web
+  brave.spring.web

--- a/instrumentation/spring-web/bnd.bnd
+++ b/instrumentation/spring-web/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.spring.web

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Spring Rest Template</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.spring.web</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -75,16 +78,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.spring.web</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
       </plugin>

--- a/instrumentation/spring-webmvc/bnd.bnd
+++ b/instrumentation/spring-webmvc/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.spring.webmvc
+  brave.spring.webmvc

--- a/instrumentation/spring-webmvc/bnd.bnd
+++ b/instrumentation/spring-webmvc/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.spring.webmvc

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Spring Web MVC</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.spring.webmvc</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -72,16 +75,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.spring.webmvc</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
       </plugin>

--- a/instrumentation/vertx-web/bnd.bnd
+++ b/instrumentation/vertx-web/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.vertx.web

--- a/instrumentation/vertx-web/bnd.bnd
+++ b/instrumentation/vertx-web/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.vertx.web
+  brave.vertx.web

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -26,6 +26,9 @@
   <name>Brave Instrumentation: Vert.x Web</name>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.vertx.web</module.name>
+
     <main.basedir>${project.basedir}/../..</main.basedir>
     <vertx.version>3.8.1</vertx.version>
     <main.java.version>1.8</main.java.version>
@@ -58,16 +61,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.vertx.web</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin.brave</groupId>
@@ -74,7 +76,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- override to set exclusions per-project -->
-    <errorprone.args />
+    <errorprone.args/>
     <errorprone.version>2.3.3</errorprone.version>
 
     <!-- use the same values in bom/pom.xml -->
@@ -762,6 +764,48 @@
                   <goal>jar</goal>
                 </goals>
                 <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>module-info</id>
+      <!-- Build profiles can only consider static properties, such as files or ENV variables.
+           To conditionally add module information, we use existence of bnd.bnd. This allows
+           irrelevant packages such as tests and benchmarks to quietly opt-out.
+           http://maven.apache.org/guides/introduction/introduction-to-profiles.html -->
+      <activation>
+        <file>
+          <exists>bnd.bnd</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <!-- OSGi and Java Modules configuration -->
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-jar</id>
+                <configuration>
+                  <archive>
+                    <!-- Include the MANIFEST.MF maven-bundle-plugin generates from bnd.bnd -->
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF
+                    </manifestFile>
+                    <manifestEntries>
+                      <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
+                    </manifestEntries>
+                  </archive>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>

--- a/spring-beans/bnd.bnd
+++ b/spring-beans/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+	brave.spring.beans

--- a/spring-beans/bnd.bnd
+++ b/spring-beans/bnd.bnd
@@ -1,4 +1,4 @@
 Import-Package: \
   *
 Export-Package: \
-	brave.spring.beans
+  brave.spring.beans

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -27,6 +27,9 @@
   <description>Allows you to configure Brave using XML</description>
 
   <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.spring.beans</module.name>
+
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
@@ -58,19 +61,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>brave.spring.beans</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
This uses file-based detection to ensure projects with bnd.bnd end up with both OSGi and Java Modules manifests

Fixes #266