### PR TITLE
Allows client instrumentation to avoid thread local scoping

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -733,8 +733,19 @@ use of `Tracer.currentSpan()` from external code.
 Here's an example of explicit propagation:
 ```java
 class MyFilter extends Filter {
+
+  public void onSchedule(Attributes attributes) {
+    // Stash the invoking trace context as this will be the correct parent of
+    // the request.
+    attributes.put(TraceContext.class, currentTraceContext.get());
+  }
+
   public void onStart(Request request, Attributes attributes) {
-    // Assume you have code to start the span and add relevant tags...
+    // Retrieve the parent, if any, and start the span.
+    TraceContext parent = attributes.get(TraceContext.class);
+    Span span = tracer.nextSpanWithParent(samplerFunction, request, parent);
+
+    // add tags etc..
 
     // We can't open a scope as onFinish happens on another thread.
     // Instead, we propagate the span manually so at least basic tracing

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -529,7 +529,7 @@ public class Tracer {
    */
   public <T> ScopedSpan startScopedSpan(String name, SamplerFunction<T> samplerFunction, T arg) {
     if (name == null) throw new NullPointerException("name == null");
-    return newScopedSpan(name, nextContext(samplerFunction, arg));
+    return newScopedSpan(name, nextContext(samplerFunction, arg, currentTraceContext.get()));
   }
 
   /**
@@ -543,13 +543,28 @@ public class Tracer {
    * @since 5.8
    */
   public <T> Span nextSpan(SamplerFunction<T> samplerFunction, T arg) {
-    return _toSpan(nextContext(samplerFunction, arg));
+    return _toSpan(nextContext(samplerFunction, arg, currentTraceContext.get()));
   }
 
-  <T> TraceContext nextContext(SamplerFunction<T> samplerFunction, T arg) {
+  /**
+   * Like {@link #nextSpan(SamplerFunction, Object)} except this controls the parent context
+   * explicitly. This is useful when an invocation context is propagated manually, such as commonly
+   * the case with asynchronous client frameworks.
+   *
+   * @param samplerFunction invoked if there's no {@link CurrentTraceContext#get() current trace}
+   * @param arg parameter to {@link SamplerFunction#trySample(Object)}
+   * @param parent null if the span was null.
+   * @see #nextSpan(SamplerFunction, Object)
+   * @since 5.10
+   */
+  public <T> Span nextSpanWithParent(SamplerFunction<T> samplerFunction, T arg,
+    @Nullable TraceContext parent) {
+    return _toSpan(nextContext(samplerFunction, arg, parent));
+  }
+
+  <T> TraceContext nextContext(SamplerFunction<T> samplerFunction, T arg, TraceContext parent) {
     if (samplerFunction == null) throw new NullPointerException("samplerFunction == null");
     if (arg == null) throw new NullPointerException("arg == null");
-    TraceContext parent = currentTraceContext.get();
     if (parent != null) return decorateContext(parent, parent.spanId());
 
     Boolean sampled = samplerFunction.trySample(arg);

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -548,12 +548,12 @@ public class Tracer {
 
   /**
    * Like {@link #nextSpan(SamplerFunction, Object)} except this controls the parent context
-   * explicitly. This is useful when an invocation context is propagated manually, such as commonly
+   * explicitly. This is useful when an invocation context is propagated manually, commonly
    * the case with asynchronous client frameworks.
    *
    * @param samplerFunction invoked if there's no {@link CurrentTraceContext#get() current trace}
    * @param arg parameter to {@link SamplerFunction#trySample(Object)}
-   * @param parent the potentially null parent to use for this span
+   * @param parent of the new span, or {@code null} if it should have no parent
    * @see #nextSpan(SamplerFunction, Object)
    * @since 5.10
    */

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -553,7 +553,7 @@ public class Tracer {
    *
    * @param samplerFunction invoked if there's no {@link CurrentTraceContext#get() current trace}
    * @param arg parameter to {@link SamplerFunction#trySample(Object)}
-   * @param parent null if the span was null.
+   * @param parent the potentially null parent to use for this span
    * @see #nextSpan(SamplerFunction, Object)
    * @since 5.10
    */

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -94,6 +94,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    *
    * <p>Call this before sending the request on the wire.
    *
+   * @see #handleSendWithParent(HttpClientRequest, TraceContext)
    * @since 5.7
    */
   public Span handleSend(HttpClientRequest request) {
@@ -109,7 +110,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    * @see Tracer#nextSpanWithParent(SamplerFunction, Object, TraceContext)
    * @since 5.10
    */
-  public Span handleSend(HttpClientRequest request, @Nullable TraceContext parent) {
+  public Span handleSendWithParent(HttpClientRequest request, @Nullable TraceContext parent) {
     if (request == null) throw new NullPointerException("request == null");
     return handleSend(request, tracer.nextSpanWithParent(httpSampler, request, parent));
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -102,6 +102,19 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
   }
 
   /**
+   * Like {@link #handleSend(HttpClientRequest)}, except explicitly controls the parent of the
+   * client span.
+   *
+   * @param parent the parent of the client span representing this request, or null for a new trace.
+   * @see Tracer#nextSpanWithParent(SamplerFunction, Object, TraceContext)
+   * @since 5.10
+   */
+  public Span handleSend(HttpClientRequest request, @Nullable TraceContext parent) {
+    if (request == null) throw new NullPointerException("request == null");
+    return handleSend(request, tracer.nextSpanWithParent(httpSampler, request, parent));
+  }
+
+  /**
    * Like {@link #handleSend(HttpClientRequest)}, except explicitly controls the span representing
    * the request.
    *

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -18,6 +18,8 @@ import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.http.HttpClientRequest.FromHttpAdapter;
 import brave.http.HttpClientRequest.ToHttpAdapter;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import brave.sampler.SamplerFunction;
@@ -225,6 +227,23 @@ public class HttpClientHandlerTest {
     verify(parser).request(any(ToHttpAdapter.class), eq(request), any(SpanCustomizer.class));
   }
 
+  @Test public void handleSendWithParent_overrideContext() {
+    try (Scope ws = this.defaultHandler.currentTraceContext.newScope(context)) {
+      brave.Span span = defaultHandler.handleSendWithParent(defaultRequest, null);
+
+      // If the overwrite was successful, we have a root span.
+      assertThat(span.context().parentIdAsLong()).isZero();
+    }
+  }
+
+  @Test public void handleSendWithParent_overrideNull() {
+    try (Scope ws = this.defaultHandler.currentTraceContext.newScope(null)) {
+      brave.Span span = defaultHandler.handleSendWithParent(defaultRequest, context);
+
+      // If the overwrite was successful, we have a child span.
+      assertThat(span.context().parentIdAsLong()).isEqualTo(context.spanId());
+    }
+  }
 
   @Test public void handleReceive_oldHandler() {
     brave.Span span = mock(brave.Span.class);

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -225,6 +225,7 @@ public class HttpClientHandlerTest {
     verify(parser).request(any(ToHttpAdapter.class), eq(request), any(SpanCustomizer.class));
   }
 
+
   @Test public void handleReceive_oldHandler() {
     brave.Span span = mock(brave.Span.class);
     when(span.context()).thenReturn(context);

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -77,11 +77,8 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
       HttpHost host = HttpClientContext.adapt(context).getTargetHost();
       HttpClientRequest wrapped = new HttpClientRequest(host, request);
 
-      TraceContext parent = (TraceContext) context.getAttribute(TraceContext.class.getName());
-      Span span;
-      try (Scope scope = currentTraceContext.maybeScope(parent)) {
-        span = handler.handleSend(wrapped);
-      }
+      TraceContext parent = (TraceContext) context.removeAttribute(TraceContext.class.getName());
+      Span span = handler.handleSendWithParent(wrapped, parent);
       parseTargetAddress(host, span);
 
       context.setAttribute(Span.class.getName(), span);

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingCallFactory.java
@@ -17,14 +17,10 @@ import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import java.io.IOException;
 import okhttp3.Call;
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
 
 /**
  * This internally adds an interceptor which ensures whatever current span exists is available via
@@ -33,6 +29,12 @@ import okhttp3.Response;
 // NOTE: this is not an interceptor because the current span can get lost when there's a backlog.
 // This will be completely different after https://github.com/square/okhttp/issues/270
 public final class TracingCallFactory implements Call.Factory {
+  /**
+   * To save overhead, we use a null sentinel when there's no parent. This helps avoid looking at
+   * the current trace context when there was no span in scope at invocation time.
+   */
+  static final TraceContext NULL_SENTINEL = TraceContext.newBuilder()
+    .traceId(1L).spanId(1L).build();
 
   public static Call.Factory create(Tracing tracing, OkHttpClient ok) {
     return create(HttpTracing.create(tracing), ok);
@@ -56,30 +58,9 @@ public final class TracingCallFactory implements Call.Factory {
 
   @Override public Call newCall(Request request) {
     TraceContext invocationContext = currentTraceContext.get();
-    Call call;
-    if (invocationContext != null) { // scope the call to the invocation context
-      OkHttpClient.Builder b = ok.newBuilder();
-      b.interceptors().add(0, new TraceContextInterceptor(invocationContext));
-      call = b.build().newCall(request);
-      return new TraceContextCall(call, currentTraceContext, invocationContext);
-    } else { // it is a root span, so just invoke normally
-      return ok.newCall(request);
-    }
-  }
-
-  /** In case a request is deferred due to a backlog, we re-apply the span that was in scope */
-  class TraceContextInterceptor implements Interceptor {
-    final TraceContext invocationContext;
-
-    TraceContextInterceptor(TraceContext invocationContext) {
-      this.invocationContext = invocationContext;
-    }
-
-    @Override public Response intercept(Chain chain) throws IOException {
-      // using maybeScope as when there's no backlog situation the span may already be in scope
-      try (Scope ws = currentTraceContext.maybeScope(invocationContext)) {
-        return chain.proceed(chain.request());
-      }
-    }
+    Call call = ok.newCall(request.newBuilder()
+      .tag(TraceContext.class, invocationContext != null ? invocationContext : NULL_SENTINEL)
+      .build());
+    return new TraceContextCall(call, currentTraceContext, invocationContext);
   }
 }

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
@@ -57,9 +57,9 @@ public final class TracingInterceptor implements Interceptor {
 
     Span span;
     TraceContext parent = chain.request().tag(TraceContext.class);
-    if (parent != null) {
-      span = handler.handleSend(request, parent != NULL_SENTINEL ? parent : null);
-    } else {
+    if (parent != null) { // TracingCallFactory setup this request
+      span = handler.handleSendWithParent(request, parent != NULL_SENTINEL ? parent : null);
+    } else { // This is using interceptors only
       span = handler.handleSend(request);
     }
 

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
@@ -19,12 +19,15 @@ import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import okhttp3.Connection;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import static brave.okhttp3.TracingCallFactory.NULL_SENTINEL;
 
 /**
  * This is a network-level interceptor, which creates a new span for each attempt. Note that this
@@ -52,7 +55,14 @@ public final class TracingInterceptor implements Interceptor {
   @Override public Response intercept(Chain chain) throws IOException {
     HttpClientRequest request = new HttpClientRequest(chain.request());
 
-    Span span = handler.handleSend(request);
+    Span span;
+    TraceContext parent = chain.request().tag(TraceContext.class);
+    if (parent != null) {
+      span = handler.handleSend(request, parent != NULL_SENTINEL ? parent : null);
+    } else {
+      span = handler.handleSend(request);
+    }
+
     parseRouteAddress(chain, span);
 
     HttpClientResponse response = null;

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
@@ -52,7 +52,7 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
       ClientHttpResponse result = execution.execute(request, body);
       response = new HttpClientResponse(result);
       return result;
-    } catch (IOException | RuntimeException | Error e) {
+    } catch (Throwable e) {
       error = e;
       throw e;
     } finally {


### PR DESCRIPTION
This allows async instrumentation to avoid any use of thread-local current trace context between callbacks.

The motivation for this was reactor-netty `WebClient` which needs to carry the subscription trace context to the request hook. Before this change, the code implied a threadlocal access (sometimes some other scope access) which was unnecessary and expensive.

It may not be obvious why this saves overhead. Mainly, folks hang things like log context synchronization on top of the scoping api. The more times a context is synced in tracing, the more times anything that hangs off it is synced. The total overhead is a sum of all those things, not just the threadlocal part.

Here's the jist of what this allows:

```java
class MyFilter extends Filter {

  public void onSchedule(Attributes attributes) {
    // Stash the invoking trace context as this will be the correct parent of
    // the request.
    attributes.put(TraceContext.class, currentTraceContext.get());
  }

  public void onStart(Request request, Attributes attributes) {
    // Retrieve the parent, if any, and start the span.
    TraceContext parent = attributes.get(TraceContext.class);
    Span span = tracer.nextSpanWithParent(samplerFunction, request, parent);
```

This tidies up okhttp and apache async client.. lowering overhead a bit.

Fixes #1082