### PR TITLE
Fixes bugs in B3 single parsing and completes coverage

### DIFF
--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -135,8 +135,8 @@ public final class B3SingleFormat {
   }
 
   @Nullable
-  public static TraceContextOrSamplingFlags parseB3SingleFormat(CharSequence value) {
-    return parseB3SingleFormat(value, 0, value.length());
+  public static TraceContextOrSamplingFlags parseB3SingleFormat(CharSequence b3) {
+    return parseB3SingleFormat(b3, 0, b3.length());
   }
 
   /**

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -68,9 +68,9 @@ public final class B3SingleFormat {
    * with the client.
    */
   public static String writeB3SingleFormatWithoutParentId(TraceContext context) {
-    char[] value = getCharBuffer();
-    int length = writeB3SingleFormat(context, 0L, value);
-    return new String(value, 0, length);
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, 0L, buffer);
+    return new String(buffer, 0, length);
   }
 
   /**
@@ -78,9 +78,9 @@ public final class B3SingleFormat {
    * array or byte buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatWithoutParentIdAsBytes(TraceContext context) {
-    char[] value = getCharBuffer();
-    int length = writeB3SingleFormat(context, 0L, value);
-    return asciiToNewByteArray(value, length);
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, 0L, buffer);
+    return asciiToNewByteArray(buffer, length);
   }
 
   /**
@@ -92,9 +92,9 @@ public final class B3SingleFormat {
    * reuses a client's span ID, prefer {@link #writeB3SingleFormatWithoutParentId(TraceContext)}.
    */
   public static String writeB3SingleFormat(TraceContext context) {
-    char[] value = getCharBuffer();
-    int length = writeB3SingleFormat(context, context.parentIdAsLong(), value);
-    return new String(value, 0, length);
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
+    return new String(buffer, 0, length);
   }
 
   /**
@@ -102,9 +102,9 @@ public final class B3SingleFormat {
    * buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatAsBytes(TraceContext context) {
-    char[] value = getCharBuffer();
-    int length = writeB3SingleFormat(context, context.parentIdAsLong(), value);
-    return asciiToNewByteArray(value, length);
+    char[] buffer = getCharBuffer();
+    int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
+    return asciiToNewByteArray(buffer, length);
   }
 
   static int writeB3SingleFormat(TraceContext context, long parentId, char[] result) {
@@ -301,10 +301,10 @@ public final class B3SingleFormat {
     return flags;
   }
 
-  static byte[] asciiToNewByteArray(char[] value, int length) {
+  static byte[] asciiToNewByteArray(char[] buffer, int length) {
     byte[] result = new byte[length];
     for (int i = 0; i < length; i++) {
-      result[i] = (byte) value[i];
+      result[i] = (byte) buffer[i];
     }
     return result;
   }
@@ -312,12 +312,12 @@ public final class B3SingleFormat {
   static final ThreadLocal<char[]> CHAR_BUFFER = new ThreadLocal<>();
 
   static char[] getCharBuffer() {
-    char[] result = CHAR_BUFFER.get();
-    if (result == null) {
-      result = new char[FORMAT_MAX_LENGTH];
-      CHAR_BUFFER.set(result);
+    char[] charBuffer = CHAR_BUFFER.get();
+    if (charBuffer == null) {
+      charBuffer = new char[FORMAT_MAX_LENGTH];
+      CHAR_BUFFER.set(charBuffer);
     }
-    return result;
+    return charBuffer;
   }
 
   B3SingleFormat() {

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -214,7 +214,7 @@ public final class B3SingleFormat {
     int flags = 0;
     long parentId = 0L;
     if (endIndex > pos) {
-      pos++; // consume the delimiter
+      pos++; // consume the hyphen
 
       if (endIndex == pos) { // traceid-spanid-
         Platform.get().log("Truncated after reading span ID", null);

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -75,7 +75,7 @@ public final class B3SingleFormat {
 
   /**
    * Like {@link #writeB3SingleFormatWithoutParentId(TraceContext)}, but for carriers with byte
-   * array or byte value values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
+   * array or byte buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatWithoutParentIdAsBytes(TraceContext context) {
     char[] value = getCharBuffer();
@@ -98,8 +98,8 @@ public final class B3SingleFormat {
   }
 
   /**
-   * Like {@link #writeB3SingleFormat(TraceContext)}, but for carriers with byte array or byte value
-   * values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
+   * Like {@link #writeB3SingleFormat(TraceContext)}, but for carriers with byte array or byte
+   * buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatAsBytes(TraceContext context) {
     char[] value = getCharBuffer();

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -286,12 +286,6 @@ public final class B3SingleFormat {
     return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
   }
 
-  static boolean checkHyphen(CharSequence value, int index) {
-    if (value.charAt(index) == '-') return true;
-    Platform.get().log("Invalid input: expected a hyphen(-) delimiter", null);
-    return false;
-  }
-
   static int parseSampledFlags(char sampledChar) {
     int flags;
     if (sampledChar == 'd') {

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -98,6 +98,7 @@ public interface Propagation<K> {
 
   /** Replaces a propagated key with the given value */
   interface Setter<C, K> {
+    // BRAVE6: make this a charsequence as there's no need to allocate a string
     void put(C carrier, K key, String value);
   }
 

