### PR TITLE
Add composite propagation support.

### DIFF
--- a/brave/src/main/java/brave/propagation/CompositePropagation.java
+++ b/brave/src/main/java/brave/propagation/CompositePropagation.java
@@ -40,13 +40,13 @@ public class CompositePropagation<K> implements Propagation<K> {
     boolean injectAll = true;
     final List<Propagation.Factory> propagationFactories = new ArrayList<>();
 
-    public FactoryBuilder addPropagationFactory(final Propagation.Factory propagationFactory) {
+    public FactoryBuilder addPropagationFactory(Propagation.Factory propagationFactory) {
       if (propagationFactory == null) throw new NullPointerException("propagationFactory == null");
       propagationFactories.add(propagationFactory);
       return this;
     }
 
-    public FactoryBuilder addAllPropagationFactories(final Collection<Propagation.Factory> propagationFactories) {
+    public FactoryBuilder addAllPropagationFactories(Collection<Propagation.Factory> propagationFactories) {
       if (propagationFactories == null) throw new NullPointerException("propagationFactories == null");
       this.propagationFactories.addAll(propagationFactories);
       return this;
@@ -57,7 +57,7 @@ public class CompositePropagation<K> implements Propagation<K> {
       return this;
     }
 
-    public FactoryBuilder injectAll(final boolean injectAll) {
+    public FactoryBuilder injectAll(boolean injectAll) {
       this.injectAll = injectAll;
       return this;
     }
@@ -67,15 +67,15 @@ public class CompositePropagation<K> implements Propagation<K> {
     }
   }
 
-  private final List<Propagation<K>> propagations;
-  private final List<K> keys;
-  private final boolean injectAll;
+  final List<Propagation<K>> propagations;
+  final List<K> keys;
+  final boolean injectAll;
 
-  CompositePropagation(final List<Propagation<K>> propagations, final boolean injectAll) {
+  CompositePropagation(List<Propagation<K>> propagations, boolean injectAll) {
     this.propagations = propagations;
     this.injectAll = injectAll;
-    final Set<K> keySet = new LinkedHashSet<>();
-    for (final Propagation<K> propagation : propagations) {
+    Set<K> keySet = new LinkedHashSet<>();
+    for (Propagation<K> propagation : propagations) {
       keySet.addAll(propagation.keys());
     }
     keys = new ArrayList<>(keySet);
@@ -85,11 +85,11 @@ public class CompositePropagation<K> implements Propagation<K> {
     return keys;
   }
 
-  @Override public <C> TraceContext.Injector<C> injector(final Setter<C, K> setter) {
+  @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
     return new TraceContext.Injector<C>() {
       @Override
-      public void inject(final TraceContext traceContext, final C carrier) {
-        for (final Propagation<K> propagation : propagations) {
+      public void inject(TraceContext traceContext, C carrier) {
+        for (Propagation<K> propagation : propagations) {
           propagation.injector(setter).inject(traceContext, carrier);
           if (!injectAll) {
             break;
@@ -99,12 +99,12 @@ public class CompositePropagation<K> implements Propagation<K> {
     };
   }
 
-  @Override public <C> TraceContext.Extractor<C> extractor(final Getter<C, K> getter) {
+  @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
     return new TraceContext.Extractor<C>() {
       @Override
-      public TraceContextOrSamplingFlags extract(final C carrier) {
-        for (final Propagation<K> propagation : propagations) {
-          final TraceContextOrSamplingFlags result = propagation.extractor(getter).extract(carrier);
+      public TraceContextOrSamplingFlags extract(C carrier) {
+        for (Propagation<K> propagation : propagations) {
+          TraceContextOrSamplingFlags result = propagation.extractor(getter).extract(carrier);
           if (SamplingFlags.EMPTY != result.samplingFlags()) {
             return result;
           }
@@ -115,24 +115,24 @@ public class CompositePropagation<K> implements Propagation<K> {
   }
 
   static final class Factory extends Propagation.Factory {
-    private final List<Propagation.Factory> propagationFactories;
-    private final boolean injectAll;
+    final List<Propagation.Factory> propagationFactories;
+    final boolean injectAll;
 
-    Factory(final FactoryBuilder builder) {
+    Factory(FactoryBuilder builder) {
       propagationFactories = new ArrayList<>(builder.propagationFactories);
       injectAll = builder.injectAll;
     }
 
-    @Override public <K> Propagation<K> create(final KeyFactory<K> keyFactory) {
-      final List<Propagation<K>> propagations = new ArrayList<>();
-      for (final Propagation.Factory factory : propagationFactories) {
+    @Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+      List<Propagation<K>> propagations = new ArrayList<>();
+      for (Propagation.Factory factory : propagationFactories) {
         propagations.add(factory.create(keyFactory));
       }
       return new CompositePropagation<>(propagations, injectAll);
     }
 
     @Override public String toString() {
-      final StringBuilder stringBuilder = new StringBuilder("CompositePropagationFactory{inject");
+      StringBuilder stringBuilder = new StringBuilder("CompositePropagationFactory{inject");
       stringBuilder.append(injectAll ? "All" : "First").append(':');
       for (int i = 0; i < propagationFactories.size(); ++i) {
         stringBuilder.append(propagationFactories.get(i));

--- a/brave/src/main/java/brave/propagation/CompositePropagation.java
+++ b/brave/src/main/java/brave/propagation/CompositePropagation.java
@@ -105,7 +105,10 @@ public class CompositePropagation<K> implements Propagation<K> {
       public TraceContextOrSamplingFlags extract(C carrier) {
         for (Propagation<K> propagation : propagations) {
           TraceContextOrSamplingFlags result = propagation.extractor(getter).extract(carrier);
-          if (SamplingFlags.EMPTY != result.samplingFlags()) {
+          SamplingFlags samplingFlags = result.context();
+          if (samplingFlags == null) samplingFlags = result.traceIdContext();
+          if (samplingFlags == null) samplingFlags = result.samplingFlags();
+          if (SamplingFlags.EMPTY != samplingFlags) {
             return result;
           }
         }

--- a/brave/src/main/java/brave/propagation/CompositePropagation.java
+++ b/brave/src/main/java/brave/propagation/CompositePropagation.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.propagation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Allows multiple {@link Propagation}s to be used, which is useful when transitioning from a propagation format to
+ * another.
+ *
+ * Upon injection, depending on the {@code injectAll} setting, only the first or all {@link Propagation}s are used,
+ * while at extraction time {@link Propagation}s will be tried one by one in the specified order until one is
+ * successful, at which point the remaining {@link Propagation}s will not be called. If all {@link Propagation}s fail
+ * to extract, {@link TraceContextOrSamplingFlags#EMPTY} is returned.
+ */
+public class CompositePropagation<K> implements Propagation<K> {
+  public static FactoryBuilder newFactoryBuilder() {
+    return new FactoryBuilder();
+  }
+
+  /**
+   * Defaults to {@code injectAll = true}.
+   */
+  public static final class FactoryBuilder {
+    boolean injectAll = true;
+    final List<Propagation.Factory> propagationFactories = new ArrayList<>();
+
+    public FactoryBuilder addPropagationFactory(final Propagation.Factory propagationFactory) {
+      if (propagationFactory == null) throw new NullPointerException("propagationFactory == null");
+      propagationFactories.add(propagationFactory);
+      return this;
+    }
+
+    public FactoryBuilder addAllPropagationFactories(final Collection<Propagation.Factory> propagationFactories) {
+      if (propagationFactories == null) throw new NullPointerException("propagationFactories == null");
+      this.propagationFactories.addAll(propagationFactories);
+      return this;
+    }
+
+    public FactoryBuilder clearPropagationFactories() {
+      propagationFactories.clear();
+      return this;
+    }
+
+    public FactoryBuilder injectAll(final boolean injectAll) {
+      this.injectAll = injectAll;
+      return this;
+    }
+
+    public Propagation.Factory build() {
+      return new Factory(this);
+    }
+  }
+
+  private final List<Propagation<K>> propagations;
+  private final List<K> keys;
+  private final boolean injectAll;
+
+  CompositePropagation(final List<Propagation<K>> propagations, final boolean injectAll) {
+    this.propagations = propagations;
+    this.injectAll = injectAll;
+    final Set<K> keySet = new LinkedHashSet<>();
+    for (final Propagation<K> propagation : propagations) {
+      keySet.addAll(propagation.keys());
+    }
+    keys = new ArrayList<>(keySet);
+  }
+
+  @Override public List<K> keys() {
+    return keys;
+  }
+
+  @Override public <C> TraceContext.Injector<C> injector(final Setter<C, K> setter) {
+    return new TraceContext.Injector<C>() {
+      @Override
+      public void inject(final TraceContext traceContext, final C carrier) {
+        for (final Propagation<K> propagation : propagations) {
+          propagation.injector(setter).inject(traceContext, carrier);
+          if (!injectAll) {
+            break;
+          }
+        }
+      }
+    };
+  }
+
+  @Override public <C> TraceContext.Extractor<C> extractor(final Getter<C, K> getter) {
+    return new TraceContext.Extractor<C>() {
+      @Override
+      public TraceContextOrSamplingFlags extract(final C carrier) {
+        for (final Propagation<K> propagation : propagations) {
+          final TraceContextOrSamplingFlags result = propagation.extractor(getter).extract(carrier);
+          if (SamplingFlags.EMPTY != result.samplingFlags()) {
+            return result;
+          }
+        }
+        return TraceContextOrSamplingFlags.EMPTY;
+      }
+    };
+  }
+
+  static final class Factory extends Propagation.Factory {
+    private final List<Propagation.Factory> propagationFactories;
+    private final boolean injectAll;
+
+    Factory(final FactoryBuilder builder) {
+      propagationFactories = new ArrayList<>(builder.propagationFactories);
+      injectAll = builder.injectAll;
+    }
+
+    @Override public <K> Propagation<K> create(final KeyFactory<K> keyFactory) {
+      final List<Propagation<K>> propagations = new ArrayList<>();
+      for (final Propagation.Factory factory : propagationFactories) {
+        propagations.add(factory.create(keyFactory));
+      }
+      return new CompositePropagation<>(propagations, injectAll);
+    }
+
+    @Override public String toString() {
+      final StringBuilder stringBuilder = new StringBuilder("CompositePropagationFactory{inject");
+      stringBuilder.append(injectAll ? "All" : "First").append(':');
+      for (int i = 0; i < propagationFactories.size(); ++i) {
+        stringBuilder.append(propagationFactories.get(i));
+        if (i < propagationFactories.size() - 1) stringBuilder.append(',');
+      }
+      return stringBuilder.append('}').toString();
+    }
+  }
+}

--- a/brave/src/test/java/brave/propagation/CompositePropagationTests.java
+++ b/brave/src/test/java/brave/propagation/CompositePropagationTests.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.propagation;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class CompositePropagationTests {
+  private static final long TRACE_ID = 1234;
+  private static final long TRACE_ID2 = 1235;
+  private static final long SPAN_ID = 5678;
+  private static final Propagation.Setter<Map<String, String>, String> SETTER = Map::put;
+  private static final Propagation.Getter<Map<String, String>, String> GETTER = Map::get;
+  private static final TraceContext TRACE_CONTEXT = TraceContext.newBuilder()
+          .traceId(TRACE_ID)
+          .spanId(SPAN_ID)
+          .build();
+  private static Map<String, String> FIELDS1 = new HashMap<>();
+  static {
+    FIELDS1.put("a", "1");
+    FIELDS1.put("b", "2");
+  }
+  private static Map<String, String> FIELDS2 = new HashMap<>();
+  static {
+    FIELDS2.put("a", "3");
+    FIELDS2.put("c", "4");
+  }
+
+  @Test public void testKeys() {
+    final Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
+      .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS1))
+      .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS2))
+      .build()
+      .create(Propagation.KeyFactory.STRING);
+    assertThat(propagation.keys()).containsExactly("a", "b", "c");
+  }
+
+  @Test public void testInjectAll() {
+    final Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
+      .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS1))
+      .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS2))
+      .build()
+      .create(Propagation.KeyFactory.STRING);
+    final Map<String, String> carrier = new HashMap<>();
+    propagation.injector(SETTER).inject(TRACE_CONTEXT, carrier);
+    assertThat(carrier).contains(
+      entry("a", "3"),
+      entry("b", "2"),
+      entry("c", "4")
+    );
+  }
+
+  @Test public void testInjectFirst() {
+    final Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
+      .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS1))
+      .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS2))
+      .injectAll(false)
+      .build()
+      .create(Propagation.KeyFactory.STRING);
+    final Map<String, String> carrier = new HashMap<>();
+    propagation.injector(SETTER).inject(TRACE_CONTEXT, carrier);
+    assertThat(carrier).contains(
+      entry("a", "1"),
+      entry("b", "2")
+    );
+  }
+
+  @Test public void testExtract() {
+    final TraceContext.Extractor<Map<String, String>> extractor1 = CompositePropagation.newFactoryBuilder()
+      .addPropagationFactory(FieldExtractingPropagation.newFactory("a"))
+      .addPropagationFactory(FieldExtractingPropagation.newFactory("b"))
+      .build()
+      .create(Propagation.KeyFactory.STRING)
+      .extractor(GETTER);
+    final TraceContext.Extractor<Map<String, String>> extractor2 = CompositePropagation.newFactoryBuilder()
+      .addPropagationFactory(FieldExtractingPropagation.newFactory("b"))
+      .addPropagationFactory(FieldExtractingPropagation.newFactory("a"))
+      .build()
+      .create(Propagation.KeyFactory.STRING)
+      .extractor(GETTER);
+
+    final Map<String, String> carrier = new HashMap<>();
+    carrier.put("a", String.valueOf(TRACE_ID));
+    carrier.put("b", String.valueOf(TRACE_ID2));
+
+    assertThat(extractor1.extract(carrier)).isEqualTo(
+      TraceContextOrSamplingFlags.create(TraceContext.newBuilder()
+        .traceId(TRACE_ID)
+        .spanId(TRACE_ID)
+        .build())
+    );
+
+    assertThat(extractor2.extract(carrier)).isEqualTo(
+      TraceContextOrSamplingFlags.create(TraceContext.newBuilder()
+        .traceId(TRACE_ID2)
+        .spanId(TRACE_ID2)
+        .build())
+    );
+  }
+}
+
+class MapInjectingPropagation implements Propagation<String> {
+  private final Map<String, String> fields;
+
+  static Factory newFactory(final Map<String, String> fields) {
+    return new Factory() {
+      @Override
+      public <K> Propagation<K> create(final KeyFactory<K> keyFactory) {
+        // noinspection unchecked
+        return (Propagation<K>) new MapInjectingPropagation(fields);
+      }
+    };
+  }
+
+  MapInjectingPropagation(final Map<String, String> fields) {
+    this.fields = fields;
+  }
+
+  @Override public List<String> keys() {
+    return new ArrayList<>(fields.keySet());
+  }
+
+  @Override public <C> TraceContext.Injector<C> injector(final Setter<C, String> setter) {
+    return (traceContext, carrier) -> fields.forEach((key, value) -> setter.put(carrier, key, value));
+  }
+
+  @Override public <C> TraceContext.Extractor<C> extractor(final Getter<C, String> getter) {
+    throw new UnsupportedOperationException();
+  }
+}
+
+class FieldExtractingPropagation implements Propagation<String> {
+  private final String key;
+
+  static Factory newFactory(final String key) {
+    return new Factory() {
+      @Override
+      public <K> Propagation<K> create(final KeyFactory<K> keyFactory) {
+        // noinspection unchecked
+        return (Propagation<K>) new FieldExtractingPropagation(key);
+      }
+    };
+  }
+
+  FieldExtractingPropagation(final String key) {
+    this.key = key;
+  }
+
+  @Override public List<String> keys() {
+    return Collections.singletonList(key);
+  }
+
+  @Override public <C> TraceContext.Injector<C> injector(final Setter<C, String> setter) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public <C> TraceContext.Extractor<C> extractor(final Getter<C, String> getter) {
+    return carrier -> {
+      final long value = Long.parseLong(getter.get(carrier, key));
+      return TraceContextOrSamplingFlags.create(TraceContext.newBuilder()
+              .traceId(value)
+              .spanId(value)
+              .build());
+    };
+  }
+}

--- a/brave/src/test/java/brave/propagation/CompositePropagationTests.java
+++ b/brave/src/test/java/brave/propagation/CompositePropagationTests.java
@@ -21,28 +21,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 public class CompositePropagationTests {
-  private static final long TRACE_ID = 1234;
-  private static final long TRACE_ID2 = 1235;
-  private static final long SPAN_ID = 5678;
-  private static final Propagation.Setter<Map<String, String>, String> SETTER = Map::put;
-  private static final Propagation.Getter<Map<String, String>, String> GETTER = Map::get;
-  private static final TraceContext TRACE_CONTEXT = TraceContext.newBuilder()
+  static long TRACE_ID = 1234;
+  static long TRACE_ID2 = 1235;
+  static long SPAN_ID = 5678;
+  static Propagation.Setter<Map<String, String>, String> SETTER = Map::put;
+  static Propagation.Getter<Map<String, String>, String> GETTER = Map::get;
+  static TraceContext TRACE_CONTEXT = TraceContext.newBuilder()
           .traceId(TRACE_ID)
           .spanId(SPAN_ID)
           .build();
-  private static Map<String, String> FIELDS1 = new HashMap<>();
+  static Map<String, String> FIELDS1 = new HashMap<>();
   static {
     FIELDS1.put("a", "1");
     FIELDS1.put("b", "2");
   }
-  private static Map<String, String> FIELDS2 = new HashMap<>();
+  static Map<String, String> FIELDS2 = new HashMap<>();
   static {
     FIELDS2.put("a", "3");
     FIELDS2.put("c", "4");
   }
 
   @Test public void testKeys() {
-    final Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
+    Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
       .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS1))
       .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS2))
       .build()
@@ -51,12 +51,12 @@ public class CompositePropagationTests {
   }
 
   @Test public void testInjectAll() {
-    final Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
+    Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
       .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS1))
       .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS2))
       .build()
       .create(Propagation.KeyFactory.STRING);
-    final Map<String, String> carrier = new HashMap<>();
+    Map<String, String> carrier = new HashMap<>();
     propagation.injector(SETTER).inject(TRACE_CONTEXT, carrier);
     assertThat(carrier).contains(
       entry("a", "3"),
@@ -66,13 +66,13 @@ public class CompositePropagationTests {
   }
 
   @Test public void testInjectFirst() {
-    final Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
+    Propagation<String> propagation = CompositePropagation.newFactoryBuilder()
       .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS1))
       .addPropagationFactory(MapInjectingPropagation.newFactory(FIELDS2))
       .injectAll(false)
       .build()
       .create(Propagation.KeyFactory.STRING);
-    final Map<String, String> carrier = new HashMap<>();
+    Map<String, String> carrier = new HashMap<>();
     propagation.injector(SETTER).inject(TRACE_CONTEXT, carrier);
     assertThat(carrier).contains(
       entry("a", "1"),
@@ -81,20 +81,20 @@ public class CompositePropagationTests {
   }
 
   @Test public void testExtract() {
-    final TraceContext.Extractor<Map<String, String>> extractor1 = CompositePropagation.newFactoryBuilder()
+    TraceContext.Extractor<Map<String, String>> extractor1 = CompositePropagation.newFactoryBuilder()
       .addPropagationFactory(FieldExtractingPropagation.newFactory("a"))
       .addPropagationFactory(FieldExtractingPropagation.newFactory("b"))
       .build()
       .create(Propagation.KeyFactory.STRING)
       .extractor(GETTER);
-    final TraceContext.Extractor<Map<String, String>> extractor2 = CompositePropagation.newFactoryBuilder()
+    TraceContext.Extractor<Map<String, String>> extractor2 = CompositePropagation.newFactoryBuilder()
       .addPropagationFactory(FieldExtractingPropagation.newFactory("b"))
       .addPropagationFactory(FieldExtractingPropagation.newFactory("a"))
       .build()
       .create(Propagation.KeyFactory.STRING)
       .extractor(GETTER);
 
-    final Map<String, String> carrier = new HashMap<>();
+    Map<String, String> carrier = new HashMap<>();
     carrier.put("a", String.valueOf(TRACE_ID));
     carrier.put("b", String.valueOf(TRACE_ID2));
 
@@ -115,19 +115,19 @@ public class CompositePropagationTests {
 }
 
 class MapInjectingPropagation implements Propagation<String> {
-  private final Map<String, String> fields;
+  final Map<String, String> fields;
 
-  static Factory newFactory(final Map<String, String> fields) {
+  static Factory newFactory(Map<String, String> fields) {
     return new Factory() {
       @Override
-      public <K> Propagation<K> create(final KeyFactory<K> keyFactory) {
+      public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
         // noinspection unchecked
         return (Propagation<K>) new MapInjectingPropagation(fields);
       }
     };
   }
 
-  MapInjectingPropagation(final Map<String, String> fields) {
+  MapInjectingPropagation(Map<String, String> fields) {
     this.fields = fields;
   }
 
@@ -135,29 +135,29 @@ class MapInjectingPropagation implements Propagation<String> {
     return new ArrayList<>(fields.keySet());
   }
 
-  @Override public <C> TraceContext.Injector<C> injector(final Setter<C, String> setter) {
+  @Override public <C> TraceContext.Injector<C> injector(Setter<C, String> setter) {
     return (traceContext, carrier) -> fields.forEach((key, value) -> setter.put(carrier, key, value));
   }
 
-  @Override public <C> TraceContext.Extractor<C> extractor(final Getter<C, String> getter) {
+  @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, String> getter) {
     throw new UnsupportedOperationException();
   }
 }
 
 class FieldExtractingPropagation implements Propagation<String> {
-  private final String key;
+  final String key;
 
-  static Factory newFactory(final String key) {
+  static Factory newFactory(String key) {
     return new Factory() {
       @Override
-      public <K> Propagation<K> create(final KeyFactory<K> keyFactory) {
+      public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
         // noinspection unchecked
         return (Propagation<K>) new FieldExtractingPropagation(key);
       }
     };
   }
 
-  FieldExtractingPropagation(final String key) {
+  FieldExtractingPropagation(String key) {
     this.key = key;
   }
 
@@ -165,13 +165,13 @@ class FieldExtractingPropagation implements Propagation<String> {
     return Collections.singletonList(key);
   }
 
-  @Override public <C> TraceContext.Injector<C> injector(final Setter<C, String> setter) {
+  @Override public <C> TraceContext.Injector<C> injector(Setter<C, String> setter) {
     throw new UnsupportedOperationException();
   }
 
-  @Override public <C> TraceContext.Extractor<C> extractor(final Getter<C, String> getter) {
+  @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, String> getter) {
     return carrier -> {
-      final long value = Long.parseLong(getter.get(carrier, key));
+      long value = Long.parseLong(getter.get(carrier, key));
       return TraceContextOrSamplingFlags.create(TraceContext.newBuilder()
               .traceId(value)
               .spanId(value)


### PR DESCRIPTION
This adds a `CompositePropagation` class, which allows one to use multiple propagations.

The purpose is to allow people to more easily transition between various propagations by being able to extract all of them and to emit either one of them or all of them.

Concrete example: `CompositePropagation` in conjunction with `B3Propagation` and a vendor-specific `VendorPropagation` allows one to migrate a distributed system from `VendorPropagation` to `B3Propagation` in a piece by piece fashion while maintaining interoperability.