### PR TITLE
Ensure http client callbacks are on invocation context

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,18 +15,36 @@ package brave.test.http;
 
 import brave.ScopedSpan;
 import brave.Tracer;
+import brave.propagation.TraceContext;
 import java.util.Arrays;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
+import zipkin2.Callback;
 import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
+  static final Callback<Void> NOOP_CALLBACK = new Callback<Void>() {
+    @Override public void onSuccess(Void aVoid) {
+    }
 
-  protected abstract void getAsync(C client, String pathIncludingQuery) throws Exception;
+    @Override public void onError(Throwable throwable) {
+    }
+  };
+
+  /**
+   * This invokes a GET with the indicated path, but does not block until the response is complete.
+   * The callback should always be invoked. For example, if there is a cancelation without error,
+   * you should invoke the {@link Callback#onError(Throwable)} with your own {@link
+   * CancellationException}.
+   */
+  protected abstract void getAsync(C client, String path, Callback<Void> callback) throws Exception;
 
   /**
    * This tests that the parent is determined at the time the request was made, not when the request
@@ -39,8 +57,8 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     ScopedSpan parent = tracer.startScopedSpan("test");
     try {
-      getAsync(client, "/items/1");
-      getAsync(client, "/items/2");
+      getAsync(client, "/items/1", NOOP_CALLBACK);
+      getAsync(client, "/items/2", NOOP_CALLBACK);
     } finally {
       parent.finish();
     }
@@ -60,6 +78,42 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     // Check we reported 2 in-process spans and 2 RPC client spans
     assertThat(Arrays.asList(takeSpan(), takeSpan(), takeSpan(), takeSpan()))
+      .extracting(Span::kind)
+      .containsOnly(null, Span.Kind.CLIENT);
+  }
+
+  /**
+   * This ensures that response callbacks run in the invocation context, not the client one. This
+   * allows async chaining to appear caused by the parent, not by the most recent client. Otherwise,
+   * we would see a client span child of a client span, which could be confused with duplicate
+   * instrumentation and affect dependency link counts.
+   */
+  @Test public void callbackContextIsFromInvocationTime() throws Exception {
+    BlockingQueue<Object> result = new LinkedBlockingQueue<>();
+    server.enqueue(new MockResponse());
+
+    ScopedSpan parent = tracer().startScopedSpan("test");
+    try {
+      getAsync(client, "/foo", new Callback<Void>() {
+        @Override public void onSuccess(Void success) {
+          result.add(currentTraceContext.get());
+        }
+
+        @Override public void onError(Throwable throwable) {
+          result.add(throwable);
+        }
+      });
+    } finally {
+      parent.finish();
+    }
+    server.takeRequest();
+
+    assertThat(result.poll(1, TimeUnit.SECONDS))
+      .isInstanceOf(TraceContext.class)
+      .isSameAs(parent.context());
+
+    // Check we reported 1 in-process span and 1 RPC client spans
+    assertThat(Arrays.asList(takeSpan(), takeSpan()))
       .extracting(Span::kind)
       .containsOnly(null, Span.Kind.CLIENT);
   }

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -157,36 +157,44 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
     @Override public void start() {
       delegate.start();
     }
+
+    @Override public String toString() {
+      return delegate.toString();
+    }
   }
 
   static final class TraceContextFutureCallback<T> implements FutureCallback<T> {
     final FutureCallback<T> delegate;
     final CurrentTraceContext currentTraceContext;
-    final TraceContext traceContext;
+    final TraceContext invocationContext;
 
     TraceContextFutureCallback(FutureCallback<T> delegate,
-      CurrentTraceContext currentTraceContext, TraceContext traceContext) {
-      this.currentTraceContext = currentTraceContext;
-      this.traceContext = traceContext;
+      CurrentTraceContext currentTraceContext, TraceContext invocationContext) {
       this.delegate = delegate;
+      this.currentTraceContext = currentTraceContext;
+      this.invocationContext = invocationContext;
     }
 
     @Override public void completed(T t) {
-      try (Scope scope = currentTraceContext.maybeScope(traceContext)) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
         delegate.completed(t);
       }
     }
 
     @Override public void failed(Exception e) {
-      try (Scope scope = currentTraceContext.maybeScope(traceContext)) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
         delegate.failed(e);
       }
     }
 
     @Override public void cancelled() {
-      try (Scope scope = currentTraceContext.maybeScope(traceContext)) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
         delegate.cancelled();
       }
+    }
+
+    @Override public String toString() {
+      return delegate.toString();
     }
   }
 

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -94,13 +94,13 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
       removeScope(context);
     }
   }
