### PR TITLE
Removes accidental zipkin lib dependency and fixes throwable catching

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -39,6 +39,8 @@
     <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin</artifactId>
+      <!-- TODO: should this be marked optional?
+           Brave APIs, except builder.spanReporter, shouldn't return or accept zipkin2 types -->
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>

--- a/brave/src/main/java/brave/internal/Throwables.java
+++ b/brave/src/main/java/brave/internal/Throwables.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal;
+
+public final class Throwables {
+  // Taken from RxJava throwIfFatal, which was taken from scala
+  public static void propagateIfFatal(Throwable t) {
+    if (t instanceof VirtualMachineError) {
+      throw (VirtualMachineError) t;
+    } else if (t instanceof ThreadDeath) {
+      throw (ThreadDeath) t;
+    } else if (t instanceof LinkageError) {
+      throw (LinkageError) t;
+    }
+  }
+
+  Throwables() {
+  }
+}

--- a/brave/src/main/java/brave/internal/handler/NoopAwareFinishedSpanHandler.java
+++ b/brave/src/main/java/brave/internal/handler/NoopAwareFinishedSpanHandler.java
@@ -20,7 +20,8 @@ import brave.propagation.TraceContext;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import zipkin2.Call;
+
+import static brave.internal.Throwables.propagateIfFatal;
 
 /**
  * When {@code noop}, this drops input spans by returning false. Otherwise, it logs exceptions
@@ -58,7 +59,7 @@ public abstract class NoopAwareFinishedSpanHandler extends FinishedSpanHandler {
     try {
       return doHandle(context, span);
     } catch (Throwable t) {
-      Call.propagateIfFatal(t);
+      propagateIfFatal(t);
       Platform.get().log("error handling {0}", context, t);
       return false;
     }

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -106,6 +106,8 @@ public interface Propagation<K> {
    * clear fields as they couldn't have been set before. If it is a mutable, retryable object,
    * successive calls should clear these fields first.
    *
+   * <p><em>Note:</em> Depending on the format, keys returned may not all be mandatory.
+   *
    * <p><em>Note:</em> If your implementation carries "extra fields", such as correlation IDs, do
    * not return the names of those fields here. If you do, they will be deleted, which can interfere
    * with user headers.
@@ -113,6 +115,7 @@ public interface Propagation<K> {
   // The use cases of this are:
   // * allow pre-allocation of fields, especially in systems like gRPC Metadata
   // * allow a single-pass over an iterator (ex OpenTracing has no getter in TextMap)
+  // * detection of if a context is likely to be present in a request object
   List<K> keys();
 
   /**

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageListener.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageListener.java
@@ -22,6 +22,7 @@ import javax.jms.Message;
 import javax.jms.MessageListener;
 
 import static brave.Span.Kind.CONSUMER;
+import static brave.internal.Throwables.propagateIfFatal;
 
 /**
  * When {@link #addConsumerSpan} this creates 2 spans:
@@ -61,6 +62,7 @@ final class TracingMessageListener implements MessageListener {
     try (SpanInScope ws = tracer.withSpanInScope(listenerSpan)) {
       delegate.onMessage(message);
     } catch (Throwable t) {
+      propagateIfFatal(t);
       listenerSpan.error(t);
       throw t;
     } finally {

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageProducer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageProducer.java
@@ -27,6 +27,7 @@ import javax.jms.QueueSender;
 import javax.jms.Topic;
 import javax.jms.TopicPublisher;
 
+import static brave.internal.Throwables.propagateIfFatal;
 import static brave.jms.JmsTracing.log;
 import static brave.jms.TracingConnection.TYPE_QUEUE;
 import static brave.jms.TracingConnection.TYPE_TOPIC;
@@ -64,8 +65,9 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
 
     try {
       return delegate.getDestination();
-    } catch (JMSException e) {
-      log(e, "error getting destination of producer {0}", delegate, null);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      log(t, "error getting destination of producer {0}", delegate, null);
     }
     return null;
   }
@@ -133,9 +135,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(message);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -148,9 +151,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(message, deliveryMode, priority, timeToLive);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -191,9 +195,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       sendDestination.apply(delegate, destination, message);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -207,9 +212,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(destination, message, deliveryMode, priority, timeToLive);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -223,10 +229,11 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(message, TracingCompletionListener.create(completionListener, span, current));
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
       span.finish();
-      throw e;
+      throw t;
     } finally {
       ws.close();
     }
@@ -240,10 +247,11 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(message, deliveryMode, priority, timeToLive, completionListener);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
       span.finish();
-      throw e;
+      throw t;
     } finally {
       ws.close();
     }
@@ -257,10 +265,11 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(destination, message, completionListener);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
       span.finish();
-      throw e;
+      throw t;
     } finally {
       ws.close();
     }
@@ -274,10 +283,11 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       delegate.send(destination, message, deliveryMode, priority, timeToLive, completionListener);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
       span.finish();
-      throw e;
+      throw t;
     } finally {
       ws.close();
     }
@@ -304,9 +314,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       qs.send(queue, message, deliveryMode, priority, timeToLive);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -334,9 +345,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       tp.publish(message);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -352,9 +364,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       tp.publish(message, deliveryMode, priority, timeToLive);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();
@@ -376,9 +389,10 @@ final class TracingMessageProducer extends TracingProducer<MessageProducer, Mess
     SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
     try {
       tp.publish(topic, message, deliveryMode, priority, timeToLive);
-    } catch (RuntimeException | JMSException | Error e) {
-      span.error(e);
-      throw e;
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      span.error(t);
+      throw t;
     } finally {
       ws.close();
       span.finish();

--- a/instrumentation/servlet/src/main/java/brave/servlet/internal/ServletRuntime.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/internal/ServletRuntime.java
@@ -28,7 +28,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
-import zipkin2.Call;
+
+import static brave.internal.Throwables.propagateIfFatal;
 
 /**
  * Access to servlet version-specific features
@@ -199,7 +200,7 @@ public abstract class ServletRuntime {
           getStatusMethod = clazz.getMethod("getStatus");
           return (int) ((Method) getStatusMethod).invoke(response);
         } catch (Throwable throwable) {
-          Call.propagateIfFatal(throwable);
+          propagateIfFatal(throwable);
           getStatusMethod = RETURN_NULL;
           return 0;
         } finally {
@@ -214,7 +215,7 @@ public abstract class ServletRuntime {
       try {
         return (int) ((Method) getStatusMethod).invoke(response);
       } catch (Throwable throwable) {
-        Call.propagateIfFatal(throwable);
+        propagateIfFatal(throwable);
         Map<Class<?>, Object> replacement = new LinkedHashMap<>(classesToCheck);
         replacement.put(clazz, RETURN_NULL);
         classToGetStatus.set(replacement); // prefer overriding on failure


### PR DESCRIPTION
In #1008, we only fixed one place where semi-implementation of JMS could
raise unexpected throwables. This fixes the rest and also removes the
accidental compile dep on zipkin2.