### PR TITLE
Introduces `Response.error()` and uses it in HTTP abstraction

### DIFF
--- a/brave/src/main/java/brave/Request.java
+++ b/brave/src/main/java/brave/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import brave.sampler.SamplerFunction;
  * @see SamplerFunction
  * @see TraceContext.Extractor
  * @see TraceContext.Injector
+ * @see Response
  * @since 5.9
  */
 public abstract class Request {
@@ -34,7 +35,7 @@ public abstract class Request {
   public abstract Span.Kind spanKind();
 
   /**
-   * Returns the underlying request object or {@code this} if there is none. Here are some request
+   * Returns the underlying request object or {@code null} if there is none. Here are some request
    * objects: {@code org.apache.http.HttpRequest}, {@code org.apache.dubbo.rpc.Invocation}, {@code
    * org.apache.kafka.clients.consumer.ConsumerRecord}.
    *
@@ -49,7 +50,7 @@ public abstract class Request {
 
   @Override public String toString() {
     Object unwrapped = unwrap();
-    // unwrap() returning null is a bug. It could also return this. don't NPE or stack overflow!
+    // handles case where unwrap() returning this or null: don't NPE or stack overflow!
     if (unwrapped == null || unwrapped == this) return getClass().getSimpleName();
     return getClass().getSimpleName() + "{" + unwrapped + "}";
   }

--- a/brave/src/main/java/brave/Response.java
+++ b/brave/src/main/java/brave/Response.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave;
+
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.internal.Nullable;
+
+/**
+ * Abstract response type used for parsing.
+ *
+ * <h3>No extensions outside Brave</h3>
+ * While this is an abstract type, it should not be subclassed outside the Brave repository. In
+ * other words, subtypes are sealed within this source tree.
+ *
+ * @see Request
+ * @since 5.10
+ */
+public abstract class Response {
+  /** The remote {@link Span.Kind} describing the direction and type of the response. */
+  public abstract Span.Kind spanKind();
+
+  /**
+   * The error raised during response processing or null if there was none.
+   *
+   * <p>Lack of a throwable does not mean success. For example, in HTTP, there could be a 409
+   * status code with no corresponding Java exception.
+   *
+   * <h3>Handling errors</h3>
+   * Handlers invoke {@link Span#error(Throwable)} prior to passing control to user-defined response
+   * parsers. This allows any {@link FinishedSpanHandler} to see the raw error via {@link
+   * MutableSpan#error()}, in case of export to a non-Zipkin backend such as metrics.
+   *
+   * <p>User-defined parsers can take any error here into consideration when deriving a {@link
+   * SpanCustomizer#tag(String, String) "error" tag}. For example, if they prefer defaults, they do
+   * nothing. If they have a better error tag value than what would be derived from the {@link
+   * Throwable}, they can overwrite it.
+   */
+  @Nullable public abstract Throwable error();
+
+  /**
+   * Returns the underlying response object or {@code null} if there is none. Here are some response
+   * objects: {@code org.apache.http.HttpResponse}, {@code org.apache.dubbo.rpc.Result}, {@code
+   * org.apache.kafka.clients.producer.RecordMetadata}.
+   *
+   * <p>Note: Some implementations are composed of multiple types, such as a response and matched
+   * route of the server. Moreover, an implementation may change the type returned due to
+   * refactoring. Unless you control the implementation, cast carefully (ex using {@code
+   * instanceof}) instead of presuming a specific type will always be returned.
+   *
+   * @since 5.10
+   */
+  public abstract Object unwrap();
+
+  @Override public String toString() {
+    Object unwrapped = unwrap();
+    // handles case where unwrap() returning this or null: don't NPE or stack overflow!
+    if (unwrapped == null || unwrapped == this) return getClass().getSimpleName();
+    return getClass().getSimpleName() + "{" + unwrapped + "}";
+  }
+
+  protected Response() { // no instances of this type: only subtypes
+  }
+}

--- a/brave/src/main/java/brave/Response.java
+++ b/brave/src/main/java/brave/Response.java
@@ -32,7 +32,7 @@ public abstract class Response {
   public abstract Span.Kind spanKind();
 
   /**
-   * The error raised during response processing or null if there was none.
+   * The error raised during response processing or {@code null} if there was none.
    *
    * <p>Lack of a throwable does not mean success. For example, in HTTP, there could be a 409
    * status code with no corresponding Java exception.

--- a/brave/src/main/java/brave/Response.java
+++ b/brave/src/main/java/brave/Response.java
@@ -34,8 +34,8 @@ public abstract class Response {
   /**
    * The error raised during response processing or {@code null} if there was none.
    *
-   * <p>Lack of a throwable does not mean success. For example, in HTTP, there could be a 409
-   * status code with no corresponding Java exception.
+   * <p>Lack of throwable, {@code null}, does not mean success. For example, in HTTP, there could be
+   * a 409 status code with no corresponding Java exception.
    *
    * <h3>Handling errors</h3>
    * Handlers invoke {@link Span#error(Throwable)} prior to passing control to user-defined response

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -102,7 +102,7 @@ public class RealSpanTest {
       .containsExactly("foo");
   }
 
-  @Deprecated @Test public void remoteEndpoint_nulls() {
+  @Test public void remoteEndpoint_nulls() {
     span.remoteEndpoint(Endpoint.newBuilder().build());
     span.flush();
 

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -102,7 +102,7 @@ public class RealSpanTest {
       .containsExactly("foo");
   }
 
-  @Test public void remoteEndpoint_nulls() {
+  @Deprecated @Test public void remoteEndpoint_nulls() {
     span.remoteEndpoint(Endpoint.newBuilder().build());
     span.flush();
 

--- a/brave/src/test/java/brave/ResponseTest.java
+++ b/brave/src/test/java/brave/ResponseTest.java
@@ -17,38 +17,32 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RequestTest {
+public class ResponseTest {
   @Test public void toString_mentionsDelegate() {
-    class IceCreamRequest extends Request {
+    class IceCreamResponse extends Response {
       @Override public Span.Kind spanKind() {
         return Span.Kind.SERVER;
+      }
+
+      @Override public Throwable error() {
+        return null;
       }
 
       @Override public Object unwrap() {
         return "chocolate";
       }
     }
-    assertThat(new IceCreamRequest())
-      .hasToString("IceCreamRequest{chocolate}");
+    assertThat(new IceCreamResponse())
+      .hasToString("IceCreamResponse{chocolate}");
   }
 
   @Test public void toString_doesntStackoverflowWhenUnwrapIsThis() {
-    class BuggyRequest extends Request {
+    class BuggyResponse extends Response {
       @Override public Object unwrap() {
         return this;
       }
 
-      @Override public Span.Kind spanKind() {
-        return Span.Kind.SERVER;
-      }
-    }
-    assertThat(new BuggyRequest())
-      .hasToString("BuggyRequest");
-  }
-
-  @Test public void toString_doesntNPEWhenUnwrapIsNull() {
-    class NoRequest extends Request {
-      @Override public Object unwrap() {
+      @Override public Throwable error() {
         return null;
       }
 
@@ -56,7 +50,25 @@ public class RequestTest {
         return Span.Kind.SERVER;
       }
     }
-    assertThat(new NoRequest())
-      .hasToString("NoRequest");
+    assertThat(new BuggyResponse())
+      .hasToString("BuggyResponse");
+  }
+
+  @Test public void toString_doesntNPEWhenUnwrapIsNull() {
+    class NoResponse extends Response {
+      @Override public Object unwrap() {
+        return null;
+      }
+
+      @Override public Throwable error() {
+        return null;
+      }
+
+      @Override public Span.Kind spanKind() {
+        return Span.Kind.SERVER;
+      }
+    }
+    assertThat(new NoResponse())
+      .hasToString("NoResponse");
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/jersey/server/TracingApplicationEventListenerAdapterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jersey/server/TracingApplicationEventListenerAdapterBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package brave.jersey.server;
 
-import brave.jersey.server.TracingApplicationEventListener.HttpServerResponse;
+import brave.jersey.server.TracingApplicationEventListener.RequestEventWrapper;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -85,11 +85,11 @@ public class TracingApplicationEventListenerAdapterBenchmarks {
     .build(RequestEvent.Type.FINISHED);
 
   @Benchmark public String parseRoute() {
-    return new HttpServerResponse(event).route();
+    return new RequestEventWrapper(event, null).route();
   }
 
   @Benchmark public String parseRoute_nested() {
-    return new HttpServerResponse(nestedEvent).route();
+    return new RequestEventWrapper(nestedEvent, null).route();
   }
 
   // Convenience main entry-point

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
@@ -99,6 +100,7 @@ public abstract class ITHttp {
    * config.
    */
   @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(5)); // max per method
+  @Rule public TestName testName = new TestName();
 
   public static final String EXTRA_KEY = "user-id";
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -32,8 +32,8 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
-  static final Callback<Void> LOG_ON_ERROR_CALLBACK = new Callback<Void>() {
-    @Override public void onSuccess(Void aVoid) {
+  static final Callback<Integer> LOG_ON_ERROR_CALLBACK = new Callback<Integer>() {
+    @Override public void onSuccess(Integer statusCode) {
     }
 
     @Override public void onError(Throwable throwable) {
@@ -43,11 +43,17 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
   /**
    * This invokes a GET with the indicated path, but does not block until the response is complete.
-   * The callback should always be invoked. For example, if there is a cancelation without error,
-   * you should invoke the {@link Callback#onError(Throwable)} with your own {@link
-   * CancellationException}.
+   *
+   * <p>The success callback should always be invoked with the HTTP status code. If the
+   * implementation coerces a 500 code without an exception as an error, you should call the success
+   * callback directly.
+   *
+   * <p>One of success or failure callbacks must be invoked even on unexpected scenarios. For
+   * example, if there is a cancelation that didn't issue an error callback directly, you should
+   * invoke the {@link Callback#onError(Throwable)} with your own {@link CancellationException}.
    */
-  protected abstract void getAsync(C client, String path, Callback<Void> callback) throws Exception;
+  protected abstract void getAsync(C client, String path, Callback<Integer> callback)
+    throws Exception;
 
   /**
    * This tests that the parent is determined at the time the request was made, not when the request
@@ -97,8 +103,8 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     ScopedSpan parent = tracer().startScopedSpan("test");
     try {
-      getAsync(client, "/foo", new Callback<Void>() {
-        @Override public void onSuccess(Void success) {
+      getAsync(client, "/foo", new Callback<Integer>() {
+        @Override public void onSuccess(Integer statusCode) {
           result.add(currentTraceContext.get());
         }
 
@@ -130,8 +136,8 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
     // callback thread which would cause result.poll() to await max time.
     Object nullSentinel = new Object();
 
-    getAsync(client, "/foo", new Callback<Void>() {
-      @Override public void onSuccess(Void success) {
+    getAsync(client, "/foo", new Callback<Integer>() {
+      @Override public void onSuccess(Integer statusCode) {
         TraceContext context = currentTraceContext.get();
         result.add(context != null ? context : nullSentinel);
       }
@@ -148,5 +154,34 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     assertThat(takeSpan().kind())
       .isEqualTo(Span.Kind.CLIENT);
+  }
+
+  @Test public void httpStatusCodeTagMatchesCallback() throws Exception {
+    BlockingQueue<Object> result = new LinkedBlockingQueue<>();
+    // Default policy only records non-success codes
+    int expectedStatusCode = 400;
+    server.enqueue(new MockResponse().setResponseCode(expectedStatusCode));
+
+    getAsync(client, "/foo", new Callback<Integer>() {
+      @Override public void onSuccess(Integer statusCode) {
+        result.add(statusCode);
+      }
+
+      @Override public void onError(Throwable throwable) {
+        result.add(throwable);
+      }
+    });
+
+    takeRequest();
+
+    // Ensure the getAsync() method is implemented correctly
+    Object object = result.poll(1, TimeUnit.SECONDS);
+    assertThat(object).isInstanceOf(Integer.class);
+    int statusCodeFromCallback = (int) object;
+    assertThat(statusCodeFromCallback).isEqualTo(expectedStatusCode);
+
+    Span span = takeSpan();
+    assertThat(span.tags().get("http.status_code"))
+      .isEqualTo(String.valueOf(expectedStatusCode));
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -390,6 +390,15 @@ public abstract class ITHttpServer extends ITHttp {
       .containsEntry("error", "400");
   }
 
+  @Test
+  public void httpPathTagExcludesQueryParams() throws Exception {
+    get("/foo?z=2&yAA=1");
+
+    Span span = takeSpan();
+    assertThat(span.tags())
+      .containsEntry("http.path", "/foo");
+  }
+
   /**
    * Some synchronous frameworks have limited means to adjust the HTTP status code upon raising an
    * exception. When this is the case, use the following built-in exception:
@@ -466,15 +475,6 @@ public abstract class ITHttpServer extends ITHttp {
     takeSpan();
 
     assertThat(caughtThrowable.get()).isNotNull();
-  }
-
-  @Test
-  public void httpPathTagExcludesQueryParams() throws Exception {
-    get("/foo?z=2&yAA=1");
-
-    Span span = takeSpan();
-    assertThat(span.tags())
-      .containsEntry("http.path", "/foo");
   }
 
   protected Response get(String path) throws Exception {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,10 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -30,14 +34,42 @@ import org.junit.Test;
 public abstract class ITServlet3Container extends ITServlet25Container {
   static ExecutorService executor = Executors.newCachedThreadPool();
 
-  @AfterClass
-  public static void shutdownExecutor() {
+  public ITServlet3Container() {
+    super(new Jetty9ServerController());
+  }
+
+  @AfterClass public static void shutdownExecutor() {
     executor.shutdownNow();
   }
 
+  @Test public void forward() throws Exception {
+    get("/forward");
+
+    takeSpan();
+  }
+
+  @Test public void forwardAsync() throws Exception {
+    get("/forwardAsync");
+
+    takeSpan();
+  }
+
+  static class ForwardServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+      req.getServletContext().getRequestDispatcher("/foo").forward(req, resp);
+    }
+  }
+
+  static class AsyncForwardServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      AsyncContext asyncContext = req.startAsync(req, resp);
+      executor.execute(() -> asyncContext.dispatch("/async"));
+    }
+  }
+
   static class AsyncServlet extends HttpServlet {
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
       if (Tracing.currentTracer().currentSpan() == null) {
         throw new IllegalStateException("couldn't read current span!");
       }
@@ -46,43 +78,44 @@ public abstract class ITServlet3Container extends ITServlet25Container {
     }
   }
 
-  @Test
-  public void forward() throws Exception {
-    get("/forward");
-
-    takeSpan();
-  }
-
-  @Test
-  public void forwardAsync() throws Exception {
-    get("/forwardAsync");
-
-    takeSpan();
-  }
-
-  static class ForwardServlet extends HttpServlet {
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-      throws ServletException, IOException {
-      req.getServletContext().getRequestDispatcher("/foo").forward(req, resp);
-    }
-  }
-
-  static class AsyncForwardServlet extends HttpServlet {
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
-      AsyncContext asyncContext = req.startAsync(req, resp);
-      executor.execute(() -> asyncContext.dispatch("/async"));
-    }
-  }
-
   static class ExceptionAsyncServlet extends HttpServlet {
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
+
+      AsyncContext async = req.startAsync();
+      // unless we add a listener, the onError hook will never occur
+      async.addListener(new AsyncListener() {
+        @Override public void onComplete(AsyncEvent event) {
+        }
+
+        @Override public void onTimeout(AsyncEvent event) {
+        }
+
+        @Override public void onError(AsyncEvent event) {
+          // Change the status from 500 to 503
+          req.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 503);
+        }
+
+        @Override public void onStartAsync(AsyncEvent event) {
+        }
+      });
+      throw new IllegalStateException("not ready");
+    }
+  }
+
+  @Test public void errorTag_onException_asyncTimeout() throws Exception {
+    httpStatusCodeTagMatchesResponse_onException("/exceptionAsyncTimeout");
+  }
+
+  static class TimeoutExceptionAsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
+
       AsyncContext ctx = req.startAsync();
       ctx.setTimeout(1);
       ctx.start(
         () -> {
+          resp.setStatus(504);
           try {
             Thread.sleep(10L);
           } catch (InterruptedException e) {
@@ -94,13 +127,33 @@ public abstract class ITServlet3Container extends ITServlet25Container {
     }
   }
 
-  @Override
-  public void init(ServletContextHandler handler) {
+  @Test public void errorTag_onException_asyncDispatch() throws Exception {
+    httpStatusCodeTagMatchesResponse_onException("/exceptionAsyncDispatch");
+  }
+
+  static class DispatchExceptionAsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
+
+      if (req.getAttribute("dispatched") != null) {
+        throw new IllegalStateException("not ready");
+      }
+
+      req.setAttribute("dispatched", Boolean.TRUE);
+      req.startAsync().dispatch();
+    }
+  }
+
+  @Override public void init(ServletContextHandler handler) {
     super.init(handler);
     // add servlet 3.0+
     handler.addServlet(new ServletHolder(new AsyncServlet()), "/async");
     handler.addServlet(new ServletHolder(new ForwardServlet()), "/forward");
     handler.addServlet(new ServletHolder(new AsyncForwardServlet()), "/forwardAsync");
     handler.addServlet(new ServletHolder(new ExceptionAsyncServlet()), "/exceptionAsync");
+    handler.addServlet(new ServletHolder(new TimeoutExceptionAsyncServlet()),
+      "/exceptionAsyncTimeout");
+    handler.addServlet(new ServletHolder(new DispatchExceptionAsyncServlet()),
+      "/exceptionAsyncDispatch");
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,15 +13,22 @@
  */
 package brave.test.http;
 
+import brave.test.http.ServletContainer.ServerController;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.After;
 
 /** Starts a jetty server which runs a servlet container */
 public abstract class ITServletContainer extends ITHttpServer {
+  final ServerController serverController;
+
+  protected ITServletContainer(ServerController serverController) {
+    this.serverController = serverController;
+  }
+
   ServletContainer container;
 
   protected ServletContainer newServletContainer() {
-    return new ServletContainer() {
+    return new ServletContainer(serverController) {
       @Override public void init(ServletContextHandler handler) {
         ITServletContainer.this.init(handler);
       }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/Jetty9ServerController.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/Jetty9ServerController.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test.http;
+
+import brave.test.http.ServletContainer.ServerController;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+public final class Jetty9ServerController implements ServerController {
+  @Override public Server newServer(int port) {
+    Server result = new Server();
+    ServerConnector connector = new ServerConnector(result);
+    connector.setPort(port);
+    connector.setIdleTimeout(1000 * 60 * 60);
+    result.setConnectors(new Connector[] {connector});
+    return result;
+  }
+
+  @Override public int getLocalPort(Server server) {
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+}

--- a/instrumentation/http-tests/src/test/java/brave/http/features/TracingInterceptor.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/TracingInterceptor.java
@@ -17,6 +17,8 @@ import brave.Span;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
 import brave.http.HttpClientHandler;
+import brave.http.HttpClientRequest;
+import brave.http.HttpClientResponse;
 import brave.http.HttpTracing;
 import brave.internal.Nullable;
 import java.io.IOException;
@@ -27,7 +29,7 @@ import okhttp3.Response;
 /** Example interceptor. Use the real deal brave-instrumentation-okhttp3 in real life */
 final class TracingInterceptor implements Interceptor {
   final Tracer tracer;
-  final HttpClientHandler<brave.http.HttpClientRequest, brave.http.HttpClientResponse> handler;
+  final HttpClientHandler<HttpClientRequest, HttpClientResponse> handler;
 
   TracingInterceptor(HttpTracing httpTracing) {
     tracer = httpTracing.tracing().tracer();
@@ -50,7 +52,7 @@ final class TracingInterceptor implements Interceptor {
     }
   }
 
-  static final class RequestWrapper extends brave.http.HttpClientRequest {
+  static final class RequestWrapper extends HttpClientRequest {
     final Request delegate;
     Request.Builder builder;
 
@@ -88,7 +90,7 @@ final class TracingInterceptor implements Interceptor {
     }
   }
 
-  static final class ResponseWrapper extends brave.http.HttpClientResponse {
+  static final class ResponseWrapper extends HttpClientResponse {
     final Response delegate;
     @Nullable final Throwable error;
 

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -158,7 +158,7 @@ You generally need to...
 5. Complete the span
 
 ```java
-Span span = handler.handleSend(new WrappedHttpClientRequest(request)); // 1.
+Span span = handler.handleSend(new HttpClientRequestWrapper(request)); // 1.
 Result result = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
@@ -167,8 +167,8 @@ try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
   error = e; // 4.
   throw e;
 } finally {
-  WrappedHttpClientResponse response = result != null
-    ? new WrappedHttpClientResponse(result, error)
+  HttpClientResponseWrapper response = result != null
+    ? new HttpClientResponseWrapper(result, error)
     : null;
   handler.handleReceive(response, error, span); // 5.
 }
@@ -195,7 +195,7 @@ public void onSchedule(HttpContext context) {
 public void onStart(HttpContext context, HttpClientRequest req) {
   TraceContext parent = context.getAttribute(TraceContext.class); // 2.
 
-  WrappedHttpClientRequest request = new WrappedHttpClientRequest(req);
+  HttpClientRequestWrapper request = new HttpClientRequestWrapper(req);
   Span span = handler.handleSendWithParent(request, parent); // 3.
 ```
 
@@ -228,7 +228,7 @@ You generally need to...
 5. Complete the span
 
 ```java
-Span span = handler.handleReceive(new WrappedHttpServerRequest(request)); // 1.
+Span span = handler.handleReceive(new HttpServerRequestWrapper(request)); // 1.
 Result result = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
@@ -237,8 +237,8 @@ try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
   error = e; // 4.
   throw e;
 } finally {
-  WrappedHttpServerResponse response = result != null
-    ? new WrappedHttpServerResponse(result, error)
+  HttpServerResponseWrapper response = result != null
+    ? new HttpServerResponseWrapper(result, error)
     : null;
   handler.handleSend(response, error, span); // 5.
 }

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -24,16 +24,15 @@ Naming and tags are configurable in a library-agnostic way. For example,
 the same `HttpTracing` component configures OkHttp or Apache HttpClient
 identically.
 
-For example, to change the tagging policy for clients, you can do
-something like this:
+For example, to add a non-default tag for HTTP clients, you can do this:
 
 ```java
 httpTracing = httpTracing.toBuilder()
     .clientParser(new HttpClientParser() {
       @Override
-      public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
-        customizer.name(spanName(adapter, req)); // default span name
-        customizer.tag("http.url", adapter.url(req)); // the whole url, not just the path
+      public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer span) {
+        super.request(adapter, req, span);
+        span.tag("http.url", req.url()); // add the url in addition to defaults
       }
     })
     .build();
@@ -49,14 +48,12 @@ Ex:
 ```java
 overrideSpanName = new HttpClientParser() {
   @Override public <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
-    // If using JAX-RS, maybe we want to use the resource method
-    if (adapter instanceof ContainerAdapter) {
-      Method method = ((ContainerAdapter) adapter).resourceMethod(req);
-      return method.getName().toLowerCase();
+    // If using Armeria, maybe we want to reuse the request log name
+    if (req instanceof ServiceRequestContext) {
+      RequestLog requestLog = ((ServiceRequestContext) req).log();
+      return requestLog.name();
     }
-    // If not using framework-specific knowledge, we can use http
-    // attributes or go with the default.
-    return super.spanName(adapter, req);
+    return super.spanName(adapter, req); // otherwise, go with the defaults
   }
 };
 ```
@@ -101,10 +98,10 @@ httpTracingBuilder.serverSampler(HttpRuleSampler.newBuilder()
 
 ## Http Route
 The http route is an expression such as `/items/:itemId` representing an
-application endpoint. `HttpAdapter.route()` parses this from a response,
-returning the route that matched the request, empty if no route matched,
-or null if routes aren't supported. This value is either used to create
-a tag "http.route" or as an input to a span naming function.
+application endpoint. Implement `HttpServerResponse.route()` to return the
+route that matched the request, empty if no route matched, or null if routes
+aren't supported. This value is either used to create a tag "http.route" or as
+an input to a span naming function.
 
 ### Http route cardinality
 The http route groups similar requests together, so results in limited
@@ -162,16 +159,17 @@ You generally need to...
 
 ```java
 Span span = handler.handleSend(new WrappedHttpClientRequest(request)); // 1.
-HttpClientResponse response = null;
+Result result = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
-  result = invoke(request);
-  response = new WrappedHttpClientResponse(result); // 3.
-  return result;
+  return result = invoke(request); // 3.
 } catch (Throwable e) {
   error = e; // 4.
   throw e;
 } finally {
+  WrappedHttpClientResponse response = result != null
+    ? new WrappedHttpClientResponse(result, error)
+    : null;
   handler.handleReceive(response, error, span); // 5.
 }
 ```
@@ -208,9 +206,10 @@ The first step in developing http server instrumentation is implementing
 library. This ensures your instrumentation can extract headers, sample and
 control tags.
 
-With these two items, you now have the most important parts needed to
-trace your server library. You'll likely initialize the following in a
-constructor like so:
+With these two implemented, you have the most important parts needed to trace
+your server library. Initialize the HTTP server handler that uses the request
+and response types along with the tracer.
+
 ```java
 MyTracingInterceptor(HttpTracing httpTracing) {
   tracer = httpTracing.tracing().tracer();
@@ -229,78 +228,66 @@ You generally need to...
 5. Complete the span
 
 ```java
-Span span = handler.handleReceive(extractor, request); // 1.
+Span span = handler.handleReceive(new WrappedHttpServerRequest(request)); // 1.
+Result result = null;
 Throwable error = null;
-SpanInScope scope = tracer.withSpanInScope(span); // 2.
-try { // 2.
-  response = invoke(request); // 3.
+try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
+  return result = process(request); // 3.
 } catch (RuntimeException | Error e) {
   error = e; // 4.
   throw e;
 } finally {
+  WrappedHttpServerResponse response = result != null
+    ? new WrappedHttpServerResponse(result, error)
+    : null;
   handler.handleSend(response, error, span); // 5.
-  scope.close();
 }
 ```
 
-### Supporting HttpAdapter.route(response)
+### Supporting HttpResponse.route()
 
-Although the route is associated with the request, not the response,
-it is parsed from the response object. The reason is that many server
-implementations process the request before they can identify the route.
+Although the route is associated with the request, not the response, it is
+parsed from the response object. The reason is that many server implementations
+process the request before they can identify the route.
 
-Instrumentation authors implement support via extending HttpAdapter
+Instrumentation authors implement support via extending `HttpResponse`
 accordingly. There are a few patterns which might help.
 
-#### Callback with non-final type
-When a framework uses an callback model, you are in control of the type
-being parsed. If the response type isn't final, simply subclass it with
-the route data.
+#### Servlet based libraries
+'brave-instrumentation-servlet' includes the type `HttpServletResponseWrapper`.
+This looks for the request attribute "http.route", which can be set in any way.
 
-For example, if Spring MVC, it would be this:
+For example, Spring WebMVC can add the route using `HandlerInterceptorAdapter`.
+This is how our 'brave-instrumentation-spring-webmvc' works:
+
 ```java
-    // check for a wrapper type which holds the template
-    handler = HttpServerHandler.create(httpTracing, new HttpServletAdapter() {
-      @Override public String template(HttpServletResponse response) {
-        return response instanceof HttpServletResponseWithTemplate
-            ? ((HttpServletResponseWithTemplate) response).route : null;
-      }
-
-      @Override public String toString() {
-        return "WebMVCAdapter{}";
-      }
-    });
-
---snip--
-
-// when parsing the response, scope the route from the request
-
-    Object template = request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
-    if (route != null) {
-      response = new HttpServletResponseWithTemplate(response, route.toString());
-    }
-    handler.handleSend(response, ex, span);
+static void setHttpRouteAttribute(HttpServletRequest request) {
+  Object httpRoute = request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
+  request.setAttribute("http.route", httpRoute != null ? httpRoute.toString() : "");
+}
 ```
 
-#### Callback with final type
-If the response type is final, you may be able to make a copy and stash
-the route as a synthetic header. Since this is a copy of the response,
-there's no chance a user will receive this header in a real response.
+#### Adding a field to `HttpServerResponse`
+Another easy way is to add a field to your `HttpServerResponse` wrapper, and
+parse that in your implementation of `HttpServerResponse.route()`
 
-Here's an example for Play, where the header "brave-http-route" holds
-the route temporarily until the parser can read it.
+Here is an example for Play, which passes the template along with the `Result`
+to the HTTP server handler:
 ```scala
-    result.onComplete {
-      case Failure(t) => handler.handleSend(null, t, span)
-      case Success(r) => {
-        // add a synthetic header if there was a routing path set
-        var resp = template.map(t => r.withHeaders("brave-http-route" -> t)).getOrElse(r)
-        handler.handleSend(resp, null, span)
-      }
-    }
+var template = req.attrs.get(Router.Attrs.HandlerDef).map(_.path)
+
 --snip--
-    override def route(response: Result): String =
-      response.header.headers.apply("brave-http-route")
+
+result.onComplete {
+  case Failure(t) => handler.handleSend(null, t, span)
+  case Success(r) => {
+    handler.handleSend(new ResultWrapper(result, template), null, span)
+  }
+}
+
+--snip--
+  override def route(): String =
+    template.map(t => StringUtils.replace(t, "<[^/]+>", "")).getOrElse("")
 ```
 
 #### Common mistakes

--- a/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package brave.http;
 
 import brave.Span;
-import brave.internal.Nullable;
 
 /**
  * Marks an interface for use in {@link HttpClientHandler#handleReceive(Object, Throwable, Span)}.
@@ -23,38 +22,13 @@ import brave.internal.Nullable;
  * @see HttpClientRequest
  * @since 5.7
  */
-public abstract class HttpClientResponse {
-  /**
-   * Returns the underlying http response object. Ex. {@code org.apache.http.HttpResponse}
-   *
-   * <p>Note: Some implementations are composed of multiple types, such as a response and an object
-   * representing the matched route. Moreover, an implementation may change the type returned due to
-   * refactoring. Unless you control the implementation, cast carefully (ex using {@code instance
-   * of}) instead of presuming a specific type will always be returned.
-   */
-  public abstract Object unwrap();
-
-  /** @see HttpAdapter#methodFromResponse(Object) */
-  @Nullable public String method() {
-    return null;
+public abstract class HttpClientResponse extends HttpResponse {
+  @Override public Span.Kind spanKind() {
+    return Span.Kind.CLIENT;
   }
 
-  /** @see HttpAdapter#route(Object) */
-  @Nullable public String route() {
-    return null;
-  }
-
-  /** @see HttpAdapter#statusCodeAsInt(Object) */
-  public abstract int statusCode();
-
-  /** @see HttpAdapter#finishTimestamp(Object) */
-  public long finishTimestamp() {
-    return 0L;
-  }
-
-  @Override public String toString() {
-    // unwrap() returning null is a bug, but don't NPE during toString()
-    return "HttpServerResponse{" + unwrap() + "}";
+  @Override public Throwable error() {
+    return null; // error() was added in v5.10, but this type was added in v5.7
   }
 
   /**

--- a/instrumentation/http/src/main/java/brave/http/HttpHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpHandler.java
@@ -60,6 +60,9 @@ abstract class HttpHandler {
   <Resp> void handleFinish(HttpAdapter<?, Resp> adapter, @Nullable Resp response,
     @Nullable Throwable error, Span span) {
     if (span.isNoop()) return;
+
+    if (error != null) span.error(error); // Ensures MutableSpan.error() for FinishedSpanHandler
+
     long finishTimestamp = response != null ? adapter.finishTimestamp(response) : 0L;
 
     // Scope the trace context so that log statements are valid and also parse code can use

--- a/instrumentation/http/src/main/java/brave/http/HttpResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpResponse.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.Clock;
+import brave.Response;
+import brave.Span;
+import brave.internal.Nullable;
+import brave.propagation.TraceContext;
+
+/**
+ * Abstract response type used for parsing and sampling of http clients and servers.
+ *
+ * @see HttpClientResponse
+ * @see HttpServerResponse
+ * @since 5.10
+ */
+public abstract class HttpResponse extends Response {
+  /**
+   * Like {@link HttpRequest#method()} except used in response parsing.
+   *
+   * <p>Notably, this is used to create a route-based span name.
+   *
+   * @since 5.10
+   */
+  @Nullable public String method() {
+    return null;
+  }
+
+  /**
+   * Returns an expression such as "/items/:itemId" representing an application endpoint,
+   * conventionally associated with the tag key "http.route". If no route matched, "" (empty string)
+   * is returned. Null indicates this instrumentation doesn't understand http routes.
+   *
+   * <p>Eventhough the route is associated with the request, not the response, this is present
+   * on the response object. The reasons is that many server implementations process the request
+   * before they can identify the route route.
+   *
+   * @see HttpRequest#path()
+   * @since 5.10
+   */
+  @Nullable public String route() {
+    return null;
+  }
+
+  /**
+   * The HTTP status code or zero if unreadable.
+   *
+   * <p>Conventionally associated with the key "http.status_code"
+   *
+   * @since 5.10
+   */
+  public abstract int statusCode();
+
+  /**
+   * The timestamp in epoch microseconds of the end of this request or zero to take this implicitly
+   * from the current clock. Defaults to zero.
+   *
+   * <p>This is helpful in two scenarios: late parsing and avoiding redundant timestamp overhead.
+   * For example, you can asynchronously handle span completion without losing precision of the
+   * actual end.
+   *
+   * <p>Note: Overriding has the same problems as using {@link Span#finish(long)}. For
+   * example, it can result in negative duration if the clock used is allowed to correct backwards.
+   * It can also result in misalignments in the trace, unless {@link brave.Tracing.Builder#clock(Clock)}
+   * uses the same implementation.
+   *
+   * @see HttpRequest#startTimestamp()
+   * @see brave.Span#finish(long)
+   * @see brave.Tracing#clock(TraceContext)
+   * @since 5.10
+   */
+  public long finishTimestamp() {
+    return 0L;
+  }
+
+  HttpResponse() { // sealed type: only client and server
+  }
+}

--- a/instrumentation/http/src/main/java/brave/http/HttpResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpResponse.java
@@ -34,6 +34,7 @@ public abstract class HttpResponse extends Response {
    *
    * @since 5.10
    */
+  // TODO: see if we can return HttpRequest instead before cutting 5.10
   @Nullable public String method() {
     return null;
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
@@ -40,14 +40,14 @@ public abstract class HttpServerRequest extends HttpRequest {
 
   /**
    * Used by {@link HttpServerHandler#handleReceive(HttpServerRequest)} to add remote socket
-   * information about the client from the {@link #unwrap() delegate}.
+   * information about the client from the {@linkplain #unwrap() delegate}.
    *
-   * <p>By default, this tries to parse the {@link #parseClientIpFromXForwardedFor(Span) forwarded
-   * IP}. Override to add client socket information when forwarded info is not available.
+   * <p>By default, this tries to parse the {@linkplain #parseClientIpFromXForwardedFor(Span)
+   * forwarded IP}. Override to add client socket information when forwarded info is not available.
    *
-   * <p>Aside: the ability to parse socket information on server request objects is likely even if
-   * it is not as likely on the client side. This is because client requests are often parsed before
-   * a network route is chosen, whereas server requests are parsed after the network layer.
+   * <p>Aside: It is more likely a server request object will be able to parse socket information
+   * as opposed to a client object. This is because client requests are often parsed before a
+   * network route is chosen, whereas server requests are parsed after the network layer.
    *
    * @return true if parsing was successful.
    * @since 5.7

--- a/instrumentation/http/src/main/java/brave/http/HttpServerResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package brave.http;
 
 import brave.Span;
-import brave.internal.Nullable;
 
 /**
  * Marks an interface for use in {@link HttpServerHandler#handleSend(Object, Throwable, Span)}. This
@@ -23,38 +22,13 @@ import brave.internal.Nullable;
  * @see HttpServerRequest
  * @since 5.7
  */
-public abstract class HttpServerResponse {
-  /**
-   * Returns the underlying http response object. Ex. {@code javax.servlet.http.HttpServletResponse}
-   *
-   * <p>Note: Some implementations are composed of multiple types, such as a response and an object
-   * representing the matched route. Moreover, an implementation may change the type returned due to
-   * refactoring. Unless you control the implementation, cast carefully (ex using {@code instance
-   * of}) instead of presuming a specific type will always be returned.
-   */
-  public abstract Object unwrap();
-
-  /** @see HttpAdapter#methodFromResponse(Object) */
-  @Nullable public String method() {
-    return null;
+public abstract class HttpServerResponse extends HttpResponse {
+  @Override public Span.Kind spanKind() {
+    return Span.Kind.SERVER;
   }
 
-  /** @see HttpAdapter#route(Object) */
-  @Nullable public String route() {
-    return null;
-  }
-
-  /** @see HttpAdapter#statusCodeAsInt(Object) */
-  public abstract int statusCode();
-
-  /** @see HttpAdapter#finishTimestamp(Object) */
-  public long finishTimestamp() {
-    return 0L;
-  }
-
-  @Override public String toString() {
-    // unwrap() returning null is a bug, but don't NPE during toString()
-    return "HttpServerResponse{" + unwrap() + "}";
+  @Override public Throwable error() {
+    return null; // error() was added in v5.10, but this type was added in v5.7
   }
 
   /**

--- a/instrumentation/http/src/test/java/brave/http/HttpServerRequestTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerRequestTest.java
@@ -49,6 +49,18 @@ public class HttpServerRequestTest {
     verifyNoMoreInteractions(span);
   }
 
+  @Test public void parseClientIpAndPort_picksFirstXForwardedFor() {
+    when(serverRequest.header("X-Forwarded-For")).thenReturn("1.2.3.4,3.4.5.6");
+
+    when(serverRequest.parseClientIpAndPort(span)).thenCallRealMethod();
+    when(serverRequest.parseClientIpFromXForwardedFor(span)).thenCallRealMethod();
+
+    serverRequest.parseClientIpAndPort(span);
+
+    verify(span).remoteIpAndPort("1.2.3.4", 0);
+    verifyNoMoreInteractions(span);
+  }
+
   @Test public void parseClientIpAndPort_skipsOnNoIp() {
     when(serverRequest.parseClientIpAndPort(span)).thenCallRealMethod();
     when(serverRequest.parseClientIpFromXForwardedFor(span)).thenCallRealMethod();

--- a/instrumentation/http/src/test/java/brave/http/HttpServerRequestTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -36,7 +37,28 @@ public class HttpServerRequestTest {
   HttpServerRequest.ToHttpAdapter toAdapter;
   HttpServerRequest.FromHttpAdapter<Object> fromAdapter;
 
-  @Before public void callRealMethod() {
+  @Test public void parseClientIpAndPort_prefersXForwardedFor() {
+    when(serverRequest.header("X-Forwarded-For")).thenReturn("1.2.3.4");
+
+    when(serverRequest.parseClientIpAndPort(span)).thenCallRealMethod();
+    when(serverRequest.parseClientIpFromXForwardedFor(span)).thenCallRealMethod();
+
+    serverRequest.parseClientIpAndPort(span);
+
+    verify(span).remoteIpAndPort("1.2.3.4", 0);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void parseClientIpAndPort_skipsOnNoIp() {
+    when(serverRequest.parseClientIpAndPort(span)).thenCallRealMethod();
+    when(serverRequest.parseClientIpFromXForwardedFor(span)).thenCallRealMethod();
+
+    serverRequest.parseClientIpAndPort(span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Before public void setup() {
     when(serverRequest.unwrap()).thenReturn(request);
     toAdapter = new HttpServerRequest.ToHttpAdapter(serverRequest);
     fromAdapter = new HttpServerRequest.FromHttpAdapter<>(adapter, request);

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,11 +11,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.netty.http;
+package brave.httpasyncclient;
 
-import brave.netty.http.TracingHttpServerHandler.HttpServerResponse;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
+import brave.httpasyncclient.TracingHttpAsyncClientBuilder.HttpResponseWrapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -25,18 +25,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpServerResponseTest {
+public class HttpResponseWrapperTest {
   @Mock HttpResponse response;
-  @Mock HttpResponseStatus status;
+  @Mock StatusLine statusLine;
 
-  @Test public void statusCodeAsInt() {
-    when(response.status()).thenReturn(status);
-    when(status.code()).thenReturn(200);
+  @Test public void statusCode() {
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
 
-    assertThat(new HttpServerResponse(response).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(response).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCodeAsInt_zeroNoResponse() {
-    assertThat(new HttpServerResponse(response).statusCode()).isZero();
+  @Test public void statusCode_zeroWhenNoStatusLine() {
+    assertThat(new HttpResponseWrapper(response).statusCode()).isZero();
   }
 }

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -94,11 +94,12 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
   }
 
   @Override
-  protected void getAsync(CloseableHttpAsyncClient client, String path, Callback<Void> callback) {
+  protected void getAsync(CloseableHttpAsyncClient client, String path,
+    Callback<Integer> callback) {
     HttpGet get = new HttpGet(URI.create(url(path)));
     client.execute(get, new FutureCallback<HttpResponse>() {
       @Override public void completed(HttpResponse res) {
-        callback.onSuccess(null);
+        callback.onSuccess(res.getStatusLine().getStatusCode());
       }
 
       @Override public void failed(Exception ex) {

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,9 +11,9 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.httpasyncclient;
+package brave.httpclient;
 
-import brave.httpasyncclient.TracingHttpAsyncClientBuilder.HttpClientResponse;
+import brave.httpclient.TracingProtocolExec.HttpResponseWrapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.junit.Test;
@@ -25,18 +25,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpClientResponseTest {
+public class HttpResponseWrapperTest {
   @Mock HttpResponse response;
   @Mock StatusLine statusLine;
 
-  @Test public void statusCodeAsInt() {
+  @Test public void statusCode() {
     when(response.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    assertThat(new HttpClientResponse(response).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(response, null).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCodeAsInt_zeroWhenNoStatusLine() {
-    assertThat(new HttpClientResponse(response).statusCode()).isZero();
+  @Test public void statusCode__zeroWhenNoStatusLine() {
+    assertThat(new HttpResponseWrapper(response, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientRequestContextWrapperTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientRequestContextWrapperTest.java
@@ -13,7 +13,7 @@
  */
 package brave.jaxrs2;
 
-import brave.jaxrs2.TracingClientFilter.HttpClientRequest;
+import brave.jaxrs2.TracingClientFilter.ClientRequestContextWrapper;
 import java.net.URI;
 import java.util.Collections;
 import javax.ws.rs.client.ClientRequestContext;
@@ -29,38 +29,38 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpClientRequestTest {
+public class ClientRequestContextWrapperTest {
   @Mock ClientRequestContext request;
 
   @Test public void method() {
     when(request.getMethod()).thenReturn("GET");
 
-    assertThat(new HttpClientRequest(request).method()).isEqualTo("GET");
+    assertThat(new ClientRequestContextWrapper(request).method()).isEqualTo("GET");
   }
 
   @Test public void path() {
     when(request.getUri()).thenReturn(URI.create("http://localhost/api"));
 
-    assertThat(new HttpClientRequest(request).path()).isEqualTo("/api");
+    assertThat(new ClientRequestContextWrapper(request).path()).isEqualTo("/api");
   }
 
   @Test public void url() {
     when(request.getUri()).thenReturn(URI.create("http://localhost/api"));
 
-    assertThat(new HttpClientRequest(request).url()).isEqualTo("http://localhost/api");
+    assertThat(new ClientRequestContextWrapper(request).url()).isEqualTo("http://localhost/api");
   }
 
   @Test public void header() {
     when(request.getHeaderString("name")).thenReturn("value");
 
-    assertThat(new HttpClientRequest(request).header("name")).isEqualTo("value");
+    assertThat(new ClientRequestContextWrapper(request).header("name")).isEqualTo("value");
   }
 
   @Test public void putHeader() {
     MultivaluedMap<String, Object> headers = new Headers<>();
     when(request.getHeaders()).thenReturn(headers);
 
-    new HttpClientRequest(request).header("name", "value");
+    new ClientRequestContextWrapper(request).header("name", "value");
 
     assertThat(headers).containsExactly(entry("name", Collections.singletonList("value")));
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientResponseContextWrapperTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientResponseContextWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package brave.jaxrs2;
 
-import brave.jaxrs2.TracingClientFilter.HttpClientResponse;
+import brave.jaxrs2.TracingClientFilter.ClientResponseContextWrapper;
 import javax.ws.rs.client.ClientResponseContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,18 +24,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpClientResponseTest {
+public class ClientResponseContextWrapperTest {
   @Mock ClientResponseContext response;
 
   @Test public void statusCode() {
     when(response.getStatus()).thenReturn(200);
 
-    assertThat(new HttpClientResponse(response).statusCode()).isEqualTo(200);
+    assertThat(new ClientResponseContextWrapper(response).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroWhenNegative() {
     when(response.getStatus()).thenReturn(-1);
 
-    assertThat(new HttpClientResponse(response).statusCode()).isZero();
+    assertThat(new ClientResponseContextWrapper(response).statusCode()).isZero();
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -32,7 +32,7 @@ import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.ResteasyDeployment;
-import org.junit.AssumptionViolatedException;
+import org.junit.Ignore;
 import org.junit.Test;
 import zipkin2.Span;
 
@@ -40,8 +40,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITSpanCustomizingContainerFilter extends ITServletContainer {
 
-  @Override @Test public void reportsClientAddress() {
-    throw new AssumptionViolatedException("ContainerRequestContext doesn't include remote address");
+  @Override @Ignore("ContainerRequestContext doesn't include remote address")
+  public void reportsClientAddress() {
+  }
+
+  @Override @Ignore("resteasy swallows the exception")
+  public void errorTag_exceptionOverridesHttpStatus() {
+  }
+
+  @Override @Ignore("resteasy swallows the exception")
+  public void finishedSpanHandlerSeesException() {
   }
 
   @Test public void tagsResource() throws Exception {

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -15,6 +15,7 @@ package brave.jaxrs2;
 
 import brave.servlet.TracingFilter;
 import brave.test.http.ITServletContainer;
+import brave.test.http.Jetty9ServerController;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
@@ -39,6 +40,9 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITSpanCustomizingContainerFilter extends ITServletContainer {
+  public ITSpanCustomizingContainerFilter() {
+    super(new Jetty9ServerController());
+  }
 
   @Override @Ignore("ContainerRequestContext doesn't include remote address")
   public void reportsClientAddress() {

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -52,6 +52,14 @@ public class ITSpanCustomizingContainerFilter extends ITServletContainer {
   public void finishedSpanHandlerSeesException() {
   }
 
+  @Override @Ignore("resteasy swallows the exception")
+  public void errorTag_exceptionOverridesHttpStatus_async() {
+  }
+
+  @Override @Ignore("resteasy swallows the exception")
+  public void finishedSpanHandlerSeesException_async() {
+  }
+
   @Test public void tagsResource() throws Exception {
     get("/foo");
 

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
@@ -71,7 +71,15 @@ public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
   }
 
   @Override @Ignore("automatic error propagation is impossible")
-  public void addsErrorTagOnTransportException() {
+  public void errorTag_onTransportException() {
+  }
+
+  @Override @Ignore("automatic error propagation is impossible")
+  public void errorTag_exceptionOverridesHttpStatus() {
+  }
+
+  @Override @Ignore("automatic error propagation is impossible")
+  public void finishedSpanHandlerSeesException() {
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
@@ -20,6 +20,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.Ignore;
 import zipkin2.Callback;
@@ -44,13 +45,13 @@ public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
       .get(String.class);
   }
 
-  @Override protected void getAsync(Client client, String path, Callback<Void> callback) {
+  @Override protected void getAsync(Client client, String path, Callback<Integer> callback) {
     client.target(url(path))
       .request(MediaType.TEXT_PLAIN_TYPE)
       .async()
-      .get(new InvocationCallback<String>() {
-        @Override public void completed(String response) {
-          callback.onSuccess(null);
+      .get(new InvocationCallback<Response>() {
+        @Override public void completed(Response response) {
+          callback.onSuccess(response.getStatus());
         }
 
         @Override public void failed(Throwable throwable) {
@@ -72,10 +73,6 @@ public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
 
   @Override @Ignore("automatic error propagation is impossible")
   public void errorTag_onTransportException() {
-  }
-
-  @Override @Ignore("automatic error propagation is impossible")
-  public void errorTag_exceptionOverridesHttpStatus() {
   }
 
   @Override @Ignore("automatic error propagation is impossible")

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
@@ -17,9 +17,11 @@ import brave.SpanCustomizer;
 import brave.internal.Nullable;
 import java.util.List;
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.internal.process.MappableException;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
@@ -27,7 +29,6 @@ import org.glassfish.jersey.server.monitoring.RequestEventListener;
 import org.glassfish.jersey.uri.UriTemplate;
 
 import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.FINISHED;
-import static org.glassfish.jersey.server.monitoring.RequestEvent.Type.REQUEST_MATCHED;
 
 /**
  * Adds application-tier data to an existing http span via {@link EventParser}. This also sets the
@@ -67,13 +68,30 @@ public class SpanCustomizingApplicationEventListener
     // Note: until REQUEST_MATCHED, we don't know metadata such as if the request is async or not
     if (event.getType() != FINISHED) return;
     ContainerRequest request = event.getContainerRequest();
-    SpanCustomizer span = (SpanCustomizer) request.getProperty(SpanCustomizer.class.getName());
-    if (span == null) return;
+    Object maybeSpan = request.getProperty(SpanCustomizer.class.getName());
+    if (!(maybeSpan instanceof SpanCustomizer)) return;
 
-    // Set the route attribute on completion to avoid any thread visibility issues reading it
-    request.setProperty("http.route", route(event.getContainerRequest()));
-    if (request.getProperty("error") == null) request.setProperty("error", event.getException());
-    parser.requestMatched(event, span);
+    // Set the HTTP route attribute so that TracingFilter can see it
+    request.setProperty("http.route", route(request));
+
+    Throwable error = unwrapError(event);
+    // Set the error attribute so that TracingFilter can see it
+    if (error != null && request.getProperty("error") == null) request.setProperty("error", error);
+
+    parser.requestMatched(event, (SpanCustomizer) maybeSpan);
+  }
+
+  @Nullable static Throwable unwrapError(RequestEvent event) {
+    Throwable error = event.getException();
+    // For example, if thrown in an async controller
+    if (error instanceof MappableException && error.getCause() != null) {
+      error = error.getCause();
+    }
+    // MappableException can wrap a WebApplicationException!
+    if (error instanceof WebApplicationException && error.getCause() != null) {
+      error = error.getCause();
+    }
+    return error;
   }
 
   /**

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -16,7 +16,10 @@ package brave.jersey.server;
 import brave.Span;
 import brave.Tracer;
 import brave.http.HttpServerHandler;
+import brave.http.HttpServerRequest;
+import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.ext.Provider;
@@ -37,7 +40,7 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
   }
 
   final Tracer tracer;
-  final HttpServerHandler<brave.http.HttpServerRequest, brave.http.HttpServerResponse> handler;
+  final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
   final EventParser parser;
 
   @Inject TracingApplicationEventListener(HttpTracing httpTracing, EventParser parser) {
@@ -52,7 +55,7 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
 
   @Override public RequestEventListener onRequest(RequestEvent event) {
     if (event.getType() != RequestEvent.Type.START) return null;
-    Span span = handler.handleReceive(new HttpServerRequest(event.getContainerRequest()));
+    Span span = handler.handleReceive(new ContainerRequestWrapper(event.getContainerRequest()));
     return new TracingRequestEventListener(span, tracer.withSpanInScope(span));
   }
 
@@ -100,11 +103,9 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
           spanInScope = tracer.withSpanInScope(span);
           break;
         case FINISHED:
-          String maybeHttpRoute = route(event.getContainerRequest());
-          if (maybeHttpRoute != null) {
-            event.getContainerRequest().setProperty("http.route", maybeHttpRoute);
-          }
-          handler.handleSend(new HttpServerResponse(event), event.getException(), span);
+          String route = route(event.getContainerRequest());
+          RequestEventWrapper response = new RequestEventWrapper(event, route);
+          handler.handleSend(response, response.error(), span);
           // In async FINISHED can happen before RESOURCE_METHOD_FINISHED, and on different threads!
           // Don't close the scope unless it is a synchronous method.
           if (!async && (maybeSpanInScope = spanInScope) != null) {
@@ -121,10 +122,10 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
       || event.getUriInfo().getMatchedResourceMethod().isSuspendDeclared();
   }
 
-  static final class HttpServerRequest extends brave.http.HttpServerRequest {
+  static final class ContainerRequestWrapper extends HttpServerRequest {
     final ContainerRequest delegate;
 
-    HttpServerRequest(ContainerRequest delegate) {
+    ContainerRequestWrapper(ContainerRequest delegate) {
       this.delegate = delegate;
     }
 
@@ -154,11 +155,13 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     // HttpServletRequest.getRemoteAddr
   }
 
-  static final class HttpServerResponse extends brave.http.HttpServerResponse {
+  static final class RequestEventWrapper extends HttpServerResponse {
     final RequestEvent delegate;
+    @Nullable final String route;
 
-    HttpServerResponse(RequestEvent delegate) {
+    RequestEventWrapper(RequestEvent delegate, @Nullable String route) {
       this.delegate = delegate;
+      this.route = route;
     }
 
     @Override public Object unwrap() {
@@ -166,7 +169,7 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     }
 
     @Override public Throwable error() {
-      return delegate.getException();
+      return SpanCustomizingApplicationEventListener.unwrapError(delegate);
     }
 
     @Override public String method() {
@@ -174,8 +177,7 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     }
 
     @Override public String route() {
-      Object maybeRoute = delegate.getContainerRequest().getProperty("http.route");
-      return maybeRoute instanceof String ? (String) maybeRoute : null;
+      return route;
     }
 
     @Override public int statusCode() {

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -165,12 +165,17 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
       return delegate;
     }
 
+    @Override public Throwable error() {
+      return delegate.getException();
+    }
+
     @Override public String method() {
       return delegate.getContainerRequest().getMethod();
     }
 
     @Override public String route() {
-      return (String) delegate.getContainerRequest().getProperty("http.route");
+      Object maybeRoute = delegate.getContainerRequest().getProperty("http.route");
+      return maybeRoute instanceof String ? (String) maybeRoute : null;
     }
 
     @Override public int statusCode() {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ContainerRequestWrapperTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ContainerRequestWrapperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jersey.server;
+
+import brave.jersey.server.TracingApplicationEventListener.ContainerRequestWrapper;
+import java.net.URI;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ContainerRequestWrapperTest {
+  ContainerRequest request = mock(ContainerRequest.class);
+
+  @Test public void path_prefixesSlashWhenMissing() {
+    when(request.getPath(false)).thenReturn("bar");
+
+    assertThat(new ContainerRequestWrapper(request).path())
+      .isEqualTo("/bar");
+  }
+
+  @Test public void url_derivedFromExtendedUriInfo() {
+    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
+    when(request.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getRequestUri()).thenReturn(URI.create("http://foo:8080/bar?hello=world"));
+
+    assertThat(new ContainerRequestWrapper(request).url())
+      .isEqualTo("http://foo:8080/bar?hello=world");
+  }
+}

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package brave.jersey.server;
 
 import brave.servlet.TracingFilter;
 import brave.test.http.ITServletContainer;
+import brave.test.http.Jetty9ServerController;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration.Dynamic;
@@ -30,6 +31,9 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITSpanCustomizingApplicationEventListener extends ITServletContainer {
+  public ITSpanCustomizingApplicationEventListener() {
+    super(new Jetty9ServerController());
+  }
 
   @Override @Test public void reportsClientAddress() {
     throw new AssumptionViolatedException("TODO!");

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package brave.jersey.server;
 
 import brave.test.http.ITServletContainer;
+import brave.test.http.Jetty9ServerController;
 import okhttp3.Response;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -26,6 +27,9 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITTracingApplicationEventListener extends ITServletContainer {
+  public ITTracingApplicationEventListener() {
+    super(new Jetty9ServerController());
+  }
 
   @Override @Test public void reportsClientAddress() {
     throw new AssumptionViolatedException("TODO!");

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/RequestEventWrapperTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/RequestEventWrapperTest.java
@@ -13,12 +13,9 @@
  */
 package brave.jersey.server;
 
-import brave.jersey.server.TracingApplicationEventListener.HttpServerRequest;
-import brave.jersey.server.TracingApplicationEventListener.HttpServerResponse;
-import java.net.URI;
+import brave.jersey.server.TracingApplicationEventListener.RequestEventWrapper;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
-import org.glassfish.jersey.server.ExtendedUriInfo;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,55 +23,35 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TracingApplicationEventListenerTest {
+public class RequestEventWrapperTest {
   @Mock ContainerRequest request;
   @Mock RequestEvent event;
   @Mock ContainerResponse response;
 
-  @Test public void methodFromResponse() {
+  @Test public void method() {
     when(event.getContainerRequest()).thenReturn(request);
     when(request.getMethod()).thenReturn("GET");
 
-    assertThat(new HttpServerResponse(event).method())
+    assertThat(new RequestEventWrapper(event, null).method())
       .isEqualTo("GET");
   }
 
-  @Test public void path_prefixesSlashWhenMissing() {
-    when(request.getPath(false)).thenReturn("bar");
-
-    assertThat(new HttpServerRequest(request).path())
-      .isEqualTo("/bar");
-  }
-
   @Test public void route() {
-    when(event.getContainerRequest()).thenReturn(request);
-    when(request.getProperty("http.route")).thenReturn("/items/{itemId}");
-
-    assertThat(new HttpServerResponse(event).route())
+    assertThat(new RequestEventWrapper(event, "/items/{itemId}").route())
       .isEqualTo("/items/{itemId}");
-  }
-
-  @Test public void url_derivedFromExtendedUriInfo() {
-    ExtendedUriInfo uriInfo = mock(ExtendedUriInfo.class);
-    when(request.getUriInfo()).thenReturn(uriInfo);
-    when(uriInfo.getRequestUri()).thenReturn(URI.create("http://foo:8080/bar?hello=world"));
-
-    assertThat(new HttpServerRequest(request).url())
-      .isEqualTo("http://foo:8080/bar?hello=world");
   }
 
   @Test public void statusCode() {
     when(event.getContainerResponse()).thenReturn(response);
     when(response.getStatus()).thenReturn(200);
 
-    assertThat(new HttpServerResponse(event).statusCode()).isEqualTo(200);
+    assertThat(new RequestEventWrapper(event, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroNoResponse() {
-    assertThat(new HttpServerResponse(event).statusCode()).isZero();
+    assertThat(new RequestEventWrapper(event, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -88,12 +89,6 @@ public class TestResource {
   }
 
   @GET
-  @Path("exception")
-  public Response disconnect() throws IOException {
-    throw new IOException();
-  }
-
-  @GET
   @Path("items/{itemId}")
   public String item(@PathParam("itemId") String itemId) {
     return itemId;
@@ -115,9 +110,17 @@ public class TestResource {
   }
 
   @GET
+  @Path("exception")
+  public Response notReady() {
+    throw new WebApplicationException(new IllegalStateException("not ready"), 503);
+  }
+
+  @GET
   @Path("exceptionAsync")
-  public void disconnectAsync(@Suspended AsyncResponse response) {
-    Thread thread = new Thread(() -> response.resume(new IOException()));
+  public void notReadyAsync(@Suspended AsyncResponse response) {
+    Thread thread = new Thread(() -> response.resume(
+      new WebApplicationException(new IllegalStateException("not ready"), 503)
+    ));
     thread.start();
     try {
       thread.join();

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TracingApplicationEventListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -67,14 +67,14 @@ public class TracingApplicationEventListenerTest {
       .isEqualTo("http://foo:8080/bar?hello=world");
   }
 
-  @Test public void statusCodeAsInt() {
+  @Test public void statusCode() {
     when(event.getContainerResponse()).thenReturn(response);
     when(response.getStatus()).thenReturn(200);
 
     assertThat(new HttpServerResponse(event).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCodeAsInt_zeroNoResponse() {
+  @Test public void statusCode_zeroNoResponse() {
     assertThat(new HttpServerResponse(event).statusCode()).isZero();
   }
 }

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/HttpResponseWrapperTest.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/HttpResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,11 +11,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.httpclient;
+package brave.netty.http;
 
-import brave.httpclient.TracingProtocolExec.HttpClientResponse;
-import org.apache.http.HttpResponse;
-import org.apache.http.StatusLine;
+import brave.netty.http.TracingHttpServerHandler.HttpResponseWrapper;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -25,18 +25,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpClientResponseTest {
+public class HttpResponseWrapperTest {
   @Mock HttpResponse response;
-  @Mock StatusLine statusLine;
+  @Mock HttpResponseStatus status;
 
-  @Test public void statusCodeAsInt() {
-    when(response.getStatusLine()).thenReturn(statusLine);
-    when(statusLine.getStatusCode()).thenReturn(200);
+  @Test public void statusCode() {
+    when(response.status()).thenReturn(status);
+    when(status.code()).thenReturn(200);
 
-    assertThat(new HttpClientResponse(response).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(response, null).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCodeAsInt_zeroWhenNoStatusLine() {
-    assertThat(new HttpClientResponse(response).statusCode()).isZero();
+  @Test public void statusCode_zeroNoResponse() {
+    assertThat(new HttpResponseWrapper(response, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpServerCodec;
 import java.net.InetSocketAddress;
 import org.junit.After;
+import org.junit.Ignore;
 
 public class ITNettyHttpTracing extends ITHttpServer {
   EventLoopGroup bossGroup;
@@ -62,5 +63,13 @@ public class ITNettyHttpTracing extends ITHttpServer {
   @After public void stop() {
     if (bossGroup != null) bossGroup.shutdownGracefully();
     if (workerGroup != null) workerGroup.shutdownGracefully();
+  }
+
+  @Override @Ignore("TODO: last handler in the pipeline did not handle the exception")
+  public void errorTag_exceptionOverridesHttpStatus() {
+  }
+
+  @Override @Ignore("TODO: last handler in the pipeline did not handle the exception")
+  public void finishedSpanHandlerSeesException() {
   }
 }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
-import okhttp3.Dispatcher;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -62,7 +61,7 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
   }
 
   @Override
-  protected void getAsync(Call.Factory client, String path, zipkin2.Callback<Void> callback) {
+  protected void getAsync(Call.Factory client, String path, zipkin2.Callback<Integer> callback) {
     client.newCall(new Request.Builder().url(url(path)).build())
       .enqueue(new Callback() {
         @Override public void onFailure(Call call, IOException e) {
@@ -70,7 +69,7 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
         }
 
         @Override public void onResponse(Call call, Response response) {
-          callback.onSuccess(null);
+          callback.onSuccess(response.code());
         }
       });
   }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -59,7 +59,7 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
   }
 
   @Override
-  protected void getAsync(Call.Factory client, String path, zipkin2.Callback<Void> callback) {
+  protected void getAsync(Call.Factory client, String path, zipkin2.Callback<Integer> callback) {
     client.newCall(new Request.Builder().url(url(path)).build())
       .enqueue(new Callback() {
         @Override public void onFailure(Call call, IOException e) {
@@ -67,7 +67,7 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
         }
 
         @Override public void onResponse(Call call, Response response) {
-          callback.onSuccess(null);
+          callback.onSuccess(response.code());
         }
       });
   }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ResponseWrapperTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package brave.okhttp3;
 
-import brave.okhttp3.TracingInterceptor.HttpClientResponse;
+import brave.okhttp3.TracingInterceptor.ResponseWrapper;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HttpClientResponseTest {
+public class ResponseWrapperTest {
   Response.Builder responseBuilder = new Response.Builder()
     .request(new Request.Builder().url("http://localhost/foo").build())
     .protocol(Protocol.HTTP_1_1);
@@ -29,12 +29,12 @@ public class HttpClientResponseTest {
   @Test public void statusCode() {
     Response response = responseBuilder.code(200).message("ok").build();
 
-    assertThat(new HttpClientResponse(response).statusCode()).isEqualTo(200);
+    assertThat(new ResponseWrapper(response, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zero() {
     Response response = responseBuilder.code(0).message("ice cream!").build();
 
-    assertThat(new HttpClientResponse(response).statusCode()).isZero();
+    assertThat(new ResponseWrapper(response, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -39,11 +39,11 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
     </dependency>
-    <!-- compile dep on 3.0.1 runtime on 2.5 -->
+    <!-- compile dep on 3.1.0 runtime on 2.5 -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
+++ b/instrumentation/servlet/src/it/servlet25/src/test/java/brave/servlet25/ITTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,13 +15,36 @@ package brave.servlet25;
 
 import brave.servlet.TracingFilter;
 import brave.test.http.ITServlet25Container;
+import brave.test.http.ServletContainer;
 import java.util.EnumSet;
 import javax.servlet.Filter;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.DispatcherType;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.bio.SocketConnector;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ITTracingFilter extends ITServlet25Container {
+  public ITTracingFilter() {
+    super(new Jetty7ServerController());
+  }
+
+  /** Overridden to support Jetty 7.x (that uses Servlet 2.5) */
+  static final class Jetty7ServerController implements ServletContainer.ServerController {
+    @Override public Server newServer(int port) {
+      Server result = new Server();
+      SocketConnector connector = new SocketConnector();
+      connector.setMaxIdleTime(1000 * 60 * 60);
+      connector.setPort(port);
+      result.setConnectors(new Connector[] {connector});
+      return result;
+    }
+
+    @Override public int getLocalPort(Server server) {
+      return server.getConnectors()[0].getLocalPort();
+    }
+  }
 
   @Override protected Filter newTracingFilter() {
     return TracingFilter.create(httpTracing);

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,9 +37,9 @@ public class HttpServletAdapter extends HttpServerAdapter<HttpServletRequest, Ht
    */
   // not static so that this can be overridden by implementations as needed.
   public HttpServletResponse adaptResponse(HttpServletRequest req, HttpServletResponse resp) {
-    String httpRoute = (String) req.getAttribute("http.route");
-    return httpRoute != null
-      ? new DecoratedHttpServletResponse(resp, req.getMethod(), httpRoute)
+    Object maybeRoute = req.getAttribute("http.route");
+    return maybeRoute instanceof String
+      ? new DecoratedHttpServletResponse(resp, req.getMethod(), (String) maybeRoute)
       : resp;
   }
 

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletRequestWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletRequestWrapper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.servlet;
+
+import brave.Span;
+import brave.http.HttpServerRequest;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Besides delegating to {@link HttpServletRequest} methods, this also parses the remote IP of the
+ * client.
+ *
+ * @since 5.10
+ */
+// Public for use in sparkjava or other frameworks that re-use servlet types
+public final class HttpServletRequestWrapper extends HttpServerRequest {
+  /** @since 5.10 */
+  public static HttpServerRequest create(HttpServletRequest request) {
+    return new HttpServletRequestWrapper(request);
+  }
+
+  final HttpServletRequest delegate;
+
+  HttpServletRequestWrapper(HttpServletRequest delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  /**
+   * This sets the client IP:port to the {@linkplain HttpServletRequest#getRemoteAddr() remote
+   * address} if the {@link #parseClientIpAndPort default parsing} fails.
+   */
+  @Override public boolean parseClientIpAndPort(Span span) {
+    if (parseClientIpFromXForwardedFor(span)) return true;
+    return span.remoteIpAndPort(delegate.getRemoteAddr(), delegate.getRemotePort());
+  }
+
+  @Override public final String method() {
+    return delegate.getMethod();
+  }
+
+  @Override public final String path() {
+    return delegate.getRequestURI();
+  }
+
+  // not final as some implementations may be able to do this more efficiently
+  @Override public String url() {
+    StringBuffer url = delegate.getRequestURL();
+    if (delegate.getQueryString() != null && !delegate.getQueryString().isEmpty()) {
+      url.append('?').append(delegate.getQueryString());
+    }
+    return url.toString();
+  }
+
+  @Override public final String header(String name) {
+    return delegate.getHeader(name);
+  }
+
+  @Override public final Object unwrap() {
+    return delegate;
+  }
+}

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
@@ -16,6 +16,7 @@ package brave.servlet;
 import brave.http.HttpServerResponse;
 import brave.internal.Nullable;
 import brave.servlet.internal.ServletRuntime;
+import javax.servlet.UnavailableException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -33,51 +34,65 @@ public class HttpServletResponseWrapper extends HttpServerResponse { // not fina
    * Looks for the {@link HttpServletRequest#setAttribute(String, Object) request attributes}
    * "http.route" and "error" to customize the result.
    *
+   * @param caught an exception caught serving the request.
    * @since 5.10
    */
   public static HttpServerResponse create(@Nullable HttpServletRequest req,
-    HttpServletResponse res, @Nullable Throwable error) {
-    if (req == null) return new HttpServletResponseWrapper(res, error);
-    return new WithMethodAndRoute(req, res, error);
+    HttpServletResponse res, @Nullable Throwable caught) {
+    if (req == null) return new HttpServletResponseWrapper(res, caught);
+    return new WithRequestProperties(req, res, caught);
   }
 
   final HttpServletResponse delegate;
-  @Nullable final Throwable error;
+  @Nullable final Throwable caught;
 
-  HttpServletResponseWrapper(HttpServletResponse delegate, @Nullable Throwable error) {
+  HttpServletResponseWrapper(HttpServletResponse delegate, @Nullable Throwable caught) {
     if (delegate == null) throw new NullPointerException("delegate == null");
     this.delegate = delegate;
-    this.error = error;
+    this.caught = caught;
   }
 
-  @Override public final int statusCode() {
-    return ServletRuntime.get().status(delegate);
+  @Override public int statusCode() {
+    int result = ServletRuntime.get().status(delegate);
+    if (caught != null && result == 200) { // We may have a potentially bad status due to defaults
+      // Servlet only seems to define one exception that has a built-in code. Logic in Jetty
+      // defaults the status to 500 otherwise.
+      if (caught instanceof UnavailableException) {
+        return ((UnavailableException) caught).isPermanent() ? 404 : 503;
+      }
+      return 500;
+    }
+    return result;
   }
 
   @Override public Throwable error() {
-    return error;
+    return caught;
   }
 
   @Override public final Object unwrap() {
     return delegate;
   }
 
-  static final class WithMethodAndRoute extends HttpServletResponseWrapper {
-    final String method, route;
+  static final class WithRequestProperties extends HttpServletResponseWrapper {
+    final HttpServletRequest req;
 
-    WithMethodAndRoute(HttpServletRequest req, HttpServletResponse res, @Nullable Throwable error) {
-      super(res, maybeError(error, req));
-      this.method = req.getMethod();
-      Object maybeRoute = req.getAttribute("http.route");
-      this.route = maybeRoute instanceof String ? (String) maybeRoute : null;
+    WithRequestProperties(HttpServletRequest req, HttpServletResponse res,
+      @Nullable Throwable error) {
+      super(res, error);
+      this.req = req;
+    }
+
+    @Override public Throwable error() {
+      return maybeError(caught, req);
     }
 
     @Override public String method() {
-      return method;
+      return req.getMethod();
     }
 
     @Override public String route() {
-      return route;
+      Object maybeRoute = req.getAttribute("http.route");
+      return maybeRoute instanceof String ? (String) maybeRoute : null;
     }
   }
 }

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
@@ -55,7 +55,7 @@ public class HttpServletResponseWrapper extends HttpServerResponse { // not fina
   }
 
   @Override public Throwable error() {
-    return null;
+    return error;
   }
 
   @Override public final Object unwrap() {

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.servlet;
+
+import brave.http.HttpServerResponse;
+import brave.internal.Nullable;
+import brave.servlet.internal.ServletRuntime;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static brave.servlet.internal.ServletRuntime.maybeError;
+
+/**
+ * This delegates to {@link HttpServletResponse} methods, taking care to portably handle {@link
+ * #statusCode()}.
+ *
+ * @since 5.10
+ */
+// Public for use in sparkjava or other frameworks that re-use servlet types
+public class HttpServletResponseWrapper extends HttpServerResponse { // not final for inner subtype
+  /**
+   * Looks for the {@link HttpServletRequest#setAttribute(String, Object) request attributes}
+   * "http.route" and "error" to customize the result.
+   *
+   * @since 5.10
+   */
+  public static HttpServerResponse create(@Nullable HttpServletRequest req,
+    HttpServletResponse res, @Nullable Throwable error) {
+    if (req == null) return new HttpServletResponseWrapper(res, error);
+    return new WithMethodAndRoute(req, res, error);
+  }
+
+  final HttpServletResponse delegate;
+  @Nullable final Throwable error;
+
+  HttpServletResponseWrapper(HttpServletResponse delegate, @Nullable Throwable error) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+    this.error = error;
+  }
+
+  @Override public final int statusCode() {
+    return ServletRuntime.get().status(delegate);
+  }
+
+  @Override public Throwable error() {
+    return null;
+  }
+
+  @Override public final Object unwrap() {
+    return delegate;
+  }
+
+  static final class WithMethodAndRoute extends HttpServletResponseWrapper {
+    final String method, route;
+
+    WithMethodAndRoute(HttpServletRequest req, HttpServletResponse res, @Nullable Throwable error) {
+      super(res, maybeError(error, req));
+      this.method = req.getMethod();
+      Object maybeRoute = req.getAttribute("http.route");
+      this.route = maybeRoute instanceof String ? (String) maybeRoute : null;
+    }
+
+    @Override public String method() {
+      return method;
+    }
+
+    @Override public String route() {
+      return route;
+    }
+  }
+}

--- a/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,8 @@ import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.http.HttpServerHandler;
+import brave.http.HttpServerRequest;
+import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
@@ -43,7 +45,7 @@ public final class TracingFilter implements Filter {
 
   final ServletRuntime servlet = ServletRuntime.get();
   final CurrentTraceContext currentTraceContext;
-  final HttpServerHandler<brave.http.HttpServerRequest, brave.http.HttpServerResponse> handler;
+  final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
 
   TracingFilter(HttpTracing httpTracing) {
     currentTraceContext = httpTracing.tracing().currentTraceContext();
@@ -53,8 +55,8 @@ public final class TracingFilter implements Filter {
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
     throws IOException, ServletException {
-    HttpServletRequest httpRequest = (HttpServletRequest) request;
-    HttpServletResponse httpResponse = servlet.httpServletResponse(response);
+    HttpServletRequest req = (HttpServletRequest) request;
+    HttpServletResponse res = servlet.httpServletResponse(response);
 
     // Prevent duplicate spans for the same request
     TraceContext context = (TraceContext) request.getAttribute(TraceContext.class.getName());
@@ -69,7 +71,7 @@ public final class TracingFilter implements Filter {
       return;
     }
 
-    Span span = handler.handleReceive(new HttpServerRequest(httpRequest));
+    Span span = handler.handleReceive(new HttpServletRequestWrapper(req));
 
     // Add attributes for explicit access to customization or span context
     request.setAttribute(SpanCustomizer.class.getName(), span.customizer());
@@ -79,15 +81,20 @@ public final class TracingFilter implements Filter {
     Scope scope = currentTraceContext.newScope(span.context());
     try {
       // any downstream code can see Tracer.currentSpan() or use Tracer.currentSpanCustomizer()
-      chain.doFilter(httpRequest, httpResponse);
-    } catch (IOException | ServletException | RuntimeException | Error e) {
+      chain.doFilter(req, res);
+    } catch (Throwable e) {
       error = e;
       throw e;
     } finally {
-      if (servlet.isAsync(httpRequest)) { // we don't have the actual response, handle later
-        servlet.handleAsync(handler, httpRequest, httpResponse, span);
+      if (error == null) {
+        Object maybeError = req.getAttribute("error");
+        // guard as user code may be using the attribute name "error"
+        if (maybeError instanceof Throwable) error = (Throwable) maybeError;
+      }
+      if (servlet.isAsync(req)) { // we don't have the actual response, handle later
+        servlet.handleAsync(handler, req, res, span);
       } else { // we have a synchronous response, so we can finish the span
-        handler.handleSend(servlet.httpServerResponse(httpRequest, httpResponse), error, span);
+        handler.handleSend(HttpServletResponseWrapper.create(req, res, error), error, span);
       }
       scope.close();
     }
@@ -97,41 +104,5 @@ public final class TracingFilter implements Filter {
   }
 
   @Override public void init(FilterConfig filterConfig) {
-  }
-
-  static final class HttpServerRequest extends brave.http.HttpServerRequest {
-    final HttpServletRequest delegate;
-
-    HttpServerRequest(HttpServletRequest delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override public HttpServletRequest unwrap() {
-      return delegate;
-    }
-
-    @Override public boolean parseClientIpAndPort(Span span) {
-      return span.remoteIpAndPort(delegate.getRemoteAddr(), delegate.getRemotePort());
-    }
-
-    @Override public String method() {
-      return delegate.getMethod();
-    }
-
-    @Override public String path() {
-      return delegate.getRequestURI();
-    }
-
-    @Override public String url() {
-      StringBuffer url = delegate.getRequestURL();
-      if (delegate.getQueryString() != null && !delegate.getQueryString().isEmpty()) {
-        url.append('?').append(delegate.getQueryString());
-      }
-      return url.toString();
-    }
-
-    @Override public String header(String name) {
-      return delegate.getHeader(name);
-    }
   }
 }

--- a/instrumentation/servlet/src/test/java/brave/servlet/HttpServletAdapterTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/HttpServletAdapterTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-@Deprecated public class HttpServletAdapterTest {
+public class HttpServletAdapterTest {
   HttpServletAdapter adapter = new HttpServletAdapter();
   @Mock HttpServletRequest request;
   @Mock HttpServletResponse response;

--- a/instrumentation/servlet/src/test/java/brave/servlet/HttpServletRequestWrapperTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/HttpServletRequestWrapperTest.java
@@ -14,34 +14,30 @@
 package brave.servlet;
 
 import brave.Span;
+import brave.http.HttpServerRequest;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-@Deprecated public class HttpServletAdapterTest {
-  HttpServletAdapter adapter = new HttpServletAdapter();
-  @Mock HttpServletRequest request;
-  @Mock HttpServletResponse response;
-  @Mock Span span;
+public class HttpServletRequestWrapperTest {
+  HttpServletRequest request = mock(HttpServletRequest.class);
+  HttpServerRequest wrapper = HttpServletRequestWrapper.create(request);
+  Span span = mock(Span.class);
 
   @Test public void path_doesntCrashOnNullUrl() {
-    assertThat(adapter.path(request))
+    assertThat(wrapper.path())
       .isNull();
   }
 
   @Test public void path_getRequestURI() {
     when(request.getRequestURI()).thenReturn("/bar");
 
-    assertThat(adapter.path(request))
+    assertThat(wrapper.path())
       .isEqualTo("/bar");
   }
 
@@ -49,15 +45,15 @@ import static org.mockito.Mockito.when;
     when(request.getRequestURL()).thenReturn(new StringBuffer("http://foo:8080/bar"));
     when(request.getQueryString()).thenReturn("hello=world");
 
-    assertThat(adapter.url(request))
+    assertThat(wrapper.url())
       .isEqualTo("http://foo:8080/bar?hello=world");
   }
 
   @Test public void parseClientIpAndPort_prefersXForwardedFor() {
     when(span.remoteIpAndPort("1.2.3.4", 0)).thenReturn(true);
-    when(adapter.requestHeader(request, "X-Forwarded-For")).thenReturn("1.2.3.4");
+    when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
 
-    adapter.parseClientIpAndPort(request, span);
+    wrapper.parseClientIpAndPort(span);
 
     verify(span).remoteIpAndPort("1.2.3.4", 0);
     verifyNoMoreInteractions(span);
@@ -67,7 +63,7 @@ import static org.mockito.Mockito.when;
     when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
     when(span.remoteIpAndPort("1.2.3.4", 0)).thenReturn(true);
 
-    adapter.parseClientIpAndPort(request, span);
+    wrapper.parseClientIpAndPort(span);
 
     verify(span).remoteIpAndPort("1.2.3.4", 0);
     verifyNoMoreInteractions(span);
@@ -77,21 +73,9 @@ import static org.mockito.Mockito.when;
     when(request.getRemoteAddr()).thenReturn("1.2.3.4");
     when(request.getRemotePort()).thenReturn(61687);
 
-    adapter.parseClientIpAndPort(request, span);
+    wrapper.parseClientIpAndPort(span);
 
     verify(span).remoteIpAndPort("1.2.3.4", 61687);
     verifyNoMoreInteractions(span);
-  }
-
-  @Test public void statusCodeAsInt() {
-    when(response.getStatus()).thenReturn(200);
-
-    assertThat(adapter.statusCodeAsInt(response)).isEqualTo(200);
-    assertThat(adapter.statusCode(response)).isEqualTo(200);
-  }
-
-  @Test public void statusCodeAsInt_zeroNoResponse() {
-    assertThat(adapter.statusCodeAsInt(response)).isZero();
-    assertThat(adapter.statusCode(response)).isNull();
   }
 }

--- a/instrumentation/servlet/src/test/java/brave/servlet/HttpServletRequestWrapperTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/HttpServletRequestWrapperTest.java
@@ -29,6 +29,18 @@ public class HttpServletRequestWrapperTest {
   HttpServerRequest wrapper = HttpServletRequestWrapper.create(request);
   Span span = mock(Span.class);
 
+  @Test public void unwrap() {
+    assertThat(wrapper.unwrap())
+      .isEqualTo(request);
+  }
+
+  @Test public void method() {
+    when(request.getMethod()).thenReturn("POST");
+
+    assertThat(wrapper.method())
+      .isEqualTo("POST");
+  }
+
   @Test public void path_doesntCrashOnNullUrl() {
     assertThat(wrapper.path())
       .isNull();

--- a/instrumentation/servlet/src/test/java/brave/servlet/HttpServletResponseWrapperTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/HttpServletResponseWrapperTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.servlet;
+
+import brave.http.HttpServerResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HttpServletResponseWrapperTest {
+  HttpServletRequest request = mock(HttpServletRequest.class);
+  HttpServletResponse response = mock(HttpServletResponse.class);
+
+  @Test public void statusCode() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    when(response.getStatus()).thenReturn(200);
+
+    assertThat(wrapper.statusCode()).isEqualTo(200);
+  }
+
+  @Test public void statusCode_zeroNoResponse() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    assertThat(wrapper.statusCode()).isZero();
+  }
+
+  @Test public void nullRequestOk() {
+    HttpServletResponseWrapper.create(null, response, null);
+  }
+
+  @Test public void method_isRequestMethod() {
+    when(request.getMethod()).thenReturn("POST");
+
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    assertThat(wrapper.method()).isEqualTo("POST");
+  }
+
+  @Test public void route_isHttpRouteAttribute() {
+    when(request.getAttribute("http.route")).thenReturn("/users/{userId}");
+
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    assertThat(wrapper.route()).isEqualTo("/users/{userId}");
+  }
+}

--- a/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/ITTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,13 +22,11 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class ITTracingFilter extends ITServlet3Container {
 
-  @Override
-  protected Filter newTracingFilter() {
+  @Override protected Filter newTracingFilter() {
     return TracingFilter.create(httpTracing);
   }
 
-  @Override
-  protected void addFilter(ServletContextHandler handler, Filter filter) {
+  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
     FilterRegistration.Dynamic filterRegistration =
       handler.getServletContext().addFilter(filter.getClass().getSimpleName(), filter);
     filterRegistration.setAsyncSupported(true);

--- a/instrumentation/servlet/src/test/java/brave/servlet/internal/ServletRuntimeTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/internal/ServletRuntimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,23 +13,94 @@
  */
 package brave.servlet.internal;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.Locale;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Response;
 import org.junit.Test;
 
+import static brave.servlet.internal.ServletRuntime.maybeError;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ServletRuntimeTest {
   ServletRuntime servlet25 = new ServletRuntime.Servlet25();
+  HttpServletRequest request = mock(HttpServletRequest.class);
 
-  @Test public void servlet25_status_doesntParseAnonymousTypes() throws Exception {
+  @Test public void maybeError_fromRequestAttribute() {
+    Exception requestError = new Exception();
+    when(request.getAttribute("error")).thenReturn(requestError);
+
+    assertThat(maybeError(null, request)).isSameAs(requestError);
+  }
+
+  @Test public void maybeError_badRequestAttribute() {
+    when(request.getAttribute("error")).thenReturn(new Object());
+
+    assertThat(maybeError(null, request)).isNull();
+  }
+
+  @Test public void maybeError_overridesRequestAttribute() {
+    Exception error = new Exception();
+    Exception requestError = new Exception();
+    when(request.getAttribute("error")).thenReturn(requestError);
+
+    assertThat(maybeError(error, request)).isSameAs(error);
+  }
+
+  /** getStatus doesn't exist in Servlet 2.5, so we add mechanisms to catch it. */
+  @Test public void servlet25_httpServletResponse_catchesStatus() throws IOException {
+    HttpServletResponse httpServletResponse =
+      servlet25.httpServletResponse(new HttpServletResponseImpl());
+
+    httpServletResponse.setStatus(404);
+    assertThat(servlet25.status(httpServletResponse))
+      .isEqualTo(404);
+
+    httpServletResponse.setStatus(418, "I'm a teapot");
+    assertThat(servlet25.status(httpServletResponse))
+      .isEqualTo(418);
+
+    httpServletResponse.sendError(500);
+    assertThat(servlet25.status(httpServletResponse))
+      .isEqualTo(500);
+
+    httpServletResponse.sendError(508, "Loop Detected");
+    assertThat(servlet25.status(httpServletResponse))
+      .isEqualTo(508);
+  }
+
+  @Test public void servlet25_status() {
+    assertThat(servlet25.status(new HttpServletResponseImpl()))
+      .isEqualTo(200);
+  }
+
+  @Test public void servlet25_status_cached() {
+    HttpServletResponseImpl response = new HttpServletResponseImpl();
+    assertThat(servlet25.status(response))
+      .isEqualTo(200);
+
+    assertThat(servlet25.status(response))
+      .isEqualTo(200);
+  }
+
+  @Test public void servlet25_status_cached_laterThrows() {
+    HttpServletResponseImpl response = new HttpServletResponseImpl();
+    servlet25.status(response);
+    response.shouldThrow = true;
+    assertThat(servlet25.status(response))
+      .isEqualTo(0);
+  }
+
+  @Test public void servlet25_status_doesntParseAnonymousTypes() {
     // while looks nice, this will overflow our cache
-    Response jettyResponse = new Response(null) {
+    Response jettyResponse = new Response(null, null) {
       @Override public int getStatus() {
         throw new AssertionError();
       }
@@ -38,7 +109,7 @@ public class ServletRuntimeTest {
       .isZero();
   }
 
-  @Test public void servlet25_status_doesntParseLocalTypes() throws Exception {
+  @Test public void servlet25_status_doesntParseLocalTypes() {
     // while looks nice, this will overflow our cache
     class LocalResponse extends HttpServletResponseImpl {
     }
@@ -52,7 +123,13 @@ public class ServletRuntimeTest {
     }
   }
 
-  @Test public void servlet25_status_nullOnException() throws Exception {
+  @Test public void servlet25_status_zeroOnException() {
+    assertThat(servlet25.status(new ExceptionResponse()))
+      .isZero();
+  }
+
+  @Test public void servlet25_status_zeroOnException_cached() {
+    servlet25.status(new ExceptionResponse());
     assertThat(servlet25.status(new ExceptionResponse()))
       .isZero();
   }
@@ -90,7 +167,7 @@ public class ServletRuntimeTest {
   class Response11 extends HttpServletResponseImpl {
   }
 
-  @Test public void servlet25_status_cachesUpToTenTypes() throws Exception {
+  @Test public void servlet25_status_cachesUpToTenTypes() {
     assertThat(servlet25.status(new Response1()))
       .isEqualTo(200);
     assertThat(servlet25.status(new Response2()))
@@ -115,7 +192,10 @@ public class ServletRuntimeTest {
       .isZero();
   }
 
-  public static class HttpServletResponseImpl implements HttpServletResponse {
+  static class HttpServletResponseImpl implements HttpServletResponse {
+    int statusCode = 200;
+    boolean shouldThrow;
+
     @Override public String getCharacterEncoding() {
       return null;
     }
@@ -136,6 +216,9 @@ public class ServletRuntimeTest {
     }
 
     @Override public void setContentLength(int len) {
+    }
+
+    @Override public void setContentLengthLong(long len) {
     }
 
     @Override public void setContentType(String type) {
@@ -225,7 +308,8 @@ public class ServletRuntimeTest {
     }
 
     @Override public int getStatus() {
-      return 200;
+      if (shouldThrow) throw new IllegalArgumentException();
+      return statusCode;
     }
 
     @Override public String getHeader(String name) {

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -50,13 +50,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- sparkjava provides its own jetty -->
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
+++ b/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
@@ -18,11 +18,12 @@ import brave.Tracer;
 import brave.Tracer.SpanInScope;
 import brave.Tracing;
 import brave.http.HttpServerHandler;
+import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
+import brave.servlet.HttpServletRequestWrapper;
+import brave.servlet.HttpServletResponseWrapper;
 import spark.ExceptionHandler;
 import spark.Filter;
-import spark.Request;
-import spark.Response;
 
 public final class SparkTracing {
   public static SparkTracing create(Tracing tracing) {
@@ -43,17 +44,20 @@ public final class SparkTracing {
 
   public Filter before() {
     return (request, response) -> {
-      Span span = handler.handleReceive(new HttpServerRequest(request));
+      // Add servlet attribute "http.route" if this or similar is merged:
+      // https://github.com/perwendel/spark/pull/1126
+      Span span = handler.handleReceive(HttpServletRequestWrapper.create(request.raw()));
       request.attribute(SpanInScope.class.getName(), tracer.withSpanInScope(span));
     };
   }
 
   public Filter afterAfter() {
-    return (request, response) -> {
+    return (req, res) -> {
       Span span = tracer.currentSpan();
       if (span == null) return;
-      handler.handleSend(new HttpServerResponse(response, request.requestMethod()), null, span);
-      ((SpanInScope) request.attribute(SpanInScope.class.getName())).close();
+      HttpServerResponse response = HttpServletResponseWrapper.create(req.raw(), res.raw(), null);
+      handler.handleSend(response, response.error(), span);
+      ((SpanInScope) req.attribute(SpanInScope.class.getName())).close();
     };
   }
 
@@ -64,73 +68,12 @@ public final class SparkTracing {
       } finally {
         Span span = tracer.currentSpan();
         if (span != null) {
-          HttpServerResponse res = new HttpServerResponse(response, request.requestMethod());
-          handler.handleSend(res, error, span);
+          HttpServerResponse res =
+            HttpServletResponseWrapper.create(request.raw(), response.raw(), error);
+          handler.handleSend(res, res.error(), span);
           ((SpanInScope) request.attribute(SpanInScope.class.getName())).close();
         }
       }
     };
-  }
-
-  static final class HttpServerRequest extends brave.http.HttpServerRequest {
-    final Request delegate;
-
-    HttpServerRequest(Request delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override public Request unwrap() {
-      return delegate;
-    }
-
-    @Override public boolean parseClientIpAndPort(Span span) {
-      return span.remoteIpAndPort(delegate.raw().getRemoteAddr(), delegate.raw().getRemotePort());
-    }
-
-    @Override public String method() {
-      return delegate.requestMethod();
-    }
-
-    @Override public String path() {
-      return delegate.pathInfo();
-    }
-
-    @Override public String url() {
-      String baseUrl = delegate.url();
-      if (delegate.queryString() != null && !delegate.queryString().isEmpty()) {
-        return baseUrl + "?" + delegate.queryString();
-      }
-      return baseUrl;
-    }
-
-    @Override public String header(String name) {
-      return delegate.raw().getHeader(name);
-    }
-  }
-
-  static final class HttpServerResponse extends brave.http.HttpServerResponse {
-    final Response delegate;
-    final String method;
-
-    HttpServerResponse(Response delegate, String method) {
-      this.delegate = delegate;
-      this.method = method;
-    }
-
-    @Override public Response unwrap() {
-      return delegate;
-    }
-
-    @Override public String method() {
-      return method;
-    }
-
-    @Override public String route() {
-      return null; // Update if this or similar merged https://github.com/perwendel/spark/pull/1126
-    }
-
-    @Override public int statusCode() {
-      return delegate.status();
-    }
   }
 }

--- a/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
+++ b/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
@@ -62,16 +62,16 @@ public final class SparkTracing {
   }
 
   public ExceptionHandler exception(ExceptionHandler delegate) {
-    return (error, request, response) -> {
+    return (error, req, res) -> {
       try {
-        delegate.handle(error, request, response);
+        delegate.handle(error, req, res);
       } finally {
         Span span = tracer.currentSpan();
         if (span != null) {
-          HttpServerResponse res =
-            HttpServletResponseWrapper.create(request.raw(), response.raw(), error);
-          handler.handleSend(res, res.error(), span);
-          ((SpanInScope) request.attribute(SpanInScope.class.getName())).close();
+          HttpServerResponse response =
+            HttpServletResponseWrapper.create(req.raw(), res.raw(), error);
+          handler.handleSend(response, response.error(), span);
+          ((SpanInScope) req.attribute(SpanInScope.class.getName())).close();
         }
       }
     };

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
@@ -15,38 +15,17 @@ package brave.sparkjava;
 
 import brave.servlet.TracingFilter;
 import brave.test.http.ITServletContainer;
-import brave.test.http.ServletContainer;
+import brave.test.http.Jetty9ServerController;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration.Dynamic;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.Ignore;
 import spark.servlet.SparkFilter;
 
 public class ITTracingFilter extends ITServletContainer {
-  /** Override to support Jetty 9.x */
-  @Override protected ServletContainer newServletContainer() {
-    return new ServletContainer() {
-      @Override protected Server newServer(int port) {
-        Server result = new Server();
-        ServerConnector connector = new ServerConnector(result);
-        connector.setPort(port);
-        connector.setIdleTimeout(1000 * 60 * 60);
-        result.setConnectors(new Connector[] {connector});
-        return result;
-      }
-
-      @Override protected int getLocalPort(Server server) {
-        return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
-      }
-
-      @Override public void init(ServletContextHandler handler) {
-        ITTracingFilter.this.init(handler);
-      }
-    };
+  public ITTracingFilter() {
+    super(new Jetty9ServerController());
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITTracingFilter.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Ignore;
 import spark.servlet.SparkFilter;
 
 public class ITTracingFilter extends ITServletContainer {
@@ -56,5 +57,13 @@ public class ITTracingFilter extends ITServletContainer {
     Dynamic sparkFilter = handler.getServletContext().addFilter("sparkFilter", new SparkFilter());
     sparkFilter.setInitParameter("applicationClass", TestApplication.class.getName());
     sparkFilter.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+  }
+
+  @Override @Ignore("TODO: make a spark.ExceptionMapper that adds the \"error\" request property")
+  public void errorTag_exceptionOverridesHttpStatus() {
+  }
+
+  @Override @Ignore("TODO: make a spark.ExceptionMapper that adds the \"error\" request property")
+  public void finishedSpanHandlerSeesException() {
   }
 }

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/TestApplication.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/TestApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,8 @@ public class TestApplication implements SparkApplication {
       return "happy";
     });
     Spark.get("/exception", (req, res) -> {
-      throw new Exception();
+      res.status(503);
+      throw new IllegalStateException("not ready");
     });
 
     // TODO: we need matchUri: https://github.com/perwendel/spark/issues/959

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
@@ -53,7 +53,6 @@ final class TraceContextListenableFuture<T> implements ListenableFuture<T> {
   // Do not use @Override annotation to avoid compatibility issue version < 4.1
   public void addCallback(SuccessCallback<? super T> successCallback,
     FailureCallback failureCallback) {
-    delegate.addCallback(successCallback, failureCallback);
     delegate.addCallback(
       successCallback != null
         ? new TraceContextSuccessCallback<>(successCallback, this)

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptor.java
@@ -20,7 +20,7 @@ import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
-import brave.spring.web.TracingClientHttpRequestInterceptor.HttpClientResponse;
+import brave.spring.web.TracingClientHttpRequestInterceptor.ClientHttpResponseWrapper;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpRequest;
@@ -52,7 +52,7 @@ public final class TracingAsyncClientHttpRequestInterceptor
   @Override public ListenableFuture<ClientHttpResponse> intercept(HttpRequest request,
     byte[] body, AsyncClientHttpRequestExecution execution) throws IOException {
     Span span =
-      handler.handleSend(new TracingClientHttpRequestInterceptor.HttpClientRequest(request));
+      handler.handleSend(new TracingClientHttpRequestInterceptor.HttpRequestWrapper(request));
 
     // avoid context sync overhead when we are the root span
     TraceContext invocationContext = span.context().parentIdAsLong() != 0
@@ -87,7 +87,7 @@ public final class TracingAsyncClientHttpRequestInterceptor
     }
 
     @Override public void onSuccess(ClientHttpResponse result) {
-      handler.handleReceive(new HttpClientResponse(result), null, span);
+      handler.handleReceive(new ClientHttpResponseWrapper(result, null), null, span);
     }
   }
 }

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package brave.spring.web;
 
-import brave.spring.web.TracingClientHttpRequestInterceptor.HttpClientResponse;
+import brave.spring.web.TracingClientHttpRequestInterceptor.ClientHttpResponseWrapper;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,24 +25,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpClientResponseTest {
+public class ClientHttpResponseWrapperTest {
   @Mock ClientHttpResponse response;
 
   @Test public void statusCode() throws IOException {
     when(response.getRawStatusCode()).thenReturn(200);
 
-    assertThat(new HttpClientResponse(response).statusCode()).isEqualTo(200);
+    assertThat(new ClientHttpResponseWrapper(response, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroOnIOE() throws IOException {
     when(response.getRawStatusCode()).thenThrow(new IOException());
 
-    assertThat(new HttpClientResponse(response).statusCode()).isZero();
+    assertThat(new ClientHttpResponseWrapper(response, null).statusCode()).isZero();
   }
 
   @Test public void statusCode_zeroOnIAE() throws IOException {
     when(response.getRawStatusCode()).thenThrow(new IllegalArgumentException());
 
-    assertThat(new HttpClientResponse(response).statusCode()).isZero();
+    assertThat(new ClientHttpResponseWrapper(response, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -39,7 +39,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-servlet</artifactId>
     </dependency>
-    <!-- implicitly servlet 3.0.1 -->
+    <!-- implicitly servlet 3.1.0 -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/instrumentation/spring-webmvc/src/it/servlet25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/servlet25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,12 +13,36 @@
  */
 package brave.spring.webmvc;
 
+import brave.test.http.ServletContainer;
 import java.util.EnumSet;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.DispatcherType;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.bio.SocketConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 public class ITSpanCustomizingHandlerInterceptor extends BaseITSpanCustomizingHandlerInterceptor {
+  public ITSpanCustomizingHandlerInterceptor() {
+    super(new Jetty7ServerController());
+  }
+
+  /** Overridden to support Jetty 7.x (that uses Servlet 2.5) */
+  static final class Jetty7ServerController implements ServletContainer.ServerController {
+    @Override public Server newServer(int port) {
+      Server result = new Server();
+      SocketConnector connector = new SocketConnector();
+      connector.setMaxIdleTime(1000 * 60 * 60);
+      connector.setPort(port);
+      result.setConnectors(new Connector[] {connector});
+      return result;
+    }
+
+    @Override public int getLocalPort(Server server) {
+      return server.getConnectors()[0].getLocalPort();
+    }
+  }
+
   @Override protected void addDelegatingTracingFilter(ServletContextHandler handler) {
     handler.addFilter(DelegatingTracingFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
   }

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package brave.spring.webmvc;
 
 import brave.servlet.TracingFilter;
 import brave.test.http.ITServletContainer;
+import brave.test.http.ServletContainer.ServerController;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.Test;
@@ -32,6 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** This tests when you use servlet for tracing but MVC for tagging */
 public abstract class BaseITSpanCustomizingHandlerInterceptor extends ITServletContainer {
+  protected BaseITSpanCustomizingHandlerInterceptor(ServerController serverController) {
+    super(serverController);
+  }
 
   @Test public void addsControllerTags() throws Exception {
     get("/foo");

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package brave.spring.webmvc;
 
 import brave.test.http.ITServletContainer;
+import brave.test.http.Jetty9ServerController;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration.Dynamic;
@@ -34,6 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** This tests when you use servlet for tracing but MVC for tagging */
 public class ITSpanCustomizingAsyncHandlerInterceptor extends ITServletContainer {
+  public ITSpanCustomizingAsyncHandlerInterceptor() {
+    super(new Jetty9ServerController());
+  }
 
   @Test public void addsControllerTags() throws Exception {
     get("/foo");

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,12 +13,17 @@
  */
 package brave.spring.webmvc;
 
+import brave.test.http.Jetty9ServerController;
 import java.util.EnumSet;
 import javax.servlet.DispatcherType;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 public class ITSpanCustomizingHandlerInterceptor extends BaseITSpanCustomizingHandlerInterceptor {
+  public ITSpanCustomizingHandlerInterceptor() {
+    super(new Jetty9ServerController());
+  }
+
   @Override protected void addDelegatingTracingFilter(ServletContextHandler handler) {
     handler.addFilter(DelegatingTracingFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
   }

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import brave.Tracer;
 import brave.http.HttpTracing;
 import brave.propagation.ExtraFieldPropagation;
 import brave.test.http.ITHttp;
-import java.io.IOException;
+import javax.servlet.UnavailableException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller class Servlet25TestController {
   final Tracer tracer;
@@ -59,9 +60,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
     return new ResponseEntity<>(HttpStatus.OK);
   }
 
+  @ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE)
   @RequestMapping(value = "/exception")
-  public ResponseEntity<Void> disconnect() throws IOException {
-    throw new IOException();
+  public ResponseEntity<Void> notReady() throws UnavailableException {
+    throw new UnavailableException("not ready", 1 /* temporary implies 503 */);
   }
 
   @RequestMapping(value = "/items/{itemId}")

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package brave.spring.webmvc;
 
 import brave.http.HttpTracing;
-import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller class Servlet3TestController extends Servlet25TestController {
 
@@ -34,10 +34,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
     return () -> new ResponseEntity<>(HttpStatus.OK);
   }
 
+  @ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE)
   @RequestMapping(value = "/exceptionAsync")
-  public Callable<ResponseEntity<Void>> disconnectAsync() {
+  public Callable<ResponseEntity<Void>> notReadyAsync() {
     return () -> {
-      throw new IOException();
+      throw new IllegalStateException("not ready");
     };
   }
 

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/HttpServerResponseWrapperTest.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/HttpServerResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,8 +13,9 @@
  */
 package brave.vertx.web;
 
-import brave.vertx.web.TracingRoutingContextHandler.HttpServerResponse;
+import brave.vertx.web.TracingRoutingContextHandler.HttpServerResponseWrapper;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.Before;
@@ -27,10 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HttpServerResponseTest {
+public class HttpServerResponseWrapperTest {
   @Mock RoutingContext context;
   @Mock HttpServerRequest request;
-  @Mock io.vertx.core.http.HttpServerResponse response;
+  @Mock HttpServerResponse response;
   @Mock Route currentRoute;
 
   @Before public void setup() {
@@ -42,31 +43,31 @@ public class HttpServerResponseTest {
   @Test public void method() {
     when(request.rawMethod()).thenReturn("GET");
 
-    assertThat(new HttpServerResponse(context).method())
+    assertThat(new HttpServerResponseWrapper(context).method())
       .isEqualTo("GET");
   }
 
   @Test public void route_emptyByDefault() {
-    assertThat(new HttpServerResponse(context).route())
+    assertThat(new HttpServerResponseWrapper(context).route())
       .isEmpty();
   }
 
   @Test public void route() {
     when(currentRoute.getPath()).thenReturn("/users/:userID");
 
-    assertThat(new HttpServerResponse(context).route())
+    assertThat(new HttpServerResponseWrapper(context).route())
       .isEqualTo("/users/:userID");
   }
 
   @Test public void statusCode() {
     when(response.getStatusCode()).thenReturn(200);
 
-    assertThat(new HttpServerResponse(context).statusCode())
+    assertThat(new HttpServerResponseWrapper(context).statusCode())
       .isEqualTo(200);
   }
 
   @Test public void statusCode_zero() {
-    assertThat(new HttpServerResponse(context).statusCode())
+    assertThat(new HttpServerResponseWrapper(context).statusCode())
       .isZero();
   }
 }

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -79,7 +79,7 @@ public class ITVertxWebTracing extends ITHttpServer {
       ctx.response().end("happy");
     });
     router.route("/exception").handler(ctx -> {
-      ctx.fail(new Exception());
+      ctx.fail(503, new IllegalStateException("not ready"));
     });
     router.route("/items/:itemId").handler(ctx -> {
       ctx.response().end(ctx.request().getParam("itemId"));
@@ -96,7 +96,7 @@ public class ITVertxWebTracing extends ITHttpServer {
     });
     router.mountSubRouter("/nested", subrouter);
     router.route("/exceptionAsync").handler(ctx -> {
-      ctx.request().endHandler(v -> ctx.fail(new Exception()));
+      ctx.request().endHandler(v -> ctx.fail(503, new IllegalStateException("not ready")));
     });
 
     Handler<RoutingContext> routingContextHandler =

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,9 @@
     <spring5.version>5.2.3.RELEASE</spring5.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
-    <!-- don't use apis not in jetty 7.6* else testing servlet 2.5 will imply duplication -->
-    <jetty.version>8.1.22.v20160922</jetty.version>
+    <!-- Apis used, but not in Jetty 7.6* imply duplication in servlet25 test fixtures -->
+    <!-- prefer sparkjava's jetty to reduce downloads -->
+    <jetty.version>9.4.18.v20190429</jetty.version>
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.10.0.Final</resteasy.version>


### PR DESCRIPTION
This introduces `Response.error()`, present when there was an exception
invoking a client request, or processing a server request. This also
ensures that `FinishedSpanHandler` can read it independently of the
"error" tag.

This implied retro-fitting this in the HTTP abstraction and backfilling
tests that tell the difference between HTTP status and a parsed
exception. This identified a gap in Servlet libraries which formerly
swallowed application level exceptions. To bridge that gap, we now
look at the request attribute "error" when ending a server span.