### PR TITLE
Adds really long explanation about JMS being horrible

### DIFF
--- a/instrumentation/jms/src/main/java/brave/jms/MessageParser.java
+++ b/instrumentation/jms/src/main/java/brave/jms/MessageParser.java
@@ -43,13 +43,17 @@ final class MessageParser {
 
   /**
    * Handles special case of a destination being both a Queue and a Topic by checking if the
-   * {@linkplain Queue#getQueueName() queue name} is readable.
+   * {@linkplain Queue#getQueueName() queue name} is readable and not {@code null}.
    */
   static boolean isQueue(@Nullable Destination destination) {
     boolean isQueue = destination instanceof Queue;
     boolean isTopic = destination instanceof Topic;
     if (isQueue && isTopic) {
       try {
+        // The JMS 1.1 specification does not define the result of queue name or topic name,
+        // including whether it is null or not. In practice, at least one implementation of both
+        // Queue and Topic conditionally returns non-null on getQueueName() or getTopicName()
+        // at runtime to indicate if it is a Queue or Topic. See issue #1098.
         isQueue = ((Queue) destination).getQueueName() != null;
       } catch (Throwable t) {
         propagateIfFatal(t);
@@ -62,12 +66,12 @@ final class MessageParser {
   /**
    * Similar to other properties, {@code null} should be expected even if it seems unintuitive.
    *
-   * <p>The JMS 1.1 specification 4.2.1 suggests destination details are provider specific. Further,
-   * JavaDoc on {@link Queue#getQueueName()} and {@link Topic#getTopicName()} say "Clients that
-   * depend upon the name are not portable." Next, such operations can raise {@link JMSException}
-   * messages which this code can coerce to null. Finally, destinations are not constrained to
-   * implement only one of {@link Queue} or {@link Destination}. This implies one could return null
-   * while the other doesn't, such as was the case in issue #1098.
+   * <p>The JMS 1.1 specification 4.2.1 suggests destination details are provider specific.
+   * Further, JavaDoc on {@link Queue#getQueueName()} and {@link Topic#getTopicName()} say "Clients
+   * that depend upon the name are not portable." Next, such operations can raise {@link
+   * JMSException} messages which this code can coerce to null. Finally, destinations are not
+   * constrained to implement only one of {@link Queue} or {@link Destination}. This implies one
+   * could return null while the other doesn't, such as was the case in issue #1098.
    */
   @Nullable static String channelName(@Nullable Destination destination) {
     if (destination == null) return null;

--- a/instrumentation/jms/src/main/java/brave/jms/MessageParser.java
+++ b/instrumentation/jms/src/main/java/brave/jms/MessageParser.java
@@ -62,7 +62,7 @@ final class MessageParser {
   /**
    * Similar to other properties, {@code null} should be expected even if it seems unintuitive.
    *
-   * The JMS 1.1 specification 4.2.1 suggests destination details are provider specific. Further,
+   * <p>The JMS 1.1 specification 4.2.1 suggests destination details are provider specific. Further,
    * JavaDoc on {@link Queue#getQueueName()} and {@link Topic#getTopicName()} say "Clients that
    * depend upon the name are not portable." Next, such operations can raise {@link JMSException}
    * messages which this code can coerce to null. Finally, destinations are not constrained to

--- a/instrumentation/jms/src/main/java/brave/jms/MessageParser.java
+++ b/instrumentation/jms/src/main/java/brave/jms/MessageParser.java
@@ -15,6 +15,7 @@ package brave.jms;
 
 import brave.internal.Nullable;
 import javax.jms.Destination;
+import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.Topic;
@@ -58,6 +59,16 @@ final class MessageParser {
     return isQueue;
   }
 
+  /**
+   * Similar to other properties, {@code null} should be expected even if it seems unintuitive.
+   *
+   * The JMS 1.1 specification 4.2.1 suggests destination details are provider specific. Further,
+   * JavaDoc on {@link Queue#getQueueName()} and {@link Topic#getTopicName()} say "Clients that
+   * depend upon the name are not portable." Next, such operations can raise {@link JMSException}
+   * messages which this code can coerce to null. Finally, destinations are not constrained to
+   * implement only one of {@link Queue} or {@link Destination}. This implies one could return null
+   * while the other doesn't, such as was the case in issue #1098.
+   */
   @Nullable static String channelName(@Nullable Destination destination) {
     if (destination == null) return null;
     boolean isQueue = isQueue(destination);


### PR DESCRIPTION
This is mainly to answer a request, the same rationale would apply to
just about anything as it is common for implementations to implement
multiple interfaces (ex connection factory) and also everything in old
apis to return null.

See https://github.com/openzipkin/brave/pull/1099#discussion_r383629865