### PR TITLE
Switches non-request based header default to B3 single format

### DIFF
--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -47,10 +47,10 @@ public final class B3Propagation<K> implements Propagation<K> {
 
   /**
    * Defaults to {@link Format#MULTI} for client/server spans and {@link Format#SINGLE_NO_PARENT}
-   * for messaging. Non-request spans default to {@link Format#MULTI}.
+   * for messaging. Non-request spans, such as message processors, default to {@link Format#SINGLE}.
    */
   public static final class FactoryBuilder {
-    Format injectFormat = Format.MULTI;
+    Format injectFormat = Format.SINGLE;
     final EnumMap<Span.Kind, Format[]> kindToInjectFormats = new EnumMap<>(Span.Kind.class);
 
     FactoryBuilder() {

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -47,7 +47,7 @@ public final class B3Propagation<K> implements Propagation<K> {
 
   /**
    * Defaults to {@link Format#MULTI} for client/server spans and {@link Format#SINGLE_NO_PARENT}
-   * for messaging. Non-request spans, such as message processors, default to {@link Format#SINGLE}.
+   * for messaging. Non-remote spans, such as message processors, default to {@link Format#SINGLE}.
    */
   public static final class FactoryBuilder {
     Format injectFormat = Format.SINGLE;

--- a/brave/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave/src/test/java/brave/propagation/B3PropagationTest.java
@@ -42,6 +42,7 @@ public class B3PropagationTest {
 
   @Test public void keys_withoutB3Single() {
     Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+      .injectFormat(Format.MULTI)
       .injectFormat(Span.Kind.PRODUCER, Format.MULTI)
       .injectFormat(Span.Kind.CONSUMER, Format.MULTI)
       .build().create(Propagation.KeyFactory.STRING);
@@ -57,7 +58,6 @@ public class B3PropagationTest {
 
   @Test public void keys_onlyB3Single() {
     Propagation<String> propagation = B3Propagation.newFactoryBuilder()
-      .injectFormat(Format.SINGLE)
       .injectFormat(Span.Kind.CLIENT, Format.SINGLE)
       .injectFormat(Span.Kind.SERVER, Format.SINGLE)
       .build().create(Propagation.KeyFactory.STRING);
@@ -67,11 +67,11 @@ public class B3PropagationTest {
 
   @Test public void injectFormat() {
     B3Propagation.Factory factory = (B3Propagation.Factory) B3Propagation.newFactoryBuilder()
-      .injectFormat(Format.SINGLE)
+      .injectFormat(Format.MULTI)
       .build();
 
     assertThat(factory.injectFormat)
-      .isEqualTo(Format.SINGLE);
+      .isEqualTo(Format.MULTI);
   }
 
   @Test public void injectKindFormat() {


### PR DESCRIPTION
This might be contentious. This switches the default when not using http
messaging or rpc abstractions to b3 single. In doing so, this implicitly
lowers overhead of things like message processors (which are neither
producers nor consumers). The overhead is lower because one header would
be used instead of many (for each stage in Kafka Streams, for example).

On the other hand, not everything uses our http, messaging or rpc
abstractions. What would happen is if someone manually created an http
instrumentation, they would silently switch to B3 single by default.
This risk should be considered.