### PR TITLE
Extends version range of Spring to 5

### DIFF
--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -29,7 +29,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <undertow.version>2.0.29.Final</undertow.version>
-    <spring.version>${spring4.version}</spring.version>
+    <spring.version>${spring5.version}</spring.version>
   </properties>
 
   <!-- can't import brave-bom due to build-support/go-offline.sh -->

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>${spring4.version}</version>
+      <version>${spring5.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>${spring4.version}</version>
+      <version>${spring5.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -66,6 +66,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring5.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <scope>test</scope>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -42,15 +42,16 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>${spring4.version}</version>
+      <version>${spring5.version}</version>
       <scope>provided</scope>
     </dependency>
 
-    <!-- needed for AsyncClientHttpRequestInterceptor -->
+    <!-- needed for org.springframework.util.concurrent.ListenableFuture
+         used by AsyncClientHttpRequestInterceptor -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>${spring4.version}</version>
+      <version>${spring5.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <zipkin-reporter.version>2.12.1</zipkin-reporter.version>
 
     <!-- Ensure older versions of spring still work -->
-    <spring4.version>4.3.26.RELEASE</spring4.version>
+    <spring5.version>5.2.3.RELEASE</spring5.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
     <!-- don't use apis not in jetty 7.6* else testing servlet 2.5 will imply duplication -->


### PR DESCRIPTION
Increasing the tested version spread of Spring from 4 -> 5 allows us to
test portability of code that has been retrofitted with Java 8 things,
ex `org.springframework.util.concurrent.ListenableFuture.completable()`