### PR TITLE
Fixes NPE when client cannot return a valid status code

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpClientAdapters.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientAdapters.java
@@ -214,7 +214,7 @@ import brave.internal.Nullable;
     }
 
     @Override public int statusCode() {
-      return adapter.statusCode(response);
+      return adapter.statusCodeAsInt(response);
     }
 
     @Override public long finishTimestamp() {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerAdapters.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerAdapters.java
@@ -224,7 +224,7 @@ import brave.internal.Nullable;
     }
 
     @Override public int statusCode() {
-      return adapter.statusCode(response);
+      return adapter.statusCodeAsInt(response);
     }
 
     @Override public long finishTimestamp() {

--- a/instrumentation/http/src/test/java/brave/http/HttpAdaptersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpAdaptersTest.java
@@ -338,11 +338,11 @@ import static org.mockito.Mockito.when;
     assertThat(fromResponseAdapter.statusCode()).isZero();
   }
 
-  @Test public void fromResponseAdapter_statusCode_delegatesToAdapter() {
-    when(responseAdapter.statusCode(response)).thenReturn(200);
+  @Test public void fromResponseAdapter_statusCode_delegatesToAdapterStatusCodeAsInt() {
+    when(responseAdapter.statusCodeAsInt(response)).thenReturn(200);
 
     assertThat(fromResponseAdapter.statusCode()).isEqualTo(200);
 
-    verify(responseAdapter).statusCode(response);
+    verify(responseAdapter).statusCodeAsInt(response);
   }
 }


### PR DESCRIPTION
This occurs in an old branch of sleuth.. I didn't notice it.