-  
+
   static void removeScope(HttpContext context) {
-      Scope scope = (Scope) context.getAttribute(Scope.class.getName());
-      if (scope == null) return;
-      context.removeAttribute(Scope.class.getName());
-      scope.close();
-    }
+    Scope scope = (Scope) context.getAttribute(Scope.class.getName());
+    if (scope == null) return;
+    context.removeAttribute(Scope.class.getName());
+    scope.close();
+  }
 
   final class HandleReceive implements HttpResponseInterceptor {
     @Override public void process(HttpResponse response, HttpContext context) {
@@ -128,15 +128,21 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
     }
 
     @Override public <T> Future<T> execute(HttpAsyncRequestProducer requestProducer,
-      HttpAsyncResponseConsumer<T> responseConsumer, HttpContext context,
+      HttpAsyncResponseConsumer<T> responseConsumer, HttpContext httpContext,
       FutureCallback<T> callback) {
-      TraceContext traceCtx = currentTraceContext.get();
-      context.setAttribute(TraceContext.class.getName(), traceCtx);
+
+      TraceContext invocationContext = currentTraceContext.get();
+      if (invocationContext != null) {
+        httpContext.setAttribute(TraceContext.class.getName(), invocationContext);
+      }
+
       return delegate.execute(
-        new TracingAsyncRequestProducer(requestProducer, context),
-        new TracingAsyncResponseConsumer<>(responseConsumer, context),
-        context,
-        callback == null ? null : new TraceContextAwareFutureCallback(currentTraceContext, traceCtx, callback)
+        new TracingAsyncRequestProducer(requestProducer, httpContext),
+        new TracingAsyncResponseConsumer<>(responseConsumer, httpContext),
+        httpContext,
+        callback != null && invocationContext != null
+          ? new TraceContextFutureCallback<>(callback, currentTraceContext, invocationContext)
+          : callback
       );
     }
 
@@ -153,32 +159,33 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
     }
   }
 
