### PR TITLE
Hardens HTTP integration tests to catch more bugs easier

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -23,11 +23,11 @@ import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
@@ -195,9 +195,11 @@ public abstract class ITHttp {
     // Intentionally pull both spans first to ensure neither are errors.
     Span span1 = takeSpan(), span2 = takeSpan();
 
-    Stream.of(span1, span2).forEach(span -> assertThat(span.kind())
-      .withFailMessage("Expected %s to have kind=%s or %s", span, kind1, kind2)
-      .isIn(kind1, kind2));
+    for (Span span : Arrays.asList(span1, span2)) {
+      assertThat(span.kind())
+        .withFailMessage("Expected %s to have kind=%s or %s", span, kind1, kind2)
+        .isIn(kind1, kind2);
+    }
 
     // Now, check the kinds are different
     if (Objects.equals(span1.kind(), span2.kind())) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -216,7 +216,7 @@ public abstract class ITHttp {
 
     // First, check if the order is backwards
     if (Objects.equals(span2.kind(), kind1) && Objects.equals(span1.kind(), kind2)) {
-      throw new AssertionError("Expected span " + span1 + " to report before span " + span2);
+      throw new AssertionError("Expected span " + span2 + " to report before span " + span1);
     }
 
     // Now, check each span

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -123,7 +123,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
       .isInstanceOf(TraceContext.class)
       .isSameAs(parent.context());
 
-    assertSpansReportedInKindOrder(null, Span.Kind.CLIENT);
+    assertSpansReportedKindInAnyOrder(null, Span.Kind.CLIENT);
   }
 
   /** This ensures that response callbacks run when there is no invocation trace context. */

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -26,6 +26,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 import zipkin2.Callback;
+import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -115,7 +116,6 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
     } finally {
       parent.finish();
     }
-    takeLocalSpan();
 
     takeRequest();
 
@@ -123,7 +123,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
       .isInstanceOf(TraceContext.class)
       .isSameAs(parent.context());
 
-    takeClientSpan();
+    assertSpansReportedInKindOrder(null, Span.Kind.CLIENT);
   }
 
   /** This ensures that response callbacks run when there is no invocation trace context. */

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -101,7 +101,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
     assertThat(request.getHeader("x-b3-parentspanid"))
       .isEqualTo(parent.context().spanIdString());
 
-    assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
+    assertSpansReportedKindInAnyOrder(null, Span.Kind.CLIENT);
   }
 
   /** This prevents confusion as a blocking client should end before, the start of the next span. */
@@ -116,7 +116,8 @@ public abstract class ITHttpClient<C> extends ITHttp {
       parent.finish();
     }
 
-    Span[] reportedSpans = assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
+    // We expect the last to report to be the parent
+    Span[] reportedSpans = assertSpansReportedKindInOrder(Span.Kind.CLIENT, null);
     assertChildEnclosedByParent(reportedSpans[0], reportedSpans[1]);
   }
 
@@ -135,7 +136,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
     assertThat(takeRequest().getHeader(EXTRA_KEY))
       .isEqualTo("joey");
 
