### PR TITLE
add flag to not share trace on consumption

### DIFF
--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -8,7 +8,6 @@ Add decorators for Kafka producer and consumer to enable tracing.
 First, setup the generic Kafka component like this:
 ```java
 kafkaTracing = KafkaTracing.newBuilder(messagingTracing)
-                           .writeB3SingleFormat(true) // for more efficient propagation
                            .remoteServiceName("my-broker")
                            .build();
 ```

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -10,7 +10,6 @@ First, setup the generic Kafka component like this:
 kafkaTracing = KafkaTracing.newBuilder(messagingTracing)
                            .writeB3SingleFormat(true) // for more efficient propagation
                            .remoteServiceName("my-broker")
-                           .singleRootSpanOnReceiveBatch(true) // to share a single root span when starting a trace from consumer
                            .build();
 ```
 
@@ -103,6 +102,14 @@ to trace manually or you can do similar via automatic instrumentation like Aspec
   }
 }
 ```
+
+## Single Root Span on Consumer
+
+When a Tracing Kafka Consumer is processing records that do not have trace-context (i.e. Producer is not tracing)
+it will reuse the same root span `poll` to group all processing of records returned.
+
+If this is not the desired behavior, users can customize it by setting `singleRootSpanOnReceiveBatch` to `false`. 
+This will create a root span `poll` for each record received. 
 
 ## Notes
 * This tracer is only compatible with Kafka versions including headers support ( > 0.11.0).

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -10,7 +10,7 @@ First, setup the generic Kafka component like this:
 kafkaTracing = KafkaTracing.newBuilder(messagingTracing)
                            .writeB3SingleFormat(true) // for more efficient propagation
                            .remoteServiceName("my-broker")
-                           .shareTraceOnConsumption(true) // to create a trace with all records consumed in a batch
+                           .singleRootSpanOnReceiveBatch(true) // to share a single root span when starting a trace from consumer
                            .build();
 ```
 

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -108,8 +108,31 @@ to trace manually or you can do similar via automatic instrumentation like Aspec
 When a Tracing Kafka Consumer is processing records that do not have trace-context (i.e. Producer is not tracing)
 it will reuse the same root span `poll` to group all processing of records returned.
 
+```
+trace 1:
+poll
+|- processing1
+|- processing2
+...
++- processing N
+```
+
 If this is not the desired behavior, users can customize it by setting `singleRootSpanOnReceiveBatch` to `false`. 
 This will create a root span `poll` for each record received. 
+
+```
+trace 1:
+poll
++- processing1
+
+trace 2:
+poll
++- processing2
+...
+trace N:
+poll
++- processing N
+```
 
 ## Notes
 * This tracer is only compatible with Kafka versions including headers support ( > 0.11.0).

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -10,6 +10,7 @@ First, setup the generic Kafka component like this:
 kafkaTracing = KafkaTracing.newBuilder(messagingTracing)
                            .writeB3SingleFormat(true) // for more efficient propagation
                            .remoteServiceName("my-broker")
+                           .shareTraceOnConsumption(true) // to create a trace with all records consumed in a batch
                            .build();
 ```
 

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -85,10 +85,11 @@ public final class KafkaTracing {
     }
 
     /**
-     * Controls the sharing of a poll span for incoming spans with no trace context.
+     * Controls the sharing of a {@code poll} span for incoming spans with no trace context.
      *
-     * <b/>If true, all the spans received in a poll batch that do not have trace-context will be added
-     * to a single new poll root span. Otherwise, a poll span will be created for each such message.
+     * <b/>If true, all the spans received in a {@code poll} batch that do not have trace-context
+     * will be added to a single new poll root span. Otherwise, a {@code poll} span will be created
+     * for each such message.
      *
      * @since 5.10
      */

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -84,7 +84,16 @@ public final class KafkaTracing {
       return this;
     }
 
