### PR TITLE
Corrects attribution of the fragment of guava we modified

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,8 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-This product contains a modified part of Guava, distributed by Google:
-
-  * License: Apache License v2.0
-  * Homepage: https://github.com/google/guava

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+Brave
+
+Copyright 2013-2020 The OpenZipkin Authors
+
+-------------------------------------------------------------------------------
+
+This product contains a modified portion of 'InetAddresses', distributed
+by Google in the Guava Library:
+
+  * Copyright (C) 2008 The Guava Authors
+  * License: Apache License v2.0
+  * Homepage: https://github.com/google/guava

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2019 The OpenZipkin Authors
+    Copyright 2013-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -491,6 +491,16 @@
           <exclude>**/*.java</exclude>
         </excludes>
       </resource>
+      <!-- This adds the LICENSE and NOTICE file to the jar and -sources jar of each module -->
+      <resource>
+        <filtering>false</filtering>
+        <directory>${main.basedir}</directory>
+        <targetPath>META-INF/</targetPath>
+        <includes>
+          <include>LICENSE</include>
+          <include>NOTICE</include>
+        </includes>
+      </resource>
     </resources>
     <testResources>
       <testResource>
@@ -656,6 +666,7 @@
             <exclude>**/.editorconfig</exclude>
             <exclude>**/log4j2.properties</exclude>
             <exclude>LICENSE</exclude>
+            <exclude>NOTICE</exclude>
             <exclude>**/*.md</exclude>
             <exclude>**/*.bnd</exclude>
             <exclude>**/com.alibaba.dubbo.rpc.Filter</exclude>


### PR DESCRIPTION
This corrects the LICENSE by moving the copyright citation to NOTICE instead.
This also adds LICENSE and NOTICE to each jar and sources jar.

See https://www.apache.org/dev/licensing-howto.html#mod-notice