--- a/brave/src/test/java/brave/internal/HexCodecTest.java
+++ b/brave/src/test/java/brave/internal/HexCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package brave.internal;
 
 import org.junit.Test;
 
+import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 import static brave.internal.HexCodec.lowerHexToUnsignedLong;
 import static brave.internal.HexCodec.toLowerHex;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +28,22 @@ public class HexCodecTest {
   public void lowerHexToUnsignedLong_downgrades128bitIdsByDroppingHighBits() {
     assertThat(lowerHexToUnsignedLong("463ac35c9f6413ad48485a3953bb6124"))
       .isEqualTo(lowerHexToUnsignedLong("48485a3953bb6124"));
+  }
+
+  /** This tests that the being index is inclusive and the end index is exclusive */
+  @Test
+  public void lenientLowerHexToUnsignedLong_ignoresBeforeAndAfter() {
+    // intentionally shorter than 16 characters
+    lenientLowerHexToUnsignedLong_ignoresBeforeAndAfter("12345678");
+    // exactly 16 characters
+    lenientLowerHexToUnsignedLong_ignoresBeforeAndAfter("1234567812345678");
+  }
+
+  void lenientLowerHexToUnsignedLong_ignoresBeforeAndAfter(String encoded) {
+    String sequence = "??" + encoded + "??";
+    assertThat(lenientLowerHexToUnsignedLong(sequence, 2, 2 + encoded.length()))
+      .isEqualTo(lowerHexToUnsignedLong(encoded))
+      .isEqualTo(Long.parseUnsignedLong(encoded, 16));
   }
 
   @Test

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -14,8 +14,6 @@
 package brave.propagation;
 
 import brave.internal.Platform;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +29,6 @@ import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentI
 import static brave.propagation.B3SingleFormat.writeB3SingleFormatWithoutParentIdAsBytes;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -189,29 +186,29 @@ public class B3SingleFormatTest {
       .isSameAs(SamplingFlags.DEBUG);
   }
 
-  @Test public void parseB3SingleFormat_middleOfString_incorrectOffset() {
+  @Test public void parseB3SingleFormat_middleOfString_incorrectIndex() {
     String input = "b2=foo,b3=d,b4=bar";
     assertThat(parseB3SingleFormat(input, 10, 12))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: truncated", null);
+    verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
   }
 
-  @Test public void parseB3SingleFormat_idsNotYetSampled() {
+  @Test public void parseB3SingleFormat_spanIdsNotYetSampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId).context())
       .isEqualToComparingFieldByField(
         TraceContext.newBuilder().traceId(1).spanId(3).build()
       );
   }
 
