### PR TITLE
Refactor: From extractAndClear .. inject approach to extract .. clearAndInject

### DIFF
--- a/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
+++ b/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
@@ -236,6 +236,7 @@ public final class JmsTracing {
   public Span nextSpan(Message message) {
     TraceContextOrSamplingFlags extracted =
       extractAndClearTraceIdProperties(processorExtractor, message, message);
+ //TODO   TraceContextOrSamplingFlags extracted = processorExtractor.extract(message);
     Span result = tracer.nextSpan(extracted); // Processor spans use the normal sampler.
 
     // When an upstream context was not present, lookup keys are unlikely added
@@ -254,6 +255,10 @@ public final class JmsTracing {
     // message writable
     PropertyFilter.filterProperties(message, traceIdProperties);
     return extracted;
+//TODO  void clearProperties(Message message) {
+//    if (!TraceContextOrSamplingFlags.EMPTY.equals(extracted)) {
+//      PropertyFilter.filterProperties(message, propagationKeys);
+//    }
   }
 
   /** Creates a potentially noop remote span representing this request */

--- a/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
@@ -47,8 +47,12 @@ abstract class TracingConsumer<C> {
     if (message == null || tracing.isNoop()) return;
     MessageConsumerRequest request = new MessageConsumerRequest(message, destination(message));
 
+<<<<<<< HEAD
     TraceContextOrSamplingFlags extracted =
       jmsTracing.extractAndClearTraceIdProperties(extractor, request, message);
+=======
+    TraceContextOrSamplingFlags extracted = extractor.extract(request);
+>>>>>>> baba417ef... refactor: from extractAndClear and later inject to extract and later clearAndInject
     Span span = jmsTracing.nextMessagingSpan(sampler, request, extracted);
 
     if (!span.isNoop()) {
@@ -61,6 +65,7 @@ abstract class TracingConsumer<C> {
       long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
       span.start(timestamp).finish(timestamp);
     }
+    jmsTracing.clearProperties(message);
     injector.inject(span.context(), request);
   }
 

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageListener.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageListener.java
@@ -92,6 +92,7 @@ final class TracingMessageListener implements MessageListener {
 
     TraceContextOrSamplingFlags extracted =
       jmsTracing.extractAndClearTraceIdProperties(extractor, request, message);
+// TODO   TraceContextOrSamplingFlags extracted = extractor.extract(request);
     Span consumerSpan = jmsTracing.nextMessagingSpan(sampler, request, extracted);
 
     // JMS has no visibility of the incoming message, which incidentally could be local!

--- a/instrumentation/jms/src/main/java/brave/jms/TracingProducer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingProducer.java
@@ -53,8 +53,9 @@ abstract class TracingProducer<R extends ProducerRequest> {
     // sending one. At any rate, as long as we are using b3-single format, this is an overwrite not
     // a clear.
     Span span;
+    TraceContextOrSamplingFlags extracted = null;
     if (maybeParent == null) {
-      TraceContextOrSamplingFlags extracted = extractor.extract(request);
+      extracted = extractor.extract(request);
       span = jmsTracing.nextMessagingSpan(sampler, request, extracted);
     } else {
       span = tracer.newChild(maybeParent);

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
@@ -237,7 +237,9 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     assertChildOf(listenerSpan, consumerSpan);
     assertThat(listenerSpan.tags())
       .hasSize(1) // no redundant copy of consumer tags
-      .containsEntry("b3", "false"); // b3 header not leaked to listener
+      // This assumption does not hold.
+//      .containsEntry("b3", "false"); // b3 header not leaked to listener
+      .containsEntry("b3", "true"); // b3 header not leaked to listener
   }
 
   @Test public void messageListener_readsBaggage() throws JMSException {

--- a/instrumentation/jms/src/test/java/brave/jms/ITTracingJMSConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITTracingJMSConsumer.java
@@ -140,7 +140,9 @@ public class ITTracingJMSConsumer extends ITJms {
 
     assertThat(listenerSpan.tags())
       .hasSize(1) // no redundant copy of consumer tags
-      .containsEntry("b3", "false"); // b3 header not leaked to listener
+      // This expectation does not hold
+//      .containsEntry("b3", "false"); // b3 header not leaked to listener
+      .containsEntry("b3", "true"); // b3 header kept
   }
 
   @Test public void messageListener_readsBaggage() {

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
@@ -245,12 +245,23 @@ public class JmsTracingTest extends ITJms {
     assertThat(testSpanHandler.takeLocalSpan().tags()).isEmpty();
   }
 
+<<<<<<< HEAD
   @Test public void nextSpan_should_clear_propagation_headers() {
     Propagation.B3_STRING.injector(SETTER).inject(parent, message);
     Propagation.B3_SINGLE_STRING.injector(SETTER).inject(parent, message);
 
     jmsTracing.nextSpan(message);
     assertThat(ITJms.propertiesToMap(message)).isEmpty();
+=======
+  @Test public void nextSpan_should_not_clear_propagation_headers() throws Exception {
+    TraceContext context =
+      TraceContext.newBuilder().traceId(1L).parentId(2L).spanId(3L).debug(true).build();
+    Propagation.B3_STRING.injector(SETTER).inject(context, message);
+    Propagation.B3_SINGLE_STRING.injector(SETTER).inject(context, message);
+
+    jmsTracing.nextSpan(message);
+    assertThat(JmsTest.propertiesToMap(message)).isNotEmpty();
+>>>>>>> baba417ef... refactor: from extractAndClear and later inject to extract and later clearAndInject
   }
 
   @Test public void nextSpan_should_retain_baggage_headers() throws JMSException {

--- a/instrumentation/jms/src/test/java/brave/jms/TracingMessageListenerTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/TracingMessageListenerTest.java
@@ -150,8 +150,12 @@ public class TracingMessageListenerTest extends ITJms {
 
     onMessageConsumed(message);
 
+<<<<<<< HEAD
     // clearing headers ensures later work doesn't try to use the old parent
     assertNoProperties(message);
+=======
+    assertThat(message.getProperties()).isNotEmpty();
+>>>>>>> baba417ef... refactor: from extractAndClear and later inject to extract and later clearAndInject
 
     MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
     MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
@@ -169,8 +173,12 @@ public class TracingMessageListenerTest extends ITJms {
 
     onMessageConsumed(message);
 
+<<<<<<< HEAD
     // clearing headers ensures later work doesn't try to use the old parent
     assertNoProperties(message);
+=======
+    assertThat(message.getProperties()).isNotEmpty();
+>>>>>>> baba417ef... refactor: from extractAndClear and later inject to extract and later clearAndInject
 
     assertChildOf(testSpanHandler.takeLocalSpan(), parent);
   }
@@ -196,8 +204,12 @@ public class TracingMessageListenerTest extends ITJms {
 
     onMessageConsumed(message);
 
+<<<<<<< HEAD
     // clearing headers ensures later work doesn't try to use the old parent
     assertNoProperties(message);
+=======
+    assertThat(message.getProperties()).isNotEmpty();
+>>>>>>> baba417ef... refactor: from extractAndClear and later inject to extract and later clearAndInject
 
     MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
     MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
@@ -215,8 +227,12 @@ public class TracingMessageListenerTest extends ITJms {
 
     onMessageConsumed(message);
 
+<<<<<<< HEAD
     // clearing headers ensures later work doesn't try to use the old parent
     assertNoProperties(message);
+=======
+    assertThat(message.getProperties()).isNotEmpty();
+>>>>>>> baba417ef... refactor: from extractAndClear and later inject to extract and later clearAndInject
 
     assertChildOf(testSpanHandler.takeLocalSpan(), parent);
   }

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -194,6 +194,7 @@ public final class KafkaTracing {
     // events create consumer spans. Since this is a processor span, we use the normal sampler.
     TraceContextOrSamplingFlags extracted =
       extractAndClearTraceIdHeaders(processorExtractor, record.headers(), record.headers());
+//TODO        processorExtractor.extract(record.headers());
     Span result = tracer.nextSpan(extracted);
     if (extracted.context() == null && !result.isNoop()) {
       addTags(record, result);
@@ -201,6 +202,7 @@ public final class KafkaTracing {
     return result;
   }
 
+  //TODO remove
   <R> TraceContextOrSamplingFlags extractAndClearTraceIdHeaders(
     Extractor<R> extractor, R request, Headers headers
   ) {
@@ -233,6 +235,13 @@ public final class KafkaTracing {
     for (Iterator<Header> i = headers.iterator(); i.hasNext(); ) {
       Header next = i.next();
       if (traceIdHeaders.contains(next.key())) i.remove();
+//TODO  void clearHeaders(TraceContextOrSamplingFlags extracted, Headers headers) {
+//    if (!TraceContextOrSamplingFlags.EMPTY.equals(extracted)) {
+//      // Headers::remove creates and consumes an iterator each time. This does one loop instead.
+//      for (Iterator<Header> i = headers.iterator(); i.hasNext(); ) {
+//        Header next = i.next();
+//        if (propagationKeys.contains(next.key())) i.remove();
+//      }
     }
   }
 

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -98,6 +98,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
         KafkaConsumerRequest request = new KafkaConsumerRequest(record);
         TraceContextOrSamplingFlags extracted =
           kafkaTracing.extractAndClearTraceIdHeaders(extractor, request, record.headers());
+//TODO        TraceContextOrSamplingFlags extracted = extractor.extract(request);
 
         // If we extracted neither a trace context, nor request-scoped data (extra),
         // and sharing trace is enabled make or reuse a span for this topic
@@ -115,6 +116,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
             }
             consumerSpansForTopic.put(topic, span);
           }
+ //TODO         kafkaTracing.clearHeaders(extracted, record.headers());
           injector.inject(span.context(), request);
         } else { // we extracted request-scoped data, so cannot share a consumer span.
           Span span = kafkaTracing.nextMessagingSpan(sampler, request, extracted);
@@ -126,6 +128,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
             }
             span.start(timestamp).finish(timestamp); // span won't be shared by other records
           }
+         //TODO kafkaTracing.clearHeaders(extracted, record.headers());
           injector.inject(span.context(), request);
         }
       }

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
@@ -103,9 +103,11 @@ final class TracingProducer<K, V> implements Producer<K, V> {
     // NOTE: Brave instrumentation used properly does not result in stale header entries, as we
     // always clear message headers after reading.
     Span span;
+//TODO    TraceContextOrSamplingFlags extracted = null;
     if (maybeParent == null) {
       TraceContextOrSamplingFlags extracted =
         kafkaTracing.extractAndClearTraceIdHeaders(extractor, request, record.headers());
+//TODO      extracted = extractor.extract(request);
       span = kafkaTracing.nextMessagingSpan(sampler, request, extracted);
     } else { // If we have a span in scope assume headers were cleared before
       span = tracer.newChild(maybeParent);
@@ -121,6 +123,7 @@ final class TracingProducer<K, V> implements Producer<K, V> {
       span.start();
     }
 
+//TODO    kafkaTracing.clearHeaders(extracted, record.headers());
     injector.inject(span.context(), request);
 
     Tracer.SpanInScope ws = tracer.withSpanInScope(span);

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
@@ -112,6 +112,12 @@ public class KafkaTracingTest extends KafkaTest {
     kafkaTracing.nextSpan(consumerRecord);
     assertThat(consumerRecord.headers().headers(BAGGAGE_FIELD_KEY)).isNotEmpty();
   }
+//  @Test public void nextSpan_should_clear_propagation_headers() {
+//    addB3MultiHeaders(fakeRecord);
+//
+//    kafkaTracing.nextSpan(fakeRecord);
+//    assertThat(fakeRecord.headers().toArray()).isEmpty();
+//  }
 
   @Test public void nextSpan_should_not_clear_other_headers() {
     consumerRecord.headers().add("foo", new byte[0]);

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
@@ -217,6 +217,7 @@ public final class SpringRabbitTracing {
     return factory;
   }
 
+  //TODO remove
   <R> TraceContextOrSamplingFlags extractAndClearTraceIdHeaders(
     Extractor<R> extractor, R request, Message message
   ) {
@@ -247,5 +248,10 @@ public final class SpringRabbitTracing {
   // multi, or visa versa.
   void clearTraceIdHeaders(Map<String, Object> headers) {
     for (String traceIDHeader : traceIdHeaders) headers.remove(traceIDHeader);
+//TODO  void clearHeaders(TraceContextOrSamplingFlags extracted, Message message) {
+//    if (!TraceContextOrSamplingFlags.EMPTY.equals(extracted)) {
+//      Map<String, Object> headers = message.getMessageProperties().getHeaders();
+//      for (String key : propagationKeys) headers.remove(key);
+//    }
   }
 }

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
@@ -66,9 +66,11 @@ final class TracingMessagePostProcessor implements MessagePostProcessor {
     // NOTE: Brave instrumentation used properly does not result in stale header entries, as we
     // always clear message headers after reading.
     Span span;
+//TODO    TraceContextOrSamplingFlags extracted = null;
     if (maybeParent == null) {
       TraceContextOrSamplingFlags extracted =
         springRabbitTracing.extractAndClearTraceIdHeaders(extractor, request, message);
+//TODO      extracted = extractor.extract(request);
       span = springRabbitTracing.nextMessagingSpan(sampler, request, extracted);
     } else { // If we have a span in scope assume headers were cleared before
       span = tracer.newChild(maybeParent);
@@ -82,6 +84,7 @@ final class TracingMessagePostProcessor implements MessagePostProcessor {
       span.start(timestamp).finish(timestamp);
     }
 
+//TODO    springRabbitTracing.clearHeaders(extracted, message);
     injector.inject(span.context(), request);
     return message;
   }

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingRabbitListenerAdvice.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingRabbitListenerAdvice.java
@@ -77,6 +77,7 @@ final class TracingRabbitListenerAdvice implements MethodInterceptor {
 
     TraceContextOrSamplingFlags extracted =
       springRabbitTracing.extractAndClearTraceIdHeaders(extractor, request, message);
+//TODO      extractor.extract(request);
 
     // named for BlockingQueueConsumer.nextMessage, which we can't currently see
     Span consumerSpan = springRabbitTracing.nextMessagingSpan(sampler, request, extracted);

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/TracingRabbitListenerAdviceTest.java
@@ -128,8 +128,7 @@ public class TracingRabbitListenerAdviceTest {
     Message message = MessageBuilder.withBody(new byte[0]).andProperties(props).build();
     onMessageConsumed(message);
 
-    // cleared the headers to later work doesn't try to use the old parent
-    assertThat(message.getMessageProperties().getHeaders()).isEmpty();
+    assertThat(message.getMessageProperties().getHeaders()).isNotEmpty();
 
     assertThat(spans)
       .filteredOn(span -> span.kind() == CONSUMER)
@@ -144,8 +143,7 @@ public class TracingRabbitListenerAdviceTest {
     Message message = MessageBuilder.withBody(new byte[0]).andProperties(props).build();
     onMessageConsumed(message);
 
-    // cleared the headers to later work doesn't try to use the old parent
-    assertThat(message.getMessageProperties().getHeaders()).isEmpty();
+    assertThat(message.getMessageProperties().getHeaders()).isNotEmpty();
 
     assertThat(spans)
       .filteredOn(span -> span.kind() == CONSUMER)


### PR DESCRIPTION
Draft to explore refactoring the approached used on messaging instrumentation (1) where context is first extracted _and_ cleared from headers to later inject if needed, to an approach (2) where context is extracted to later clear context form headers if needed to then inject.

Messaging instrumentation has mainly 2 features on consumer side: `onConsume` that under (1) it extracts and clear headers, start/finish on-consume span, and injects context. And `nextSpan` that under (2) it extracts and clear headers, and creates a span from extracted context.

Current effects of approach (1):
- By clearing context after extracting we make sure context is not "leaked" and propagated downstream. 
  - On `on-consume` feature we eventually inject context again, then this is not as critical. 
  - On `nextSpan` feature this restrict users to have only one child from `onConsume` span as we remove headers. This (potentially) could restrict users on how to continue a trace. There could be scenarios where users do a batch of operations after a message is consumed, requiring multiple spans to be created from `onConsume` span.

Following approach (2) we can allow users to continue `onConsume` span multiple times.

A side-effect of approach (2) is to reduce impact on current JMS consumer implementation:
- JMS consumed message properties (i.e. headers) need to be "resetted" before injecting context. This currently requires to cache non-context properties, reset all properties, and write non-context properties again. All these to inject context later. Under approach (1) we do the reset after extracting context, to at the end of instrumentation inject new context, impacting both features `onConsume` and `nextSpan`
- With approach (2) we can move reset logic right before injecting. By doing this only `onConsume` we remove this overhead from `nextSpan` feature.