-    assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
+    assertSpansReportedKindInAnyOrder(null, Span.Kind.CLIENT);
   }
 
   @Test public void propagatesExtra_unsampledTrace() throws Exception {
@@ -442,7 +443,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
   void assertClientSpan(Span span) {
     assertThat(span.kind())
-      .withFailMessage("Expected span %s to have kind=CLIENT", span)
+      .withFailMessage("Expected %s to have kind=CLIENT", span)
       .isEqualTo(Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -13,9 +13,7 @@
  */
 package brave.test.http;
 
-import brave.ScopedSpan;
 import brave.SpanCustomizer;
-import brave.Tracer;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.http.HttpAdapter;
@@ -40,7 +38,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.http.HttpHeaders;
-import okhttp3.mockwebserver.MockResponse;
 import okio.Buffer;
 import org.eclipse.jetty.util.log.Log;
 import org.junit.AssumptionViolatedException;
@@ -180,17 +177,8 @@ public abstract class ITHttpServer extends ITHttp {
   public void createsChildSpan() throws Exception {
     get("/child");
 
-    Span[] reportedSpans = assertSpansReportedInKindOrder(null, Span.Kind.SERVER);
-    Span child = reportedSpans[0], server = reportedSpans[1];
-
-    assertThat(server.traceId()).isEqualTo(child.traceId());
-    assertThat(server.id()).isEqualTo(child.parentId());
-  }
-
-  @Test public void handlerTimestampAndDurationEnclosedByServer() throws Exception {
-    get("/child");
-
-    Span[] reportedSpans = assertSpansReportedInKindOrder(null, Span.Kind.SERVER);
+    // We expect the last to report to be the parent
+    Span[] reportedSpans = assertSpansReportedKindInOrder(null, Span.Kind.SERVER);
     assertChildEnclosedByParent(reportedSpans[0], reportedSpans[1]);
   }
 
@@ -569,7 +557,7 @@ public abstract class ITHttpServer extends ITHttp {
 
   void assertServerSpan(Span span) {
     assertThat(span.kind())
-      .withFailMessage("Expected span %s to have kind=SERVER", span)
+      .withFailMessage("Expected %s to have kind=SERVER", span)
       .isEqualTo(Span.Kind.SERVER);
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -13,7 +13,9 @@
  */
 package brave.test.http;
 
+import brave.ScopedSpan;
 import brave.SpanCustomizer;
+import brave.Tracer;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.http.HttpAdapter;
@@ -38,6 +40,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.http.HttpHeaders;
+import okhttp3.mockwebserver.MockResponse;
 import okio.Buffer;
 import org.eclipse.jetty.util.log.Log;
 import org.junit.AssumptionViolatedException;
@@ -78,7 +81,7 @@ public abstract class ITHttpServer extends ITHttp {
       .header("X-B3-Sampled", "1")
       .build());
 
-    Span span = takeSpan();
+    Span span = takeServerSpan();
     assertThat(span.traceId()).isEqualTo(traceId);
     assertThat(span.parentId()).isEqualTo(parentId);
     assertThat(span.id()).isEqualTo(spanId);
@@ -88,7 +91,7 @@ public abstract class ITHttpServer extends ITHttp {
   public void readsExtra_newTrace() throws Exception {
     readsExtra(new Request.Builder());
 
-    takeSpan();
+    takeServerSpan();
   }
 
   @Test
@@ -107,7 +110,7 @@ public abstract class ITHttpServer extends ITHttp {
       .header("X-B3-TraceId", traceId)
       .header("X-B3-SpanId", traceId));
 
-    Span span = takeSpan();
+    Span span = takeServerSpan();
     assertThat(span.traceId()).isEqualTo(traceId);
     assertThat(span.id()).isEqualTo(traceId);
   }
@@ -164,7 +167,7 @@ public abstract class ITHttpServer extends ITHttp {
     Response response = get("/async");
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    takeSpan();
+    takeServerSpan();
   }
 
   /**
@@ -177,8 +180,8 @@ public abstract class ITHttpServer extends ITHttp {
   public void createsChildSpan() throws Exception {
     get("/child");
 
-    Span child = takeSpan();
-    Span parent = takeSpan();
+    Span child = takeLocalSpan();
+    Span parent = takeServerSpan();
 
     assertThat(parent.traceId()).isEqualTo(child.traceId());
     assertThat(parent.id()).isEqualTo(child.parentId());
@@ -186,12 +189,19 @@ public abstract class ITHttpServer extends ITHttp {
     assertThat(parent.duration()).isGreaterThan(child.duration());
   }
 
+  @Test public void handlerTimestampAndDurationEnclosedByServer() throws Exception {
+    get("/child");
+
+    // takeLocalSpan() enforces there is no span kind. If this fails, it is likely we have an
+    // instrumentation bug as the most likely cause is the server finished prior to its child.
+    assertChildEnclosedByParent(takeLocalSpan(), takeServerSpan());
+  }
+
   @Test
   public void reportsClientAddress() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.remoteEndpoint())
+    assertThat(takeServerSpan().remoteEndpoint())
       .isNotNull();
   }
 
@@ -201,8 +211,7 @@ public abstract class ITHttpServer extends ITHttp {
       .header("X-Forwarded-For", "1.2.3.4")
       .build());
 
-    Span span = takeSpan();
-    assertThat(span.remoteEndpoint())
+    assertThat(takeServerSpan().remoteEndpoint())
       .extracting(Endpoint::ipv4)
       .isEqualTo("1.2.3.4");
   }
@@ -211,16 +220,14 @@ public abstract class ITHttpServer extends ITHttp {
   public void reportsServerKindToZipkin() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.kind())
-      .isEqualTo(Span.Kind.SERVER);
+    takeServerSpan();
   }
 
   @Test
   public void defaultSpanNameIsMethodNameOrRoute() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
+    Span span = takeServerSpan();
     if (!span.name().equals("get")) {
       assertThat(span.name())
         .isEqualTo("get /foo");
@@ -239,7 +246,7 @@ public abstract class ITHttpServer extends ITHttp {
     String uri = "/foo?z=2&yAA=1";
     get(uri);
 
-    assertThat(takeSpan().tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("http.url", url(uri));
   }
 
@@ -261,8 +268,7 @@ public abstract class ITHttpServer extends ITHttp {
     String uri = "/foo?z=2&yAA=1";
     get(uri);
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("http.url", url(uri))
       .containsEntry("request_customizer.is_span", "false")
       .containsEntry("response_customizer.is_span", "false");
@@ -290,8 +296,7 @@ public abstract class ITHttpServer extends ITHttp {
     String uri = "/foo?z=2&yAA=1";
     get(uri);
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("http.url", url(uri))
       .containsEntry("context.visible", "true")
       .containsEntry("request_customizer.is_span", "false")
@@ -349,7 +354,7 @@ public abstract class ITHttpServer extends ITHttp {
     assertThat(request2.body().string())
       .isEqualTo("2");
 
-    Span span1 = takeSpan(), span2 = takeSpan();
+    Span span1 = takeServerSpan(), span2 = takeServerSpan();
 
     // verify that the path and url reflect the initial request (not a route expression)
     assertThat(span1.tags())
@@ -378,18 +383,18 @@ public abstract class ITHttpServer extends ITHttp {
 
   /** If http route is supported, then the span name should include it */
   @Test public void notFound() throws Exception {
+    // we can't use get("/foo/bark") because get(path) throws assumption fail on 404
     assertThat(call("GET", "/foo/bark").code())
       .isEqualTo(404);
 
-    Span span = takeSpan();
+    Span span = takeServerSpanWithError("404");
 
     // verify normal tags
     assertThat(span.tags())
       .hasSize(4)
       .containsEntry("http.method", "GET")
       .containsEntry("http.path", "/foo/bark")
-      .containsEntry("http.status_code", "404")
-      .containsKey("error"); // as 404 is an error
+      .containsEntry("http.status_code", "404");
 
     // Either the span name is the method, or it is a route expression
     String name = span.name();
@@ -406,7 +411,7 @@ public abstract class ITHttpServer extends ITHttp {
     assertThat(call("OPTIONS", "/").isSuccessful())
       .isTrue();
 
-    Span span = takeSpan();
+    Span span = takeServerSpan();
 
     // verify normal tags
     assertThat(span.tags())
@@ -428,9 +433,7 @@ public abstract class ITHttpServer extends ITHttp {
       // some servers think 400 is an error
     }
 
-    Span span = takeSpan();
-    assertThat(span.tags())
-      .containsEntry("http.status_code", "400")
+    assertThat(takeServerSpanWithError("400").tags())
       .containsEntry("error", "400");
   }
 
@@ -438,8 +441,7 @@ public abstract class ITHttpServer extends ITHttp {
   public void httpPathTagExcludesQueryParams() throws Exception {
     get("/foo?z=2&yAA=1");
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("http.path", "/foo");
   }
 
@@ -453,40 +455,31 @@ public abstract class ITHttpServer extends ITHttp {
    */
   @Test
   public void httpStatusCodeTagMatchesResponse_onException() throws Exception {
-    httpStatusCodeTagMatchesResponse_onException("/exception");
+    httpStatusCodeTagMatchesResponse("/exception", ".+");
   }
 
   @Test
   public void httpStatusCodeTagMatchesResponse_onException_async() throws Exception {
-    httpStatusCodeTagMatchesResponse_onException("/exceptionAsync");
+    httpStatusCodeTagMatchesResponse("/exceptionAsync", ".+");
   }
 
-  Span httpStatusCodeTagMatchesResponse_onException(String path) throws Exception {
+  Span httpStatusCodeTagMatchesResponse(String path, String message) throws Exception {
     Response response = get(path);
 
-    Span span = takeSpan();
+    Span span = takeServerSpanWithError(message);
     assertThat(span.tags())
       .containsEntry("http.status_code", String.valueOf(response.code()));
-
     return span;
   }
 
   @Test
   public void errorTag_exceptionOverridesHttpStatus() throws Exception {
-    errorTag_exceptionOverridesHttpStatus("/exception");
+    httpStatusCodeTagMatchesResponse("/exception", ".*not ready");
   }
 
   @Test
   public void errorTag_exceptionOverridesHttpStatus_async() throws Exception {
-    errorTag_exceptionOverridesHttpStatus("/exceptionAsync");
-  }
-
-  void errorTag_exceptionOverridesHttpStatus(String path) throws Exception {
-    get(path);
-
-    Span span = takeSpan();
-    assertThat(span.tags().get("error"))
-      .contains("not ready"); // some controllers format the exception
+    httpStatusCodeTagMatchesResponse("/exceptionAsync", ".*not ready");
   }
 
   @Test
@@ -515,8 +508,7 @@ public abstract class ITHttpServer extends ITHttp {
       .build());
     init();
 
-    get(path);
-    takeSpan();
+    httpStatusCodeTagMatchesResponse(path, ".*not ready");
 
     assertThat(caughtThrowable.get()).isNotNull();
   }
@@ -562,5 +554,25 @@ public abstract class ITHttpServer extends ITHttp {
       }
       return response.newBuilder().body(toReturn).build();
     }
+  }
+
+  /** Call this to block until a server span was reported. The span must not have an "error" tag. */
+  protected Span takeServerSpan() throws InterruptedException {
+    Span result = takeSpan();
+    assertServerSpan(result);
+    return result;
+  }
+
+  /** Like {@link #takeServerSpan()} except an error tag must match the given value. */
+  protected Span takeServerSpanWithError(String errorTag) throws InterruptedException {
+    Span result = takeSpanWithError(errorTag);
+    assertServerSpan(result);
+    return result;
+  }
+
+  void assertServerSpan(Span span) {
+    assertThat(span.kind())
+      .withFailMessage("Expected span %s to have kind=SERVER", span)
+      .isEqualTo(Span.Kind.SERVER);
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -180,21 +180,18 @@ public abstract class ITHttpServer extends ITHttp {
   public void createsChildSpan() throws Exception {
     get("/child");
 
-    Span child = takeLocalSpan();
-    Span parent = takeServerSpan();
+    Span[] reportedSpans = assertSpansReportedInKindOrder(null, Span.Kind.SERVER);
+    Span child = reportedSpans[0], server = reportedSpans[1];
 
-    assertThat(parent.traceId()).isEqualTo(child.traceId());
-    assertThat(parent.id()).isEqualTo(child.parentId());
-    assertThat(parent.timestamp()).isLessThan(child.timestamp());
-    assertThat(parent.duration()).isGreaterThan(child.duration());
+    assertThat(server.traceId()).isEqualTo(child.traceId());
+    assertThat(server.id()).isEqualTo(child.parentId());
   }
 
   @Test public void handlerTimestampAndDurationEnclosedByServer() throws Exception {
     get("/child");
 
-    // takeLocalSpan() enforces there is no span kind. If this fails, it is likely we have an
-    // instrumentation bug as the most likely cause is the server finished prior to its child.
-    assertChildEnclosedByParent(takeLocalSpan(), takeServerSpan());
+    Span[] reportedSpans = assertSpansReportedInKindOrder(null, Span.Kind.SERVER);
+    assertChildEnclosedByParent(reportedSpans[0], reportedSpans[1]);
   }
 
   @Test

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -34,7 +34,6 @@ import okhttp3.Response;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.Test;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -138,7 +137,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
         .isEqualTo("abcdefg");
     }
 
-    takeSpan();
+    takeServerSpan();
   }
 
   // copies the header to the response
@@ -172,7 +171,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
         .isEqualTo("abcdefg");
     }
 
-    takeSpan();
+    takeServerSpan();
   }
 
   // Shows how a framework can layer on "http.route" logic
@@ -200,8 +199,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.name())
+    assertThat(takeServerSpan().name())
       .isEqualTo("get /foo");
   }
 
@@ -229,8 +227,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("foo", "bar");
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ServletContainer.java
@@ -13,9 +13,7 @@
  */
 package brave.test.http;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
 /** Starts a jetty server which runs a servlet container */

--- a/instrumentation/http/src/main/java/brave/http/HttpHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpHandler.java
@@ -14,7 +14,6 @@
 package brave.http;
 
 import brave.Span;
-import brave.SpanCustomizer;
 import brave.internal.Nullable;
 
 abstract class HttpHandler {

--- a/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRuleSampler.java
@@ -19,8 +19,8 @@ import brave.sampler.CountingSampler;
 import brave.sampler.Matcher;
 import brave.sampler.ParameterizedSampler;
 import brave.sampler.RateLimitingSampler;
-import brave.sampler.SamplerFunction;
 import brave.sampler.Sampler;
+import brave.sampler.SamplerFunction;
 
 import static brave.http.HttpRequestMatchers.methodEquals;
 import static brave.http.HttpRequestMatchers.pathStartsWith;

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -17,12 +17,14 @@ import brave.test.http.ITHttpAsyncClient;
 import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.entity.NStringEntity;
@@ -47,7 +49,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
   @Override protected void get(CloseableHttpAsyncClient client, String pathIncludingQuery)
     throws Exception {
     HttpGet get = new HttpGet(URI.create(url(pathIncludingQuery)));
-    EntityUtils.consume(client.execute(get, null).get().getEntity());
+    blockOnFuture(client, get);
   }
 
   @Override
@@ -55,7 +57,13 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
     throws Exception {
     HttpPost post = new HttpPost(URI.create(url(pathIncludingQuery)));
     post.setEntity(new NStringEntity(body));
-    EntityUtils.consume(client.execute(post, null).get().getEntity());
+    blockOnFuture(client, post);
+  }
+
+  static void blockOnFuture(CloseableHttpAsyncClient client, HttpUriRequest req) throws Exception {
+    Future<HttpResponse> future = client.execute(req, null);
+    HttpResponse response = future.get();
+    EntityUtils.consume(response.getEntity());
   }
 
   @Test public void currentSpanVisibleToUserFilters() throws Exception {

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -74,7 +74,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeSpan();
+    takeClientSpan();
   }
 
   @Test public void failedInterceptorRemovesScope() throws Exception {
@@ -90,7 +90,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
 
     assertThat(currentTraceContext.get()).isNull();
 
-    takeSpan();
+    takeClientSpanWithError("Test");
   }
 
   @Override

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package brave.httpclient;
 import okhttp3.mockwebserver.MockResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,10 +41,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
 
     assertThat(server.getRequestCount()).isEqualTo(1);
 
-    Span first = takeSpan();
-    assertThat(first.kind()).isEqualTo(Span.Kind.CLIENT);
-    Span second = takeSpan();
-    assertThat(second.kind()).isNull();
-    assertThat(second.tags()).containsKey("http.cache_hit");
+    takeClientSpan();
+    assertThat(takeLocalSpan().tags()).containsKey("http.cache_hit");
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -42,7 +42,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
 
     assertThat(server.getRequestCount()).isEqualTo(1);
 
-    Span[] reportedSpans = assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
+    Span[] reportedSpans = assertSpansReportedKindInOrder(Span.Kind.CLIENT, null);
     assertThat(reportedSpans[1].tags()).containsKey("http.cache_hit");
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -16,6 +16,7 @@ package brave.httpclient;
 import okhttp3.mockwebserver.MockResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
+import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +42,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
 
     assertThat(server.getRequestCount()).isEqualTo(1);
 
-    takeClientSpan();
-    assertThat(takeLocalSpan().tags()).containsKey("http.cache_hit");
+    Span[] reportedSpans = assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
+    assertThat(reportedSpans[1].tags()).containsKey("http.cache_hit");
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -64,6 +64,6 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeSpan();
+    takeClientSpan();
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -35,7 +35,6 @@ import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.junit.Ignore;
 import org.junit.Test;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,8 +66,7 @@ public class ITSpanCustomizingContainerFilter extends ITServletContainer {
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
@@ -68,10 +68,6 @@ public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
   }
 
   @Override @Ignore("automatic error propagation is impossible")
-  public void reportsSpanOnTransportException() {
-  }
-
-  @Override @Ignore("automatic error propagation is impossible")
   public void errorTag_onTransportException() {
   }
 

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/SpanCustomizingApplicationEventListener.java
@@ -17,6 +17,7 @@ import brave.SpanCustomizer;
 import brave.internal.Nullable;
 import java.util.List;
 import javax.inject.Inject;
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.server.ContainerRequest;
@@ -90,6 +91,10 @@ public class SpanCustomizingApplicationEventListener
     // MappableException can wrap a WebApplicationException!
     if (error instanceof WebApplicationException && error.getCause() != null) {
       error = error.getCause();
+    }
+    // Don't create error messages for normal HTTP status codes.
+    if (error instanceof ClientErrorException && error.getCause() == null){
+      return null;
     }
     return error;
   }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
@@ -42,8 +42,7 @@ public class ITSpanCustomizingApplicationEventListener extends ITServletContaine
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }
@@ -53,7 +52,7 @@ public class ITSpanCustomizingApplicationEventListener extends ITServletContaine
   @Test public void managedAsync() throws Exception {
     get("/managedAsync");
 
-    takeSpan();
+    takeServerSpan();
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -22,7 +22,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,8 +37,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }
@@ -49,7 +47,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
     Response response = get("/managedAsync");
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    takeSpan();
+    takeServerSpan();
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
@@ -16,7 +16,6 @@ package brave.jersey.server;
 import brave.Tracer;
 import brave.http.HttpTracing;
 import brave.propagation.ExtraFieldPropagation;
-import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -95,6 +95,6 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
+    assertSpansReportedKindInAnyOrder(null, Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -17,7 +17,6 @@ import brave.ScopedSpan;
 import brave.Tracer;
 import brave.test.http.ITHttpAsyncClient;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -29,7 +28,6 @@ import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -97,8 +95,7 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
       .isEqualTo(request.getHeader("my-id"));
 
     // we report one in-process and one RPC client span
-    assertThat(Arrays.asList(takeSpan(), takeSpan()))
-      .extracting(Span::kind)
-      .containsOnly(null, Span.Kind.CLIENT);
+    takeClientSpan();
+    takeLocalSpan();
   }
 }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -28,6 +28,7 @@ import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
+import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,8 +95,6 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    // we report one in-process and one RPC client span
-    takeClientSpan();
-    takeLocalSpan();
+    assertSpansReportedInKindOrder(Span.Kind.CLIENT, null);
   }
 }

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -73,16 +74,14 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeSpan();
+    takeClientSpan();
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void redirect() throws Exception { // blind to the implementation of redirects
-    super.redirect();
+  @Override @Ignore("blind to the implementation of redirects")
+  public void redirect() {
   }
 
-  @Override @Test(expected = AssertionError.class)
-  public void reportsServerAddress() throws Exception { // doesn't know the remote address
-    super.reportsServerAddress();
+  @Override @Ignore("doesn't know the remote address")
+  public void reportsServerAddress() {
   }
 }

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
@@ -36,8 +36,7 @@ final class TraceContextListenableFuture<T> implements ListenableFuture<T> {
   final TraceContext invocationContext;
 
   TraceContextListenableFuture(ListenableFuture<T> delegate,
-    CurrentTraceContext currentTraceContext,
-    TraceContext invocationContext) {
+    CurrentTraceContext currentTraceContext, TraceContext invocationContext) {
     this.delegate = delegate;
     this.currentTraceContext = currentTraceContext;
     this.invocationContext = invocationContext;

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -115,4 +115,9 @@ public class ITTracingAsyncClientHttpRequestInterceptor
   @Override @Ignore("doesn't know the remote address")
   public void reportsServerAddress() {
   }
+
+  @Override @Ignore("sometimes the client span last longer than the future")
+  // ignoring flakes as AsyncRestTemplate is deprecated anyway and only impact is inaccurate timing
+  public void clientTimestampAndDurationEnclosedByParent() {
+  }
 }

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -105,7 +105,7 @@ public class ITTracingAsyncClientHttpRequestInterceptor
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeSpan();
+    takeClientSpan();
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -73,7 +73,7 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeSpan();
+    takeClientSpan();
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -96,8 +96,9 @@ public class ITSpanCustomizingHandlerInterceptor extends ITServletContainer {
     }
 
     @RequestMapping(value = "/child")
-    public void child() {
+    public void child(HttpServletResponse response) throws IOException {
       tracer.nextSpan().name("child").start().finish();
+      response.getWriter().write("child");
     }
 
     @RequestMapping(value = "/exception")

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
@@ -40,7 +40,7 @@ public abstract class BaseITSpanCustomizingHandlerInterceptor extends ITServletC
   @Test public void addsControllerTags() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
+    Span span = takeServerSpan();
     assertThat(span.tags())
       .containsKeys("mvc.controller.class", "mvc.controller.method");
     assertThat(span.tags().get("mvc.controller.class"))

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
@@ -29,7 +29,6 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,8 +41,7 @@ public class ITSpanCustomizingAsyncHandlerInterceptor extends ITServletContainer
   @Test public void addsControllerTags() throws Exception {
     get("/foo");
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("mvc.controller.class", "Servlet3TestController")
       .containsEntry("mvc.controller.method", "foo");
   }

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.Response;
 import org.junit.After;
 import org.junit.Test;
-import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -147,8 +146,7 @@ public class ITVertxWebTracing extends ITHttpServer {
     Response response = get(path);
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    Span span = takeSpan();
-    assertThat(span.tags())
+    assertThat(takeServerSpan().tags())
       .containsEntry("http.path", path)
       .containsEntry("http.url", url(path));
   }


### PR DESCRIPTION
It was very hard to detect subtle bugs in reactor until I redid the
tests to force us to be conscious of whether a span error is expected or
if we are expecting a remote or local span. Further, this makes sure
these two most difficult to debug things end up with better assertion
failures, including the entire span json. This is super handy when
tests flake due to timing. For example, using a debugger could actually
slow things to the point they pass!