-  @Test public void parseB3SingleFormat_idsNotYetSampled128() {
+  @Test public void parseB3SingleFormat_spanIdsNotYetSampled128() {
     assertThat(parseB3SingleFormat(traceId + traceId + "-" + spanId).context())
       .isEqualToComparingFieldByField(
         TraceContext.newBuilder().traceIdHigh(1).traceId(1).spanId(3).build()
       );
   }
 
-  @Test public void parseB3SingleFormat_idsUnsampled() {
+  @Test public void parseB3SingleFormat_spanIdsUnsampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0").context())
       .isEqualToComparingFieldByField(
         TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build()
@@ -232,7 +229,15 @@ public class B3SingleFormatTest {
       );
   }
 
-  @Test public void parseB3SingleFormat_idsWithDebug() {
+  // odd but possible to not yet sample a child
+  @Test public void parseB3SingleFormat_parentid_notYetSampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId).context())
+      .isEqualToComparingFieldByField(
+        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).build()
+      );
+  }
+
+  @Test public void parseB3SingleFormat_spanIdsWithDebug() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-d").context())
       .isEqualToComparingFieldByField(
         TraceContext.newBuilder().traceId(1).spanId(3).debug(true).build()
@@ -249,85 +254,59 @@ public class B3SingleFormatTest {
       .isEqualTo(TraceContextOrSamplingFlags.SAMPLED);
   }
 
-  @Test public void parseB3SingleFormat_ascii() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-💩"))
-      .isNull(); // instead of crashing
-
-    verify(platform)
-      .log("Invalid input: non-ASCII character at offset {0}", 34, null);
-  }
-
-  @Test public void parseB3SingleFormat_sampledCorrupt() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-y"))
-      .isNull(); // instead of crashing
-
-    verify(platform)
-      .log("Invalid input: expected 0, 1 or d for sampled at offset {0}", 34, null);
-  }
-
   @Test public void parseB3SingleFormat_debug() {
     assertThat(parseB3SingleFormat("d"))
       .isEqualTo(TraceContextOrSamplingFlags.DEBUG);
   }
 