-    /** @since 5.10  **/
+    /**
+     * When no trace context or extra fields have been added to an incoming consumed message propagation,
+     * records from the same partition are been traced under the same parent id, sharing the same trace.
+     *
+     * <b/>If true, this will share a trace for messages received as part of
+     * a batch with no trace context, and create an individual trace by message; leading to 1 trace
+     * per poll operation.
+     *
+     * @since 5.10
+     */
     public Builder shareTraceOnConsumption(boolean shareTraceOnConsumption) {
       this.shareTraceOnConsumption = shareTraceOnConsumption;
       return this;

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -62,7 +62,7 @@ public final class KafkaTracing {
   public static final class Builder {
     final MessagingTracing messagingTracing;
     String remoteServiceName = "kafka";
-    boolean shareTraceOnConsumption = true;
+    boolean rootSpanOnReceiveBatch = true;
 
     Builder(MessagingTracing messagingTracing) {
       if (messagingTracing == null) throw new NullPointerException("messagingTracing == null");
@@ -72,7 +72,7 @@ public final class KafkaTracing {
     Builder(KafkaTracing kafkaTracing) {
       this.messagingTracing = kafkaTracing.messagingTracing;
       this.remoteServiceName = kafkaTracing.remoteServiceName;
-      this.shareTraceOnConsumption = kafkaTracing.shareTraceOnConsumption;
+      this.rootSpanOnReceiveBatch = kafkaTracing.rootSpanOnReceiveBatch;
     }
 
     /**
@@ -95,8 +95,8 @@ public final class KafkaTracing {
      *
      * @since 5.10
      */
-    public Builder shareTraceOnConsumption(boolean shareTraceOnConsumption) {
-      this.shareTraceOnConsumption = shareTraceOnConsumption;
+    public Builder rootSpanOnReceiveBatch(boolean rootSpanOnReceiveBatch) {
+      this.rootSpanOnReceiveBatch = rootSpanOnReceiveBatch;
       return this;
     }
 
@@ -123,7 +123,7 @@ public final class KafkaTracing {
   final SamplerFunction<MessagingRequest> producerSampler, consumerSampler;
   final Set<String> propagationKeys;
   final String remoteServiceName;
-  final boolean shareTraceOnConsumption;
+  final boolean rootSpanOnReceiveBatch;
 
   KafkaTracing(Builder builder) { // intentionally hidden constructor
     this.messagingTracing = builder.messagingTracing;
@@ -138,7 +138,7 @@ public final class KafkaTracing {
     this.consumerSampler = messagingTracing.consumerSampler();
     this.propagationKeys = new LinkedHashSet<>(propagation.keys());
     this.remoteServiceName = builder.remoteServiceName;
-    this.shareTraceOnConsumption = builder.shareTraceOnConsumption;
+    this.rootSpanOnReceiveBatch = builder.rootSpanOnReceiveBatch;
   }
 
   /** @since 5.9 exposed for Kafka Streams tracing. */

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -13,16 +13,6 @@
  */
 package brave.kafka.clients;
 
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
-
 import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracer;
@@ -35,6 +25,14 @@ import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.SamplerFunction;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 
 /** Use this class to decorate your Kafka consumer / producer and enable Tracing. */
 public final class KafkaTracing {
@@ -89,7 +87,7 @@ public final class KafkaTracing {
     /**
      * Controls the sharing of a poll span for incoming spans with no trace context.
      *
-     * <b/>If true, all the spans received in a poll batch that do not have trace-context will be added 
+     * <b/>If true, all the spans received in a poll batch that do not have trace-context will be added
      * to a single new poll root span. Otherwise, a poll span will be created for each such message.
      *
      * @since 5.10

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -54,13 +54,25 @@ public final class KafkaTracing {
     return new Builder(messagingTracing);
   }
 
+  /** @since 5.10 **/
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
   public static final class Builder {
     final MessagingTracing messagingTracing;
     String remoteServiceName = "kafka";
+    boolean shareTraceOnConsumption = true;
 
     Builder(MessagingTracing messagingTracing) {
       if (messagingTracing == null) throw new NullPointerException("messagingTracing == null");
       this.messagingTracing = messagingTracing;
+    }
+
+    Builder(KafkaTracing kafkaTracing) {
+      this.messagingTracing = kafkaTracing.messagingTracing;
+      this.remoteServiceName = kafkaTracing.remoteServiceName;
+      this.shareTraceOnConsumption = kafkaTracing.shareTraceOnConsumption;
     }
 
     /**
@@ -69,6 +81,12 @@ public final class KafkaTracing {
      */
     public Builder remoteServiceName(String remoteServiceName) {
       this.remoteServiceName = remoteServiceName;
+      return this;
+    }
+
+    /** @since 5.10  **/
+    public Builder shareTraceOnConsumption(boolean shareTraceOnConsumption) {
+      this.shareTraceOnConsumption = shareTraceOnConsumption;
       return this;
     }
 
@@ -95,6 +113,7 @@ public final class KafkaTracing {
   final SamplerFunction<MessagingRequest> producerSampler, consumerSampler;
   final Set<String> propagationKeys;
   final String remoteServiceName;
+  final boolean shareTraceOnConsumption;
 
   KafkaTracing(Builder builder) { // intentionally hidden constructor
     this.messagingTracing = builder.messagingTracing;
@@ -109,6 +128,7 @@ public final class KafkaTracing {
     this.consumerSampler = messagingTracing.consumerSampler();
     this.propagationKeys = new LinkedHashSet<>(propagation.keys());
     this.remoteServiceName = builder.remoteServiceName;
+    this.shareTraceOnConsumption = builder.shareTraceOnConsumption;
   }
 
   /** @since 5.9 exposed for Kafka Streams tracing. */

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -85,12 +85,13 @@ public final class KafkaTracing {
     }
 
     /**
-     * When no trace context or extra fields have been added to an incoming consumed message propagation,
-     * records from the same partition are been traced under the same parent id, sharing the same trace.
+     * Opt-out of sharing poll span when no trace-context or extra propagation field is available on
+     * incoming messages.
      *
-     * <b/>If true, this will share a trace for messages received as part of
-     * a batch with no trace context, and create an individual trace by message; leading to 1 trace
-     * per poll operation.
+     * <b/>If true, a poll root span will be created for all messages without trace-context, and all
+     * following processing spans will be under the same trace.
+     *
+     * <b/>If false, a poll span will be created by message received.
      *
      * @since 5.10
      */

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -53,7 +53,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   final SamplerFunction<MessagingRequest> sampler;
   final Injector<KafkaConsumerRequest> injector;
   final String remoteServiceName;
-  final boolean rootSpanOnReceiveBatch;
+  final boolean singleRootSpanOnReceiveBatch;
   // replicate org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener behaviour
   static final ConsumerRebalanceListener NO_OP_CONSUMER_REBALANCE_LISTENER =
     new ConsumerRebalanceListener() {
@@ -72,7 +72,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
     this.sampler = kafkaTracing.consumerSampler;
     this.injector = kafkaTracing.consumerInjector;
     this.remoteServiceName = kafkaTracing.remoteServiceName;
-    this.rootSpanOnReceiveBatch = kafkaTracing.rootSpanOnReceiveBatch;
+    this.singleRootSpanOnReceiveBatch = kafkaTracing.singleRootSpanOnReceiveBatch;
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0
@@ -98,7 +98,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
 
         // If we extracted neither a trace context, nor request-scoped data (extra),
         // and sharing trace is enabled make or reuse a span for this topic
-        if (extracted.equals(TraceContextOrSamplingFlags.EMPTY) && rootSpanOnReceiveBatch) {
+        if (extracted.equals(TraceContextOrSamplingFlags.EMPTY) && singleRootSpanOnReceiveBatch) {
           Span span = consumerSpansForTopic.get(topic);
           if (span == null) {
             span = kafkaTracing.nextMessagingSpan(sampler, request, extracted);

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -97,7 +97,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
           kafkaTracing.extractAndClearHeaders(extractor, request, record.headers());
 
         // If we extracted neither a trace context, nor request-scoped data (extra),
-        // make or reuse a span for this topic
+        // and sharing trace is enabled make or reuse a span for this topic
         if (extracted.equals(TraceContextOrSamplingFlags.EMPTY) && shareTraceOnConsumption) {
           Span span = consumerSpansForTopic.get(topic);
           if (span == null) {

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -53,7 +53,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   final SamplerFunction<MessagingRequest> sampler;
   final Injector<KafkaConsumerRequest> injector;
   final String remoteServiceName;
-  final boolean shareTraceOnConsumption;
+  final boolean rootSpanOnReceiveBatch;
   // replicate org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener behaviour
   static final ConsumerRebalanceListener NO_OP_CONSUMER_REBALANCE_LISTENER =
     new ConsumerRebalanceListener() {
@@ -72,7 +72,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
     this.sampler = kafkaTracing.consumerSampler;
     this.injector = kafkaTracing.consumerInjector;
     this.remoteServiceName = kafkaTracing.remoteServiceName;
-    this.shareTraceOnConsumption = kafkaTracing.shareTraceOnConsumption;
+    this.rootSpanOnReceiveBatch = kafkaTracing.rootSpanOnReceiveBatch;
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0
@@ -98,7 +98,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
 
         // If we extracted neither a trace context, nor request-scoped data (extra),
         // and sharing trace is enabled make or reuse a span for this topic
-        if (extracted.equals(TraceContextOrSamplingFlags.EMPTY) && shareTraceOnConsumption) {
+        if (extracted.equals(TraceContextOrSamplingFlags.EMPTY) && rootSpanOnReceiveBatch) {
           Span span = consumerSpansForTopic.get(topic);
           if (span == null) {
             span = kafkaTracing.nextMessagingSpan(sampler, request, extracted);

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
@@ -124,7 +124,7 @@ public class TracingConsumerTest extends BaseTracingTest {
   }
 
   @Test
-  public void should_create_only_one_consumer_span_per_topic() {
+  public void should_create_only_one_consumer_span_per_topic_whenSharingEnabled() {
     Map<TopicPartition, Long> offsets = new HashMap<>();
     // 2 partitions in the same topic
     offsets.put(new TopicPartition(TEST_TOPIC, 0), 0L);
@@ -147,5 +147,33 @@ public class TracingConsumerTest extends BaseTracingTest {
       .hasSize(1)
       .flatExtracting(s -> s.tags().entrySet())
       .containsOnly(entry("kafka.topic", "myTopic"));
+  }
+
+  @Test
+  public void should_create_individual_span_per_topic_whenSharingDisabled() {
+    kafkaTracing = kafkaTracing.toBuilder().shareTraceOnConsumption(false).build();
+
+    Map<TopicPartition, Long> offsets = new HashMap<>();
+    // 2 partitions in the same topic
+    offsets.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+    offsets.put(new TopicPartition(TEST_TOPIC, 1), 0L);
+
+    consumer.updateBeginningOffsets(offsets);
+    consumer.assign(offsets.keySet());
+
+    // create 500 messages
+    for (int i = 0; i < 250; i++) {
+      consumer.addRecord(new ConsumerRecord<>(TEST_TOPIC, 0, i, TEST_KEY, TEST_VALUE));
+      consumer.addRecord(new ConsumerRecord<>(TEST_TOPIC, 1, i, TEST_KEY, TEST_VALUE));
+    }
+
+    Consumer<String, String> tracingConsumer = kafkaTracing.consumer(consumer);
+    tracingConsumer.poll(10);
+
+    // only one consumer span reported
+    assertThat(spans)
+        .hasSize(500)
+        .flatExtracting(s -> s.tags().entrySet())
+        .containsOnly(entry("kafka.topic", "myTopic"));
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
@@ -151,7 +151,7 @@ public class TracingConsumerTest extends BaseTracingTest {
 
   @Test
   public void should_create_individual_span_per_topic_whenSharingDisabled() {
-    kafkaTracing = kafkaTracing.toBuilder().shareTraceOnConsumption(false).build();
+    kafkaTracing = kafkaTracing.toBuilder().rootSpanOnReceiveBatch(false).build();
 
     Map<TopicPartition, Long> offsets = new HashMap<>();
     // 2 partitions in the same topic

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingConsumerTest.java
@@ -151,7 +151,7 @@ public class TracingConsumerTest extends BaseTracingTest {
 
   @Test
   public void should_create_individual_span_per_topic_whenSharingDisabled() {
-    kafkaTracing = kafkaTracing.toBuilder().rootSpanOnReceiveBatch(false).build();
+    kafkaTracing = kafkaTracing.toBuilder().singleRootSpanOnReceiveBatch(false).build();
 
     Map<TopicPartition, Long> offsets = new HashMap<>();
     // 2 partitions in the same topic

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -90,11 +90,6 @@ public final class KafkaStreamsTracing {
     return new Builder(KafkaTracing.create(messagingTracing));
   }
 
-  /** @since 5.10 */
-  public static Builder newBuilder(KafkaTracing kafkaTracing) {
-    return new Builder(kafkaTracing);
-  }
-
   /**
    * Provides a {@link KafkaClientSupplier} with tracing enabled, hence Producer and Consumer
    * operations will be traced.

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -57,7 +57,7 @@ public final class KafkaStreamsTracing {
 
   KafkaStreamsTracing(Builder builder) { // intentionally hidden constructor
     this.kafkaTracing = builder.kafkaTracing.toBuilder()
-        .rootSpanOnReceiveBatch(builder.rootSpanOnReceiveBatch)
+        .singleRootSpanOnReceiveBatch(builder.singleRootSpanOnReceiveBatch)
         .build();
     this.tracer = kafkaTracing.messagingTracing().tracing().tracer();
     Propagation<String> propagation = kafkaTracing.messagingTracing().tracing().propagation();
@@ -449,7 +449,7 @@ public final class KafkaStreamsTracing {
 
   public static final class Builder {
     final KafkaTracing kafkaTracing;
-    boolean rootSpanOnReceiveBatch = false;
+    boolean singleRootSpanOnReceiveBatch = false;
 
     Builder(KafkaTracing kafkaTracing) {
       if (kafkaTracing == null) throw new NullPointerException("kafkaTracing == null");
@@ -457,18 +457,15 @@ public final class KafkaStreamsTracing {
     }
 
     /**
-     * Opt-out of sharing poll span when no trace-context or extra propagation field is available on
-     * incoming messages.
+     * Controls the sharing of a poll span for incoming spans with no trace context.
      *
-     * <b/>If true, a poll root span will be created for all messages without trace-context, and all
-     * following processing spans will be under the same trace.
-     *
-     * <b/>If false, a poll span will be created by message received.
+     * <b/>If true, all the spans received in a poll batch that do not have trace-context will be added 
+     * to a single new poll root span. Otherwise, a poll span will be created for each such message.
      *
      * @since 5.10
      */
-    public Builder rootSpanOnReceiveBatch(boolean rootSpanOnReceiveBatch) {
-      this.rootSpanOnReceiveBatch = rootSpanOnReceiveBatch;
+    public Builder singleRootSpanOnReceiveBatch(boolean singleRootSpanOnReceiveBatch) {
+      this.singleRootSpanOnReceiveBatch = singleRootSpanOnReceiveBatch;
       return this;
     }
 

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -440,7 +440,17 @@ public final class KafkaStreamsTracing {
       this.kafkaTracing = kafkaTracing;
     }
 
-    /** @since 5.10 **/
+    /**
+     * When no trace context or extra fields have been added to an incoming consumed message
+     * propagation, records from the same partition are been traced under the same parent id,
+     * sharing the same trace.
+     *
+     * <b/>If true, this will share a trace for messages received as part of
+     * a batch with no trace context, and create an individual trace by message; leading to 1 trace
+     * per poll operation.
+     *
+     * @since 5.10
+     */
     public Builder shareTraceOnConsumption(boolean shareTraceOnConsumption) {
       this.shareTraceOnConsumption = shareTraceOnConsumption;
       return this;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -55,7 +55,9 @@ public final class KafkaStreamsTracing {
   final TraceContext.Injector<Headers> injector;
 
   KafkaStreamsTracing(Builder builder) { // intentionally hidden constructor
-    this.kafkaTracing = builder.kafkaTracing;
+    this.kafkaTracing = builder.kafkaTracing.toBuilder()
+        .shareTraceOnConsumption(builder.shareTraceOnConsumption)
+        .build();
     this.tracer = kafkaTracing.messagingTracing().tracing().tracer();
     Propagation<String> propagation = kafkaTracing.messagingTracing().tracing().propagation();
     this.propagationKeys = new LinkedHashSet<>(propagation.keys());
@@ -431,10 +433,17 @@ public final class KafkaStreamsTracing {
 
   public static final class Builder {
     final KafkaTracing kafkaTracing;
+    boolean shareTraceOnConsumption = false;
 
     Builder(KafkaTracing kafkaTracing) {
       if (kafkaTracing == null) throw new NullPointerException("kafkaTracing == null");
       this.kafkaTracing = kafkaTracing;
+    }
+
+    /** @since 5.10 **/
+    public Builder shareTraceOnConsumption(boolean shareTraceOnConsumption) {
+      this.shareTraceOnConsumption = shareTraceOnConsumption;
+      return this;
     }
 
     public KafkaStreamsTracing build() {

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -18,6 +18,7 @@ import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.Tracing;
 import brave.kafka.clients.KafkaTracing;
+import brave.messaging.MessagingTracing;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -69,9 +70,29 @@ public final class KafkaStreamsTracing {
     return create(KafkaTracing.create(tracing));
   }
 
+  /** @since 5.10 */
+  public static KafkaStreamsTracing create(MessagingTracing messagingTracing) {
+    return new Builder(KafkaTracing.create(messagingTracing)).build();
+  }
+
   /** @since 5.9 */
   public static KafkaStreamsTracing create(KafkaTracing kafkaTracing) {
     return new Builder(kafkaTracing).build();
+  }
+
+  /** @since 5.10 */
+  public static Builder newBuilder(Tracing tracing) {
+    return new Builder(KafkaTracing.create(tracing));
+  }
+
+  /** @since 5.10 */
+  public static Builder newBuilder(MessagingTracing messagingTracing) {
+    return new Builder(KafkaTracing.create(messagingTracing));
+  }
+
+  /** @since 5.10 */
+  public static Builder newBuilder(KafkaTracing kafkaTracing) {
+    return new Builder(kafkaTracing);
   }
 
   /**

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -57,7 +57,7 @@ public final class KafkaStreamsTracing {
 
   KafkaStreamsTracing(Builder builder) { // intentionally hidden constructor
     this.kafkaTracing = builder.kafkaTracing.toBuilder()
-        .shareTraceOnConsumption(builder.shareTraceOnConsumption)
+        .rootSpanOnReceiveBatch(builder.rootSpanOnReceiveBatch)
         .build();
     this.tracer = kafkaTracing.messagingTracing().tracing().tracer();
     Propagation<String> propagation = kafkaTracing.messagingTracing().tracing().propagation();
@@ -449,7 +449,7 @@ public final class KafkaStreamsTracing {
 
   public static final class Builder {
     final KafkaTracing kafkaTracing;
-    boolean shareTraceOnConsumption = false;
+    boolean rootSpanOnReceiveBatch = false;
 
     Builder(KafkaTracing kafkaTracing) {
       if (kafkaTracing == null) throw new NullPointerException("kafkaTracing == null");
@@ -467,8 +467,8 @@ public final class KafkaStreamsTracing {
      *
      * @since 5.10
      */
-    public Builder shareTraceOnConsumption(boolean shareTraceOnConsumption) {
-      this.shareTraceOnConsumption = shareTraceOnConsumption;
+    public Builder rootSpanOnReceiveBatch(boolean rootSpanOnReceiveBatch) {
+      this.rootSpanOnReceiveBatch = rootSpanOnReceiveBatch;
       return this;
     }
 

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -457,10 +457,11 @@ public final class KafkaStreamsTracing {
     }
 
     /**
-     * Controls the sharing of a poll span for incoming spans with no trace context.
+     * Controls the sharing of a {@code poll} span for incoming spans with no trace context.
      *
-     * <b/>If true, all the spans received in a poll batch that do not have trace-context will be added 
-     * to a single new poll root span. Otherwise, a poll span will be created for each such message.
+     * <b/>If true, all the spans received in a {@code poll} batch that do not have trace-context
+     * will be added to a single new poll root span. Otherwise, a {@code poll} span will be created
+     * for each such message.
      *
      * @since 5.10
      */

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -457,13 +457,13 @@ public final class KafkaStreamsTracing {
     }
 
     /**
-     * When no trace context or extra fields have been added to an incoming consumed message
-     * propagation, records from the same partition are been traced under the same parent id,
-     * sharing the same trace.
+     * Opt-out of sharing poll span when no trace-context or extra propagation field is available on
+     * incoming messages.
      *
-     * <b/>If true, this will share a trace for messages received as part of
-     * a batch with no trace context, and create an individual trace by message; leading to 1 trace
-     * per poll operation.
+     * <b/>If true, a poll root span will be created for all messages without trace-context, and all
+     * following processing spans will be under the same trace.
+     *
+     * <b/>If false, a poll span will be created by message received.
      *
      * @since 5.10
      */

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/BaseTracingTest.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/BaseTracingTest.java
@@ -14,6 +14,7 @@
 package brave.kafka.streams;
 
 import brave.Tracing;
+import brave.messaging.MessagingTracing;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -61,7 +62,8 @@ abstract class BaseTracingTest {
       .build())
     .spanReporter(spans::add)
     .build();
-  KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.create(tracing);
+  MessagingTracing messagingTracing = MessagingTracing.create(tracing);
+  KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.create(messagingTracing);
 
   ProcessorSupplier<String, String> fakeProcessorSupplier =
     kafkaStreamsTracing.processor(

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -150,7 +150,7 @@ public class ITKafkaStreamsTracing {
         .spanReporter(spans::add)
         .build();
     KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.newBuilder(tracing)
-        .shareTraceOnConsumption(false)
+        .rootSpanOnReceiveBatch(false)
         .build();
     KafkaStreams streams = kafkaStreamsTracing.kafkaStreams(topology, streamsProperties());
 
@@ -189,7 +189,7 @@ public class ITKafkaStreamsTracing {
         .build();
     MessagingTracing messagingTracing = MessagingTracing.create(tracing);
     KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.newBuilder(messagingTracing)
-        .shareTraceOnConsumption(true)
+        .rootSpanOnReceiveBatch(true)
         .build();
     KafkaStreams streams = kafkaStreamsTracing.kafkaStreams(topology, streamsProperties());
 

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -150,7 +150,7 @@ public class ITKafkaStreamsTracing {
         .spanReporter(spans::add)
         .build();
     KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.newBuilder(tracing)
-        .rootSpanOnReceiveBatch(false)
+        .singleRootSpanOnReceiveBatch(false)
         .build();
     KafkaStreams streams = kafkaStreamsTracing.kafkaStreams(topology, streamsProperties());
 
@@ -189,7 +189,7 @@ public class ITKafkaStreamsTracing {
         .build();
     MessagingTracing messagingTracing = MessagingTracing.create(tracing);
     KafkaStreamsTracing kafkaStreamsTracing = KafkaStreamsTracing.newBuilder(messagingTracing)
-        .rootSpanOnReceiveBatch(true)
+        .singleRootSpanOnReceiveBatch(true)
         .build();
     KafkaStreams streams = kafkaStreamsTracing.kafkaStreams(topology, streamsProperties());
 


### PR DESCRIPTION
fix #1032 

**Context:**

Kafka Consumers obtain records from a Kafka topics by polling from an offset. By design, poll operation return an array of records, to be processed usually in a loop.

This `poll` operation is traced and create an initial span on the consumer application. Right before creating this span, incoming record is checked to see if it has a trace context or not. If it does, `poll` span will be created to continue a record's trace. If it doesn't, it will create a `poll` span to be shared with other records that doesn't have a trace context in its headers.

 This PR is aimed to allow users to opt-out this mechanism of creating a shared span for records without a trace context. Instead, a `poll` span will be created by record.

I'd like to propose the following defaults:

- Kafka Consumer: `shareTraceOnConsumption=true` to don't break current behavior on consumers; as plain Kafka Consumers are usually used to sink data somewhere.
- Kafka Streams: `shareTraceOnConsumption=false` as Kafka Streams usually propagate context to other topics, leading to even larger traces that if batched, parent trace will be too big.