### PR TITLE
Updates kafka-clients version to 2.4

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -227,6 +227,17 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   // Do not use @Override annotation to avoid compatibility issue version < 2.0
   public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
     return delegate.committed(partition, timeout);
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 2.4
+  public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions) {
+    return delegate.committed(partitions);
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 2.4
+  public Map<TopicPartition, OffsetAndMetadata> committed(
+    Set<TopicPartition> partitions, Duration timeout) {
+    return delegate.committed(partitions, timeout);
   }
 
   @Override public Map<MetricName, ? extends Metric> metrics() {

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.10.0.Final</resteasy.version>
 
-    <kafka.version>2.3.0</kafka.version>
+    <kafka.version>2.4.0</kafka.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.1.6</kafka-junit.version>
+    <kafka-junit.version>4.1.7</kafka-junit.version>
     <activemq.version>5.15.11</activemq.version>
     <spring-rabbit.version>2.2.3.RELEASE</spring-rabbit.version>
 


### PR DESCRIPTION
Note: this does not add additional tracing functionality for kstreams described in #1053. This just ensures the library can be used and compiled against.