-  @Test public void parseB3SingleFormat_malformed_traceId() {
-    assertThat(parseB3SingleFormat(traceId.substring(0, 15) + "?-" + spanId))
-      .isNull(); // instead of raising exception
-
-    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID at offset 0", null);
-  }
-
-  @Test public void parseB3SingleFormat_malformed_id() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15) + "?"))
-      .isNull(); // instead of raising exception
-
-    verify(platform).log("Invalid input: expected a 16 lower hex span ID at offset {0}", 17, null);
-  }
-
-  @Test public void parseB3SingleFormat_malformed_sampled_parentid() {
-    assertThat(
-      parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId.substring(0, 15) + "?"))
-      .isNull(); // instead of raising exception
-
-    verify(platform).log("Invalid input: expected a 16 lower hex parent ID at offset {0}", 36,
-      null);
-  }
-
-  @Test public void parseB3SingleFormat_malformed_invalid_delimiter_before_parent() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1!" + parentId))
-      .isNull(); // instead of raising exception
-
-    verify(platform).log("Invalid input: expected a hyphen(-) delimiter at offset {0}", 35, null);
-  }
-
-  // odd but possible to not yet sample a child
-  @Test public void parseB3SingleFormat_parentid_notYetSampled() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).build()
-      );
-  }
-
-  @Test public void parseB3SingleFormat_malformed_parentid_notYetSampled() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15) + "?"))
-      .isNull(); // instead of raising exception
-
-    verify(platform).log("Invalid input: expected a 16 lower hex parent ID at offset {0}", 34,
-      null);
+  /** This tests that the being index is inclusive and the end index is exclusive */
+  @Test public void parseB3SingleFormat_ignoresBeforeAndAfter() {
+    String encoded = traceId + "-" + spanId;
+    String sequence = "??" + encoded + "??";
+    assertThat(parseB3SingleFormat(sequence, 2, 2 + encoded.length()))
+      .isEqualToComparingFieldByField(parseB3SingleFormat(encoded));
   }
 
   @Test public void parseB3SingleFormat_malformed() {
     assertThat(parseB3SingleFormat("not-a-tumor"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: truncated", null);
+    verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
+  }
+
+  @Test public void parseB3SingleFormat_malformed_notAscii() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-💩"))
+      .isNull(); // instead of crashing
+
+    verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
   }
 
   @Test public void parseB3SingleFormat_malformed_uuid() {
     assertThat(parseB3SingleFormat("b970dafd-0d95-40aa-95d8-1d8725aebe40"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID at offset 0", null);
+    verify(platform).log("Invalid input: more than 4 fields exist", null);
+  }
+
+  @Test public void parseB3SingleFormat_malformed_hyphenForSampled() {
+    assertThat(parseB3SingleFormat("-")).isNull();
+
+    verify(platform).log("Invalid input: expected 0, 1 or d for sampled", null);
+  }
+
+  @Test public void parseB3SingleFormat_too_many_fields() {
+    assertThat(
+      parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId + "-"))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: more than 4 fields exist", null);
+  }
+
+  @Test public void parseB3SingleFormat_sampledCorrupt() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-f"))
+      .isNull(); // instead of crashing
+
+    verify(platform).log("Invalid input: expected 0, 1 or d for sampled", null);
   }
 
   @Test public void parseB3SingleFormat_empty() {
@@ -336,51 +315,117 @@ public class B3SingleFormatTest {
     verify(platform).log("Invalid input: empty", null);
   }
 
-  @Test public void parseB3SingleFormat_hyphenNotSampled() {
-    assertThat(parseB3SingleFormat("-")).isNull();
+  @Test public void parseB3SingleFormat_empty_traceId() {
+    assertThat(parseB3SingleFormat("-234567812345678-" + spanId))
+      .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: expected 0, 1 or d for sampled at offset {0}", 0, null);
+    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
   }
 
-  @Test public void parseB3SingleFormat_truncated() {
-    List<String> truncated = Arrays.asList(
-      "-1",
-      "1-",
-      traceId.substring(0, 15),
-      traceId,
-      traceId + "-",
-      traceId.substring(0, 15) + "-" + spanId,
-      traceId + "-" + spanId.substring(0, 15),
-      traceId + "-" + spanId + "-",
-      traceId + "-" + spanId + "-1-",
-      traceId + "-" + spanId + "-1-" + parentId.substring(0, 15)
-    );
-    for (String b3 : truncated) {
-      assertThat(parseB3SingleFormat(b3))
-        .withFailMessage("expected " + b3 + " to not parse").isNull();
-      verify(platform).log("Invalid input: truncated", null);
-      reset(platform);
-    }
+  @Test public void parseB3SingleFormat_empty_spanId() {
+    assertThat(parseB3SingleFormat(traceId + "--"))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: empty {0} ID", "span", null);
+  }
+
+  @Test public void parseB3SingleFormat_empty_spanId_with_parent() {
+    assertThat(parseB3SingleFormat(traceId + "--" + parentId))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: empty {0} ID", "span", null);
+  }
+
+  /** We say truncated as we don't know if the intent was a sampled flag or a parent ID */
+  @Test public void parseB3SingleFormat_empty_after_spanId() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-"))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Truncated after reading span ID", null);
+  }
+
+  @Test public void parseB3SingleFormat_empty_sampled_with_parentId() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "--" + parentId))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: empty sampled field", null);
+  }
+
+  @Test public void parseB3SingleFormat_empty_parent_after_sampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-d-"))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: empty {0} ID", "parent", null);
+  }
+
+  @Test public void parseB3SingleFormat_truncated_traceId() {
+    assertThat(parseB3SingleFormat("1-" + spanId))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
+  }
+
+  @Test public void parseB3SingleFormat_truncated_traceId128() {
+    assertThat(parseB3SingleFormat(traceIdHigh.substring(0, 15) + traceId + "-" + spanId))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
+  }
+
+  @Test public void parseB3SingleFormat_truncated_spanId() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15)))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Truncated reading {0} ID", "span", null);
+  }
+
+  @Test public void parseB3SingleFormat_truncated_parentId() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15)))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Truncated reading {0} ID", "parent", null);
+  }
+
+  @Test public void parseB3SingleFormat_truncated_parentId_after_sampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId.substring(0, 15)))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Truncated reading {0} ID", "parent", null);
   }
 
   @Test public void parseB3SingleFormat_traceIdTooLong() {
     assertThat(parseB3SingleFormat(traceId + traceId + "a" + "-" + spanId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: trace ID is too long", null);
+    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_spanIdTooLong() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "a"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: span ID is too long", null);
+    verify(platform).log("Invalid input: {0} ID is too long", "span", null);
+  }
+
+  /** Sampled too long without parent looks the same as a truncated parent ID */
+  @Test public void parseB3SingleFormat_sampledTooLong() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-11-" + parentId))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: sampled is too long", null);
   }
 
   @Test public void parseB3SingleFormat_parentIdTooLong() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId + "a"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: parent ID is too long", null);
