### PR TITLE
Adds HttpResponse.request()

### DIFF
--- a/brave/src/main/java/brave/Response.java
+++ b/brave/src/main/java/brave/Response.java
@@ -32,10 +32,20 @@ public abstract class Response {
   public abstract Span.Kind spanKind();
 
   /**
+   * The request that initiated this response or {@code null} if unknown.
+   *
+   * <p>Implementations should return the last wire-level request that caused this response or
+   * error.
+   */
+  @Nullable public Request request() {
+    return null;
+  }
+
+  /**
    * The error raised during response processing or {@code null} if there was none.
    *
-   * <p>Lack of throwable, {@code null}, does not mean success. For example, in HTTP, there could be
-   * a 409 status code with no corresponding Java exception.
+   * <p>Lack of throwable, {@code null}, does not mean success. For example, in HTTP, there could
+   * be a 409 status code with no corresponding Java exception.
    *
    * <h3>Handling errors</h3>
    * Handlers invoke {@link Span#error(Throwable)} prior to passing control to user-defined response

--- a/instrumentation/benchmarks/src/main/java/brave/jersey/server/TracingApplicationEventListenerAdapterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jersey/server/TracingApplicationEventListenerAdapterBenchmarks.java
@@ -13,7 +13,7 @@
  */
 package brave.jersey.server;
 
-import brave.jersey.server.TracingApplicationEventListener.RequestEventWrapper;
+import brave.jersey.server.TracingApplicationEventListener.ContainerRequestWrapper;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -79,17 +79,13 @@ public class TracingApplicationEventListenerAdapterBenchmarks {
       return nestedUriInfo;
     }
   };