-  static final class TraceContextAwareFutureCallback<T> implements FutureCallback<T> {
-    private final CurrentTraceContext currentTraceContext;
-    private final TraceContext traceCtx;
-    private final FutureCallback<T> callback;
+  static final class TraceContextFutureCallback<T> implements FutureCallback<T> {
+    final FutureCallback<T> delegate;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext traceContext;
 
-    TraceContextAwareFutureCallback(CurrentTraceContext currentTraceContext, TraceContext traceCtx, FutureCallback<T> callback) {
+    TraceContextFutureCallback(FutureCallback<T> delegate,
+      CurrentTraceContext currentTraceContext, TraceContext traceContext) {
       this.currentTraceContext = currentTraceContext;
-      this.traceCtx = traceCtx;
-      this.callback = callback;
+      this.traceContext = traceContext;
+      this.delegate = delegate;
     }
 
     @Override public void completed(T t) {
-      try (Scope scope = currentTraceContext.maybeScope(traceCtx)) {
-        callback.completed(t);
+      try (Scope scope = currentTraceContext.maybeScope(traceContext)) {
+        delegate.completed(t);
       }
     }
 
     @Override public void failed(Exception e) {
-      try (Scope scope = currentTraceContext.maybeScope(traceCtx)) {
-        callback.failed(e);
+      try (Scope scope = currentTraceContext.maybeScope(traceContext)) {
+        delegate.failed(e);
       }
     }
 
     @Override public void cancelled() {
-      try (Scope scope = currentTraceContext.maybeScope(traceCtx)) {
-        callback.cancelled();
+      try (Scope scope = currentTraceContext.maybeScope(traceContext)) {
+        delegate.cancelled();
       }
     }
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
@@ -22,6 +22,7 @@ import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.core.MediaType;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.Ignore;
+import zipkin2.Callback;
 
 public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
   @Override protected Client newClient(int port) {
@@ -43,16 +44,17 @@ public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
       .get(String.class);
   }
 
-  @Override protected void getAsync(Client client, String pathIncludingQuery) {
-    client.target(url(pathIncludingQuery))
+  @Override protected void getAsync(Client client, String path, Callback<Void> callback) {
+    client.target(url(path))
       .request(MediaType.TEXT_PLAIN_TYPE)
       .async()
       .get(new InvocationCallback<String>() {
         @Override public void completed(String response) {
+          callback.onSuccess(null);
         }
 
         @Override public void failed(Throwable throwable) {
-          throwable.printStackTrace();
+          callback.onError(throwable);
         }
       });
   }

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -54,4 +54,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/README.md
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/README.md
@@ -1,0 +1,2 @@
+# kafka1
+This tests that KafkaPropagation can be used with kafka-client v<2

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/README.md
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/README.md
@@ -1,2 +1,2 @@
-# kafka1
-This tests that KafkaPropagation can be used with kafka-client v<2
+# okhttp3_v3
+This tests that TracingCallFactory can be used with okhttp3 <3.12

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/pom.xml
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013-2020 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>okhttp3_v3</artifactId>
+  <version>@project.version@</version>
+  <name>okhttp3_v3</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- Last version before Call.timeout was added -->
+    <okhttp.version>3.11.0</okhttp.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>brave-instrumentation-okhttp3</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>@project.version@</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>mockwebserver</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>@project.build.testSourceDirectory@</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+        <configuration>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-failsafe-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave.okhttp3_v3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave.okhttp3_v3/ITTracingCallFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.brave.okhttp3_v3;
+
+public class ITTracingCallFactory extends brave.okhttp3.ITTracingCallFactory {
+}

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave.okhttp3_v3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave.okhttp3_v3/ITTracingInterceptor.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.brave.okhttp3_v3;
+
+public class ITTracingInterceptor extends brave.okhttp3.ITTracingInterceptor {
+}

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TraceContextCall.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TraceContextCall.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.okhttp3;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
+import okio.Timeout;
+
+/**
+ * Ensures callbacks run in the invocation trace context.
+ *
+ * <p>Note: {@link #timeout()} was added in OkHttp 3.12
+ */
+final class TraceContextCall implements Call {
+  final Call delegate;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext invocationContext;
+
+  TraceContextCall(Call delegate, CurrentTraceContext currentTraceContext,
+    TraceContext invocationContext) {
+    this.delegate = delegate;
+    this.currentTraceContext = currentTraceContext;
+    this.invocationContext = invocationContext;
+  }
+
+  @Override public void cancel() {
+    delegate.cancel();
+  }
+
+  @Override public Call clone() {
+    return new TraceContextCall(delegate.clone(), currentTraceContext, invocationContext);
+  }
+
+  @Override public void enqueue(Callback callback) {
+    delegate.enqueue(callback != null ? new TraceContextCallback(this, callback) : null);
+  }
+
+  @Override public Response execute() throws IOException {
+    try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+      return delegate.execute();
+    }
+  }
+
+  @Override public boolean isCanceled() {
+    return delegate.isCanceled();
+  }
+
+  @Override public boolean isExecuted() {
+    return delegate.isExecuted();
+  }
+
+  @Override public Request request() {
+    return delegate.request();
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 5.0
+  public Timeout timeout() {
+    return delegate.timeout();
+  }
+
+  @Override public String toString() {
+    return delegate.toString();
+  }
+
+  static final class TraceContextCallback implements Callback {
+    final Callback delegate;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext invocationContext;
+
+    TraceContextCallback(TraceContextCall call, Callback delegate) {
+      this.delegate = delegate;
+      this.currentTraceContext = call.currentTraceContext;
+      this.invocationContext = call.invocationContext;
+    }
+
+    @Override public void onResponse(Call call, Response response) throws IOException {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+        delegate.onResponse(call, response);
+      }
+    }
+
+    @Override public void onFailure(Call call, IOException e) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+        delegate.onFailure(call, e);
+      }
+    }
+
+    @Override public String toString() {
+      return delegate.toString();
+    }
+  }
+}

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,24 +55,26 @@ public final class TracingCallFactory implements Call.Factory {
   }
 
   @Override public Call newCall(Request request) {
-    TraceContext currentSpan = currentTraceContext.get();
+    TraceContext invocationContext = currentTraceContext.get();
     OkHttpClient.Builder b = ok.newBuilder();
-    if (currentSpan != null) b.interceptors().add(0, new SetParentSpanInScope(currentSpan));
+    if (invocationContext != null) {
+      b.interceptors().add(0, new TraceContextInterceptor(invocationContext));
+    }
     // TODO: This can hide errors at the beginning of call.execute, such as invalid host!
     return b.build().newCall(request);
   }
 
   /** In case a request is deferred due to a backlog, we re-apply the span that was in scope */
-  class SetParentSpanInScope implements Interceptor {
-    final TraceContext previous;
+  class TraceContextInterceptor implements Interceptor {
+    final TraceContext invocationContext;
 
-    SetParentSpanInScope(TraceContext previous) {
-      this.previous = previous;
+    TraceContextInterceptor(TraceContext invocationContext) {
+      this.invocationContext = invocationContext;
     }
 
     @Override public Response intercept(Chain chain) throws IOException {
       // using maybeScope as when there's no backlog situation the span may already be in scope
-      try (Scope ws = currentTraceContext.maybeScope(previous)) {
+      try (Scope ws = currentTraceContext.maybeScope(invocationContext)) {
         return chain.proceed(chain.request());
       }
     }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -62,7 +62,8 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
     throws Exception {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery))
-      .post(RequestBody.create(body, MediaType.parse("text/plain"))).build())
+      // intentionally deprecated method so that the v3.x tests can compile
+      .post(RequestBody.create(MediaType.parse("text/plain"), body)).build())
       .execute();
   }
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Dispatcher;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -40,6 +41,10 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
       .connectTimeout(1, TimeUnit.SECONDS)
       .readTimeout(1, TimeUnit.SECONDS)
       .retryOnConnectionFailure(false)
+      .dispatcher(new Dispatcher(
+        httpTracing.tracing().currentTraceContext()
+          .executorService(new Dispatcher().executorService())
+      ))
       .build()
     );
   }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -61,14 +61,16 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
       .execute();
   }
 
-  @Override protected void getAsync(Call.Factory client, String pathIncludingQuery) {
-    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
+  @Override
+  protected void getAsync(Call.Factory client, String path, zipkin2.Callback<Void> callback) {
+    client.newCall(new Request.Builder().url(url(path)).build())
       .enqueue(new Callback() {
         @Override public void onFailure(Call call, IOException e) {
-          e.printStackTrace();
+          callback.onError(e);
         }
 
         @Override public void onResponse(Call call, Response response) {
+          callback.onSuccess(null);
         }
       });
   }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -41,10 +41,6 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
       .connectTimeout(1, TimeUnit.SECONDS)
       .readTimeout(1, TimeUnit.SECONDS)
       .retryOnConnectionFailure(false)
-      .dispatcher(new Dispatcher(
-        httpTracing.tracing().currentTraceContext()
-          .executorService(new Dispatcher().executorService())
-      ))
       .build()
     );
   }
