### PR TITLE
Preserve case of local and remote service names

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,6 @@ import brave.sampler.SamplerFunction;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -152,8 +151,8 @@ public abstract class Tracing implements Closeable {
     Set<FinishedSpanHandler> finishedSpanHandlers = new LinkedHashSet<>(); // dupes not ok
 
     /**
-     * Lower-case label of the remote node in the service graph, such as "favstar". Avoid names with
-     * variables or unique identifiers embedded. Defaults to "unknown".
+     * Label of the remote node in the service graph, such as "favstar". Avoid names with variables
+     * or unique identifiers embedded. Defaults to "unknown".
      *
      * <p>This is a primary label for trace lookup and aggregation, so it should be intuitive and
      * consistent. Many use a name from service discovery.
@@ -164,7 +163,7 @@ public abstract class Tracing implements Closeable {
       if (localServiceName == null || localServiceName.isEmpty()) {
         throw new IllegalArgumentException(localServiceName + " is not a valid serviceName");
       }
-      this.localServiceName = localServiceName.toLowerCase(Locale.ROOT);
+      this.localServiceName = localServiceName;
       return this;
     }
 

--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import brave.internal.IpLiteral;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
-import java.util.Locale;
 
 /**
  * This represents a span except for its {@link TraceContext}. It is mutable, for late adjustments.
@@ -148,7 +147,7 @@ public final class MutableSpan implements Cloneable {
     if (localServiceName == null || localServiceName.isEmpty()) {
       throw new NullPointerException("localServiceName is empty");
     }
-    this.localServiceName = localServiceName.toLowerCase(Locale.ROOT);
+    this.localServiceName = localServiceName;
   }
 
   /** When null {@link brave.Tracing.Builder#localIp(String) default} will be used for zipkin. */
@@ -184,7 +183,7 @@ public final class MutableSpan implements Cloneable {
     if (remoteServiceName == null || remoteServiceName.isEmpty()) {
       throw new NullPointerException("remoteServiceName is empty");
     }
-    this.remoteServiceName = remoteServiceName.toLowerCase(Locale.ROOT);
+    this.remoteServiceName = remoteServiceName;
   }
 
   /**

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -67,6 +67,12 @@ public class TracingTest {
     }
 
     assertThat(spans).isEmpty();
+  }
+
+  @Test public void localServiceNamePreservesCase() {
+    String expectedLocalServiceName = "FavStar";
+    Tracing.Builder builder = Tracing.newBuilder().localServiceName(expectedLocalServiceName);
+    assertThat(builder).extracting("localServiceName").isEqualTo(expectedLocalServiceName);
   }
 
   @Test public void spanReporter_getsLocalEndpointInfo() {

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -176,6 +176,20 @@ public class MutableSpanTest {
       entry(2L, "cc=xxxx-xxxx-xxxx-xxxx"),
       entry(3L, "3")
     );
+  }
+
+  @Test public void localServiceNamePreservesCase() {
+    String expectedLocalServiceName = "FavStar";
+    MutableSpan span = new MutableSpan();
+    span.localServiceName(expectedLocalServiceName);
+    assertThat(span.localServiceName()).isEqualTo(expectedLocalServiceName);
+  }
+
+  @Test public void remoteServiceNamePreservesCase() {
+    String expectedRemoteServiceName = "FavStar";
+    MutableSpan span = new MutableSpan();
+    span.remoteServiceName(expectedRemoteServiceName);
+    assertThat(span.remoteServiceName()).isEqualTo(expectedRemoteServiceName);
   }
 
   /**


### PR DESCRIPTION
`MutableSpan` should preserve the case of the service name string in the `localServiceName(String)` and `remoteServiceName(String)` setters.

This will allow one to report service names in a case-preserving manner to back-ends that support it. (The Zipkin back-end will continue to see lowercase service names since `zipkin2.Endpoint` enforces lowercase.)

See [this Gitter discussion](https://gitter.im/openzipkin/zipkin?at=5e3db3f855b6b04bf69b3c6d) for more reasoning.