### PR TITLE
fix #1045: Fix tracing of JAX-RS2 compatible clients.

### DIFF
--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -100,7 +100,7 @@ public final class TracingClientFilter implements ClientRequestFilter, ClientRes
     }
 
     @Override public void header(String name, String value) {
-      delegate.getStringHeaders().putSingle(name, value);
+      delegate.getHeaders().putSingle(name, value);
     }
   }
 

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/HttpClientRequestTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/HttpClientRequestTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jaxrs2;
+
+import brave.jaxrs2.TracingClientFilter.HttpClientRequest;
+import org.jboss.resteasy.core.Headers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpClientRequestTest {
+  @Mock ClientRequestContext request;
+
+  @Test public void method() {
+    when(request.getMethod()).thenReturn("GET");
+
+    assertThat(new HttpClientRequest(request).method()).isEqualTo("GET");
+  }
+
+  @Test public void path() {
+    when(request.getUri()).thenReturn(URI.create("http://localhost/api"));
+
+    assertThat(new HttpClientRequest(request).path()).isEqualTo("/api");
+  }
+
+  @Test public void url() {
+    when(request.getUri()).thenReturn(URI.create("http://localhost/api"));
+
+    assertThat(new HttpClientRequest(request).url()).isEqualTo("http://localhost/api");
+  }
+
+  @Test public void header() {
+    when(request.getHeaderString("name")).thenReturn("value");
+
+    assertThat(new HttpClientRequest(request).header("name")).isEqualTo("value");
+  }
+
+  @Test public void putHeader() {
+    MultivaluedMap<String, Object> headers = new Headers<>();
+    when(request.getHeaders()).thenReturn(headers);
+
+    new HttpClientRequest(request).header("name", "value");
+
+    assertThat(headers).containsExactly(entry("name", Collections.singletonList("value")));
+  }
+}

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jaxrs2;
+
+import brave.Span;
+import brave.test.http.ITHttpAsyncClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.Ignore;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.core.MediaType;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
+  @Override protected Client newClient(int port) {
+    return new ResteasyClientBuilder()
+      .register(TracingClientFilter.create(httpTracing))
+      .connectTimeout(1, TimeUnit.SECONDS)
+      .readTimeout(1, TimeUnit.SECONDS)
+      .executorService(httpTracing.tracing().currentTraceContext()
+        .executorService(Executors.newCachedThreadPool()))
+      .build();
+  }
+
+  @Override protected void closeClient(Client client) {
+    client.close();
+  }
+
+  @Override protected void get(Client client, String pathIncludingQuery) {
+    try {
+      client.target(url(pathIncludingQuery))
+        .request(MediaType.TEXT_PLAIN_TYPE)
+        .get(String.class);
+    } catch (ProcessingException ex) {
+      Span span = tracer().currentSpan();
+      if (null != span) {
+        span.error(ex).finish();
+      }
+      throw ex;
+    }
+  }
+
+  @Override protected void getAsync(Client client, String pathIncludingQuery) {
+    client.target(url(pathIncludingQuery))
+      .request(MediaType.TEXT_PLAIN_TYPE)
+      .async()
+      .get(new InvocationCallback<String>() {
+        @Override public void completed(String response) {
+        }
+
+        @Override public void failed(Throwable throwable) {
+          Span span = tracer().currentSpan();
+          if (null != span) {
+            span.error(throwable).finish();
+          }
+          throwable.printStackTrace();
+        }
+      });
+  }
+
+  @Override
+  protected void post(Client client, String pathIncludingQuery, String body) {
+      try {
+        client.target(url(pathIncludingQuery))
+          .request(MediaType.TEXT_PLAIN_TYPE)
+          .post(Entity.text(body), String.class);
+      } catch (ProcessingException ex) {
+        Span span = tracer().currentSpan();
+        if (null != span) {
+          span.error(ex).finish();
+        }
+        throw ex;
+      }
+  }
+
+  @Override @Ignore("blind to the implementation of redirects")
+  public void redirect() {
+  }
+
+  @Override @Ignore("doesn't know the remote address")
+  public void reportsServerAddress() {
+  }
+}


### PR DESCRIPTION
Addresses the issue when JAX-RS filter is unable to set the tracing headers because it's using the immutable view on request header's map.