### PR TITLE
fix re-setting properties on BytesMessage

### DIFF
--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -52,7 +52,7 @@ final class PropertyFilter {
       return;
     }
     
-    if (disjoint(namesToClear, names)) {
+    if (disjoint(namesToClear, names) && message instanceof BytesMessage) {
       return;
     }
 
@@ -81,10 +81,10 @@ final class PropertyFilter {
     }
 
     // workaround for ActiveMQBytesMessage
-    if ( message instanceof BytesMessage ) {
-      resetBytesMessageProperties( message, out );
+    if (message instanceof BytesMessage) {
+      resetBytesMessageProperties(message, out);
     } else {
-      resetProperties( message, out );
+      resetProperties(message, out);
     }
   }
 

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -13,88 +13,112 @@
  */
 package brave.jms;
 
+import static brave.jms.JmsTracing.log;
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.Message;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
-import javax.jms.Message;
-
-import static brave.internal.Throwables.propagateIfFatal;
-import static brave.jms.JmsTracing.log;
+import brave.internal.Platform;
 
 // Similar to https://github.com/apache/camel/blob/b9a3117f19dd19abd2ea8b789c42c3e86fe4c488/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessageHelper.java
 final class PropertyFilter {
-  /**
-   * This implies copying properties because the JMS spec says you can't write properties upon
-   * receipt until {@link Message#clearProperties()} has been called.
-   *
-   * <p> See https://docs.oracle.com/javaee/6/api/javax/jms/Message.html
-   */
-  static void filterProperties(Message message, Set<String> namesToClear) {
-    ArrayList<Object> retainedProperties = messagePropertiesBuffer();
-    try {
-      filterProperties(message, namesToClear, retainedProperties);
-    } finally {
-      retainedProperties.clear(); // ensure no object references are held due to any exception
-    }
-  }
 
-  static void filterProperties(Message message, Set<String> namesToClear, List<Object> out) {
-    Enumeration<?> names;
-    try {
-      names = message.getPropertyNames();
-    } catch (Throwable t) {
-      propagateIfFatal(t);
-      log(t, "error getting property names from {0}", message, null);
-      return;
+    /**
+     * This implies copying properties because the JMS spec says you can't write properties upon
+     * receipt until {@link Message#clearProperties()} has been called.
+     * <p> See https://docs.oracle.com/javaee/6/api/javax/jms/Message.html
+     */
+    static void filterProperties( Message message, Set<String> namesToClear ) {
+        ArrayList<Object> retainedProperties = messagePropertiesBuffer();
+        try {
+            filterProperties( message, namesToClear, retainedProperties );
+        } finally {
+            retainedProperties.clear(); // ensure no object references are held due to any exception
+        }
     }
 
-    while (names.hasMoreElements()) {
-      String name = (String) names.nextElement();
-      Object value;
-      try {
-        value = message.getObjectProperty(name);
-      } catch (Throwable t) {
-        propagateIfFatal(t);
-        log(t, "error getting property {0} from message {1}", name, message);
-        return;
-      }
-      if (!namesToClear.contains(name) && value != null) {
-        out.add(name);
-        out.add(value);
-      }
+    static void filterProperties( Message message, Set<String> namesToClear, List<Object> out ) {
+        Enumeration<?> names;
+        try {
+            names = message.getPropertyNames();
+        } catch ( JMSException e ) {
+            Platform.get().log( "error getting property names from {0}", message, e );
+            return;
+        }
+
+        while ( names.hasMoreElements() ) {
+            String name = (String) names.nextElement();
+            Object value;
+            try {
+                value = message.getObjectProperty( name );
+            } catch ( JMSException e ) {
+                log( e, "error getting property {0} from message {1}", name, message );
+                return;
+            }
+            if ( !namesToClear.contains( name ) && value != null ) {
+                out.add( name );
+                out.add( value );
+            }
+        }
+
+        // redo the properties to keep
+        try {
+            message.clearProperties();
+        } catch ( JMSException e ) {
+            Platform.get().log( "error clearing properties of {0}", message, e );
+            return;
+        }
+
+        // workaround for ActiveMQBytesMessage
+        if ( message instanceof BytesMessage ) {
+            resetBytesMessageProperties( message, out );
+        } else {
+            resetProperties( message, out );
+        }
+
     }
 
-    // redo the properties to keep
-    try {
-      message.clearProperties();
-    } catch (Throwable t) {
-      propagateIfFatal(t);
-      log(t, "error clearing properties of {0}", message, null);
-      return;
+    private static void resetBytesMessageProperties( Message message, List<Object> out ) {
+        try {
+            BytesMessage bytesMessage = (BytesMessage) message;
+            byte[] body = new byte[(int) bytesMessage.getBodyLength()];
+            bytesMessage.reset();
+            bytesMessage.readBytes( body );
+            message.clearBody();
+            resetProperties( message, out );
+            bytesMessage.writeBytes( body );
+            bytesMessage.reset();
+        } catch ( JMSException e ) {
+            log( e, "unable to reset BytesMessage body {0}", message, e );
+        }
     }
 
-    for (int i = 0, length = out.size(); i < length; i += 2) {
-      String name = out.get(i).toString();
-      try {
-        message.setObjectProperty(name, out.get(i + 1));
-      } catch (Throwable t) {
-        propagateIfFatal(t);
-        log(t, "error setting property {0} on message {1}", name, message);
-        // continue on error when re-setting properties as it is better than not.
-      }
+    private static void resetProperties( Message message, List<Object> out ) {
+        for ( int i = 0, length = out.size(); i < length; i += 2 ) {
+            String name = out.get( i ).toString();
+            try {
+                message.setObjectProperty( name, out.get( i + 1 ) );
+            } catch ( JMSException e ) {
+                log( e, "error setting property {0} on message {1}", name, message );
+                // continue on error when re-setting properties as it is better than not.
+            }
+        }
     }
-  }
 
-  static final ThreadLocal<ArrayList<Object>> MESSAGE_PROPERTIES_BUFFER = new ThreadLocal<>();
+    static final ThreadLocal<ArrayList<Object>> MESSAGE_PROPERTIES_BUFFER = new ThreadLocal<>();
 
-  /** Also use pair indexing for temporary message properties: (name, value). */
-  static ArrayList<Object> messagePropertiesBuffer() {
-    ArrayList<Object> messagePropertiesBuffer = MESSAGE_PROPERTIES_BUFFER.get();
-    if (messagePropertiesBuffer == null) {
-      messagePropertiesBuffer = new ArrayList<>();
-      MESSAGE_PROPERTIES_BUFFER.set(messagePropertiesBuffer);
+    /**
+     * Also use pair indexing for temporary message properties: (name, value).
+     */
+    static ArrayList<Object> messagePropertiesBuffer() {
+        ArrayList<Object> messagePropertiesBuffer = MESSAGE_PROPERTIES_BUFFER.get();
+        if ( messagePropertiesBuffer == null ) {
+            messagePropertiesBuffer = new ArrayList<>();
+            MESSAGE_PROPERTIES_BUFFER.set( messagePropertiesBuffer );
+        }
+        return messagePropertiesBuffer;
     }
-    return messagePropertiesBuffer;
-  }
 }

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -51,25 +51,28 @@ final class PropertyFilter {
       return;
     }
     
+    boolean disjoint = true;
     for (String name: names) {
-        if (!namesToClear.contains(name)) {
-            Object value;
-            try {
-                value = message.getObjectProperty( name );
-            } catch ( Throwable t ) {
-                propagateIfFatal( t );
-                log( t, "error getting property {0} from message {1}", name, message );
-                return;
-            }
-            if ( value != null ) {
-                out.add( name );
-                out.add( value );
-            }
+      if (!namesToClear.contains(name)) {
+        Object value;
+        try {
+          value = message.getObjectProperty( name );
+        } catch ( Throwable t ) {
+          propagateIfFatal( t );
+          log( t, "error getting property {0} from message {1}", name, message );
+          return;
         }
+        if ( value != null ) {
+          out.add( name );
+          out.add( value );
+        }
+      } else {
+        disjoint = false;
+      }
     }
-    
-    if (out.isEmpty()) {
-        return;
+
+    if (disjoint) {
+      return;
     }
 
     // redo the properties to keep

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -56,7 +56,7 @@ final class PropertyFilter {
       return;
     }
 
-    names.forEach( name -> {
+    for (String name: names) {
       Object value;
       try {
         value = message.getObjectProperty(name);
@@ -69,7 +69,7 @@ final class PropertyFilter {
         out.add(name);
         out.add(value);
       }
-    });
+    }
 
     // redo the properties to keep
     try {

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -52,20 +52,19 @@ final class PropertyFilter {
     }
     
     for (String name: names) {
-      if (namesToClear.contains(name)) {
-        continue;
-      }
-      Object value;
-      try {
-        value = message.getObjectProperty(name);
-      } catch (Throwable t) {
-        propagateIfFatal(t);
-        log(t, "error getting property {0} from message {1}", name, message);
-        return;
-      }
-      if (value != null) {
-        out.add(name);
-        out.add(value);
+      if (!namesToClear.contains(name)) {
+        Object value;
+        try {
+          value = message.getObjectProperty(name);
+        } catch (Throwable t) {
+          propagateIfFatal(t);
+          log(t, "error getting property {0} from message {1}", name, message);
+          return;
+        }
+        if (value != null) {
+          out.add(name);
+          out.add(value);
+        }
       }
     }
 
@@ -87,9 +86,6 @@ final class PropertyFilter {
   }
 
   private static void resetBytesMessageProperties( Message message, List<Object> out ) {
-    if (out.isEmpty()) {
-      return;
-    }
     try {
       BytesMessage bytesMessage = (BytesMessage) message;
       byte[] body = new byte[(int) bytesMessage.getBodyLength()];

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -95,7 +95,6 @@ final class PropertyFilter {
       message.clearBody();
       resetProperties(message, out);
       bytesMessage.writeBytes(body);
-      bytesMessage.reset();
     } catch (JMSException e) {
       propagateIfFatal(e);
       log(e, "unable to reset BytesMessage body {0}", message, e);

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -95,7 +95,7 @@ final class PropertyFilter {
       bytesMessage.writeBytes( body );
       bytesMessage.reset();
     } catch ( JMSException e ) {
-      propagateIfFatal(t);
+      propagateIfFatal(e);
       log( e, "unable to reset BytesMessage body {0}", message, e );
     }
   }

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -81,7 +81,7 @@ final class PropertyFilter {
     }
 
     // workaround for ActiveMQBytesMessage
-    if (message instanceof BytesMessage) {
+    if (message instanceof BytesMessage) { // BytesMessage requires clearing the body before reset properties otherwise it fails with MessageNotWriteableException
       resetBytesMessageProperties(message, out);
     } else {
       resetProperties(message, out);

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -51,10 +51,8 @@ final class PropertyFilter {
       return;
     }
     
-    boolean disjoint = true;
     for (String name: names) {
       if (namesToClear.contains(name)) {
-        disjoint = false;
         continue;
       }
       Object value;
@@ -69,10 +67,6 @@ final class PropertyFilter {
         out.add(name);
         out.add(value);
       }
-    }
-
-    if (disjoint && message instanceof BytesMessage) {
-      return;
     }
 
     // redo the properties to keep

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -13,112 +13,114 @@
  */
 package brave.jms;
 
-import static brave.jms.JmsTracing.log;
-import javax.jms.BytesMessage;
-import javax.jms.JMSException;
-import javax.jms.Message;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
-import brave.internal.Platform;
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import static brave.internal.Throwables.propagateIfFatal;
+import static brave.jms.JmsTracing.log;
 
 // Similar to https://github.com/apache/camel/blob/b9a3117f19dd19abd2ea8b789c42c3e86fe4c488/components/camel-jms/src/main/java/org/apache/camel/component/jms/JmsMessageHelper.java
 final class PropertyFilter {
+  /**
+   * This implies copying properties because the JMS spec says you can't write properties upon
+   * receipt until {@link Message#clearProperties()} has been called.
+   *
+   * <p> See https://docs.oracle.com/javaee/6/api/javax/jms/Message.html
+   */
+  static void filterProperties(Message message, Set<String> namesToClear) {
+    ArrayList<Object> retainedProperties = messagePropertiesBuffer();
+    try {
+      filterProperties(message, namesToClear, retainedProperties);
+    } finally {
+      retainedProperties.clear(); // ensure no object references are held due to any exception
+    }
+  }
 
-    /**
-     * This implies copying properties because the JMS spec says you can't write properties upon
-     * receipt until {@link Message#clearProperties()} has been called.
-     * <p> See https://docs.oracle.com/javaee/6/api/javax/jms/Message.html
-     */
-    static void filterProperties( Message message, Set<String> namesToClear ) {
-        ArrayList<Object> retainedProperties = messagePropertiesBuffer();
-        try {
-            filterProperties( message, namesToClear, retainedProperties );
-        } finally {
-            retainedProperties.clear(); // ensure no object references are held due to any exception
-        }
+  static void filterProperties(Message message, Set<String> namesToClear, List<Object> out) {
+    Enumeration<?> names;
+    try {
+      names = message.getPropertyNames();
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      log(t, "error getting property names from {0}", message, null);
+      return;
     }
 
-    static void filterProperties( Message message, Set<String> namesToClear, List<Object> out ) {
-        Enumeration<?> names;
-        try {
-            names = message.getPropertyNames();
-        } catch ( JMSException e ) {
-            Platform.get().log( "error getting property names from {0}", message, e );
-            return;
-        }
-
-        while ( names.hasMoreElements() ) {
-            String name = (String) names.nextElement();
-            Object value;
-            try {
-                value = message.getObjectProperty( name );
-            } catch ( JMSException e ) {
-                log( e, "error getting property {0} from message {1}", name, message );
-                return;
-            }
-            if ( !namesToClear.contains( name ) && value != null ) {
-                out.add( name );
-                out.add( value );
-            }
-        }
-
-        // redo the properties to keep
-        try {
-            message.clearProperties();
-        } catch ( JMSException e ) {
-            Platform.get().log( "error clearing properties of {0}", message, e );
-            return;
-        }
-
-        // workaround for ActiveMQBytesMessage
-        if ( message instanceof BytesMessage ) {
-            resetBytesMessageProperties( message, out );
-        } else {
-            resetProperties( message, out );
-        }
-
+    while (names.hasMoreElements()) {
+      String name = (String) names.nextElement();
+      Object value;
+      try {
+        value = message.getObjectProperty(name);
+      } catch (Throwable t) {
+        propagateIfFatal(t);
+        log(t, "error getting property {0} from message {1}", name, message);
+        return;
+      }
+      if (!namesToClear.contains(name) && value != null) {
+        out.add(name);
+        out.add(value);
+      }
     }
 
-    private static void resetBytesMessageProperties( Message message, List<Object> out ) {
-        try {
-            BytesMessage bytesMessage = (BytesMessage) message;
-            byte[] body = new byte[(int) bytesMessage.getBodyLength()];
-            bytesMessage.reset();
-            bytesMessage.readBytes( body );
-            message.clearBody();
-            resetProperties( message, out );
-            bytesMessage.writeBytes( body );
-            bytesMessage.reset();
-        } catch ( JMSException e ) {
-            log( e, "unable to reset BytesMessage body {0}", message, e );
-        }
+    // redo the properties to keep
+    try {
+      message.clearProperties();
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      log(t, "error clearing properties of {0}", message, null);
+      return;
     }
 
-    private static void resetProperties( Message message, List<Object> out ) {
-        for ( int i = 0, length = out.size(); i < length; i += 2 ) {
-            String name = out.get( i ).toString();
-            try {
-                message.setObjectProperty( name, out.get( i + 1 ) );
-            } catch ( JMSException e ) {
-                log( e, "error setting property {0} on message {1}", name, message );
-                // continue on error when re-setting properties as it is better than not.
-            }
-        }
+    // workaround for ActiveMQBytesMessage
+    if ( message instanceof BytesMessage ) {
+      resetBytesMessageProperties( message, out );
+    } else {
+      resetProperties( message, out );
     }
+  }
 
-    static final ThreadLocal<ArrayList<Object>> MESSAGE_PROPERTIES_BUFFER = new ThreadLocal<>();
-
-    /**
-     * Also use pair indexing for temporary message properties: (name, value).
-     */
-    static ArrayList<Object> messagePropertiesBuffer() {
-        ArrayList<Object> messagePropertiesBuffer = MESSAGE_PROPERTIES_BUFFER.get();
-        if ( messagePropertiesBuffer == null ) {
-            messagePropertiesBuffer = new ArrayList<>();
-            MESSAGE_PROPERTIES_BUFFER.set( messagePropertiesBuffer );
-        }
-        return messagePropertiesBuffer;
+  private static void resetBytesMessageProperties( Message message, List<Object> out ) {
+    try {
+      BytesMessage bytesMessage = (BytesMessage) message;
+      byte[] body = new byte[(int) bytesMessage.getBodyLength()];
+      bytesMessage.reset();
+      bytesMessage.readBytes( body );
+      message.clearBody();
+      resetProperties( message, out );
+      bytesMessage.writeBytes( body );
+      bytesMessage.reset();
+    } catch ( JMSException e ) {
+      log( e, "unable to reset BytesMessage body {0}", message, e );
     }
+  }
+
+  private static void resetProperties( Message message, List<Object> out ) {
+    for (int i = 0, length = out.size(); i < length; i += 2) {
+      String name = out.get(i).toString();
+      try {
+        message.setObjectProperty(name, out.get(i + 1));
+      } catch (Throwable t) {
+        propagateIfFatal(t);
+        log(t, "error setting property {0} on message {1}", name, message);
+        // continue on error when re-setting properties as it is better than not.
+      }
+    }
+  }
+
+  static final ThreadLocal<ArrayList<Object>> MESSAGE_PROPERTIES_BUFFER = new ThreadLocal<>();
+
+  /** Also use pair indexing for temporary message properties: (name, value). */
+  static ArrayList<Object> messagePropertiesBuffer() {
+    ArrayList<Object> messagePropertiesBuffer = MESSAGE_PROPERTIES_BUFFER.get();
+    if (messagePropertiesBuffer == null) {
+      messagePropertiesBuffer = new ArrayList<>();
+      MESSAGE_PROPERTIES_BUFFER.set(messagePropertiesBuffer);
+    }
+    return messagePropertiesBuffer;
+  }
 }

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -94,6 +94,7 @@ final class PropertyFilter {
       byte[] body = new byte[(int) bytesMessage.getBodyLength()];
       bytesMessage.reset();
       bytesMessage.readBytes(body);
+      // setObjectProperty on BytesMessage requires clearing the body otherwise it fails with MessageNotWriteableException
       message.clearBody();
       resetProperties(message, out);
       bytesMessage.writeBytes(body);

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -53,25 +53,25 @@ final class PropertyFilter {
     
     boolean disjoint = true;
     for (String name: names) {
-      if (!namesToClear.contains(name)) {
-        Object value;
-        try {
-          value = message.getObjectProperty( name );
-        } catch ( Throwable t ) {
-          propagateIfFatal( t );
-          log( t, "error getting property {0} from message {1}", name, message );
-          return;
-        }
-        if ( value != null ) {
-          out.add( name );
-          out.add( value );
-        }
-      } else {
+      if (namesToClear.contains(name)) {
         disjoint = false;
+        continue;
+      }
+      Object value;
+      try {
+        value = message.getObjectProperty(name);
+      } catch (Throwable t) {
+        propagateIfFatal(t);
+        log(t, "error getting property {0} from message {1}", name, message);
+        return;
+      }
+      if (value != null) {
+        out.add(name);
+        out.add(value);
       }
     }
 
-    if (disjoint) {
+    if (disjoint && message instanceof BytesMessage) {
       return;
     }
 
@@ -93,6 +93,9 @@ final class PropertyFilter {
   }
 
   private static void resetBytesMessageProperties( Message message, List<Object> out ) {
+    if (out.isEmpty()) {
+      return;
+    }
     try {
       BytesMessage bytesMessage = (BytesMessage) message;
       byte[] body = new byte[(int) bytesMessage.getBodyLength()];

--- a/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
+++ b/instrumentation/jms/src/main/java/brave/jms/PropertyFilter.java
@@ -95,6 +95,7 @@ final class PropertyFilter {
       bytesMessage.writeBytes( body );
       bytesMessage.reset();
     } catch ( JMSException e ) {
+      propagateIfFatal(t);
       log( e, "unable to reset BytesMessage body {0}", message, e );
     }
   }

--- a/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
@@ -21,9 +21,12 @@ import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.SamplerFunction;
-import javax.jms.Destination;
-import javax.jms.Message;
 import javax.jms.BytesMessage;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import static brave.jms.JmsTracing.log;
 
 abstract class TracingConsumer<C> {
   final C delegate;
@@ -64,7 +67,11 @@ abstract class TracingConsumer<C> {
     }
     injector.inject(span.context(), request);
     if (message instanceof BytesMessage) {
-      (BytesMessage message).reset();
+      try {
+        ((BytesMessage) message).reset();
+      } catch (JMSException e) {
+        log(e, "Unable to reset message {0}", message, null);
+      }
     }
   }
 

--- a/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
@@ -23,6 +23,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.SamplerFunction;
 import javax.jms.Destination;
 import javax.jms.Message;
+import javax.jms.BytesMessage;
 
 abstract class TracingConsumer<C> {
   final C delegate;
@@ -62,6 +63,9 @@ abstract class TracingConsumer<C> {
       span.start(timestamp).finish(timestamp);
     }
     injector.inject(span.context(), request);
+    if (message instanceof BytesMessage) {
+      (BytesMessage message).reset();
+    }
   }
 
   abstract @Nullable Destination destination(Message message);

--- a/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
@@ -21,12 +21,8 @@ import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.SamplerFunction;
-import javax.jms.BytesMessage;
 import javax.jms.Destination;
-import javax.jms.JMSException;
 import javax.jms.Message;
-
-import static brave.jms.JmsTracing.log;
 
 abstract class TracingConsumer<C> {
   final C delegate;
@@ -66,13 +62,6 @@ abstract class TracingConsumer<C> {
       span.start(timestamp).finish(timestamp);
     }
     injector.inject(span.context(), request);
-    if (message instanceof BytesMessage) {
-      try {
-        ((BytesMessage) message).reset();
-      } catch (JMSException e) {
-        log(e, "Unable to reset message {0}", message, null);
-      }
-    }
   }
 
   abstract @Nullable Destination destination(Message message);

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
@@ -250,7 +250,7 @@ public class ITJms_1_1_TracingMessageConsumer extends JmsTest {
     receive_resumesTrace(() -> messageProducer.send(message), messageConsumer);
   }
 
-  @Test(expected = ComparisonFailure.class) // TODO: https://github.com/openzipkin/brave/issues/967
+  @Test //(expected = ComparisonFailure.class) // TODO: https://github.com/openzipkin/brave/issues/967
   public void receive_resumesTrace_bytes() throws Exception {
     receive_resumesTrace(() -> messageProducer.send(bytesMessage), messageConsumer);
   }

--- a/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
@@ -61,7 +61,7 @@ public class PropertyFilterTest {
   // https://github.com/awslabs/amazon-sqs-java-messaging-lib/blob/b462bdceac814c56e75ee0ba638b3928ce8adee1/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java#L904-L909
   @Test public void filterProperties_message_handlesOnSetException() throws Exception {
     Message message = mock(Message.class);
-    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.enumeration(Arrays.asList("JMS_SQS_DeduplicationId", "b3"))));
+    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.singletonList("JMS_SQS_DeduplicationId")));
     when(message.getObjectProperty("JMS_SQS_DeduplicationId")).thenReturn("");
     doThrow(new IllegalArgumentException()).when(message).setObjectProperty(anyString(), eq(""));
 
@@ -70,7 +70,7 @@ public class PropertyFilterTest {
 
   @Test public void filterProperties_message_passesFatalOnSetException() throws Exception {
     Message message = mock(Message.class);
-    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.singletonList("JMS_SQS_DeduplicationId")));
+    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Arrays.asList("JMS_SQS_DeduplicationId", "b3")));
     when(message.getObjectProperty("JMS_SQS_DeduplicationId")).thenReturn("");
     doThrow(new LinkageError()).when(message).setObjectProperty(anyString(), eq(""));
 

--- a/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
@@ -61,7 +61,7 @@ public class PropertyFilterTest {
   // https://github.com/awslabs/amazon-sqs-java-messaging-lib/blob/b462bdceac814c56e75ee0ba638b3928ce8adee1/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java#L904-L909
   @Test public void filterProperties_message_handlesOnSetException() throws Exception {
     Message message = mock(Message.class);
-    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.singletonList("JMS_SQS_DeduplicationId")));
+    when(message.getPropertyNames()).thenReturn(Collections.enumeration(Collections.enumeration(Arrays.asList("JMS_SQS_DeduplicationId", "b3"))));
     when(message.getObjectProperty("JMS_SQS_DeduplicationId")).thenReturn("");
     doThrow(new IllegalArgumentException()).when(message).setObjectProperty(anyString(), eq(""));
 

--- a/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/PropertyFilterTest.java
@@ -13,6 +13,7 @@
  */
 package brave.jms;
 
+import java.util.Arrays;
 import java.util.Collections;
 import javax.jms.JMSException;
 import javax.jms.Message;


### PR DESCRIPTION
Sleuth JMS instrumentation cleared all properties on ActiveMQBytesMessage and was unable to put them back. 

fix MessageNotWriteableException - Message body is read-only while re-setting properties on BytesMessage

please squash commits with merge