### PR TITLE
TracingAdvice should come first when decorating listener by SpringRabbitTracing

### DIFF
--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
@@ -207,8 +207,8 @@ public final class SpringRabbitTracing {
 
     // Otherwise, add ours and return
     Advice[] newChain = new Advice[chain.length + 1];
-    System.arraycopy(chain, 0, newChain, 0, chain.length);
-    newChain[chain.length] = tracingAdvice;
+    newChain[0] = tracingAdvice;
+    System.arraycopy(chain, 0, newChain, 1, chain.length);
     factory.setAdviceChain(newChain);
     return factory;
   }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -15,14 +15,6 @@ package brave.spring.rabbit;
 
 import brave.Tracing;
 import brave.propagation.ThreadLocalCurrentTraceContext;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
-import org.aopalliance.aop.Advice;
-import org.assertj.core.api.Condition;
-import org.assertj.core.data.Index;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -31,7 +23,10 @@ import org.springframework.amqp.support.postprocessor.UnzipPostProcessor;
 import org.springframework.cache.interceptor.CacheInterceptor;
 import zipkin2.reporter.Reporter;
 
-import static java.util.Arrays.*;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringRabbitTracingTest {

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -86,6 +86,7 @@ public class SpringRabbitTracingTest {
     SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
     factory.setAdviceChain(new CacheInterceptor());
 
+    // the order of advices is important for the downstream interceptor to see the tracing context
     assertThat(rabbitTracing.decorateSimpleRabbitListenerContainerFactory(factory).getAdviceChain())
       .hasSize(2)
       .matches(adviceArray -> adviceArray[0] instanceof TracingRabbitListenerAdvice);

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -15,8 +15,14 @@ package brave.spring.rabbit;
 
 import brave.Tracing;
 import brave.propagation.ThreadLocalCurrentTraceContext;
+
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+
+import org.aopalliance.aop.Advice;
+import org.assertj.core.api.Condition;
+import org.assertj.core.data.Index;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -25,6 +31,7 @@ import org.springframework.amqp.support.postprocessor.UnzipPostProcessor;
 import org.springframework.cache.interceptor.CacheInterceptor;
 import zipkin2.reporter.Reporter;
 
+import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringRabbitTracingTest {
@@ -82,11 +89,12 @@ public class SpringRabbitTracingTest {
       .hasSize(1);
   }
 
-  @Test public void decorateSimpleRabbitListenerContainerFactory_appends_when_absent() {
+  @Test public void decorateSimpleRabbitListenerContainerFactory_appends_as_first_when_absent() {
     SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
     factory.setAdviceChain(new CacheInterceptor());
 
     assertThat(rabbitTracing.decorateSimpleRabbitListenerContainerFactory(factory).getAdviceChain())
-      .anyMatch(advice -> advice instanceof TracingRabbitListenerAdvice);
+      .hasSize(2)
+      .matches(adviceArray -> asList(adviceArray).get(0) instanceof TracingRabbitListenerAdvice);
   }
 }

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -15,6 +15,8 @@ package brave.spring.rabbit;
 
 import brave.Tracing;
 import brave.propagation.ThreadLocalCurrentTraceContext;
+import java.util.Collection;
+import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -22,9 +24,6 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.postprocessor.UnzipPostProcessor;
 import org.springframework.cache.interceptor.CacheInterceptor;
 import zipkin2.reporter.Reporter;
-
-import java.util.Collection;
-import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/SpringRabbitTracingTest.java
@@ -25,7 +25,6 @@ import org.springframework.amqp.support.postprocessor.UnzipPostProcessor;
 import org.springframework.cache.interceptor.CacheInterceptor;
 import zipkin2.reporter.Reporter;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringRabbitTracingTest {
@@ -89,6 +88,6 @@ public class SpringRabbitTracingTest {
 
     assertThat(rabbitTracing.decorateSimpleRabbitListenerContainerFactory(factory).getAdviceChain())
       .hasSize(2)
-      .matches(adviceArray -> asList(adviceArray).get(0) instanceof TracingRabbitListenerAdvice);
+      .matches(adviceArray -> adviceArray[0] instanceof TracingRabbitListenerAdvice);
   }
 }


### PR DESCRIPTION
When decorating an existing `SimpleRabbitListenerContainerFactory` in `spring-rabbit`, the tracingAdvice should come first, in front of existing advice, not last. 

**Rationale**
`adviceChain` is - for example - used to manage retrials via `RetryOperationInterceptors`. When `tracingAdvice` comes first, it sets MDC headers, so that consecutive interceptors log with property set trace and span ids. 

**Example scenario**
`StatelessRetryOperationsInterceptorFactoryBean` warns on dropping message due to absent recoverer (https://github.com/spring-projects/spring-amqp/blob/master/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java#L71). With the current way listener container is decorated, tracing advice will be the last one and the log message will lack the tracing information. 
With the chain reversed, the MDC context is set up as expected.