+    verify(platform).log("Invalid input: {0} ID is too long", "parent", null);
+  }
+
+  @Test public void parseB3SingleFormat_parentIdTooLong_afterSampled() {
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId + "a"))
+      .isNull(); // instead of raising exception
+
+    verify(platform).log("Invalid input: {0} ID is too long", "parent", null);
   }
 }

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -326,36 +326,36 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat(traceId + "--"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: empty {0} ID", "span", null);
+    verify(platform).log("Invalid input: empty {0}", "span ID", null);
   }
 
   @Test public void parseB3SingleFormat_empty_spanId_with_parent() {
     assertThat(parseB3SingleFormat(traceId + "--" + parentId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: empty {0} ID", "span", null);
+    verify(platform).log("Invalid input: empty {0}", "span ID", null);
   }
 
-  /** We say truncated as we don't know if the intent was a sampled flag or a parent ID */
+  /** We don't know if the intent was a sampled flag or a parent ID, but less logic to pick one. */
   @Test public void parseB3SingleFormat_empty_after_spanId() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated after reading span ID", null);
+    verify(platform).log("Invalid input: empty {0}", "sampled", null);
   }
 
   @Test public void parseB3SingleFormat_empty_sampled_with_parentId() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "--" + parentId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: empty sampled field", null);
+    verify(platform).log("Invalid input: empty {0}", "sampled", null);
   }
 
   @Test public void parseB3SingleFormat_empty_parent_after_sampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-d-"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: empty {0} ID", "parent", null);
+    verify(platform).log("Invalid input: empty {0}", "parent ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_traceId() {
@@ -376,21 +376,21 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15)))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated reading {0} ID", "span", null);
+    verify(platform).log("Truncated reading {0}", "span ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_parentId() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15)))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated reading {0} ID", "parent", null);
+    verify(platform).log("Truncated reading {0}", "parent ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_parentId_after_sampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId.substring(0, 15)))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated reading {0} ID", "parent", null);
+    verify(platform).log("Truncated reading {0}", "parent ID", null);
   }
 
   @Test public void parseB3SingleFormat_traceIdTooLong() {
@@ -404,7 +404,7 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "a"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: {0} ID is too long", "span", null);
+    verify(platform).log("Invalid input: {0} is too long", "span ID", null);
   }
 
   /** Sampled too long without parent looks the same as a truncated parent ID */
@@ -412,20 +412,20 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-11-" + parentId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: sampled is too long", null);
+    verify(platform).log("Invalid input: {0} is too long", "sampled", null);
   }
 
   @Test public void parseB3SingleFormat_parentIdTooLong() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId + "a"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: {0} ID is too long", "parent", null);
+    verify(platform).log("Invalid input: {0} is too long", "parent ID", null);
   }
 
   @Test public void parseB3SingleFormat_parentIdTooLong_afterSampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId + "a"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: {0} ID is too long", "parent", null);
+    verify(platform).log("Invalid input: {0} is too long", "parent ID", null);
   }
 }


### PR DESCRIPTION
This hardens the code, as it formerly conflated missing fields or too many fields with truncation in general. It also formerly checked valid characters in multiple places.

It sporadically mentioned an offset, which is not helpful as the source is not logged and is often a reusable buffer. Instead, this mentions the field that had an error as opposed to the string position.

This is preparation for the trace context format as it is a simplification of the B3 single code.