### PR TITLE
Increase timeout to 10 seconds for tests

### DIFF
--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -36,7 +36,7 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITTracingFilter {
-  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(5)); // max per method
+  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10)); // max per method
 
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -37,7 +37,7 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITTracingFilter {
-  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(5)); // max per method
+  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10)); // max per method
 
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -99,7 +99,7 @@ public abstract class ITHttp {
    * This way, there's visibility on which method hung without asking the end users to edit build
    * config.
    */
-  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(5)); // max per method
+  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10)); // max per method
   @Rule public TestName testName = new TestName();
 
   public static final String EXTRA_KEY = "user-id";


### PR DESCRIPTION
Related: https://github.com/line/armeria/pull/2559
The tests could take longer because of instrumenting test coverage.
So I think it's better to increase it upto 10 seconds.