### PR TITLE
Backports Apache HttpClient v4.3 support

### DIFF
--- a/instrumentation/httpclient/README.md
+++ b/instrumentation/httpclient/README.md
@@ -1,5 +1,5 @@
 # brave-instrumentation-httpclient
-This module contains a tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.4.x/index.html) 4.4+.
+This module contains a tracing decorator for [Apache HttpClient](http://hc.apache.org/httpcomponents-client-4.3.x/index.html) 4.3+.
 `TracingHttpClientBuilder` adds trace headers to outgoing requests. It
 then reports to Zipkin how long each request takes, along with relevant
 tags like the http url.

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -61,4 +61,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/instrumentation/httpclient/src/it/httpclient_v43/README.md
+++ b/instrumentation/httpclient/src/it/httpclient_v43/README.md
@@ -1,0 +1,2 @@
+# httpclient_v43
+This tests that TracingHttpClientBuilder can be used with httpclient 4.3

--- a/instrumentation/httpclient/src/it/httpclient_v43/pom.xml
+++ b/instrumentation/httpclient/src/it/httpclient_v43/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013-2020 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>httpclient_v43</artifactId>
+  <version>@project.version@</version>
+  <name>httpclient_v43</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <httpclient.version>4.3.6</httpclient.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>brave-instrumentation-httpclient</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-cache</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>@project.build.testSourceDirectory@</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+        <configuration>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-failsafe-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/httpclient/src/it/httpclient_v43/src/test/java/brave/httpclient_v43/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/it/httpclient_v43/src/test/java/brave/httpclient_v43/ITTracingCachingHttpClientBuilder.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.httpclient_v43;
+
+public class ITTracingCachingHttpClientBuilder
+  extends brave.httpclient.ITTracingCachingHttpClientBuilder {
+}

--- a/instrumentation/httpclient/src/it/httpclient_v43/src/test/java/brave/httpclient_v43/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/it/httpclient_v43/src/test/java/brave/httpclient_v43/ITTracingHttpClientBuilder.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.brave.okhttp3_v3;
+package brave.httpclient_v43;
 
-public class ITTracingInterceptor extends brave.okhttp3.ITTracingInterceptor {
+public class ITTracingHttpClientBuilder extends brave.httpclient.ITTracingHttpClientBuilder {
 }

--- a/instrumentation/httpclient/src/main/java/brave/httpclient/TracingMainExec.java
+++ b/instrumentation/httpclient/src/main/java/brave/httpclient/TracingMainExec.java
@@ -58,13 +58,15 @@ class TracingMainExec implements ClientExecChain { // not final for subclassing
     throws IOException, HttpException {
     Span span = (Span) context.removeAttribute(Span.class.getName());
 
-    if (span != null) handler.handleSend(new HttpRequestWrapper(request), span);
+    if (span != null) {
+      handler.handleSend(new HttpRequestWrapper(request, route.getTargetHost()), span);
+    }
 
     CloseableHttpResponse response = mainExec.execute(route, request, context, execAware);
     if (span != null) {
       if (isRemote(context, span)) {
         if (serverName != null) span.remoteServiceName(serverName);
-        parseTargetAddress(request, span);
+        parseTargetAddress(route.getTargetHost(), span);
       } else {
         span.kind(null); // clear as cache hit
       }
@@ -76,10 +78,7 @@ class TracingMainExec implements ClientExecChain { // not final for subclassing
     return true;
   }
 
-  static void parseTargetAddress(org.apache.http.client.methods.HttpRequestWrapper httpRequest,
-    Span span) {
-    if (span.isNoop()) return;
-    HttpHost target = httpRequest.getTarget();
+  static void parseTargetAddress(HttpHost target, Span span) {
     if (target == null) return;
     InetAddress address = target.getAddress();
     if (address != null) {

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave/okhttp3_v3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave/okhttp3_v3/ITTracingCallFactory.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.brave.okhttp3_v3;
+package brave.okhttp3_v3;
 
 public class ITTracingCallFactory extends brave.okhttp3.ITTracingCallFactory {
 }

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave/okhttp3_v3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/java/brave/okhttp3_v3/ITTracingInterceptor.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.okhttp3_v3;
+
+public class ITTracingInterceptor extends brave.okhttp3.ITTracingInterceptor {
+}


### PR DESCRIPTION
After switching to `HttpClientRequest` type, it is easier than before to
support Apache HttpClient v4.3. Before, we tried to access everything we
needed to parse with the same raw object. Now, we can just look at the
context instead, which is portable across 4.3 and 4.4.

Fixes #1079
Fixes #431