### PR TITLE
Bump ActiveMQ client

### DIFF
--- a/instrumentation/jms/README.md
+++ b/instrumentation/jms/README.md
@@ -98,6 +98,10 @@ void process(Message message) {
 }
 ```
 
+## Compatibility issues
+
+* There are known issues with ActiveMQ Client versions <= `5.15.11` when using `BytesMessage`: <https://github.com/openzipkin/brave/issues/967>. ActiveMQ has [fixed this issue](https://issues.apache.org/jira/browse/AMQ-7291) and following versions should work when using `BytesMessage`.
+
 ## Troubleshooting
 If you have problems with a JMS provider, such as broken traces, please capture the "FINE" output of
 the Java logger: `brave.jms.JmsTracing` and ask on [gitter](https://gitter.im/openzipkin/zipkin).

--- a/instrumentation/jms/README.md
+++ b/instrumentation/jms/README.md
@@ -100,7 +100,7 @@ void process(Message message) {
 
 ## Compatibility issues
 
-* There are known issues with ActiveMQ Client versions <= `5.15.11` when using `BytesMessage`: <https://github.com/openzipkin/brave/issues/967>. ActiveMQ has [fixed this issue](https://issues.apache.org/jira/browse/AMQ-7291) and following versions should work when using `BytesMessage`.
+* There are known issues with ActiveMQ Client versions < `5.16.0` when using `BytesMessage`: <https://github.com/openzipkin/brave/issues/967>. ActiveMQ has [fixed this issue](https://issues.apache.org/jira/browse/AMQ-7291) and following versions should work when using `BytesMessage`.
 
 ## Troubleshooting
 If you have problems with a JMS provider, such as broken traces, please capture the "FINE" output of

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
@@ -319,8 +319,7 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     receive_resumesTrace(() -> messageProducer.send(message), messageConsumer);
   }
 
-  @Test(expected = ComparisonFailure.class) // TODO: https://github.com/openzipkin/brave/issues/967
-  public void receive_resumesTrace_bytes() throws JMSException {
+  @Test public void receive_resumesTrace_bytes() throws JMSException {
     receive_resumesTrace(() -> messageProducer.send(bytesMessage), messageConsumer);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <kafka.version>2.5.0</kafka.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
     <kafka-junit.version>4.1.9</kafka-junit.version>
-    <activemq.version>5.15.12</activemq.version>
+    <activemq.version>5.16.0</activemq.version>
     <spring-rabbit.version>2.2.6.RELEASE</spring-rabbit.version>
 
     <finagle.version>20.4.1</finagle.version>


### PR DESCRIPTION
Fixes issue with `BytesMessage` on ActiveMQ clients #967. 

Waiting for https://issues.apache.org/jira/browse/AMQ-7291 to be released.