### PR TITLE
Adds defense for incorrectly implemented client and server requests

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -182,8 +182,11 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    * @since 4.3
    */
   public void handleReceive(@Nullable Resp response, @Nullable Throwable error, Span span) {
-    assert response != null || error != null :
-      "Either the response or error parameters may be null, but not both";
+    if (response == null && error == null) {
+      throw new IllegalArgumentException(
+        "Either the response or error parameters may be null, but not both");
+    }
+
     if (!(response instanceof HttpClientResponse)) {
       handleFinish(adapter, response, error, span);
       return;

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -176,16 +176,25 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    * <p>This is typically called once the response headers are received, and after the span is
    * {@link brave.Tracer.SpanInScope#close() no longer in scope}.
    *
+   * <p>Note: Either the response or error parameters may be null, but not both.
+   *
    * @see HttpClientParser#response(HttpAdapter, Object, Throwable, SpanCustomizer)
    * @since 4.3
    */
   public void handleReceive(@Nullable Resp response, @Nullable Throwable error, Span span) {
-    if (response instanceof HttpClientResponse) {
-      HttpClientResponse.Adapter adapter =
-        new HttpClientResponse.Adapter((HttpClientResponse) response);
-      handleFinish(adapter, adapter.unwrapped, error, span);
-    } else {
+    assert response != null || error != null :
+      "Either the response or error parameters may be null, but not both";
+    if (!(response instanceof HttpClientResponse)) {
       handleFinish(adapter, response, error, span);
+      return;
+    }
+
+    HttpClientResponse clientResponse = (HttpClientResponse) response;
+    Object unwrapped = clientResponse.unwrap();
+    if (unwrapped == null) { // Handle bad implementation of HttpClientResponse
+      handleFinish(error, span);
+    } else {
+      handleFinish(new HttpClientResponse.Adapter(clientResponse), unwrapped, error, span);
     }
   }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -50,7 +50,7 @@ public abstract class HttpClientRequest extends HttpRequest {
    * @see #SETTER
    * @since 5.7
    */
-  @Nullable public abstract void header(String name, String value);
+  public abstract void header(String name, String value);
 
   /**
    * <h3>Why do we need an {@link HttpClientAdapter}?</h3>

--- a/instrumentation/http/src/main/java/brave/http/HttpHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -48,6 +48,14 @@ abstract class HttpHandler {
 
   /** parses remote IP:port and tags while the span is in scope (for logging for example) */
   abstract <Req> void parseRequest(HttpAdapter<Req, ?> adapter, Req request, Span span);
+
+
+  // adapter shouldn't be null. we accept it only to not crash on bad instrumentation
+  void handleFinish(@Nullable Throwable error, Span span) {
+    if (span.isNoop()) return;
+    if (error != null) parser.errorParser().error(error, span.customizer());
+    span.finish();
+  }
 
   <Resp> void handleFinish(HttpAdapter<?, Resp> adapter, @Nullable Resp response,
     @Nullable Throwable error, Span span) {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -148,8 +148,11 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
    * @since 4.3
    */
   public void handleSend(@Nullable Resp response, @Nullable Throwable error, Span span) {
-    assert response != null || error != null :
-      "Either the response or error parameters may be null, but not both";
+    if (response == null && error == null) {
+      throw new IllegalArgumentException(
+        "Either the response or error parameters may be null, but not both");
+    }
+
     if (!(response instanceof HttpServerResponse)) {
       handleFinish(adapter, response, error, span);
       return;

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -142,16 +142,25 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
    * <p>This is typically called once the response headers are sent, and after the span is {@link
    * brave.Tracer.SpanInScope#close() no longer in scope}.
    *
+   * <p>Note: Either the response or error parameters may be null, but not both.
+   *
    * @see HttpServerParser#response(HttpAdapter, Object, Throwable, SpanCustomizer)
    * @since 4.3
    */
   public void handleSend(@Nullable Resp response, @Nullable Throwable error, Span span) {
-    if (response instanceof HttpServerResponse) {
-      HttpServerResponse.Adapter adapter =
-        new HttpServerResponse.Adapter((HttpServerResponse) response);
-      handleFinish(adapter, adapter.unwrapped, error, span);
-    } else {
+    assert response != null || error != null :
+      "Either the response or error parameters may be null, but not both";
+    if (!(response instanceof HttpServerResponse)) {
       handleFinish(adapter, response, error, span);
+      return;
+    }
+
+    HttpServerResponse serverResponse = (HttpServerResponse) response;
+    Object unwrapped = serverResponse.unwrap();
+    if (unwrapped == null) { // Handle bad implementation of HttpServerResponse
+      handleFinish(error, span);
+    } else {
+      handleFinish(new HttpServerResponse.Adapter(serverResponse), unwrapped, error, span);
     }
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -35,6 +35,7 @@ import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -281,5 +282,13 @@ public class HttpClientHandlerTest {
     verify(span).tag("error", "peanuts");
     verify(span).finish();
     verifyNoMoreInteractions(span);
+  }
+
+  @Test public void handleReceive_oneOfResponseError() {
+    brave.Span span = mock(brave.Span.class);
+
+    assertThatThrownBy(() -> defaultHandler.handleReceive(null, null, span))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Either the response or error parameters may be null, but not both");
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpClientHandlerTest {
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
   List<Span> spans = new ArrayList<>();
   @Mock HttpSampler sampler;
   HttpTracing httpTracing;
@@ -218,37 +219,67 @@ public class HttpClientHandlerTest {
   @Test public void handleSend_parserSeesUnwrappedType() {
     when(requestSampler.trySample(defaultRequest)).thenReturn(null);
 
-    brave.Span span = defaultHandler.handleSend(defaultRequest);
-    defaultHandler.handleReceive(defaultResponse, null, span);
+    defaultHandler.handleSend(defaultRequest);
 
     verify(parser).request(any(ToHttpAdapter.class), eq(request), any(SpanCustomizer.class));
   }
 
   @Test public void handleReceive_oldHandler() {
-    when(sampler.trySample(any(FromHttpAdapter.class))).thenReturn(null);
+    brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
+    when(span.customizer()).thenReturn(span);
 
-    brave.Span span = handler.handleSend(injector, adapter, request);
     handler.handleReceive(response, null, span);
 
-    verify(parser).response(eq(adapter), eq(response), isNull(), any(SpanCustomizer.class));
+    verify(parser).response(eq(adapter), eq(response), isNull(), eq(span));
   }
 
   @Test public void handleReceive_parserSeesUnwrappedType() {
-    when(requestSampler.trySample(defaultRequest)).thenReturn(null);
+    brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
+    when(span.customizer()).thenReturn(span);
 
-    brave.Span span = defaultHandler.handleSend(defaultRequest);
     defaultHandler.handleReceive(defaultResponse, null, span);
 
-    verify(parser).request(any(ToHttpAdapter.class), eq(request), any(SpanCustomizer.class));
+    HttpClientResponse.Adapter adapter = new HttpClientResponse.Adapter(defaultResponse);
+    verify(parser).response(eq(adapter), eq(response), isNull(), eq(span));
   }
 
   @Test public void handleReceive_parserSeesUnwrappedType_oldHandler() {
-    when(sampler.trySample(defaultRequest)).thenReturn(null);
+    brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
+    when(span.customizer()).thenReturn(span);
 
-    brave.Span span = handler.handleSend(defaultRequest);
     handler.handleReceive(defaultResponse, null, span);
 
     HttpClientResponse.Adapter adapter = new HttpClientResponse.Adapter(defaultResponse);
-    verify(parser).response(eq(adapter), eq(response), isNull(), any(SpanCustomizer.class));
+    verify(parser).response(eq(adapter), eq(response), isNull(), eq(span));
+  }
+
+  /** Ensure bad implementation of HttpClientResponse doesn't crash */
+  @Test public void handleReceive_finishesSpanEvenIfUnwrappedNull() {
+    brave.Span span = mock(brave.Span.class);
+
+    defaultHandler.handleReceive(mock(HttpClientResponse.class), null, span);
+
+    verify(span).isNoop();
+    verify(span).finish();
+    verifyNoMoreInteractions(span);
+  }
+
+  /** Ensure bad implementation of HttpClientResponse doesn't crash */
+  @Test public void handleReceive_finishesSpanEvenIfUnwrappedNull_withError() {
+    brave.Span span = mock(brave.Span.class);
+    when(span.customizer()).thenReturn(span);
+
+    Exception error = new RuntimeException("peanuts");
+
+    defaultHandler.handleReceive(mock(HttpClientResponse.class), error, span);
+
+    verify(span).isNoop();
+    verify(span).customizer();
+    verify(span).tag("error", "peanuts");
+    verify(span).finish();
+    verifyNoMoreInteractions(span);
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -34,6 +34,7 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -263,5 +264,13 @@ public class HttpServerHandlerTest {
     verify(span).tag("error", "peanuts");
     verify(span).finish();
     verifyNoMoreInteractions(span);
+  }
+
+  @Test public void handleSend_oneOfResponseError() {
+    brave.Span span = mock(brave.Span.class);
+
+    assertThatThrownBy(() -> defaultHandler.handleSend(null, null, span))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Either the response or error parameters may be null, but not both");
   }
 }


### PR DESCRIPTION
It is invalid to return null when unwrapping the portable http client
or server types. However, if someone did return null, it is hard to
determine what went wrong. This tolerates the incorrect code similarly
to how we do in toString. The result is that the span will finish and
the code won't crash.