### PR TITLE
Simplifies B3 single by parsing in a single loop

### DIFF
--- a/brave-tests/src/main/java/brave/test/propagation/B3SingleFormatClassLoaderTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/B3SingleFormatClassLoaderTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test.propagation;
+
+import brave.propagation.B3SingleFormat;
+import org.junit.Test;
+
+import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
+
+public class B3SingleFormatClassLoaderTest {
+  @Test public void unloadable_afterBasicUsage() {
+    assertRunIsUnloadable(BasicUsage.class, getClass().getClassLoader());
+  }
+
+  static class BasicUsage implements Runnable {
+    @Override public void run() {
+      String expected = "1234567812345678-1234567812345678-1";
+      String written =
+        B3SingleFormat.writeB3SingleFormat(B3SingleFormat.parseB3SingleFormat(expected).context());
+      if (!written.equals(expected)) throw new AssertionError();
+    }
+  }
+}

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -207,7 +207,7 @@ public final class B3SingleFormat {
           case FIELD_SPAN_ID:
             spanId = buffer;
 
-            // The handle malformed cases like below, it is easier to assume the next field is
+            // To handle malformed cases like below, it is easier to assume the next field is
             // sampled and revert if later not vs peek to determine if it is sampled or parent ID.
             // 'traceId-spanId--parentSpanId'
             // 'traceId-spanId-'

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -222,11 +222,13 @@ public final class B3SingleFormat {
           // 'traceId-spanId-'
           currentField = Field.SAMPLED;
         } else if (currentField.equals(Field.SAMPLED)) {
-          SamplingFlags samplingFlags = tryParseSamplingFlags(value.charAt(pos -1));
+          SamplingFlags samplingFlags = tryParseSamplingFlags(value.charAt(pos - 1));
           if (samplingFlags == null) return null;
           flags = samplingFlags.flags;
 
           currentField = Field.PARENT_SPAN_ID;
+          currentFieldLength = 0;
+          continue;
         } else {
           parentId = buffer;
 

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -257,9 +257,6 @@ public final class B3SingleFormat {
         lastFieldPos = pos;
       }
 
-      // Special case long runs of zeros. This can happen a 128-bit trace ID is left padded
-      if (c == '0' && buffer == 0L) continue;
-
       // The rest of this is normal lower-hex decoding
       buffer <<= 4;
       switch (c) {

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -227,9 +227,8 @@ public final class B3SingleFormat {
           flags = samplingFlags.flags;
 
           currentField = Field.PARENT_SPAN_ID;
-          currentFieldLength = 0;
-          continue;
         } else {
+          assert currentField == Field.PARENT_SPAN_ID;
           parentId = buffer;
 
           if (!isEof) {
@@ -241,7 +240,11 @@ public final class B3SingleFormat {
         buffer = 0L;
         currentFieldLength = 0;
         continue;
-      } else if (currentField == Field.TRACE_ID && beginIndex + 16 == pos) {
+      }
+
+      // Not a hyphen
+
+      if (currentField == Field.TRACE_ID && beginIndex + 16 == pos) {
         // special casing the only valid non-hyphen at position 16
         // we don't guard against all zeros as traceIdHigh can be all zeros for 128-bit
         traceIdHigh = buffer;

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -216,8 +216,6 @@ public final class B3SingleFormat {
         } else if (currentField.equals(Field.SPAN_ID)) {
           spanId = buffer;
 
-          if (isEof) break; // fields after span ID are optional
-
           // The handle malformed cases like below, it is easier to assume the next field is sampled
           // and revert if definitely not vs try to determine if it is definitely sampled.
           // 'traceId-spanId--parentSpanId'
@@ -237,8 +235,6 @@ public final class B3SingleFormat {
             return null;
           }
         }
-
-        if (isEof) break;
 
         buffer = 0L;
         currentFieldLength = 0;

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -186,7 +186,7 @@ public final class B3SingleFormat {
     long buffer = 0L;
 
     // Instead of pos < endIndex, this uses pos <= endIndex to keep field processing consolidated.
-    // Otherwise, we'd have to process again when outside the loop.
+    // Otherwise, we'd have to process again when outside the loop to handle dangling data on EOF.
     for (int pos = beginIndex; pos <= endIndex; pos++) {
       // treat EOF same as a hyphen for simplicity
       boolean isEof = pos == endIndex;

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -18,11 +18,7 @@ import brave.internal.Platform;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
-import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 import static brave.internal.HexCodec.writeHexLong;
-import static brave.internal.InternalPropagation.FLAG_DEBUG;
-import static brave.internal.InternalPropagation.FLAG_SAMPLED;
-import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 
 /**
  * This format corresponds to the propagation key "b3" (or "B3"), which delimits fields in the
@@ -56,6 +52,23 @@ import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
  */
 public final class B3SingleFormat {
   static final int FORMAT_MAX_LENGTH = 32 + 1 + 16 + 3 + 16; // traceid128-spanid-1-parentid
+
+  enum Field {
+    TRACE_ID("trace ID", 16, true),
+    SPAN_ID("span ID", 16, true),
+    SAMPLED("sampled", 1, false),
+    PARENT_SPAN_ID("parent ID", 16, false);
+
+    final String name;
+    final int length;
+    final boolean required;
+
+    Field(String name, int length, boolean required) {
+      this.name = name;
+      this.length = length;
+      this.required = required;
+    }
+  }
 
   /**
    * Writes all B3 defined fields in the trace context, except {@link TraceContext#parentIdAsLong()
@@ -158,79 +171,100 @@ public final class B3SingleFormat {
       Platform.get().log("Invalid input: empty", null);
       return null;
     } else if (length == 1) { // possibly sampling flags
-      return tryParseSamplingFlags(value.charAt(beginIndex));
+      SamplingFlags flags = tryParseSamplingFlags(value.charAt(beginIndex));
+      return flags != null ? TraceContextOrSamplingFlags.create(flags) : null;
     } else if (length > FORMAT_MAX_LENGTH) {
       Platform.get().log("Invalid input: too long", null);
       return null;
     }
 
-    // This initial scan helps simplify other parsing logic by constraining the amount of characters
-    // they need to consider, and if there are not enough or too many fields.
-    int hyphenCount = 0;
-    int indexOfFirstHyphen = -1;
-    for (int i = beginIndex; i < endIndex; i++) {
-      char c = value.charAt(i);
+    long traceIdHigh = 0L, traceId = 0L, spanId = 0L, parentId = 0L;
+    int flags = 0;
+
+    Field currentField = Field.TRACE_ID;
+    int currentFieldLength = 0;
+    long buffer = 0L;
+
+    // Instead of pos < endIndex, this uses pos <= endIndex to keep field processing consolidated.
+    // Otherwise, we'd have to process again when outside the loop.
+    for (int pos = beginIndex; pos <= endIndex; pos++) {
+      // treat EOF same as a hyphen for simplicity
+      boolean isEof = pos == endIndex;
+      char c = isEof ? '-' : value.charAt(pos);
+
       if (c == '-') {
-        if (indexOfFirstHyphen == -1) {
-          indexOfFirstHyphen = i;
+        if (currentField == Field.SAMPLED) {
+          // The last field could be sampled or parent ID. Revise assumption if longer than 1 char.
+          if (isEof && currentFieldLength > 1) {
+            currentField = Field.PARENT_SPAN_ID;
+          }
         }
-        hyphenCount++;
-      } else if ((c < '0' || c > '9') && (c < 'a' || c > 'f')) {
+
+        if (!validateFieldLength(currentField, currentFieldLength)) {
+          return null;
+        }
+
+        if (currentField.required && buffer == 0L) {
+          Platform.get().log("Invalid input: read all zeroes {0}", currentField.name, null);
+          return null;
+        }
+
+        if (currentField.equals(Field.TRACE_ID)) {
+          traceId = buffer;
+
+          currentField = Field.SPAN_ID;
+        } else if (currentField.equals(Field.SPAN_ID)) {
+          spanId = buffer;
+
+          if (isEof) break; // fields after span ID are optional
+
+          // The handle malformed cases like below, it is easier to assume the next field is sampled
+          // and revert if definitely not vs try to determine if it is definitely sampled.
+          // 'traceId-spanId--parentSpanId'
+          // 'traceId-spanId-'
+          currentField = Field.SAMPLED;
+        } else if (currentField.equals(Field.SAMPLED)) {
+          SamplingFlags samplingFlags = tryParseSamplingFlags(value.charAt(pos -1));
+          if (samplingFlags == null) return null;
+          flags = samplingFlags.flags;
+
+          currentField = Field.PARENT_SPAN_ID;
+        } else {
+          parentId = buffer;
+
+          if (!isEof) {
+            Platform.get().log("Invalid input: more than 4 fields exist", null);
+            return null;
+          }
+        }
+
+        if (isEof) break;
+
+        buffer = 0L;
+        currentFieldLength = 0;
+        continue;
+      } else if (currentField == Field.TRACE_ID && beginIndex + 16 == pos) {
+        // special casing the only valid non-hyphen at position 16
+        // we don't guard against all zeros as traceIdHigh can be all zeros for 128-bit
+        traceIdHigh = buffer;
+
+        // This character is the next hex. If it isn't, the next iteration will throw. Either way,
+        // reset so that we can capture the next 16 characters of the trace ID.
+        buffer = 0;
+        currentFieldLength = 0;
+      }
+
+      // The rest of this is normal lower-hex decoding
+      buffer <<= 4;
+      if (c >= '0' && c <= '9') {
+        buffer |= c - '0';
+      } else if (c >= 'a' && c <= 'f') {
+        buffer |= c - 'a' + 10;
+      } else {
         Platform.get().log("Invalid input: only valid characters are lower-hex and hyphen", null);
         return null;
       }
-    }
-
-    if (indexOfFirstHyphen == -1) {
-      Platform.get().log("Truncated reading trace ID", null);
-      return null;
-    } else if (hyphenCount > 3) {
-      Platform.get().log("Invalid input: more than 4 fields exist", null);
-      return null;
-    }
-
-    int pos = beginIndex;
-
-    long traceIdHigh, traceId;
-    int traceIdLength = indexOfFirstHyphen - beginIndex;
-    if (traceIdLength == 32) {
-      traceIdHigh = lenientLowerHexToUnsignedLong(value, pos, pos + 16);
-      pos += 16; // upper 64 bits of the trace ID
-    } else if (traceIdLength == 16) {
-      traceIdHigh = 0L;
-    } else {
-      Platform.get().log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
-      return null;
-    }
-
-    traceId = tryParseHex("trace ID", value, pos, endIndex);
-    if (traceId == 0) return null;
-    pos += 17; // lower 64 bits of the trace ID and the hyphen
-
-    long spanId = tryParseHex("span ID", value, pos, endIndex);
-    if (spanId == 0) return null;
-    pos += 16; // spanid
-
-    int flags = 0;
-    long parentId = 0L;
-    if (hyphenCount > 1) { // traceid-spanid-
-      pos++; // consume the hyphen
-
-      if (hyphenCount == 3) { // we should parse sampled AND parent ID
-        flags = tryParseSampledFlags(value, endIndex, pos);
-        if (flags == 0) return null;
-        pos += 2; // consume the sampled flag and hyphen
-        parentId = tryParseParentId(value, endIndex, pos);
-        if (parentId == 0L) return null;
-      } else { // we should parse sampled OR parent ID
-        if (endIndex - pos <= 1) {
-          flags = tryParseSampledFlags(value, endIndex, pos);
-          if (flags == 0) return null;
-        } else {
-          parentId = tryParseParentId(value, endIndex, pos);
-          if (parentId == 0L) return null;
-        }
-      }
+      currentFieldLength++;
     }
 
     return TraceContextOrSamplingFlags.create(new TraceContext(
@@ -244,62 +278,32 @@ public final class B3SingleFormat {
     ));
   }
 
-  static int tryParseSampledFlags(CharSequence value, int endIndex, int pos) {
-    if (!validateFieldLength("sampled", 1, value, pos, endIndex)) return 0;
-    return parseSampledFlags(value.charAt(pos));
+  @Nullable static SamplingFlags tryParseSamplingFlags(char sampledChar) {
+    switch (sampledChar) {
+      case '1':
+        return SamplingFlags.SAMPLED;
+      case '0':
+        return SamplingFlags.NOT_SAMPLED;
+      case 'd':
+        return SamplingFlags.DEBUG;
+      default:
+        Platform.get().log("Invalid input: expected 0, 1 or d for sampled", null);
+        return null;
+    }
   }
 
-  static long tryParseParentId(CharSequence value, int endIndex, int pos) {
-    return tryParseHex("parent ID", value, pos, endIndex);
-  }
-
-  /** Returns zero if truncated, malformed, or too big after logging */
-  static long tryParseHex(String name, CharSequence value, int beginIndex, int endIndex) {
-    if (!validateFieldLength(name, 16, value, beginIndex, endIndex)) return 0L;
-
-    long id = lenientLowerHexToUnsignedLong(value, beginIndex, beginIndex + 16);
-    if (id != 0L) return id;
-
-    // If we got here, we either read 16 zeroes or a mix of hyphens and hex.
-    Platform.get().log("Invalid input: expected a lower hex {0}", name, null);
-    return 0L;
-  }
-
-  static boolean validateFieldLength(String name, int length, CharSequence value, int beginIndex,
-    int endIndex) {
-    int endOfId = beginIndex + length;
-    if (beginIndex == endIndex || value.charAt(beginIndex) == '-') {
-      Platform.get().log("Invalid input: empty {0}", name, null);
+  static boolean validateFieldLength(Field field, int length) {
+    if (length == 0) {
+      Platform.get().log("Invalid input: empty {0}", field.name, null);
       return false;
-    } else if (endIndex < endOfId) {
-      Platform.get().log("Truncated reading {0}", name, null);
+    } else if (length < field.length) {
+      Platform.get().log("Invalid input: {0} is too short", field.name, null);
       return false;
-    } else if (endIndex > endOfId && value.charAt(endOfId) != '-') {
-      Platform.get().log("Invalid input: {0} is too long", name, null);
+    } else if (length > field.length) {
+      Platform.get().log("Invalid input: {0} is too long", field.name, null);
       return false;
     }
     return true;
-  }
-
-  static TraceContextOrSamplingFlags tryParseSamplingFlags(char sampledChar) {
-    int flags = parseSampledFlags(sampledChar);
-    if (flags == 0) return null;
-    return TraceContextOrSamplingFlags.create(SamplingFlags.toSamplingFlags(flags));
-  }
-
-  static int parseSampledFlags(char sampledChar) {
-    int flags;
-    if (sampledChar == 'd') {
-      flags = FLAG_SAMPLED_SET | FLAG_SAMPLED | FLAG_DEBUG;
-    } else if (sampledChar == '1') {
-      flags = FLAG_SAMPLED_SET | FLAG_SAMPLED;
-    } else if (sampledChar == '0') {
-      flags = FLAG_SAMPLED_SET;
-    } else {
-      Platform.get().log("Invalid input: expected 0, 1 or d for sampled", null);
-      flags = 0;
-    }
-    return flags;
   }
 
   static byte[] asciiToNewByteArray(char[] buffer, int length) {

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -275,7 +275,7 @@ public class B3SingleFormatTest {
   }
 
   @Test public void parseB3SingleFormat_malformed_notAscii() {
-    assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-💩"))
+    assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15) + "💩"))
       .isNull(); // instead of crashing
 
     verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
@@ -285,7 +285,7 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat("b970dafd-0d95-40aa-95d8-1d8725aebe40"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: more than 4 fields exist", null);
+    verify(platform).log("Invalid input: {0} is too short", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_malformed_hyphenForSampled() {
@@ -319,7 +319,7 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat("-234567812345678-" + spanId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
+    verify(platform).log("Invalid input: empty {0}", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_empty_spanId() {
@@ -362,42 +362,42 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat("1-" + spanId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
+    verify(platform).log("Invalid input: {0} is too short", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_traceId128() {
     assertThat(parseB3SingleFormat(traceIdHigh.substring(0, 15) + traceId + "-" + spanId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
+    verify(platform).log("Invalid input: {0} is too short", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_spanId() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15)))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated reading {0}", "span ID", null);
+    verify(platform).log("Invalid input: {0} is too short", "span ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_parentId() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId.substring(0, 15)))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated reading {0}", "parent ID", null);
+    verify(platform).log("Invalid input: {0} is too short", "parent ID", null);
   }
 
   @Test public void parseB3SingleFormat_truncated_parentId_after_sampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-1-" + parentId.substring(0, 15)))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Truncated reading {0}", "parent ID", null);
+    verify(platform).log("Invalid input: {0} is too short", "parent ID", null);
   }
 
   @Test public void parseB3SingleFormat_traceIdTooLong() {
     assertThat(parseB3SingleFormat(traceId + traceId + "a" + "-" + spanId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: expected a 16 or 32 lower hex trace ID", null);
+    verify(platform).log("Invalid input: {0} is too long", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_spanIdTooLong() {

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -230,7 +230,8 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat(input, 10, 12))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
+    verify(platform)
+      .log("Invalid input: only valid characters are lower-hex for {0}", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_spanIdsNotYetSampled() {
@@ -325,14 +326,16 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat("not-a-tumor"))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
+    verify(platform)
+      .log("Invalid input: only valid characters are lower-hex for {0}", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_malformed_notAscii() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId.substring(0, 15) + "💩"))
       .isNull(); // instead of crashing
 
-    verify(platform).log("Invalid input: only valid characters are lower-hex and hyphen", null);
+    verify(platform)
+      .log("Invalid input: only valid characters are lower-hex for {0}", "span ID", null);
   }
 
   @Test public void parseB3SingleFormat_malformed_uuid() {
@@ -345,7 +348,7 @@ public class B3SingleFormatTest {
   @Test public void parseB3SingleFormat_malformed_hyphenForSampled() {
     assertThat(parseB3SingleFormat("-")).isNull();
 
-    verify(platform).log("Invalid input: expected 0, 1 or d for sampled", null);
+    verify(platform).log("Invalid input: expected 0, 1 or d for {0}", "sampled", null);
   }
 
   @Test public void parseB3SingleFormat_zero_traceId() {
@@ -353,7 +356,7 @@ public class B3SingleFormatTest {
       parseB3SingleFormat("0000000000000000-" + spanId + "-1-" + parentId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: read all zeroes {0}", "trace ID", null);
+    verify(platform).log("Invalid input: read all zeros {0}", "trace ID", null);
   }
 
   @Test public void parseB3SingleFormat_zero_spanId() {
@@ -361,7 +364,7 @@ public class B3SingleFormatTest {
       parseB3SingleFormat(traceId + "-0000000000000000-1-" + parentId))
       .isNull(); // instead of raising exception
 
-    verify(platform).log("Invalid input: read all zeroes {0}", "span ID", null);
+    verify(platform).log("Invalid input: read all zeros {0}", "span ID", null);
   }
 
   /** Serializing parent ID as zero is the same as none. */
@@ -384,7 +387,7 @@ public class B3SingleFormatTest {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-f"))
       .isNull(); // instead of crashing
 
-    verify(platform).log("Invalid input: expected 0, 1 or d for sampled", null);
+    verify(platform).log("Invalid input: expected 0, 1 or d for {0}", "sampled", null);
   }
 
   @Test public void parseB3SingleFormat_empty() {

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -40,10 +40,10 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PowerMockIgnore({"org.apache.logging.*", "javax.script.*"})
 @PrepareForTest({Platform.class, B3SingleFormat.class})
 public class B3SingleFormatTest {
-  String traceIdHigh = "0000000000000009";
-  String traceId = "0000000000000001";
-  String parentId = "0000000000000002";
-  String spanId = "0000000000000003";
+  String traceIdHigh = "1234567890123459";
+  String traceId = "1234567890123451";
+  String parentId = "1234567890123452";
+  String spanId = "1234567890123453";
 
   Platform platform = mock(Platform.class);
 
@@ -58,7 +58,9 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_notYetSampled() {
-    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16)).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceId + "-" + spanId)
@@ -66,7 +68,10 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_notYetSampled_128() {
-    TraceContext context = TraceContext.newBuilder().traceIdHigh(9).traceId(1).spanId(3).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16)).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceIdHigh + traceId + "-" + spanId)
@@ -74,7 +79,10 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_unsampled() {
-    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(false).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceId + "-" + spanId + "-0")
@@ -82,7 +90,10 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_sampled() {
-    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).sampled(true).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceId + "-" + spanId + "-1")
@@ -90,7 +101,10 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_debug() {
-    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).debug(true).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .debug(true).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceId + "-" + spanId + "-d")
@@ -98,8 +112,11 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_parent() {
-    TraceContext context =
-      TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(true).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceId + "-" + spanId + "-1-" + parentId)
@@ -107,14 +124,12 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormat_largest() {
-    TraceContext context =
-      TraceContext.newBuilder()
-        .traceIdHigh(9)
-        .traceId(1)
-        .parentId(2)
-        .spanId(3)
-        .sampled(true)
-        .build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build();
 
     assertThat(writeB3SingleFormat(context))
       .isEqualTo(traceIdHigh + traceId + "-" + spanId + "-1-" + parentId)
@@ -126,17 +141,18 @@ public class B3SingleFormatTest {
       parseB3SingleFormat(traceIdHigh + traceId + "-" + spanId + "-1-" + parentId)
     ).extracting(TraceContextOrSamplingFlags::context).isEqualToComparingFieldByField(
       TraceContext.newBuilder()
-        .traceIdHigh(9)
-        .traceId(1)
-        .parentId(2)
-        .spanId(3)
-        .sampled(true)
-        .build()
+        .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .parentId(Long.parseUnsignedLong(parentId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16))
+        .sampled(true).build()
     );
   }
 
   @Test public void writeB3SingleFormatWithoutParent_notYetSampled() {
-    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(3).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16)).build();
 
     assertThat(writeB3SingleFormatWithoutParentId(context))
       .isEqualTo(traceId + "-" + spanId)
@@ -144,8 +160,11 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormatWithoutParent_unsampled() {
-    TraceContext context =
-      TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(false).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(false).build();
 
     assertThat(writeB3SingleFormatWithoutParentId(context))
       .isEqualTo(traceId + "-" + spanId + "-0")
@@ -153,8 +172,11 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormatWithoutParent_sampled() {
-    TraceContext context =
-      TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(true).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build();
 
     assertThat(writeB3SingleFormatWithoutParentId(context))
       .isEqualTo(traceId + "-" + spanId + "-1")
@@ -162,8 +184,11 @@ public class B3SingleFormatTest {
   }
 
   @Test public void writeB3SingleFormatWithoutParent_debug() {
-    TraceContext context =
-      TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).debug(true).build();
+    TraceContext context = TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .debug(true).build();
 
     assertThat(writeB3SingleFormatWithoutParentId(context))
       .isEqualTo(traceId + "-" + spanId + "-d")
@@ -172,10 +197,12 @@ public class B3SingleFormatTest {
 
   /** for example, parsing a w3c context */
   @Test public void parseB3SingleFormat_middleOfString() {
-    String input = "b3=" + traceId + traceId + "-" + spanId + ",";
+    String input = "b3=" + traceIdHigh + traceId + "-" + spanId + ",";
     assertThat(parseB3SingleFormat(input, 3, input.length() - 1).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceIdHigh(1).traceId(1).spanId(3).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16)).build()
       );
   }
 
@@ -196,51 +223,66 @@ public class B3SingleFormatTest {
 
   @Test public void parseB3SingleFormat_spanIdsNotYetSampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).spanId(3).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16)).build()
       );
   }
 
   @Test public void parseB3SingleFormat_spanIdsNotYetSampled128() {
-    assertThat(parseB3SingleFormat(traceId + traceId + "-" + spanId).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceIdHigh(1).traceId(1).spanId(3).build()
+    assertThat(parseB3SingleFormat(traceIdHigh + traceId + "-" + spanId).context())
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16)).build()
       );
   }
 
   @Test public void parseB3SingleFormat_spanIdsUnsampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0").context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).spanId(3).sampled(false).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16))
+        .sampled(false).build()
       );
   }
 
   @Test public void parseB3SingleFormat_parent_unsampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-0-" + parentId).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).sampled(false).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .parentId(Long.parseUnsignedLong(parentId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16))
+        .sampled(false).build()
       );
   }
 
   @Test public void parseB3SingleFormat_parent_debug() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-d-" + parentId).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).debug(true).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .parentId(Long.parseUnsignedLong(parentId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16))
+        .debug(true).build()
       );
   }
 
   // odd but possible to not yet sample a child
   @Test public void parseB3SingleFormat_parentid_notYetSampled() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-" + parentId).context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).parentId(2).spanId(3).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .parentId(Long.parseUnsignedLong(parentId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16)).build()
       );
   }
 
   @Test public void parseB3SingleFormat_spanIdsWithDebug() {
     assertThat(parseB3SingleFormat(traceId + "-" + spanId + "-d").context())
-      .isEqualToComparingFieldByField(
-        TraceContext.newBuilder().traceId(1).spanId(3).debug(true).build()
+      .isEqualToComparingFieldByField(TraceContext.newBuilder()
+        .traceId(Long.parseUnsignedLong(traceId, 16))
+        .spanId(Long.parseUnsignedLong(spanId, 16))
+        .debug(true).build()
       );
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
@@ -49,9 +49,21 @@ public class B3SinglePropagationBenchmarks {
     .sampled(true)
     .build();
 
-  static final Map<String, String> incoming = new LinkedHashMap<String, String>() {
+  static final Map<String, String> incoming128 = new LinkedHashMap<String, String>() {
     {
-      b3Injector.inject(context, this);
+      put("b3", "67891233abcdef012345678912345678-463ac35c9f6413ad-1");
+    }
+  };
+
+  static final Map<String, String> incoming64 = new LinkedHashMap<String, String>() {
+    {
+      put("b3", "2345678912345678-463ac35c9f6413ad-1");
+    }
+  };
+
+  static final Map<String, String> incomingPadded = new LinkedHashMap<String, String>() {
+    {
+      put("b3", "00000000000000002345678912345678-463ac35c9f6413ad-1");
     }
   };
 
@@ -74,8 +86,16 @@ public class B3SinglePropagationBenchmarks {
     b3Injector.inject(context, carrier);
   }
 
-  @Benchmark public TraceContextOrSamplingFlags extract() {
-    return b3Extractor.extract(incoming);
+  @Benchmark public TraceContextOrSamplingFlags extract_128() {
+    return b3Extractor.extract(incoming128);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_64() {
+    return b3Extractor.extract(incoming64);
+  }
+
+  @Benchmark public TraceContextOrSamplingFlags extract_padded() {
+    return b3Extractor.extract(incomingPadded);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract_nothing() {


### PR DESCRIPTION
This consolidates logic and removes duplication via the following:
* it is odd that parent ID is sent without sampled flag, assume it isn't
* exploit being in the same package as `SamplingFlags`

Note: the performance isn't better, it is just less code.