### PR TITLE
Fixes accidental parse fail when trace ID is padded right

### DIFF
--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -267,8 +267,8 @@ public final class B3SingleFormat {
     }
 
     // Since we are using a hidden constructor, we need to validate here.
-    if (traceId == 0L || spanId == 0L) {
-      int field = traceId == 0L ? FIELD_TRACE_ID : FIELD_SPAN_ID;
+    if ((traceIdHigh == 0L && traceId == 0L) || spanId == 0L) {
+      int field = spanId == 0L ? FIELD_SPAN_ID : FIELD_TRACE_ID;
       log(field, "Invalid input: read all zeros {0}");
       return null;
     }

--- a/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
+++ b/brave/src/test/java/brave/propagation/B3SingleFormatTest.java
@@ -138,26 +138,35 @@ public class B3SingleFormatTest {
 
   @Test public void parseB3SingleFormat_largest() {
     assertThat(
-      parseB3SingleFormat(traceIdHigh + traceId + "-" + spanId + "-1-" + parentId)
-    ).extracting(TraceContextOrSamplingFlags::context).isEqualToComparingFieldByField(
-      TraceContext.newBuilder()
-        .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
-        .traceId(Long.parseUnsignedLong(traceId, 16))
-        .parentId(Long.parseUnsignedLong(parentId, 16))
-        .spanId(Long.parseUnsignedLong(spanId, 16))
-        .sampled(true).build()
+      parseB3SingleFormat(traceIdHigh + traceId + "-" + spanId + "-1-" + parentId).context()
+    ).isEqualToComparingFieldByField(TraceContext.newBuilder()
+      .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build()
     );
   }
 
   @Test public void parseB3SingleFormat_padded() {
     assertThat(
-      parseB3SingleFormat("0000000000000000" + traceId + "-" + spanId + "-1-" + parentId)
-    ).extracting(TraceContextOrSamplingFlags::context).isEqualToComparingFieldByField(
-      TraceContext.newBuilder()
-        .traceId(Long.parseUnsignedLong(traceId, 16))
-        .parentId(Long.parseUnsignedLong(parentId, 16))
-        .spanId(Long.parseUnsignedLong(spanId, 16))
-        .sampled(true).build()
+      parseB3SingleFormat("0000000000000000" + traceId + "-" + spanId + "-1-" + parentId).context()
+    ).isEqualToComparingFieldByField(TraceContext.newBuilder()
+      .traceId(Long.parseUnsignedLong(traceId, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build()
+    );
+  }
+
+  @Test public void parseTraceparentFormat_padded_right() {
+    assertThat(
+      parseB3SingleFormat(traceIdHigh + "0000000000000000-" + spanId + "-1-" + parentId).context()
+    ).isEqualToComparingFieldByField(TraceContext.newBuilder()
+      .traceIdHigh(Long.parseUnsignedLong(traceIdHigh, 16))
+      .parentId(Long.parseUnsignedLong(parentId, 16))
+      .spanId(Long.parseUnsignedLong(spanId, 16))
+      .sampled(true).build()
     );
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Padding the right side of the trace ID with zeros is bad practice, but
it should be permitted. This changes the code and tests to ensure we
don't accidentally fail.