-  RequestEvent nestedEvent = new RequestEventImpl.Builder()
-    .setContainerRequest(nestedRequest)
-    .setContainerResponse(new ContainerResponse(request, new ServerResponse()))
-    .build(RequestEvent.Type.FINISHED);
 
   @Benchmark public String parseRoute() {
-    return new RequestEventWrapper(event, null).route();
+    return new ContainerRequestWrapper(nestedRequest).route();
   }
 
   @Benchmark public String parseRoute_nested() {
-    return new RequestEventWrapper(nestedEvent, null).route();
+    return new ContainerRequestWrapper(nestedRequest).route();
   }
 
   // Convenience main entry-point

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -230,7 +230,7 @@ public abstract class ITHttpServer extends ITHttp {
   @Test
   public void readsRequestAtResponseTime() throws Exception {
     httpTracing = httpTracing.toBuilder()
-      .clientResponseParser((response, context, span) -> {
+      .serverResponseParser((response, context, span) -> {
         span.tag("http.url", response.request().url()); // just the path is tagged by default
       })
       .build();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -228,11 +228,27 @@ public abstract class ITHttpServer extends ITHttp {
   }
 
   @Test
+  public void readsRequestAtResponseTime() throws Exception {
+    httpTracing = httpTracing.toBuilder()
+      .clientResponseParser((response, context, span) -> {
+        span.tag("http.url", response.request().url()); // just the path is tagged by default
+      })
+      .build();
+    init();
+
+    String uri = "/foo?z=2&yAA=1";
+    get(uri);
+
+    assertThat(takeSpan().tags())
+      .containsEntry("http.url", url(uri));
+  }
+
+  @Test
   public void supportsPortableCustomization() throws Exception {
     httpTracing = httpTracing.toBuilder()
       .serverRequestParser((request, context, span) -> {
         span.name(request.method().toLowerCase() + " " + request.path());
-        span.tag("http.url", request.url()); // just the path is logged by default
+        span.tag("http.url", request.url()); // just the path is tagged by default
         span.tag("request_customizer.is_span", (span instanceof brave.Span) + "");
       })
       .serverResponseParser((response, context, span) -> {
@@ -257,7 +273,7 @@ public abstract class ITHttpServer extends ITHttp {
     httpTracing = httpTracing.toBuilder().serverParser(new HttpServerParser() {
       @Override
       public <Req> void request(HttpAdapter<Req, ?> adapter, Req req, SpanCustomizer customizer) {
-        customizer.tag("http.url", adapter.url(req)); // just the path is logged by default
+        customizer.tag("http.url", adapter.url(req)); // just the path is tagged by default
         customizer.tag("context.visible", String.valueOf(currentTraceContext.get() != null));
         customizer.tag("request_customizer.is_span", (customizer instanceof brave.Span) + "");
       }
@@ -357,7 +373,7 @@ public abstract class ITHttpServer extends ITHttp {
 
   final HttpRequestParser addHttpUrlTag = (request, context, span) -> {
     HttpRequestParser.DEFAULT.parse(request, context, span);
-    span.tag("http.url", request.url()); // just the path is logged by default
+    span.tag("http.url", request.url()); // just the path is tagged by default
   };
 
   /** If http route is supported, then the span name should include it */

--- a/instrumentation/http-tests/src/test/java/brave/http/features/TracingDispatcher.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/TracingDispatcher.java
@@ -16,7 +16,6 @@ package brave.http.features;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracer.SpanInScope;
-import brave.http.HttpRequest;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
@@ -92,16 +91,16 @@ final class TracingDispatcher extends Dispatcher {
       this.error = error;
     }
 
-    @Override public HttpRequest request() {
+    @Override public Object unwrap() {
+      return response;
+    }
+
+    @Override public RecordedRequestWrapper request() {
       return request;
     }
 
     @Override public Throwable error() {
       return error;
-    }
-
-    @Override public Object unwrap() {
-      return response;
     }
 
     @Override public int statusCode() {

--- a/instrumentation/http-tests/src/test/java/brave/http/features/TracingDispatcher.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/TracingDispatcher.java
@@ -15,6 +15,8 @@ package brave.http.features;
 
 import brave.Span;
 import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.http.HttpRequest;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
@@ -35,17 +37,18 @@ final class TracingDispatcher extends Dispatcher {
     this.delegate = delegate;
   }
 
-  @Override public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
-    Span span = handler.handleReceive(new RecordedRequestWrapper(request));
+  @Override public MockResponse dispatch(RecordedRequest req) throws InterruptedException {
+    RecordedRequestWrapper request = new RecordedRequestWrapper(req);
+    Span span = handler.handleReceive(request);
     MockResponse response = null;
     Throwable error = null;
-    try (Tracer.SpanInScope ws = tracer.withSpanInScope(span)) {
-      return response = delegate.dispatch(request);
+    try (SpanInScope ws = tracer.withSpanInScope(span)) {
+      return response = delegate.dispatch(req);
     } catch (Throwable e) {
       error = e;
       throw e;
     } finally {
-      handler.handleSend(new MockResponseWrapper(response, error), error, span);
+      handler.handleSend(new MockResponseWrapper(request, response, error), error, span);
     }
   }
 
@@ -78,12 +81,19 @@ final class TracingDispatcher extends Dispatcher {
   }
 
   static final class MockResponseWrapper extends HttpServerResponse {
-    final MockResponse delegate;
+    final RecordedRequestWrapper request;
+    final MockResponse response;
     final @Nullable Throwable error;
 
-    MockResponseWrapper(MockResponse delegate, @Nullable Throwable error) {
-      this.delegate = delegate;
+    MockResponseWrapper(RecordedRequestWrapper request, MockResponse response,
+      @Nullable Throwable error) {
+      this.request = request;
+      this.response = response;
       this.error = error;
+    }
+
+    @Override public HttpRequest request() {
+      return request;
     }
 
     @Override public Throwable error() {
@@ -91,11 +101,11 @@ final class TracingDispatcher extends Dispatcher {
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return response;
     }
 
     @Override public int statusCode() {
-      return Integer.parseInt(delegate.getStatus().split(" ")[1]);
+      return Integer.parseInt(response.getStatus().split(" ")[1]);
     }
   }
 }

--- a/instrumentation/http-tests/src/test/java/brave/http/features/TracingInterceptor.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/TracingInterceptor.java
@@ -91,16 +91,23 @@ final class TracingInterceptor implements Interceptor {
   }
 
   static final class ResponseWrapper extends HttpClientResponse {
-    final Response delegate;
+    final RequestWrapper request;
+    final Response response;
     @Nullable final Throwable error;
 
-    ResponseWrapper(Response delegate, @Nullable Throwable error) {
-      this.delegate = delegate;
+    ResponseWrapper(Response response, @Nullable Throwable error) {
+      // intentionally not the same instance as chain.proceed, as properties may have changed
+      this.request = new RequestWrapper(response.request());
+      this.response = response;
       this.error = error;
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return response;
+    }
+
+    @Override public RequestWrapper request() {
+      return request;
     }
 
     @Override public Throwable error() {
@@ -108,7 +115,7 @@ final class TracingInterceptor implements Interceptor {
     }
 
     @Override public int statusCode() {
-      return delegate.code();
+      return response.code();
     }
   }
 }

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -243,7 +243,8 @@ You generally need to...
 5. Complete the span
 
 ```java
-Span span = handler.handleReceive(new HttpServerRequestWrapper(request)); // 1.
+HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request);
+Span span = handler.handleReceive(wrapper); // 1.
 Result result = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
@@ -253,23 +254,50 @@ try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
   throw e;
 } finally {
   HttpServerResponseWrapper response = result != null
-    ? new HttpServerResponseWrapper(result, error)
+    ? new HttpServerResponseWrapper(wrapper, result, error)
     : null;
   handler.handleSend(response, error, span); // 5.
 }
 ```
 
-### Supporting HttpResponse.route()
+### Supporting HttpResponse.request()
 
-Although the route is associated with the request, not the response, it is
-parsed from the response object. The reason is that many server implementations
-process the request before they can identify the route.
+`HttpResponse.request()` is request that initiated the HTTP response. Since
 
-Instrumentation authors implement support via extending `HttpResponse`
+Implementations should return the last wire-level request that caused the
+response or error. HTTP properties like path and headers might be different,
+due to redirects or authentication. Some properties might not be visible until
+response processing, notably the route.
+
+For these reasons, you may need to generate a different `HttpRequest` instance
+when constructing the `HttpResponse` vs when it was created.
+
+Here is an example for Apache HttpAsyncClient, which grabs the request out
+of its context as it doesn't have a reference during response processing:
+
+```scala
+static final class HttpResponseWrapper extends HttpClientResponse {
+  @Nullable final HttpRequestWrapper request;
+  final HttpResponse response;
+
+  HttpResponseWrapper(HttpResponse response, HttpContext context) {
+    HttpRequest request = HttpClientContext.adapt(context).getRequest();
+    this.request = request != null ? new HttpRequestWrapper(request, context) : null;
+    this.response = response;
+  }
+```
+
+### Supporting HttpRequest.route()
+
+The route is associated with the request, but it may not be visible until
+response processing. The reasons is that many server implementations process
+the request before they can identify the route.
+
+Instrumentation authors implement support via overriding `HttpRequest.route()`
 accordingly. There are a few patterns which might help.
 
 #### Servlet based libraries
-'brave-instrumentation-servlet' includes the type `HttpServletResponseWrapper`.
+'brave-instrumentation-servlet' includes the type `HttpServletRequestWrapper`.
 This looks for the request attribute "http.route", which can be set in any way.
 
 For example, Spring WebMVC can add the route using `HandlerInterceptorAdapter`.
@@ -282,23 +310,15 @@ static void setHttpRouteAttribute(HttpServletRequest request) {
 }
 ```
 
-#### Adding a field to `HttpServerResponse`
-Another easy way is to add a field to your `HttpServerResponse` wrapper, and
-parse that in your implementation of `HttpServerResponse.route()`
+#### Adding a field to `HttpServerRequest`
+Another easy way is to add a field to your `HttpServerRequest` wrapper, and
+parse that in your implementation of `HttpServerRequest.route()`.
 
-Here is an example for Play, which passes the template along with the `Result`
+Here is an example for Play, which passes the template along with the `Request`
 to the HTTP server handler:
 ```scala
 var template = req.attrs.get(Router.Attrs.HandlerDef).map(_.path)
-
---snip--
-
-result.onComplete {
-  case Failure(t) => handler.handleSend(null, t, span)
-  case Success(r) => {
-    handler.handleSend(new ResultWrapper(result, template), null, span)
-  }
-}
+var request = new RequestWrapper(req, template)
 
 --snip--
   override def route(): String =

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -173,7 +173,8 @@ You generally need to...
 5. Complete the span
 
 ```java
-Span span = handler.handleSend(new HttpClientRequestWrapper(request)); // 1.
+HttpClientRequestWrapper wrapper = new HttpClientRequestWrapper(request);
+Span span = handler.handleSend(wrapper); // 1.
 Result result = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
@@ -183,7 +184,7 @@ try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
   throw e;
 } finally {
   HttpClientResponseWrapper response = result != null
-    ? new HttpClientResponseWrapper(result, error)
+    ? new HttpClientResponseWrapper(wrapper, result, error)
     : null;
   handler.handleReceive(response, error, span); // 5.
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -40,7 +40,8 @@ import static brave.http.HttpClientAdapters.FromResponseAdapter;
  * </ol>
  *
  * <pre>{@code
- * Span span = handler.handleSend(new HttpClientRequestWrapper(request)); // 1.
+ * HttpClientRequestWrapper wrapper = new HttpClientRequestWrapper(request);
+ * Span span = handler.handleSend(wrapper); // 1.
  * Result result = null;
  * Throwable error = null;
  * try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
@@ -50,7 +51,7 @@ import static brave.http.HttpClientAdapters.FromResponseAdapter;
  *   throw e;
  * } finally {
  *   HttpClientResponseWrapper response = result != null
- *     ? new HttpClientResponseWrapper(result, error)
+ *     ? new HttpClientResponseWrapper(wrapper, result, error)
  *     : null;
  *   handler.handleReceive(response, error, span); // 5.
  * }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
@@ -14,6 +14,7 @@
 package brave.http;
 
 import brave.Span;
+import brave.internal.Nullable;
 
 /**
  * Marks an interface for use in {@link HttpClientHandler#handleReceive(Object, Throwable, Span)}.
@@ -25,6 +26,11 @@ import brave.Span;
 public abstract class HttpClientResponse extends HttpResponse {
   @Override public final Span.Kind spanKind() {
     return Span.Kind.CLIENT;
+  }
+
+  /** {@inheritDoc} */
+  @Override @Nullable public HttpClientRequest request() {
+    return null;
   }
 
   @Override public Throwable error() {

--- a/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
@@ -23,7 +23,7 @@ import brave.Span;
  * @since 5.7
  */
 public abstract class HttpClientResponse extends HttpResponse {
-  @Override public Span.Kind spanKind() {
+  @Override public final Span.Kind spanKind() {
     return Span.Kind.CLIENT;
   }
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequest.java
@@ -73,6 +73,23 @@ public abstract class HttpRequest extends Request {
   @Nullable public abstract String path();
 
   /**
+   * Returns an expression such as "/items/:itemId" representing an application endpoint,
+   * conventionally associated with the tag key "http.route". If no route matched, "" (empty string)
+   * is returned. Null indicates this instrumentation doesn't understand http routes.
+   *
+   * <p>The route is associated with the request, but it may not be visible until response
+   * processing. The reasons is that many server implementations process the request before they can
+   * identify the route. Parsing should expect this and look at {@link HttpResponse#route()} as
+   * needed.
+   *
+   * @see HttpRequest#path()
+   * @since 5.10
+   */
+  @Nullable public String route() {
+    return null;
+  }
+
+  /**
    * The entire URL, including the scheme, host and query parameters if available or null if
    * unreadable.
    *

--- a/instrumentation/http/src/main/java/brave/http/HttpResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpResponse.java
@@ -45,7 +45,8 @@ public abstract class HttpResponse extends Response {
    * Returns the {@linkplain HttpRequest#method() HTTP method} of the request that caused this
    * response or {@code null} if unreadable.
    *
-   * <p>Note: This value may be present even when {@link #request()} is {@code null}.
+   * <p>Note: This value may be present even when {@link #request()} is {@code null}, but
+   * implementations should implement {@link #request()} when possible.
    *
    * @see HttpRequest#method()
    * @since 5.10
@@ -59,7 +60,8 @@ public abstract class HttpResponse extends Response {
    * Returns the {@linkplain HttpRequest#route() HTTP route} of the request that caused this
    * response or {@code null} if unreadable.
    *
-   * <p>Note: This value may be present even when {@link #request()} is {@code null}.
+   * <p>Note: This value may be present even when {@link #request()} is {@code null}, but
+   * implementations should implement {@link #request()} when possible.
    *
    * @see HttpRequest#route()
    * @since 5.10

--- a/instrumentation/http/src/main/java/brave/http/HttpResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpResponse.java
@@ -28,31 +28,45 @@ import brave.propagation.TraceContext;
  */
 public abstract class HttpResponse extends Response {
   /**
-   * Like {@link HttpRequest#method()} except used in response parsing.
+   * The request that initiated this HTTP response or {@code null} if unknown.
    *
-   * <p>Notably, this is used to create a route-based span name.
+   * <p>Implementations should return the last wire-level request that caused this response or
+   * error. HTTP properties like {@linkplain HttpRequest#path() path} and {@linkplain
+   * HttpRequest#header(String) headers} might be different, due to redirects or authentication.
+   * Some properties might not be visible until response processing, notably {@link #route()}.
    *
    * @since 5.10
    */
-  // TODO: Consider `httpResponse.request()` and deprecating `httpResponse.method()` #1086
-  @Nullable public String method() {
+  @Nullable public HttpRequest request() {
     return null;
   }
 
   /**
-   * Returns an expression such as "/items/:itemId" representing an application endpoint,
-   * conventionally associated with the tag key "http.route". If no route matched, "" (empty string)
-   * is returned. Null indicates this instrumentation doesn't understand http routes.
+   * Returns the {@linkplain HttpRequest#method() HTTP method} of the request that caused this
+   * response or {@code null} if unreadable.
    *
-   * <p>Eventhough the route is associated with the request, not the response, this is present
-   * on the response object. The reasons is that many server implementations process the request
-   * before they can identify the route route.
+   * <p>Note: This value may be present even when {@link #request()} is {@code null}.
    *
-   * @see HttpRequest#path()
+   * @see HttpRequest#method()
+   * @since 5.10
+   */
+  @Nullable public String method() {
+    HttpRequest request = request();
+    return request != null ? request.method() : null;
+  }
+
+  /**
+   * Returns the {@linkplain HttpRequest#route() HTTP route} of the request that caused this
+   * response or {@code null} if unreadable.
+   *
+   * <p>Note: This value may be present even when {@link #request()} is {@code null}.
+   *
+   * @see HttpRequest#route()
    * @since 5.10
    */
   @Nullable public String route() {
-    return null;
+    HttpRequest request = request();
+    return request != null ? request.route() : null;
   }
 
   /**

--- a/instrumentation/http/src/main/java/brave/http/HttpResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpResponse.java
@@ -37,7 +37,7 @@ public abstract class HttpResponse extends Response {
    *
    * @since 5.10
    */
-  @Nullable public HttpRequest request() {
+  @Override @Nullable public HttpRequest request() {
     return null;
   }
 

--- a/instrumentation/http/src/main/java/brave/http/HttpResponseParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpResponseParser.java
@@ -92,7 +92,7 @@ public interface HttpResponseParser {
       return null;
     }
 
-    static String spanNameFromRoute(HttpResponse response, int statusCode) {
+    @Nullable static String spanNameFromRoute(HttpResponse response, int statusCode) {
       String method = response.method();
       if (method == null) return null; // don't undo a valid name elsewhere
       String route = response.route();

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -36,7 +36,8 @@ import brave.sampler.SamplerFunction;
  *   <li>Complete the span</li>
  * </ol>
  * <pre>{@code
- * Span span = handler.handleReceive(new HttpServerRequestWrapper(request)); // 1.
+ * HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request);
+ * Span span = handler.handleReceive(wrapper); // 1.
  * Result result = null;
  * Throwable error = null;
  * try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
@@ -46,7 +47,7 @@ import brave.sampler.SamplerFunction;
  *   throw e;
  * } finally {
  *   HttpServerResponseWrapper response = result != null
- *     ? new HttpServerResponseWrapper(result, error)
+ *     ? new HttpServerResponseWrapper(wrapper, result, error)
  *     : null;
  *   handler.handleSend(response, error, span); // 5.
  * }

--- a/instrumentation/http/src/main/java/brave/http/HttpServerResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerResponse.java
@@ -14,6 +14,7 @@
 package brave.http;
 
 import brave.Span;
+import brave.internal.Nullable;
 
 /**
  * Marks an interface for use in {@link HttpServerHandler#handleSend(Object, Throwable, Span)}. This
@@ -23,8 +24,13 @@ import brave.Span;
  * @since 5.7
  */
 public abstract class HttpServerResponse extends HttpResponse {
-  @Override public Span.Kind spanKind() {
+  @Override public final Span.Kind spanKind() {
     return Span.Kind.SERVER;
+  }
+
+  /** {@inheritDoc} */
+  @Override @Nullable public HttpServerRequest request() {
+    return null;
   }
 
   @Override public Throwable error() {

--- a/instrumentation/httpasyncclient/README.md
+++ b/instrumentation/httpasyncclient/README.md
@@ -1,5 +1,5 @@
 # brave-instrumentation-httpasyncclient
-This module contains a tracing decorator for [Apache HttpClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+.
+This module contains a tracing decorator for [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) 4.0+.
 `TracingHttpAsyncClientBuilder` adds trace headers to outgoing requests. It
 then reports to Zipkin how long each request takes, along with relevant
 tags like the http url.

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -78,9 +78,9 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
     @Override public void process(HttpRequest request, HttpContext context) {
       TraceContext parent = (TraceContext) context.removeAttribute(TraceContext.class.getName());
 
-      HttpHost host = HttpClientContext.adapt(context).getTargetHost();
-      Span span = handler.handleSendWithParent(new HttpRequestWrapper(request, host), parent);
-      parseTargetAddress(host, span);
+      HttpRequestWrapper wrapper = new HttpRequestWrapper(request, context);
+      Span span = handler.handleSendWithParent(wrapper, parent);
+      parseTargetAddress(wrapper.target, span);
 
       context.setAttribute(Span.class.getName(), span);
       context.setAttribute(Scope.class.getName(), currentTraceContext.newScope(span.context()));
@@ -94,7 +94,7 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
   }
 
   static void removeScope(HttpContext context) {
-    Scope scope = (Scope) context.getAttribute(Scope.class.getName());
+    Scope scope = (Scope) context.removeAttribute(Scope.class.getName());
     if (scope == null) return;
     context.removeAttribute(Scope.class.getName());
     scope.close();
@@ -102,9 +102,9 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
 
   final class HandleReceive implements HttpResponseInterceptor {
     @Override public void process(HttpResponse response, HttpContext context) {
-      Span span = (Span) context.getAttribute(Span.class.getName());
+      Span span = (Span) context.removeAttribute(Span.class.getName());
       if (span == null) return;
-      handler.handleReceive(new HttpResponseWrapper(response), null, span);
+      handler.handleReceive(new HttpResponseWrapper(response, context), null, span);
     }
   }
 
@@ -227,9 +227,8 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
 
     @Override public void failed(Exception ex) {
       removeScope(context);
-      Span currentSpan = (Span) context.getAttribute(Span.class.getName());
+      Span currentSpan = (Span) context.removeAttribute(Span.class.getName());
       if (currentSpan != null) {
-        context.removeAttribute(Span.class.getName());
         handler.handleReceive(null, ex, currentSpan);
       }
       requestProducer.failed(ex);
@@ -270,9 +269,8 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
 
     @Override public void failed(Exception ex) {
       removeScope(context);
-      Span currentSpan = (Span) context.getAttribute(Span.class.getName());
+      Span currentSpan = (Span) context.removeAttribute(Span.class.getName());
       if (currentSpan != null) {
-        context.removeAttribute(Span.class.getName());
         handler.handleReceive(null, ex, currentSpan);
       }
       responseConsumer.failed(ex);
@@ -300,52 +298,59 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
   }
 
   static final class HttpRequestWrapper extends HttpClientRequest {
-    final HttpRequest delegate;
+    final HttpRequest request;
     @Nullable final HttpHost target;
 
-    HttpRequestWrapper(HttpRequest delegate, @Nullable HttpHost target) {
-      this.delegate = delegate;
-      this.target = target;
+    HttpRequestWrapper(HttpRequest request, HttpContext context) {
+      this.request = request;
+      this.target = HttpClientContext.adapt(context).getTargetHost();
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return request;
     }
 
     @Override public String method() {
-      return delegate.getRequestLine().getMethod();
+      return request.getRequestLine().getMethod();
     }
 
     @Override public String path() {
-      String result = delegate.getRequestLine().getUri();
+      String result = request.getRequestLine().getUri();
       int queryIndex = result.indexOf('?');
       return queryIndex == -1 ? result : result.substring(0, queryIndex);
     }
 
     @Override public String url() {
-      if (target != null) return target.toURI() + delegate.getRequestLine().getUri();
-      return delegate.getRequestLine().getUri();
+      if (target != null) return target.toURI() + request.getRequestLine().getUri();
+      return request.getRequestLine().getUri();
     }
 
     @Override public String header(String name) {
-      Header result = delegate.getFirstHeader(name);
+      Header result = request.getFirstHeader(name);
       return result != null ? result.getValue() : null;
     }
 
     @Override public void header(String name, String value) {
-      delegate.setHeader(name, value);
+      request.setHeader(name, value);
     }
   }
 
   static final class HttpResponseWrapper extends HttpClientResponse {
-    final HttpResponse delegate;
+    @Nullable final HttpRequestWrapper request;
+    final HttpResponse response;
 
-    HttpResponseWrapper(HttpResponse delegate) {
-      this.delegate = delegate;
+    HttpResponseWrapper(HttpResponse response, HttpContext context) {
+      HttpRequest request = HttpClientContext.adapt(context).getRequest();
+      this.request = request != null ? new HttpRequestWrapper(request, context) : null;
+      this.response = response;
+    }
+
+    @Override public brave.http.HttpRequest request() {
+      return request;
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return response;
     }
 
     @Override public Throwable error() {
@@ -353,7 +358,7 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
     }
 
     @Override public int statusCode() {
-      StatusLine statusLine = delegate.getStatusLine();
+      StatusLine statusLine = response.getStatusLine();
       return statusLine != null ? statusLine.getStatusCode() : 0;
     }
   }

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -345,12 +345,12 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
       this.response = response;
     }
 
-    @Override public brave.http.HttpRequest request() {
-      return request;
-    }
-
     @Override public Object unwrap() {
       return response;
+    }
+
+    @Override @Nullable public HttpRequestWrapper request() {
+      return request;
     }
 
     @Override public Throwable error() {

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
@@ -47,7 +47,7 @@ public class HttpResponseWrapperTest {
     assertThat(new HttpResponseWrapper(response, context).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCode__zeroWhenNoStatusLine() {
+  @Test public void statusCode_zeroWhenNoStatusLine() {
     assertThat(new HttpResponseWrapper(response, context).statusCode()).isZero();
   }
 }

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
@@ -14,8 +14,10 @@
 package brave.httpasyncclient;
 
 import brave.httpasyncclient.TracingHttpAsyncClientBuilder.HttpResponseWrapper;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,17 +28,26 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpResponseWrapperTest {
+  @Mock HttpClientContext context;
+  @Mock HttpRequest request;
   @Mock HttpResponse response;
   @Mock StatusLine statusLine;
+
+  @Test public void request() {
+    when(context.getRequest()).thenReturn(request);
+
+    assertThat(new HttpResponseWrapper(response, context).request().unwrap())
+      .isSameAs(request);
+  }
 
   @Test public void statusCode() {
     when(response.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    assertThat(new HttpResponseWrapper(response).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(response, context).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCode_zeroWhenNoStatusLine() {
-    assertThat(new HttpResponseWrapper(response).statusCode()).isZero();
+  @Test public void statusCode__zeroWhenNoStatusLine() {
+    assertThat(new HttpResponseWrapper(response, context).statusCode()).isZero();
   }
 }

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingMainExec.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingMainExec.java
@@ -56,7 +56,8 @@ class TracingMainExec implements ClientExecChain { // not final for subclassing
     org.apache.http.client.methods.HttpRequestWrapper request,
     HttpClientContext context, HttpExecutionAware execAware)
     throws IOException, HttpException {
-    Span span = tracer.currentSpan();
+    Span span = (Span) context.removeAttribute(Span.class.getName());
+
     if (span != null) handler.handleSend(new HttpRequestWrapper(request), span);
 
     CloseableHttpResponse response = mainExec.execute(route, request, context, execAware);

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
@@ -53,19 +53,23 @@ final class TracingProtocolExec implements ClientExecChain {
   }
 
   @Override public CloseableHttpResponse execute(HttpRoute route,
-    org.apache.http.client.methods.HttpRequestWrapper request,
-    HttpClientContext clientContext, HttpExecutionAware execAware)
+    org.apache.http.client.methods.HttpRequestWrapper req,
+    HttpClientContext context, HttpExecutionAware execAware)
     throws IOException, HttpException {
-    Span span = tracer.nextSpan(httpSampler, new HttpRequestWrapper(request));
+    HttpRequestWrapper request = new HttpRequestWrapper(req);
+    Span span = tracer.nextSpan(httpSampler, request);
+    context.setAttribute(Span.class.getName(), span);
+
     CloseableHttpResponse result = null;
     Throwable error = null;
     try (SpanInScope ws = tracer.withSpanInScope(span)) {
-      return result = protocolExec.execute(route, request, clientContext, execAware);
+      return result = protocolExec.execute(route, req, context, execAware);
     } catch (Throwable e) {
       error = e;
       throw e;
     } finally {
-      HttpResponseWrapper response = result != null ? new HttpResponseWrapper(result, error) : null;
+      HttpResponseWrapper response = result != null
+        ? new HttpResponseWrapper(result, context, error) : null;
       handler.handleReceive(response, error, span);
     }
   }
@@ -115,16 +119,24 @@ final class TracingProtocolExec implements ClientExecChain {
   }
 
   static final class HttpResponseWrapper extends HttpClientResponse {
-    final HttpResponse delegate;
+    final brave.http.HttpRequest request;
+    final HttpResponse response;
     @Nullable final Throwable error;
 
-    HttpResponseWrapper(HttpResponse delegate, @Nullable Throwable error) {
-      this.delegate = delegate;
+    HttpResponseWrapper(HttpResponse response, HttpClientContext context,
+      @Nullable Throwable error) {
+      HttpRequest request = context.getRequest();
+      this.request = request != null ? new HttpRequestWrapper(request) : null;
+      this.response = response;
       this.error = error;
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return response;
+    }
+
+    @Override public brave.http.HttpRequest request() {
+      return request;
     }
 
     @Override public Throwable error() {
@@ -132,7 +144,7 @@ final class TracingProtocolExec implements ClientExecChain {
     }
 
     @Override public int statusCode() {
-      StatusLine statusLine = delegate.getStatusLine();
+      StatusLine statusLine = response.getStatusLine();
       return statusLine != null ? statusLine.getStatusCode() : 0;
     }
   }

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingProtocolExec.java
@@ -119,7 +119,7 @@ final class TracingProtocolExec implements ClientExecChain {
   }
 
   static final class HttpResponseWrapper extends HttpClientResponse {
-    final brave.http.HttpRequest request;
+    final HttpRequestWrapper request;
     final HttpResponse response;
     @Nullable final Throwable error;
 
@@ -135,7 +135,7 @@ final class TracingProtocolExec implements ClientExecChain {
       return response;
     }
 
-    @Override public brave.http.HttpRequest request() {
+    @Override @Nullable public HttpRequestWrapper request() {
       return request;
     }
 

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
@@ -47,7 +47,7 @@ public class HttpResponseWrapperTest {
     assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isEqualTo(200);
   }
 
-  @Test public void statusCode__zeroWhenNoStatusLine() {
+  @Test public void statusCode_zeroWhenNoStatusLine() {
     assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
@@ -14,8 +14,10 @@
 package brave.httpclient;
 
 import brave.httpclient.TracingProtocolExec.HttpResponseWrapper;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,17 +28,26 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpResponseWrapperTest {
+  @Mock HttpClientContext context;
+  @Mock HttpRequest request;
   @Mock HttpResponse response;
   @Mock StatusLine statusLine;
+
+  @Test public void request() {
+    when(context.getRequest()).thenReturn(request);
+
+    assertThat(new HttpResponseWrapper(response, context, null).request().unwrap())
+      .isSameAs(request);
+  }
 
   @Test public void statusCode() {
     when(response.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    assertThat(new HttpResponseWrapper(response, null).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode__zeroWhenNoStatusLine() {
-    assertThat(new HttpResponseWrapper(response, null).statusCode()).isZero();
+    assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientResponseContextWrapperTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientResponseContextWrapperTest.java
@@ -14,6 +14,7 @@
 package brave.jaxrs2;
 
 import brave.jaxrs2.TracingClientFilter.ClientResponseContextWrapper;
+import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,17 +26,23 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientResponseContextWrapperTest {
+  @Mock ClientRequestContext request;
   @Mock ClientResponseContext response;
+
+  @Test public void request() {
+    assertThat(new ClientResponseContextWrapper(request, response).request().unwrap())
+      .isSameAs(request);
+  }
 
   @Test public void statusCode() {
     when(response.getStatus()).thenReturn(200);
 
-    assertThat(new ClientResponseContextWrapper(response).statusCode()).isEqualTo(200);
+    assertThat(new ClientResponseContextWrapper(request, response).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroWhenNegative() {
     when(response.getStatus()).thenReturn(-1);
 
-    assertThat(new ClientResponseContextWrapper(response).statusCode()).isZero();
+    assertThat(new ClientResponseContextWrapper(request, response).statusCode()).isZero();
   }
 }

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -15,7 +15,6 @@ package brave.jersey.server;
 
 import brave.Span;
 import brave.Tracer;
-import brave.http.HttpRequest;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
@@ -157,28 +156,28 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
   }
 
   static final class RequestEventWrapper extends HttpServerResponse {
-    final RequestEvent delegate;
+    final RequestEvent event;
     ContainerRequestWrapper request;
 
-    RequestEventWrapper(RequestEvent delegate) {
-      this.delegate = delegate;
+    RequestEventWrapper(RequestEvent event) {
+      this.event = event;
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return event;
     }
 
-    @Override public Throwable error() {
-      return SpanCustomizingApplicationEventListener.unwrapError(delegate);
-    }
-
-    @Override public HttpRequest request() {
-      if (request == null) request = new ContainerRequestWrapper(delegate.getContainerRequest());
+    @Override public ContainerRequestWrapper request() {
+      if (request == null) request = new ContainerRequestWrapper(event.getContainerRequest());
       return request;
     }
 
+    @Override public Throwable error() {
+      return SpanCustomizingApplicationEventListener.unwrapError(event);
+    }
+
     @Override public int statusCode() {
-      ContainerResponse response = delegate.getContainerResponse();
+      ContainerResponse response = event.getContainerResponse();
       if (response == null) return 0;
       return response.getStatus();
     }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/RequestEventWrapperTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/RequestEventWrapperTest.java
@@ -35,23 +35,25 @@ public class RequestEventWrapperTest {
     when(event.getContainerRequest()).thenReturn(request);
     when(request.getMethod()).thenReturn("GET");
 
-    assertThat(new RequestEventWrapper(event, null).method())
+    assertThat(new RequestEventWrapper(event).method())
       .isEqualTo("GET");
   }
 
-  @Test public void route() {
-    assertThat(new RequestEventWrapper(event, "/items/{itemId}").route())
-      .isEqualTo("/items/{itemId}");
+  @Test public void request() {
+    when(event.getContainerRequest()).thenReturn(request);
+
+    assertThat(new RequestEventWrapper(event).request().unwrap())
+      .isSameAs(request);
   }
 
   @Test public void statusCode() {
     when(event.getContainerResponse()).thenReturn(response);
     when(response.getStatus()).thenReturn(200);
 
-    assertThat(new RequestEventWrapper(event, null).statusCode()).isEqualTo(200);
+    assertThat(new RequestEventWrapper(event).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroNoResponse() {
-    assertThat(new RequestEventWrapper(event, null).statusCode()).isZero();
+    assertThat(new RequestEventWrapper(event).statusCode()).isZero();
   }
 }

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/NettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/NettyHttpTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,11 +16,14 @@ package brave.netty.http;
 import brave.Span;
 import brave.Tracer.SpanInScope;
 import brave.Tracing;
+import brave.http.HttpServerRequest;
 import brave.http.HttpTracing;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.util.AttributeKey;
 
 public final class NettyHttpTracing {
+  static final AttributeKey<HttpServerRequest> REQUEST_ATTRIBUTE =
+    AttributeKey.valueOf(HttpServerRequest.class.getName());
   static final AttributeKey<Span> SPAN_ATTRIBUTE = AttributeKey.valueOf(Span.class.getName());
   static final AttributeKey<SpanInScope> SPAN_IN_SCOPE_ATTRIBUTE =
     AttributeKey.valueOf(SpanInScope.class.getName());

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
@@ -142,6 +142,10 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
       this.error = error;
     }
 
+    @Override public String route() {
+      return null; // TODO: is there a way to get the request from the channel
+    }
+
     @Override public HttpResponse unwrap() {
       return delegate;
     }

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
@@ -49,6 +49,7 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
     HttpRequestWrapper request =
       new HttpRequestWrapper((HttpRequest) msg, (InetSocketAddress) ctx.channel().remoteAddress());
 
+    ctx.channel().attr(NettyHttpTracing.REQUEST_ATTRIBUTE).set(request);
     Span span = handler.handleReceive(request);
     ctx.channel().attr(NettyHttpTracing.SPAN_ATTRIBUTE).set(span);
     SpanInScope spanInScope = tracer.withSpanInScope(span);
@@ -86,7 +87,8 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
       error = t;
       throw t;
     } finally {
-      handler.handleSend(new HttpResponseWrapper(response, error), error, span);
+      HttpServerRequest request = ctx.channel().attr(NettyHttpTracing.REQUEST_ATTRIBUTE).get();
+      handler.handleSend(new HttpResponseWrapper(request, response, error), error, span);
       spanInScope.close();
     }
   }
@@ -134,20 +136,26 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
   }
 
   static final class HttpResponseWrapper extends HttpServerResponse {
+    @Nullable final HttpServerRequest request;
     final HttpResponse delegate;
     @Nullable final Throwable error;
 
-    HttpResponseWrapper(HttpResponse delegate, @Nullable Throwable error) {
-      this.delegate = delegate;
+    HttpResponseWrapper(
+      @Nullable HttpServerRequest request,
+      HttpResponse response,
+      @Nullable Throwable error
+    ) {
+      this.request = request;
+      this.delegate = response;
       this.error = error;
-    }
-
-    @Override public String route() {
-      return null; // TODO: is there a way to get the request from the channel
     }
 
     @Override public HttpResponse unwrap() {
       return delegate;
+    }
+
+    @Override @Nullable public HttpServerRequest request() {
+      return request;
     }
 
     @Override public Throwable error() {

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/HttpResponseWrapperTest.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/HttpResponseWrapperTest.java
@@ -13,6 +13,7 @@
  */
 package brave.netty.http;
 
+import brave.http.HttpServerRequest;
 import brave.netty.http.TracingHttpServerHandler.HttpResponseWrapper;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -26,17 +27,23 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpResponseWrapperTest {
+  @Mock HttpServerRequest request;
   @Mock HttpResponse response;
   @Mock HttpResponseStatus status;
+
+  @Test public void request() {
+    assertThat(new HttpResponseWrapper(request, response, null).request())
+      .isSameAs(request);
+  }
 
   @Test public void statusCode() {
     when(response.status()).thenReturn(status);
     when(status.code()).thenReturn(200);
 
-    assertThat(new HttpResponseWrapper(response, null).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(request, response, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroNoResponse() {
-    assertThat(new HttpResponseWrapper(response, null).statusCode()).isZero();
+    assertThat(new HttpResponseWrapper(request, response, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
@@ -72,8 +72,4 @@ public class ITNettyHttpTracing extends ITHttpServer {
   @Override @Ignore("TODO: last handler in the pipeline did not handle the exception")
   public void finishedSpanHandlerSeesException() {
   }
-
-  @Override @Ignore("TODO: is there a way to get the request from the channel")
-  public void readsRequestAtResponseTime() {
-  }
 }

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
@@ -72,4 +72,8 @@ public class ITNettyHttpTracing extends ITHttpServer {
   @Override @Ignore("TODO: last handler in the pipeline did not handle the exception")
   public void finishedSpanHandlerSeesException() {
   }
+
+  @Override @Ignore("TODO: is there a way to get the request from the channel")
+  public void readsRequestAtResponseTime() {
+  }
 }

--- a/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
+++ b/instrumentation/okhttp3/src/main/java/brave/okhttp3/TracingInterceptor.java
@@ -128,24 +128,31 @@ public final class TracingInterceptor implements Interceptor {
   }
 
   static final class ResponseWrapper extends HttpClientResponse {
-    final Response delegate;
+    final RequestWrapper request;
+    final Response response;
     @Nullable final Throwable error;
 
-    ResponseWrapper(Response delegate, @Nullable Throwable error) {
-      this.delegate = delegate;
+    ResponseWrapper(Response response, @Nullable Throwable error) {
+      // intentionally not the same instance as chain.proceed, as properties may have changed
+      this.request = new RequestWrapper(response.request());
+      this.response = response;
       this.error = error;
+    }
+
+    @Override public Object unwrap() {
+      return response;
+    }
+
+    @Override public RequestWrapper request() {
+      return request;
     }
 
     @Override public Throwable error() {
       return error;
     }
 
-    @Override public Object unwrap() {
-      return delegate;
-    }
-
     @Override public int statusCode() {
-      return delegate.code();
+      return response.code();
     }
   }
 }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ResponseWrapperTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ResponseWrapperTest.java
@@ -26,6 +26,13 @@ public class ResponseWrapperTest {
     .request(new Request.Builder().url("http://localhost/foo").build())
     .protocol(Protocol.HTTP_1_1);
 
+  @Test public void request() {
+    Response response = responseBuilder.code(200).message("ok").build();
+
+    assertThat(new ResponseWrapper(response, null).request().unwrap())
+      .isSameAs(response.request());
+  }
+
   @Test public void statusCode() {
     Response response = responseBuilder.code(200).message("ok").build();
 

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletRequestWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletRequestWrapper.java
@@ -15,6 +15,8 @@ package brave.servlet;
 
 import brave.Span;
 import brave.http.HttpServerRequest;
+import brave.internal.Nullable;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -50,6 +52,11 @@ public final class HttpServletRequestWrapper extends HttpServerRequest {
     return delegate.getMethod();
   }
 
+  @Override public String route() {
+    Object maybeRoute = delegate.getAttribute("http.route");
+    return maybeRoute instanceof String ? (String) maybeRoute : null;
+  }
+
   @Override public final String path() {
     return delegate.getRequestURI();
   }
@@ -65,6 +72,15 @@ public final class HttpServletRequestWrapper extends HttpServerRequest {
 
   @Override public final String header(String name) {
     return delegate.getHeader(name);
+  }
+
+  /** Looks for a valid request attribute "error" */
+  @Nullable Throwable maybeError() {
+    Object maybeError = delegate.getAttribute("error");
+    if (maybeError instanceof Throwable) return (Throwable) maybeError;
+    maybeError = delegate.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+    if (maybeError instanceof Throwable) return (Throwable) maybeError;
+    return null;
   }
 
   @Override public final Object unwrap() {

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletRequestWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletRequestWrapper.java
@@ -39,6 +39,10 @@ public final class HttpServletRequestWrapper extends HttpServerRequest {
     this.delegate = delegate;
   }
 
+  @Override public final Object unwrap() {
+    return delegate;
+  }
+
   /**
    * This sets the client IP:port to the {@linkplain HttpServletRequest#getRemoteAddr() remote
    * address} if the {@link #parseClientIpAndPort default parsing} fails.
@@ -81,9 +85,5 @@ public final class HttpServletRequestWrapper extends HttpServerRequest {
     maybeError = delegate.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
     if (maybeError instanceof Throwable) return (Throwable) maybeError;
     return null;
-  }
-
-  @Override public final Object unwrap() {
-    return delegate;
   }
 }

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
@@ -13,14 +13,13 @@
  */
 package brave.servlet;
 
+import brave.http.HttpRequest;
 import brave.http.HttpServerResponse;
 import brave.internal.Nullable;
 import brave.servlet.internal.ServletRuntime;
 import javax.servlet.UnavailableException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import static brave.servlet.internal.ServletRuntime.maybeError;
 
 /**
  * This delegates to {@link HttpServletResponse} methods, taking care to portably handle {@link
@@ -31,29 +30,37 @@ import static brave.servlet.internal.ServletRuntime.maybeError;
 // Public for use in sparkjava or other frameworks that re-use servlet types
 public class HttpServletResponseWrapper extends HttpServerResponse { // not final for inner subtype
   /**
-   * Looks for the {@link HttpServletRequest#setAttribute(String, Object) request attributes}
-   * "http.route" and "error" to customize the result.
-   *
    * @param caught an exception caught serving the request.
    * @since 5.10
    */
-  public static HttpServerResponse create(@Nullable HttpServletRequest req,
-    HttpServletResponse res, @Nullable Throwable caught) {
-    if (req == null) return new HttpServletResponseWrapper(res, caught);
-    return new WithRequestProperties(req, res, caught);
+  public static HttpServerResponse create(@Nullable HttpServletRequest request,
+    HttpServletResponse response, @Nullable Throwable caught) {
+    return new HttpServletResponseWrapper(request, response, caught);
   }
 
-  final HttpServletResponse delegate;
+  @Nullable final HttpServletRequestWrapper request;
+  final HttpServletResponse response;
   @Nullable final Throwable caught;
 
-  HttpServletResponseWrapper(HttpServletResponse delegate, @Nullable Throwable caught) {
-    if (delegate == null) throw new NullPointerException("delegate == null");
-    this.delegate = delegate;
+  HttpServletResponseWrapper(@Nullable HttpServletRequest request, HttpServletResponse response,
+    @Nullable Throwable caught) {
+    if (response == null) throw new NullPointerException("response == null");
+    this.request = request != null ? new HttpServletRequestWrapper(request) : null;
+    this.response = response;
     this.caught = caught;
   }
 
+  @Override public HttpRequest request() {
+    return request;
+  }
+
+  @Override public Throwable error() {
+    if (caught != null || request == null) return caught;
+    return request.maybeError();
+  }
+
   @Override public int statusCode() {
-    int result = ServletRuntime.get().status(delegate);
+    int result = ServletRuntime.get().status(response);
     if (caught != null && result == 200) { // We may have a potentially bad status due to defaults
       // Servlet only seems to define one exception that has a built-in code. Logic in Jetty
       // defaults the status to 500 otherwise.
@@ -65,34 +72,7 @@ public class HttpServletResponseWrapper extends HttpServerResponse { // not fina
     return result;
   }
 
-  @Override public Throwable error() {
-    return caught;
-  }
-
   @Override public final Object unwrap() {
-    return delegate;
-  }
-
-  static final class WithRequestProperties extends HttpServletResponseWrapper {
-    final HttpServletRequest req;
-
-    WithRequestProperties(HttpServletRequest req, HttpServletResponse res,
-      @Nullable Throwable error) {
-      super(res, error);
-      this.req = req;
-    }
-
-    @Override public Throwable error() {
-      return maybeError(caught, req);
-    }
-
-    @Override public String method() {
-      return req.getMethod();
-    }
-
-    @Override public String route() {
-      Object maybeRoute = req.getAttribute("http.route");
-      return maybeRoute instanceof String ? (String) maybeRoute : null;
-    }
+    return response;
   }
 }

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
@@ -55,7 +55,8 @@ public class HttpServletResponseWrapper extends HttpServerResponse { // not fina
   }
 
   @Override public Throwable error() {
-    if (caught != null || request == null) return caught;
+    if (caught != null) return caught;
+    if (request == null) return null;
     return request.maybeError();
   }
 

--- a/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/HttpServletResponseWrapper.java
@@ -13,7 +13,6 @@
  */
 package brave.servlet;
 
-import brave.http.HttpRequest;
 import brave.http.HttpServerResponse;
 import brave.internal.Nullable;
 import brave.servlet.internal.ServletRuntime;
@@ -50,7 +49,11 @@ public class HttpServletResponseWrapper extends HttpServerResponse { // not fina
     this.caught = caught;
   }
 
-  @Override public HttpRequest request() {
+  @Override public final Object unwrap() {
+    return response;
+  }
+
+  @Override @Nullable public HttpServletRequestWrapper request() {
     return request;
   }
 
@@ -71,9 +74,5 @@ public class HttpServletResponseWrapper extends HttpServerResponse { // not fina
       return 500;
     }
     return result;
-  }
-
-  @Override public final Object unwrap() {
-    return response;
   }
 }

--- a/instrumentation/servlet/src/main/java/brave/servlet/internal/ServletRuntime.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/internal/ServletRuntime.java
@@ -17,7 +17,6 @@ import brave.Span;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
-import brave.internal.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
@@ -28,7 +27,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.AsyncContext;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
-import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -270,15 +268,5 @@ public abstract class ServletRuntime {
     int getStatusInServlet25() {
       return httpStatus;
     }
-  }
-
-  /** Looks for a valid request attribute "error" when the error parameter is null */
-  @Nullable public static Throwable maybeError(@Nullable Throwable thrown, HttpServletRequest req) {
-    if (thrown != null) return thrown;
-    Object maybeError = req.getAttribute("error");
-    if (maybeError instanceof Throwable) return (Throwable) maybeError;
-    maybeError = req.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
-    if (maybeError instanceof Throwable) return (Throwable) maybeError;
-    return null;
   }
 }

--- a/instrumentation/servlet/src/test/java/brave/servlet/internal/ServletRuntimeTest.java
+++ b/instrumentation/servlet/src/test/java/brave/servlet/internal/ServletRuntimeTest.java
@@ -19,40 +19,14 @@ import java.util.Collection;
 import java.util.Locale;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Response;
 import org.junit.Test;
 
-import static brave.servlet.internal.ServletRuntime.maybeError;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ServletRuntimeTest {
   ServletRuntime servlet25 = new ServletRuntime.Servlet25();
-  HttpServletRequest request = mock(HttpServletRequest.class);
-
-  @Test public void maybeError_fromRequestAttribute() {
-    Exception requestError = new Exception();
-    when(request.getAttribute("error")).thenReturn(requestError);
-
-    assertThat(maybeError(null, request)).isSameAs(requestError);
-  }
-
-  @Test public void maybeError_badRequestAttribute() {
-    when(request.getAttribute("error")).thenReturn(new Object());
-
-    assertThat(maybeError(null, request)).isNull();
-  }
-
-  @Test public void maybeError_overridesRequestAttribute() {
-    Exception error = new Exception();
-    Exception requestError = new Exception();
-    when(request.getAttribute("error")).thenReturn(requestError);
-
-    assertThat(maybeError(error, request)).isSameAs(error);
-  }
 
   /** getStatus doesn't exist in Servlet 2.5, so we add mechanisms to catch it. */
   @Test public void servlet25_httpServletResponse_catchesStatus() throws IOException {

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
@@ -98,18 +98,18 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
 
   static final class ClientHttpResponseWrapper extends HttpClientResponse {
     final HttpRequestWrapper request;
-    final ClientHttpResponse delegate;
+    final ClientHttpResponse response;
     @Nullable final Throwable error;
 
     ClientHttpResponseWrapper(
-      HttpRequestWrapper request, ClientHttpResponse delegate, @Nullable Throwable error) {
+      HttpRequestWrapper request, ClientHttpResponse response, @Nullable Throwable error) {
       this.request = request;
-      this.delegate = delegate;
+      this.response = response;
       this.error = error;
     }
 
     @Override public Object unwrap() {
-      return delegate;
+      return response;
     }
 
     @Override public HttpRequestWrapper request() {
@@ -122,7 +122,7 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
 
     @Override public int statusCode() {
       try {
-        return delegate.getRawStatusCode();
+        return response.getRawStatusCode();
       } catch (Exception e) {
         return 0;
       }

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
@@ -45,19 +45,20 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
     handler = HttpClientHandler.create(httpTracing);
   }
 
-  @Override public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+  @Override public ClientHttpResponse intercept(HttpRequest req, byte[] body,
     ClientHttpRequestExecution execution) throws IOException {
-    Span span = handler.handleSend(new HttpRequestWrapper(request));
+    HttpRequestWrapper request = new HttpRequestWrapper(req);
+    Span span = handler.handleSend(request);
     ClientHttpResponse result = null;
     Throwable error = null;
     try (Scope ws = currentTraceContext.newScope(span.context())) {
-      return result = execution.execute(request, body);
+      return result = execution.execute(req, body);
     } catch (Throwable e) {
       error = e;
       throw e;
     } finally {
       ClientHttpResponseWrapper
-        response = result != null ? new ClientHttpResponseWrapper(result, error) : null;
+        response = result != null ? new ClientHttpResponseWrapper(request, result, error) : null;
       handler.handleReceive(response, error, span);
     }
   }
@@ -96,20 +97,27 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
   }
 
   static final class ClientHttpResponseWrapper extends HttpClientResponse {
+    final HttpRequestWrapper request;
     final ClientHttpResponse delegate;
     @Nullable final Throwable error;
 
-    ClientHttpResponseWrapper(ClientHttpResponse delegate, @Nullable Throwable error) {
+    ClientHttpResponseWrapper(
+      HttpRequestWrapper request, ClientHttpResponse delegate, @Nullable Throwable error) {
+      this.request = request;
       this.delegate = delegate;
       this.error = error;
     }
 
-    @Override public Throwable error() {
-      return error;
-    }
-
     @Override public Object unwrap() {
       return delegate;
+    }
+
+    @Override public HttpRequestWrapper request() {
+      return request;
+    }
+
+    @Override public Throwable error() {
+      return error;
     }
 
     @Override public int statusCode() {

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
@@ -29,8 +29,13 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientHttpResponseWrapperTest {
-  @Mock ClientHttpResponse response;
   HttpRequestWrapper request = new HttpRequestWrapper(mock(HttpRequest.class));
+  @Mock ClientHttpResponse response;
+
+  @Test public void request() {
+    assertThat(new ClientHttpResponseWrapper(request, response, null).request())
+      .isSameAs(request);
+  }
 
   @Test public void statusCode() throws IOException {
     when(response.getRawStatusCode()).thenReturn(200);

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
@@ -14,35 +14,39 @@
 package brave.spring.web;
 
 import brave.spring.web.TracingClientHttpRequestInterceptor.ClientHttpResponseWrapper;
+import brave.spring.web.TracingClientHttpRequestInterceptor.HttpRequestWrapper;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientHttpResponseWrapperTest {
   @Mock ClientHttpResponse response;
+  HttpRequestWrapper request = new HttpRequestWrapper(mock(HttpRequest.class));
 
   @Test public void statusCode() throws IOException {
     when(response.getRawStatusCode()).thenReturn(200);
 
-    assertThat(new ClientHttpResponseWrapper(response, null).statusCode()).isEqualTo(200);
+    assertThat(new ClientHttpResponseWrapper(request, response, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroOnIOE() throws IOException {
     when(response.getRawStatusCode()).thenThrow(new IOException());
 
-    assertThat(new ClientHttpResponseWrapper(response, null).statusCode()).isZero();
+    assertThat(new ClientHttpResponseWrapper(request, response, null).statusCode()).isZero();
   }
 
   @Test public void statusCode_zeroOnIAE() throws IOException {
     when(response.getRawStatusCode()).thenThrow(new IllegalArgumentException());
 
-    assertThat(new ClientHttpResponseWrapper(response, null).statusCode()).isZero();
+    assertThat(new ClientHttpResponseWrapper(request, response, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -14,13 +14,12 @@
 package brave.vertx.web;
 
 import brave.Span;
-import brave.Tracer;
-import brave.Tracer.SpanInScope;
-import brave.http.HttpRequest;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
@@ -37,12 +36,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@code TracingHandler} in https://github.com/opentracing-contrib/java-vertx-web
  */
 final class TracingRoutingContextHandler implements Handler<RoutingContext> {
-  final Tracer tracer;
   final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
+  final CurrentTraceContext currentTraceContext;
 
   TracingRoutingContextHandler(HttpTracing httpTracing) {
-    tracer = httpTracing.tracing().tracer();
     handler = HttpServerHandler.create(httpTracing);
+    currentTraceContext = httpTracing.tracing().currentTraceContext();
   }
 
   @Override public void handle(RoutingContext context) {
@@ -60,7 +59,7 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
     context.put(TracingHandler.class.getName(), handler);
     context.addHeadersEndHandler(handler);
 
-    try (SpanInScope ws = tracer.withSpanInScope(span)) {
+    try (Scope ws = currentTraceContext.maybeScope(span.context())) {
       context.next();
     }
   }
@@ -116,33 +115,33 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
   }
 
   static final class HttpServerResponseWrapper extends HttpServerResponse {
-    final RoutingContext delegate;
+    final RoutingContext context;
     HttpServerRequestWrapper request;
 
     HttpServerResponseWrapper(RoutingContext context) {
-      this.delegate = context;
+      this.context = context;
     }
 
-    @Override public HttpRequest request() {
-      if (request == null) request = new HttpServerRequestWrapper(delegate.request());
+    @Override public RoutingContext unwrap() {
+      return context;
+    }
+
+    @Override public HttpServerRequestWrapper request() {
+      if (request == null) request = new HttpServerRequestWrapper(context.request());
       return request;
     }
 
     @Override public Throwable error() {
-      return delegate.failure();
-    }
-
-    @Override public RoutingContext unwrap() {
-      return delegate;
+      return context.failure();
     }
 
     @Override public int statusCode() {
-      return delegate.response().getStatusCode();
+      return context.response().getStatusCode();
     }
 
     // This is an example of where the route is not on the request object. Hence, we override.
     @Override public String route() {
-      String httpRoute = delegate.currentRoute().getPath();
+      String httpRoute = context.currentRoute().getPath();
       return httpRoute != null ? httpRoute : "";
     }
   }

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/HttpServerResponseWrapperTest.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/HttpServerResponseWrapperTest.java
@@ -40,6 +40,11 @@ public class HttpServerResponseWrapperTest {
     when(context.currentRoute()).thenReturn(currentRoute);
   }
 
+  @Test public void request() {
+    assertThat(new HttpServerResponseWrapper(context).request().unwrap())
+      .isSameAs(request);
+  }
+
   @Test public void method() {
     when(request.rawMethod()).thenReturn("GET");
 


### PR DESCRIPTION
This adds nullable `HttpResponse.request()` per discussion in #1086

This doesn't deprecate method or route as there are a couple places you
can't see the request (unless we propagate it ourselves). Also, we have
a scenario in vert.x where the data holding the route isn't on the
request.

Fixes #1086