### PR TITLE
Works around new worker node and failed gRPC invoker tests

### DIFF
--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2019 The OpenZipkin Authors
+    Copyright 2013-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -37,6 +37,9 @@
     <opencensus.version>0.24.0</opencensus.version>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+
+    <old-grpc>io.grpc:grpc-all:1.2.0:jar</old-grpc>
+    <old-protoc>com.google.protobuf:protoc:3.2.0:exe:${os.detected.classifier}</old-protoc>
 
     <!-- disable mutability warning as TagContextBinaryMarshaller intentionally returns mixed -->
     <errorprone.args>-Xep:MixedMutabilityReturnType:OFF</errorprone.args>
@@ -117,13 +120,40 @@
           </pluginArtifact>
         </configuration>
       </plugin>
+      <!-- maven-invoker-plugin's extraArtifacts are pulled from the local repository, not the
+           remote ones. We manually resolve so that a brand new build slave with no cache will
+           end up with the dependencies it needs. -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-old-grpc</id>
+            <phase>test</phase>
+            <goals>
+              <goal>get</goal>
+            </goals>
+            <configuration>
+              <artifact>${old-grpc}</artifact>
+            </configuration>
+          </execution>
+          <execution>
+            <id>get-old-protoc</id>
+            <phase>test</phase>
+            <goals>
+              <goal>get</goal>
+            </goals>
+            <configuration>
+              <artifact>${old-protoc}</artifact>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <extraArtifacts>
-            <extraArtifact>io.grpc:grpc-all:1.2.0:jar</extraArtifact>
-            <extraArtifact>com.google.protobuf:protoc:3.2.0:exe:${os.detected.classifier}
-            </extraArtifact>
+            <extraArtifact>${old-grpc}</extraArtifact>
+            <extraArtifact>${old-protoc}</extraArtifact>
           </extraArtifacts>
         </configuration>
       </plugin>


### PR DESCRIPTION
It seems unintuitive that the maven-invoker-plugin doesn't remotely seed
dependencies listed in extraArtifacts, but they are assumed to be
present.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-invoker-plugin:3.2.1:install (default) on project brave-instrumentation-grpc: Unable to resolve dependencies for: io.grpc:grpc-all:jar:1.2.0: org.eclipse.aether.resolution.DependencyResolutionException: Could not find artifact io.grpc:grpc-all:jar:1.2.0 in local (file:///Users/acole/.m2/repository/) -> [Help 1]
```

This forces resolution via a test-scoped call to get the dependencies
needed for the grpc compatability tests.