### PR TITLE
Slightly adjusts Javadoc on HttpClientRequest

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -44,7 +44,7 @@ public abstract class HttpClientRequest extends HttpRequest {
    *
    * <p>This is only used when {@link TraceContext.Injector#inject(TraceContext, Object) injecting}
    * a trace context as internally implemented by {link HttpClientHandler}. Calls during sampling or
-   * parsing are invalid and may be ignored.
+   * parsing are invalid and may be ignored by instrumentation.
    *
    * @see #SETTER
    * @since 5.7

--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -40,11 +40,11 @@ public abstract class HttpClientRequest extends HttpRequest {
   }
 
   /**
-   * Sets a request header with the indicated name. Null values are unsupported.
+   * Sets a request header with the indicated name. {@code null} values are unsupported.
    *
-   * This is only used when {@link TraceContext.Injector#inject(TraceContext, Object) injecting} a
-   * trace context as internally implemented by {link HttpClientHandler}. Calls during sampling or
-   * parsing are invalid.
+   * <p>This is only used when {@link TraceContext.Injector#inject(TraceContext, Object) injecting}
+   * a trace context as internally implemented by {link HttpClientHandler}. Calls during sampling or
+   * parsing are invalid and may be ignored.
    *
    * @see #SETTER
    * @since 5.7


### PR DESCRIPTION
Before, we said calls during parsing were invalid, but we didn't say
they could be ignored. This clarifies the point to avoid a temptation
to throw an exception which could crash things.