### PR TITLE
trim mysql statement name.

### DIFF
--- a/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
+++ b/instrumentation/mysql/src/main/java/brave/mysql/TracingStatementInterceptor.java
@@ -51,7 +51,7 @@ public class TracingStatementInterceptor implements StatementInterceptorV2 {
       sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
     }
     int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
-    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex).trim());
     span.tag("sql.query", sql);
     parseServerIpAndPort(connection, span);
     span.start();

--- a/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
+++ b/instrumentation/mysql6/src/main/java/brave/mysql6/TracingStatementInterceptor.java
@@ -55,7 +55,7 @@ public class TracingStatementInterceptor implements StatementInterceptor {
       sql = ((PreparedStatement) interceptedStatement).getPreparedSql();
     }
     int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
-    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex).trim());
     span.tag("sql.query", sql);
     parseServerIpAndPort(connection, span);
     span.start();

--- a/instrumentation/mysql8/src/main/java/brave/mysql8/TracingQueryInterceptor.java
+++ b/instrumentation/mysql8/src/main/java/brave/mysql8/TracingQueryInterceptor.java
@@ -52,7 +52,7 @@ public class TracingQueryInterceptor implements QueryInterceptor {
 
     String sql = sqlSupplier.get();
     int spaceIndex = sql.indexOf(' '); // Allow span names of single-word statements like COMMIT
-    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex));
+    span.kind(Span.Kind.CLIENT).name(spaceIndex == -1 ? sql : sql.substring(0, spaceIndex).trim());
     span.tag("sql.query", sql);
     parseServerIpAndPort(connection, span);
     span.start();


### PR DESCRIPTION
The mysql span name like "select" will be "select\n"  if you are using mybatis or ibatis.
A sql generated by mybatis looks like 
`select\n          item_ids\n        from item_recommand\n        where\n          delete_mark = 0 and user_id = ?`
Then we get a span name "select\n"
A TRIM will fix it . 