### PR TITLE
Ensures integration tests won't hang

### DIFF
--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import com.alibaba.dubbo.rpc.RpcContext;
 import com.alibaba.dubbo.rpc.service.GenericService;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
@@ -80,7 +81,7 @@ class TestServer {
   }
 
   TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
-    return requestQueue.take();
+    return requestQueue.poll(3, TimeUnit.SECONDS);
   }
 
   void enqueueDelay(long millis) {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.Constants;
@@ -85,7 +86,7 @@ class TestServer {
   }
 
   TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
-    return requestQueue.take();
+    return requestQueue.poll(3, TimeUnit.SECONDS);
   }
 
   void enqueueDelay(long millis) {

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import io.grpc.ServerInterceptors;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 class TestServer {
   BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
@@ -68,7 +69,7 @@ class TestServer {
   }
 
   TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
-    return requestQueue.take();
+    return requestQueue.poll(3, TimeUnit.SECONDS);
   }
 
   void enqueueDelay(long millis) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -92,6 +92,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * breaking are less.
  */
 public abstract class ITHttp {
+  /**
+   * We use a global rule instead of surefire config as this could be executed in gradle, sbt, etc.
+   * This way, there's visibility on which method hung without asking the end users to edit build
+   * config.
+   */
   @Rule public Timeout globalTimeout = Timeout.seconds(5); // 5 seconds max per method
 
   public static final String EXTRA_KEY = "user-id";

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import zipkin2.Span;
 
@@ -91,6 +92,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * breaking are less.
  */
 public abstract class ITHttp {
+  @Rule public Timeout globalTimeout = Timeout.seconds(5); // 5 seconds max per method
+
   public static final String EXTRA_KEY = "user-id";
 
   /**

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -66,7 +66,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
     ScopedSpan otherSpan = tracer.startScopedSpan("test2");
     try {
       for (int i = 0; i < 2; i++) {
-        RecordedRequest request = server.takeRequest();
+        RecordedRequest request = takeRequest();
         assertThat(request.getHeader("x-b3-traceId"))
           .isEqualTo(parent.context().traceIdString());
         assertThat(request.getHeader("x-b3-parentspanid"))
@@ -106,7 +106,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
     } finally {
       parent.finish();
     }
-    server.takeRequest();
+    takeRequest();
 
     assertThat(result.poll(1, TimeUnit.SECONDS))
       .isInstanceOf(TraceContext.class)
@@ -133,7 +133,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
       }
     });
 
-    server.takeRequest();
+    takeRequest();
 
     assertThat(result.poll(1, TimeUnit.SECONDS))
       .isNull();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -21,6 +21,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
@@ -30,11 +32,12 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
-  static final Callback<Void> NOOP_CALLBACK = new Callback<Void>() {
+  static final Callback<Void> LOG_ON_ERROR_CALLBACK = new Callback<Void>() {
     @Override public void onSuccess(Void aVoid) {
     }
 
     @Override public void onError(Throwable throwable) {
+      Logger.getAnonymousLogger().log(Level.SEVERE, "Unexpected error", throwable);
     }
   };
 
@@ -57,8 +60,8 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     ScopedSpan parent = tracer.startScopedSpan("test");
     try {
-      getAsync(client, "/items/1", NOOP_CALLBACK);
-      getAsync(client, "/items/2", NOOP_CALLBACK);
+      getAsync(client, "/items/1", LOG_ON_ERROR_CALLBACK);
+      getAsync(client, "/items/2", LOG_ON_ERROR_CALLBACK);
     } finally {
       parent.finish();
     }

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -70,7 +70,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
 
     get(client, "/foo");
 
-    RecordedRequest request = server.takeRequest();
+    RecordedRequest request = takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -60,7 +60,7 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
 
     get(client, "/foo");
 
-    RecordedRequest request = server.takeRequest();
+    RecordedRequest request = takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -93,7 +93,7 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
       parent.finish();
     }
 
-    RecordedRequest request = server.takeRequest();
+    RecordedRequest request = takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -96,7 +96,7 @@ public class ITTracingAsyncClientHttpRequestInterceptor
     }));
     restTemplate.getForEntity(server.url("/foo").toString(), String.class).get();
 
-    RecordedRequest request = server.takeRequest();
+    RecordedRequest request = takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -69,7 +69,7 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     }));
     restTemplate.getForObject(server.url("/foo").toString(), String.class);
 
-    RecordedRequest request = server.takeRequest();
+    RecordedRequest request = takeRequest();
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 


### PR DESCRIPTION
This adds a global timeout of 5s/method for HTTP integration tests.
It also carries over the 3s/poll timeout from taking a span for other
queue based operations. This is an effort to reduce the impact of
testing async libraries with bugs in their callback management.