### PR TITLE
Fix path parsing of HttpClient to return the whole path, not only las…

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -198,7 +198,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
   }
 
   @Test public void supportsPortableCustomization() throws Exception {
-    String uri = "/foo?z=2&yAA=1";
+    String uri = "/foo/bar?z=2&yAA=1";
 
     close();
     httpTracing = httpTracing.toBuilder()
@@ -227,7 +227,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
     Span span = takeSpan();
     assertThat(span.name())
-      .isEqualTo("get /foo");
+      .isEqualTo("get /foo/bar");
 
     assertThat(span.remoteServiceName())
       .isEqualTo("remote-service");

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
@@ -81,6 +81,9 @@ final class TracingProtocolExec implements ClientExecChain {
     }
 
     @Override public String path() {
+      if (delegate instanceof HttpRequestWrapper) {
+        return ((HttpRequestWrapper) delegate).getURI().getPath();
+      }
       String result = delegate.getRequestLine().getUri();
       int queryIndex = result.indexOf('?');
       return queryIndex == -1 ? result : result.substring(0, queryIndex);

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
@@ -82,9 +82,8 @@ final class TracingProtocolExec implements ClientExecChain {
 
     @Override public String path() {
       String result = delegate.getRequestLine().getUri();
-      int begin = result.lastIndexOf('/');
       int queryIndex = result.indexOf('?');
-      return queryIndex == -1 ? result.substring(begin) : result.substring(begin, queryIndex);
+      return queryIndex == -1 ? result : result.substring(0, queryIndex);
     }
 
     @Override public String url() {


### PR DESCRIPTION
…t part.

Parsers are supposed to return the whole path, not just last part. I copied the implementation from https://github.com/openzipkin/brave/blob/master/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java#L269

Fixes #1035 