### PR TITLE
Makes HTTP request method mandatory

### DIFF
--- a/instrumentation/http/RATIONALE.md
+++ b/instrumentation/http/RATIONALE.md
@@ -55,6 +55,28 @@ of adding more surface to the public api of the new types like
 all of the public methods defined in the adapter. This would cause confusion,
 something worse than adding an object allocation on these paths.
 
+## Method as a required property
+
+Even though we've seen method incorrectly set in the past, we've never seen it
+missing. In v5.10 we changed HTTP method to be a required property.
+
+### Why not HTTP path?
+While it seems path would also always be available, it isn't valid for all HTTP
+methods (ex OPTIONS and CONNECT). Also, it can be null due to bad parsing (ex
+some things don't natively return the path, only the URL). Finally, it has been
+found [missing before](https://github.com/reactor/reactor-netty/pull/998).
+
+If we started to make HTTP path a required property, it would invalidate
+instrumentation not located here, which have been working under the assumption
+that it could be null. A late change to make something known to be nullable,
+would result in our library raising `NullPointerExceptions`, crashing requests
+for scenarios that would neither crash, nor impact tracing formerly.
+
+Moreover, we have not had any complaints about the HTTP path property being
+optional, and it has been for several years. If we knew users aren't demanding
+this, yet forced a known set of problems by doing so, we'd be actively against
+an priority of telemetry development: do no harm.
+
 ## `HttpRequestParser` and `HttpResponseParser`
 
 `HttpRequestParser` and `HttpResponseParser`replace the deprecated type

--- a/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpAdapter.java
@@ -19,7 +19,7 @@ import java.net.URI;
 /** @deprecated Since 5.10, use {@link HttpRequest} and {@link HttpResponse} */
 @Deprecated public abstract class HttpAdapter<Req, Resp> {
   /** @see HttpRequest#method() */
-  @Nullable public abstract String method(Req request);
+  public abstract String method(Req request);
 
   /** @see HttpRequest#path() */
   @Nullable public String path(Req request) {

--- a/instrumentation/http/src/main/java/brave/http/HttpParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpParser.java
@@ -68,8 +68,11 @@ import static brave.http.HttpResponseParser.Default.catchAllName;
     if (path != null) customizer.tag("http.path", path);
   }
 
-  /** Returns the span name of the request. Defaults to the http method. */
-  protected <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
+  /**
+   * Returns the span name of the request or null if the data needed is unavailable. Defaults to the
+   * http method.
+   */
+  @Nullable protected <Req> String spanName(HttpAdapter<Req, ?> adapter, Req req) {
     return adapter.method(req);
   }
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequest.java
@@ -58,7 +58,7 @@ public abstract class HttpRequest extends Request {
    * that an HTTP method is case-sensitive. Do not downcase results. If you do, not only will
    * integration tests fail, but you will surprise any consumers who expect compliant results.
    */
-  @Nullable public abstract String method();
+  public abstract String method();
 
   /**
    * The absolute http path, without any query parameters or null if unreadable. Ex.

--- a/instrumentation/http/src/main/java/brave/http/HttpRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequest.java
@@ -49,7 +49,7 @@ public abstract class HttpRequest extends Request {
   }
 
   /**
-   * The HTTP method, or verb, such as "GET" or "POST" or null if unreadable.
+   * The HTTP method, or verb, such as "GET" or "POST".
    *
    * <p>Conventionally associated with the key "http.method"
    *
@@ -61,10 +61,11 @@ public abstract class HttpRequest extends Request {
   public abstract String method();
 
   /**
-   * The absolute http path, without any query parameters or null if unreadable. Ex.
-   * "/objects/abcd-ff"
+   * The absolute http path, without any query parameters. Ex. "/objects/abcd-ff"
    *
    * <p>Conventionally associated with the key "http.path"
+   *
+   * <p>{@code null} could mean not applicable to the HTTP method (ex CONNECT).
    *
    * @see #url()
    * @see HttpResponse#route()

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestParser.java
@@ -14,7 +14,7 @@
 package brave.http;
 
 import brave.SpanCustomizer;
-import brave.propagation.ExtraFieldPropagation;
+import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 
 /**
@@ -67,8 +67,11 @@ public interface HttpRequestParser {
       if (path != null) span.tag("http.path", path);
     }
 
-    /** Returns the span name of the request. Defaults to the http method. */
-    protected String spanName(HttpRequest req, TraceContext context) {
+    /**
+     * Returns the span name of the request or null if the data needed is unavailable. Defaults to
+     * the http method.
+     */
+    @Nullable protected String spanName(HttpRequest req, TraceContext context) {
       return req.method();
     }
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestParser.java
@@ -62,8 +62,7 @@ public interface HttpRequestParser {
     @Override public void parse(HttpRequest req, TraceContext context, SpanCustomizer span) {
       String name = spanName(req, context);
       if (name != null) span.name(name);
-      String method = req.method();
-      if (method != null) span.tag("http.method", method);
+      span.tag("http.method", req.method());
       String path = req.path();
       if (path != null) span.tag("http.path", path);
     }

--- a/instrumentation/http/src/test/java/brave/http/HttpAdaptersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpAdaptersTest.java
@@ -157,10 +157,6 @@ import static org.mockito.Mockito.when;
     verify(requestAdapter).startTimestamp(request);
   }
 
-  @Test public void fromRequestAdapter_method_nullOnNoMatch() {
-    assertThat(fromRequestAdapter.method()).isNull();
-  }
-
   @Test public void fromRequestAdapter_method_delegatesToAdapter() {
     when(requestAdapter.method(request)).thenReturn("GET");
 

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -54,6 +54,7 @@ public class HttpClientHandlerTest {
 
   @Before public void init() {
     init(httpTracingBuilder(tracingBuilder()));
+    when(request.method()).thenReturn("GET");
   }
 
   void init(HttpTracing.Builder builder) {

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -57,6 +57,7 @@ public class HttpServerHandlerTest {
     close();
     httpTracing = builder.build();
     handler = HttpServerHandler.create(httpTracing);
+    when(request.method()).thenReturn("GET");
   }
 
   HttpTracing.Builder httpTracingBuilder(Tracing.Builder tracingBuilder) {


### PR DESCRIPTION
While all other properties can be absent or invalid, this makes the HTTP
method mandatory. This will help when we create a path to the request
from the response, as it allows chaining to the method without a null
check.

Note: Eventhough we've seen method incorrectly set in the past,
we've never seen it missing.

PS: While it seems path would also always be available even recently,
it isn't valid for all HTTP methods (ex OPTIONS and CONNECT). Also,
it can be null due to bad parsing (ex some things don't natively return
the path, only the URL). Also, it has been found missing before, most
recently due to a [request availablility bug](https://github.com/reactor/reactor-netty/pull/998) which is still not released! If we started enforcing path be present, it
would force a known set of scenarios to NPE causing people who can't
change their implementations to become revlocked until they can. This
makes forcing path to be not nullable, so late in the game, to be a cure
worse than the disease.

Fixes #1089