### PR TITLE
Remove duplicate mockito dependency

### DIFF
--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -73,12 +73,6 @@
       <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Removing duplicate dependency declaration.
mockito-core is already defined in the brave-parent pom.xml