### PR TITLE
Enforces sampled field must be well formed

### DIFF
--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -117,7 +117,7 @@ public final class B3Propagation<K> implements Propagation<K> {
    */
   static final String SAMPLED_NAME = "X-B3-Sampled";
   static final String SAMPLED_MALFORMED =
-    "Invalid input: expected 0 or 1 for " + SAMPLED_NAME + ": {0}";
+    "Invalid input: expected 0 or 1 for " + SAMPLED_NAME + ", but found '{0}'";
 
   /**
    * "1" implies sampled and is a request to override collection-tier sampling policy.

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -15,6 +15,7 @@ package brave.propagation;
 
 import brave.Request;
 import brave.Span;
+import brave.internal.Platform;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -115,10 +116,14 @@ public final class B3Propagation<K> implements Propagation<K> {
    * decision to the receiver of this header).
    */
   static final String SAMPLED_NAME = "X-B3-Sampled";
+  static final String SAMPLED_MALFORMED =
+    "Invalid input: expected 0 or 1 for " + SAMPLED_NAME + ": {0}";
+
   /**
    * "1" implies sampled and is a request to override collection-tier sampling policy.
    */
   static final String FLAGS_NAME = "X-B3-Flags";
+
   final K b3Key, traceIdKey, spanIdKey, parentSpanIdKey, sampledKey, debugKey;
   final List<K> fields;
   final Format[] injectFormats;
@@ -236,9 +241,31 @@ public final class B3Propagation<K> implements Propagation<K> {
       // Start by looking at the sampled state as this is used regardless
       // Official sampled value is 1, though some old instrumentation send true
       String sampled = getter.get(carrier, propagation.sampledKey);
-      Boolean sampledV = sampled != null
-        ? sampled.equals("1") || sampled.equalsIgnoreCase("true")
-        : null;
+      Boolean sampledV;
+      if (sampled == null) {
+        sampledV = null; // defer decision
+      } else if (sampled.length() == 1) { // handle fast valid paths
+        char sampledC = sampled.charAt(0);
+
+        if (sampledC == '1') {
+          sampledV = true;
+        } else if (sampledC == '0') {
+          sampledV = false;
+        } else {
+          Platform.get().log(SAMPLED_MALFORMED, sampled, null);
+          return TraceContextOrSamplingFlags.EMPTY; // trace context is malformed so return empty
+        }
+      } else if (sampled.equalsIgnoreCase("true")) { // old clients
+        sampledV = true;
+      } else if (sampled.equalsIgnoreCase("false")) { // old clients
+        sampledV = false;
+      } else {
+        Platform.get().log(SAMPLED_MALFORMED, sampled, null);
+        return TraceContextOrSamplingFlags.EMPTY; // Restart trace instead of propagating false
+      }
+
+      // The only flag we action is 1, but it could be that any integer is present.
+      // Here, we leniently parse as debug is not a primary consideration of the trace context.
       boolean debug = "1".equals(getter.get(carrier, propagation.debugKey));
 
       String traceIdString = getter.get(carrier, propagation.traceIdKey);

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -165,6 +165,15 @@ public final class B3SingleFormat {
       return null;
     }
 
+    // Cheaply check for only ASCII characters. This allows for more precise messages later, but
+    // kicks out early on data such as unicode.
+    for (int i = beginIndex; i < endIndex; i++) {
+      if (b3.charAt(i) >= 128) {
+        Platform.get().log("Invalid input: non-ASCII character at offset {0}", i, null);
+        return null;
+      }
+    }
+
     long traceIdHigh, traceId;
     if (b3.charAt(pos + 32) == '-') {
       traceIdHigh = tryParse16HexCharacters(b3, pos, endIndex);

--- a/brave/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave/src/test/java/brave/propagation/B3PropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,19 +15,54 @@ package brave.propagation;
 
 import brave.Request;
 import brave.Span;
+import brave.internal.Platform;
 import brave.propagation.B3Propagation.Format;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@RunWith(PowerMockRunner.class)
+// Added to declutter console: tells power mock not to mess with implicit classes we aren't testing
+@PowerMockIgnore({"org.apache.logging.*", "javax.script.*"})
+@PrepareForTest({Platform.class, B3Propagation.class})
 public class B3PropagationTest {
+  String traceIdHigh = "0000000000000009";
+  String traceId = "0000000000000001";
+  String parentId = "0000000000000002";
+  String spanId = "0000000000000003";
+
   TraceContext context = TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).build();
 
+  Propagation<String> propagation = B3Propagation.B3_STRING;
+  Platform platform = mock(Platform.class);
+
+  @Before public void setupLogger() {
+    mockStatic(Platform.class);
+    when(Platform.get()).thenReturn(platform);
+  }
+
+  /** Either we asserted on the log messages or there weren't any */
+  @After public void ensureNothingLogged() {
+    verifyNoMoreInteractions(platform);
+  }
+
   @Test public void keys_defaultToAll() {
-    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+    propagation = B3Propagation.newFactoryBuilder()
       .build().create(Propagation.KeyFactory.STRING);
 
     assertThat(propagation.keys()).containsExactly(
@@ -41,7 +76,7 @@ public class B3PropagationTest {
   }
 
   @Test public void keys_withoutB3Single() {
-    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+    propagation = B3Propagation.newFactoryBuilder()
       .injectFormat(Span.Kind.PRODUCER, Format.MULTI)
       .injectFormat(Span.Kind.CONSUMER, Format.MULTI)
       .build().create(Propagation.KeyFactory.STRING);
@@ -56,7 +91,7 @@ public class B3PropagationTest {
   }
 
   @Test public void keys_onlyB3Single() {
-    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+    propagation = B3Propagation.newFactoryBuilder()
       .injectFormat(Format.SINGLE)
       .injectFormat(Span.Kind.CLIENT, Format.SINGLE)
       .injectFormat(Span.Kind.SERVER, Format.SINGLE)
@@ -157,7 +192,7 @@ public class B3PropagationTest {
   }
 
   @Test public void canConfigureSingle() {
-    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+    propagation = B3Propagation.newFactoryBuilder()
       .injectFormat(Format.SINGLE_NO_PARENT)
       .build().create(Propagation.KeyFactory.STRING);
 
@@ -170,7 +205,7 @@ public class B3PropagationTest {
   }
 
   @Test public void canConfigureBasedOnKind() {
-    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+    propagation = B3Propagation.newFactoryBuilder()
       .injectFormats(Span.Kind.CLIENT, Format.SINGLE, Format.MULTI)
       .build().create(Propagation.KeyFactory.STRING);
 
@@ -179,9 +214,62 @@ public class B3PropagationTest {
 
     assertThat(request.headers)
       .hasSize(4)
-      .containsEntry("X-B3-TraceId", "0000000000000001")
-      .containsEntry("X-B3-ParentSpanId", "0000000000000002")
-      .containsEntry("X-B3-SpanId", "0000000000000003")
-      .containsEntry("b3", "0000000000000001-0000000000000003-0000000000000002");
+      .containsEntry("X-B3-TraceId", traceId)
+      .containsEntry("X-B3-ParentSpanId", parentId)
+      .containsEntry("X-B3-SpanId", spanId)
+      .containsEntry("b3", traceId + "-" + spanId + "-" + parentId);
+  }
+
+  @Test public void extract_notYetSampled() {
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("X-B3-TraceId", traceId);
+    headers.put("X-B3-SpanId", spanId);
+
+    assertThat(extract(headers).sampled()).isNull();
+  }
+
+  @Test public void extract_sampled() {
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("X-B3-TraceId", traceId);
+    headers.put("X-B3-SpanId", spanId);
+
+    headers.put("X-B3-Sampled", "1");
+
+    assertThat(extract(headers).sampled()).isTrue();
+
+    headers.put("X-B3-Sampled", "true"); // old clients
+
+    assertThat(extract(headers).sampled()).isTrue();
+  }
+
+  @Test public void extract_sampled_false() {
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("X-B3-TraceId", traceId);
+    headers.put("X-B3-SpanId", spanId);
+
+    headers.put("X-B3-Sampled", "0");
+
+    assertThat(extract(headers).sampled()).isFalse();
+
+    headers.put("X-B3-Sampled", "false"); // old clients
+
+    assertThat(extract(headers).sampled()).isFalse();
+  }
+
+  @Test public void extract_sampledCorrupt() {
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("X-B3-TraceId", traceId);
+    headers.put("X-B3-SpanId", spanId);
+
+    Stream.of("", "d", "hello").forEach(sampled -> {
+      headers.put("X-B3-Sampled", sampled);
+      assertThat(extract(headers)).isSameAs(TraceContextOrSamplingFlags.EMPTY);
+
+      verify(platform).log("Invalid input: expected 0 or 1 for X-B3-Sampled: {0}", sampled, null);
+    });
+  }
+
+  TraceContextOrSamplingFlags extract(Map<String, String> headers) {
+    return propagation.<Map<String, String>>extractor(Map::get).extract(headers);
   }
 }

--- a/brave/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave/src/test/java/brave/propagation/B3PropagationTest.java
@@ -261,7 +261,7 @@ public class B3PropagationTest {
     headers.put("X-B3-TraceId", traceId);
     headers.put("X-B3-SpanId", spanId);
 
-    Stream.of("", "d", "hello").forEach(sampled -> {
+    Stream.of("", "d", "💩", "hello").forEach(sampled -> {
       headers.put("X-B3-Sampled", sampled);
       assertThat(extract(headers)).isSameAs(TraceContextOrSamplingFlags.EMPTY);
 

--- a/brave/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave/src/test/java/brave/propagation/B3PropagationTest.java
@@ -265,7 +265,7 @@ public class B3PropagationTest {
       headers.put("X-B3-Sampled", sampled);
       assertThat(extract(headers)).isSameAs(TraceContextOrSamplingFlags.EMPTY);
 
-      verify(platform).log("Invalid input: expected 0 or 1 for X-B3-Sampled: {0}", sampled, null);
+      verify(platform).log("Invalid input: expected 0 or 1 for X-B3-Sampled, but found '{0}'", sampled, null);
     });
   }
 

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -247,6 +247,22 @@ public class B3SingleFormatTest {
   @Test public void parseB3SingleFormat_sampled() {
     assertThat(parseB3SingleFormat("1"))
       .isEqualTo(TraceContextOrSamplingFlags.SAMPLED);
+  }
+
+  @Test public void parseB3SingleFormat_ascii() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-💩"))
+      .isNull(); // instead of crashing
+
+    verify(platform)
+      .log("Invalid input: non-ASCII character at offset {0}", 34, null);
+  }
+
+  @Test public void parseB3SingleFormat_sampledCorrupt() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-y"))
+      .isNull(); // instead of crashing
+
+    verify(platform)
+      .log("Invalid input: expected 0, 1 or d for sampled at offset {0}", 34, null);
   }
 
   @Test public void parseB3SingleFormat_debug() {


### PR DESCRIPTION
Currently, we restart the trace if the identity fields: traceId and
spanId are malformed. This restarts on malformed sampled flag. Formerly,
we treated malformed the same as an explicit sampled=false decision.