@@ -53,10 +49,8 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     ((TracingCallFactory) client).ok.dispatcher().executorService().shutdownNow();
   }
 
-  @Override protected void get(Call.Factory client, String pathIncludingQuery)
-    throws IOException {
-    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
-      .execute();
+  @Override protected void get(Call.Factory client, String pathIncludingQuery) throws IOException {
+    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build()).execute();
   }
 
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -40,7 +40,7 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
       .build();
   }
 
-  @Override protected void closeClient(Call.Factory client) throws IOException {
+  @Override protected void closeClient(Call.Factory client) {
     ((OkHttpClient) client).dispatcher().executorService().shutdownNow();
   }
 
@@ -53,7 +53,8 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
     throws Exception {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery))
-      .post(RequestBody.create(body, MediaType.parse("text/plain"))).build())
+      // intentionally deprecated method so that the v3.x tests can compile
+      .post(RequestBody.create(MediaType.parse("text/plain"), body)).build())
       .execute();
   }
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -57,14 +57,16 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
       .execute();
   }
 
-  @Override protected void getAsync(Call.Factory client, String pathIncludingQuery) {
-    client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build())
+  @Override
+  protected void getAsync(Call.Factory client, String path, zipkin2.Callback<Void> callback) {
+    client.newCall(new Request.Builder().url(url(path)).build())
       .enqueue(new Callback() {
         @Override public void onFailure(Call call, IOException e) {
-          e.printStackTrace();
+          callback.onError(e);
         }
 
-        @Override public void onResponse(Call call, Response response) throws IOException {
+        @Override public void onResponse(Call call, Response response) {
+          callback.onSuccess(null);
         }
       });
   }

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -45,6 +45,13 @@
       <version>${spring5.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jvnet</groupId>
+      <artifactId>animal-sniffer-annotation</artifactId>
+      <version>1.0</version>
+      <!-- annotations are not runtime retention, so don't need a runtime dep -->
+      <scope>provided</scope>
+    </dependency>
 
     <!-- needed for org.springframework.util.concurrent.ListenableFuture
          used by AsyncClientHttpRequestInterceptor -->

--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2019 The OpenZipkin Authors
+    Copyright 2013-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -50,25 +50,10 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>@httpclient.version@</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>@junit.version@</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>@assertj.version@</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
@@ -19,6 +19,7 @@ import brave.propagation.TraceContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -67,7 +68,8 @@ final class TraceContextListenableFuture<T> implements ListenableFuture<T> {
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 5.0
-  public CompletableFuture<T> completable() {
+  // Only called when in JRE 1.8+
+  @IgnoreJRERequirement public CompletableFuture<T> completable() {
     return delegate.completable(); // NOTE: trace context is not propagated
   }
 

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.spring.web;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.springframework.util.concurrent.FailureCallback;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
+
+/**
+ * Ensures callbacks run in the invocation trace context.
+ *
+ * <p>Note: {@link #completable()} is not instrumented to propagate the invocation trace context.
+ */
+final class TraceContextListenableFuture<T> implements ListenableFuture<T> {
+  final ListenableFuture<T> delegate;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext invocationContext;
+
+  TraceContextListenableFuture(ListenableFuture<T> delegate,
+    CurrentTraceContext currentTraceContext,
+    TraceContext invocationContext) {
+    this.delegate = delegate;
+    this.currentTraceContext = currentTraceContext;
+    this.invocationContext = invocationContext;
+  }
+
+  @Override public void addCallback(ListenableFutureCallback<? super T> callback) {
+    delegate.addCallback(callback != null
+      ? new TraceContextListenableFutureCallback<>(callback, currentTraceContext,
+      invocationContext)
+      : null
+    );
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 4.1
+  public void addCallback(SuccessCallback<? super T> successCallback,
+    FailureCallback failureCallback) {
+    delegate.addCallback(successCallback, failureCallback);
+    delegate.addCallback(
+      successCallback != null
+        ? new TraceContextSuccessCallback<>(successCallback, currentTraceContext,
+        invocationContext)
+        : null,
+      failureCallback != null
+        ? new TraceContextFailureCallback(failureCallback, currentTraceContext,
+        invocationContext)
+        : null
+    );
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 5.0
+  public CompletableFuture<T> completable() {
+    return delegate.completable(); // NOTE: trace context is not propagated
+  }
+
+  // Methods from java.util.concurrent.Future
+  @Override public boolean cancel(boolean mayInterruptIfRunning) {
+    return delegate.cancel(mayInterruptIfRunning);
+  }
+
+  @Override public boolean isCancelled() {
+    return delegate.isCancelled();
+  }
+
+  @Override public boolean isDone() {
+    return delegate.isDone();
+  }
+
+  @Override public T get() throws InterruptedException, ExecutionException {
+    return delegate.get();
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException {
+    return delegate.get();
+  }
+
+  static final class TraceContextListenableFutureCallback<T>
+    implements ListenableFutureCallback<T> {
+    final ListenableFutureCallback<T> delegate;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext invocationContext;
+
+    TraceContextListenableFutureCallback(ListenableFutureCallback<T> delegate,
+      CurrentTraceContext currentTraceContext, TraceContext invocationContext) {
+      this.currentTraceContext = currentTraceContext;
+      this.invocationContext = invocationContext;
+      this.delegate = delegate;
+    }
+
+    @Override public void onSuccess(T result) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+        delegate.onSuccess(result);
+      }
+    }
+
+    @Override public void onFailure(Throwable ex) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+        delegate.onFailure(ex);
+      }
+    }
+  }
+
+  static final class TraceContextSuccessCallback<T> implements SuccessCallback<T> {
+    final SuccessCallback<T> delegate;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext invocationContext;
+
+    TraceContextSuccessCallback(SuccessCallback<T> delegate,
+      CurrentTraceContext currentTraceContext, TraceContext invocationContext) {
+      this.currentTraceContext = currentTraceContext;
+      this.invocationContext = invocationContext;
+      this.delegate = delegate;
+    }
+
+    @Override public void onSuccess(T result) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+        delegate.onSuccess(result);
+      }
+    }
+  }
+
+  static final class TraceContextFailureCallback implements FailureCallback {
+    final FailureCallback delegate;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext invocationContext;
+
+    TraceContextFailureCallback(FailureCallback delegate,
+      CurrentTraceContext currentTraceContext, TraceContext invocationContext) {
+      this.currentTraceContext = currentTraceContext;
+      this.invocationContext = invocationContext;
+      this.delegate = delegate;
+    }
+
+    @Override public void onFailure(Throwable ex) {
+      try (Scope scope = currentTraceContext.maybeScope(invocationContext)) {
+        delegate.onFailure(ex);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a generalization of @simontoens work in #1055 towards the other
http client impls. This ensures http client callbacks are made with invocation context as the current trace context.

- [x] httpasyncclient #1055
- [x] jaxrs2
- [x] okhttp3 (users need to configure the dispatcher's executor service)
- [x] spring-web
