### PR TITLE
Add labels to issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: Bug
 about: If you’ve found a bug, spend the time to write a failing test. Bugs with tests get fixed and stay fixed. If you have a solution in mind, skip raising an issue and open a pull request instead.
-
+labels: bug
 ---
 ## Describe the Bug
 A clear and concise description of what the bug is. If you have a solution in mind, skip raising an issue and open a pull request instead.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Please first, look at existing issues to see if the feature has been requested before.
-
+labels: enhancement
 ---
 Please first, look at [existing issues](https://github.com/openzipkin/brave/issues) to see if the feature has been requested before. If you don't find anything tell us what problem you’re trying to solve. Often a solution already exists! Don’t send pull requests to implement new features without first getting our support. Sometimes we leave features out on purpose to keep the project small.
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: This issue tracker is not for questions. If you want to ask how to do something, or to understand why something isn't working the way you expect it to, please use https://gitter.im/openzipkin/zipkin
-
+labels: question
 ---
 
 This issue tracker is not for questions. If you want to ask how to do something, or to understand why something isn't working the way you expect it to, please use [Gitter](https://gitter.im/openzipkin/zipkin), [Stack Overflow](https://stackoverflow.com/questions/tagged/zipkin) or [email zipkin-user@googlegroups.com](https://groups.google.com/forum/#!forum/zipkin-user)


### PR DESCRIPTION
From step 7 in https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository