### PR TITLE
Enforces parent on ITHttpClient.redirect() and other minor issues

### DIFF
--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -200,7 +200,7 @@ public abstract class Span implements SpanCustomizer {
    */
   // Design note: This differs from Brave 3's LocalTracer which completes with a given duration.
   // This was changed for a few use cases.
-  // * Finishing a one-way span on another host https://github.com/apache/incubator-zipkin/issues/1243
+  // * Finishing a one-way span on another host https://github.com/openzipkin/zipkin/issues/1243
   //   * The other host will not be able to read the start timestamp, so can't calculate duration
   // * Consistency in Api: All units and measures are epoch microseconds
   //   * This can reduce accidents where people use duration when they mean a timestamp

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -225,7 +225,7 @@ public abstract class Tracing implements Closeable {
      * tracingBuilder.spanReporter(spanReporter);
      * }</pre>
      *
-     * <p>See https://github.com/apache/incubator-zipkin-reporter-java
+     * <p>See https://github.com/openzipkin/zipkin-reporter-java
      */
     public Builder spanReporter(Reporter<zipkin2.Span> spanReporter) {
       if (spanReporter == null) throw new NullPointerException("spanReporter == null");

--- a/brave/src/main/java/brave/propagation/Propagation.java
+++ b/brave/src/main/java/brave/propagation/Propagation.java
@@ -44,9 +44,9 @@ public interface Propagation<K> {
      * Does the propagation implementation support sharing client and server span IDs. For example,
      * should an RPC server span share the same identifiers extracted from an incoming request?
      *
-     * In usual <a href="https://github.com/apache/incubator-zipkin-b3-propagation">B3
-     * Propagation</a>, the parent span ID is sent across the wire so that the client and server can
-     * share the same identifiers. Other propagation formats, like <a href="https://github.com/TraceContext/tracecontext-spec">trace-context</a>
+     * In usual <a href="https://github.com/openzipkin/b3-propagation">B3 Propagation</a>, the
+     * parent span ID is sent across the wire so that the client and server can share the same
+     * identifiers. Other propagation formats, like <a href="https://github.com/w3c/trace-context">trace-context</a>
      * only propagate the calling trace and span ID, with an assumption that the receiver always
      * starts a new child span. When join is supported, you can assume that when {@link
      * TraceContext#parentId() the parent span ID} is null, you've been propagated a root span. When

--- a/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
+++ b/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * span if a query occurred on it. By default, spans have a clock pinned to the trace. To use a
  * clock pinned to a connection, you have to control timestamps manually.
  *
- * <p>See https://github.com/apache/incubator-zipkin-brave/issues/564
+ * <p>See https://github.com/openzipkin/brave/issues/564
  */
 public class CustomScopedClockTracingTest {
   List<Span> spans = new ArrayList<>();

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -36,7 +36,11 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITTracingFilter {
-  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10)); // max per method
+  /**
+   * Normal tests will pass in less than 5 seconds. This timeout is set to 20 to be higher than
+   * needed even in a an overloaded CI server or extreme garbage collection pause.
+   */
+  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(20)); // max per method
 
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -37,7 +37,11 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITTracingFilter {
-  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10)); // max per method
+  /**
+   * Normal tests will pass in less than 5 seconds. This timeout is set to 20 to be higher than
+   * needed even in a an overloaded CI server or extreme garbage collection pause.
+   */
+  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(20)); // max per method
 
   /** See brave.http.ITHttp for rationale on using a concurrent blocking queue */
   BlockingQueue<Span> spans = new LinkedBlockingQueue<>();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -186,8 +186,11 @@ public abstract class ITHttp {
   };
 
   /**
-   * Like {@link #takeParentAndChildSpansWithKind(Span.Kind, Span.Kind)} except order isn't
-   * enforced. However, the results will return in the kind order specified.
+   * Invokes {@link #takeSpan()} twice, returning results in the kind order specified.
+   *
+   * <p>Note: Reporting order is irrelevant as some libraries report asynchronously with correct
+   * timestamps. To enforce order, consider {@link #takeParentAndChildSpansWithKind(Span.Kind,
+   * Span.Kind)}.
    */
   protected Span[] takeSpansWithKind(@Nullable Span.Kind kind1, @Nullable Span.Kind kind2)
     throws InterruptedException {
@@ -224,8 +227,7 @@ public abstract class ITHttp {
 
   /**
    * Like {@link #takeSpansWithKind(Span.Kind, Span.Kind)}, except the child duration must be
-   * enclosed by the parent duration. Reporting order is irrelevant as some libraries report
-   * asynchronously with correct timestamps.
+   * enclosed by the parent duration.
    */
   protected Span[] takeParentAndChildSpansWithKind(@Nullable Span.Kind parentKind,
     @Nullable Span.Kind childKind) throws InterruptedException {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -238,7 +238,7 @@ public abstract class ITHttp {
       .isEqualTo(child.traceId());
 
     assertThat(parent.id())
-      .withFailMessage("Expected the different span IDs: %s %s", parent, child)
+      .withFailMessage("Expected different span IDs: %s %s", parent, child)
       .isNotEqualTo(child.id());
 
     assertThat(parent.id())
@@ -258,25 +258,27 @@ public abstract class ITHttp {
       .isLessThanOrEqualTo(parentFinishTimeStamp);
   }
 
-  /** Ensures the inputs have the same parent, and the first finished before the other started. */
-  protected void assertSiblingsAreSequential(Span span1, Span span2) {
-    assertThat(span1.traceId())
-      .withFailMessage("Expected the same trace ID: %s %s", span1, span2)
-      .isEqualTo(span2.traceId());
+  /** Ensures the children have the same parent, and the first finished before the other started. */
+  protected void assertChildrenAreSequential(Span parent, Span child1, Span child2) {
+    for (Span child : Arrays.asList(child1, child2)) {
+      assertThat(child.traceId())
+        .withFailMessage("Expected to have trace ID(%s): %s", parent.traceId(), child)
+        .isEqualTo(parent.traceId());
 
-    assertThat(span1.parentId())
-      .withFailMessage("Expected the same parent ID: %s %s", span1, span2)
-      .isEqualTo(span2.parentId());
+      assertThat(child.parentId())
+        .withFailMessage("Expected to have parent ID(%s): %s", parent.id(), child)
+        .isEqualTo(parent.id());
+    }
 
-    assertThat(span1.id())
-      .withFailMessage("Expected the different span IDs: %s %s", span1, span2)
-      .isNotEqualTo(span2.id());
+    assertThat(child1.id())
+      .withFailMessage("Expected different span IDs: %s %s", child1, child2)
+      .isNotEqualTo(child2.id());
 
-    long span1FinishTimeStamp = span1.timestampAsLong() + span1.durationAsLong();
+    long span1FinishTimeStamp = child1.timestampAsLong() + child1.durationAsLong();
 
     assertThat(span1FinishTimeStamp)
-      .withFailMessage("Expected %s to finish before %s started", span1, span2)
-      .isLessThanOrEqualTo(span2.timestampAsLong());
+      .withFailMessage("Expected %s to finish before %s started", child1, child2)
+      .isLessThanOrEqualTo(child2.timestampAsLong());
   }
 
   protected Tracing.Builder tracingBuilder(Sampler sampler) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttp.java
@@ -102,8 +102,11 @@ public abstract class ITHttp {
    * We use a global rule instead of surefire config as this could be executed in gradle, sbt, etc.
    * This way, there's visibility on which method hung without asking the end users to edit build
    * config.
+   *
+   * <p>Normal tests will pass in less than 5 seconds. This timeout is set to 20 to be higher than
+   * needed even in a an overloaded CI server or extreme garbage collection pause.
    */
-  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(10)); // max per method
+  @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(20)); // max per method
   @Rule public TestName testName = new TestName();
 
   public static final String EXTRA_KEY = "user-id";
@@ -183,11 +186,11 @@ public abstract class ITHttp {
   };
 
   /**
-   * Like {@link #assertSpansReportedKindInOrder(Span.Kind, Span.Kind)} except order isn't enforced.
-   * However, the results will return in the kind order specified.
+   * Like {@link #takeParentAndChildSpansWithKind(Span.Kind, Span.Kind)} except order isn't
+   * enforced. However, the results will return in the kind order specified.
    */
-  protected Span[] assertSpansReportedKindInAnyOrder(@Nullable Span.Kind kind1,
-    @Nullable Span.Kind kind2) throws InterruptedException {
+  protected Span[] takeSpansWithKind(@Nullable Span.Kind kind1, @Nullable Span.Kind kind2)
+    throws InterruptedException {
     if (Objects.equals(kind1, kind2)) {
       throw new AssertionError("Expected test to pass different span kinds");
     }
@@ -211,28 +214,6 @@ public abstract class ITHttp {
     return result[0].kind() == kind1 ? result : new Span[] {span2, span1};
   }
 
-  protected Span[] assertSpansReportedKindInOrder(@Nullable Span.Kind kind1,
-    @Nullable Span.Kind kind2) throws InterruptedException {
-    // Intentionally pull both spans first to ensure neither are errors.
-    Span span1 = takeSpan(), span2 = takeSpan();
-
-    // First, check if the order is backwards
-    if (Objects.equals(span2.kind(), kind1) && Objects.equals(span1.kind(), kind2)) {
-      throw new AssertionError("Expected span " + span2 + " to report before span " + span1);
-    }
-
-    // Now, check each span
-    assertThat(span1.kind())
-      .withFailMessage("Expected first %s to have kind=%s", span1, kind1)
-      .isEqualTo(kind1);
-
-    assertThat(span2.kind())
-      .withFailMessage("Expected second %s to have kind=%s", span2, kind2)
-      .isEqualTo(kind2);
-
-    return new Span[] {span1, span2};
-  }
-
   protected Span takeLocalSpan() throws InterruptedException {
     Span local = takeSpan();
     assertThat(local.kind())
@@ -241,10 +222,23 @@ public abstract class ITHttp {
     return local;
   }
 
-  protected void assertChildEnclosedByParent(Span child, Span parent) {
+  /**
+   * Like {@link #takeSpansWithKind(Span.Kind, Span.Kind)}, except the child duration must be
+   * enclosed by the parent duration. Reporting order is irrelevant as some libraries report
+   * asynchronously with correct timestamps.
+   */
+  protected Span[] takeParentAndChildSpansWithKind(@Nullable Span.Kind parentKind,
+    @Nullable Span.Kind childKind) throws InterruptedException {
+    Span[] parentAndChild = takeSpansWithKind(parentKind, childKind);
+    Span parent = parentAndChild[0], child = parentAndChild[1];
+
     assertThat(parent.traceId())
       .withFailMessage("Expected the same trace ID: %s %s", parent, child)
       .isEqualTo(child.traceId());
+
+    assertThat(parent.id())
+      .withFailMessage("Expected the different span IDs: %s %s", parent, child)
+      .isNotEqualTo(child.id());
 
     assertThat(parent.id())
       .withFailMessage("Expected %s to be the parent of %s", parent, child)
@@ -258,8 +252,11 @@ public abstract class ITHttp {
     long serverFinishTimeStamp = parent.timestampAsLong() + parent.durationAsLong();
 
     assertThat(childFinishTimeStamp)
+      .withFailMessage("Expected %s to finish after %s", parent, child)
       .isGreaterThanOrEqualTo(child.timestampAsLong())
       .isLessThanOrEqualTo(serverFinishTimeStamp);
+
+    return parentAndChild;
   }
 
   protected Tracing.Builder tracingBuilder(Sampler sampler) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -123,7 +123,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
       .isInstanceOf(TraceContext.class)
       .isSameAs(parent.context());
 
-    assertSpansReportedKindInAnyOrder(null, Span.Kind.CLIENT);
+    takeSpansWithKind(null, Span.Kind.CLIENT);
   }
 
   /** This ensures that response callbacks run when there is no invocation trace context. */

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -339,13 +339,13 @@ public abstract class ITHttpClient<C> extends ITHttp {
 
     Span initial = takeClientSpan();
     Span redirected = takeClientSpanWithError("404");
+    Span parentSpan = takeLocalSpan();
+    assertThat(parentSpan.name()).isEqualTo("parent");
 
-    assertSiblingsAreSequential(initial, redirected);
+    assertChildrenAreSequential(parentSpan, initial, redirected);
 
     assertThat(initial.tags().get("http.path")).isEqualTo("/foo");
     assertThat(redirected.tags().get("http.path")).isEqualTo("/bar");
-
-    assertThat(takeLocalSpan().name()).isEqualTo("parent");
   }
 
   @Test public void post() throws Exception {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -29,7 +29,6 @@ import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import brave.sampler.SamplerFunction;
 import brave.sampler.SamplerFunctions;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -116,9 +115,9 @@ public abstract class ITHttpClient<C> extends ITHttp {
       parent.finish();
     }
 
-    Span[] parentAndChild = takeParentAndChildSpansWithKind(null, Span.Kind.CLIENT);
-    assertThat(parentAndChild[0].name())
-      .isEqualTo("parent");
+    Span[] parentAndChild = takeSpansWithKind(null, Span.Kind.CLIENT);
+    assertParentEnclosesChild(parentAndChild[0], parentAndChild[1]);
+    assertThat(parentAndChild[0].name()).isEqualTo("parent");
   }
 
   @Test public void propagatesExtra_newTrace() throws Exception {
@@ -329,7 +328,7 @@ public abstract class ITHttpClient<C> extends ITHttp {
       .addHeader("Location: " + url("/bar")));
     server.enqueue(new MockResponse().setResponseCode(404)); // hehe to a bad location!
 
-    ScopedSpan parent = tracer.startScopedSpan("test");
+    ScopedSpan parent = tracer.startScopedSpan("parent");
     try {
       get(client, "/foo");
     } catch (RuntimeException e) {
@@ -338,12 +337,15 @@ public abstract class ITHttpClient<C> extends ITHttp {
       parent.finish();
     }
 
-    Span client1 = takeClientSpan();
-    Span client2 = takeClientSpanWithError("404");
-    assertThat(Arrays.asList(client1.tags().get("http.path"), client2.tags().get("http.path")))
-      .contains("/foo", "/bar");
+    Span redirected = takeClientSpan();
+    Span initial = takeClientSpanWithError("404");
 
-    takeLocalSpan();
+    assertSiblingsAreSequential(initial, redirected);
+
+    assertThat(initial.tags().get("http.path")).isEqualTo("/foo");
+    assertThat(redirected.tags().get("http.path")).isEqualTo("/bar");
+
+    assertThat(takeLocalSpan().name()).isEqualTo("parent");
   }
 
   @Test public void post() throws Exception {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -337,8 +337,8 @@ public abstract class ITHttpClient<C> extends ITHttp {
       parent.finish();
     }
 
-    Span redirected = takeClientSpan();
-    Span initial = takeClientSpanWithError("404");
+    Span initial = takeClientSpan();
+    Span redirected = takeClientSpanWithError("404");
 
     assertSiblingsAreSequential(initial, redirected);
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -177,9 +177,9 @@ public abstract class ITHttpServer extends ITHttp {
   public void createsChildSpan() throws Exception {
     get("/child");
 
-    Span[] parentAndChild = takeParentAndChildSpansWithKind(Span.Kind.SERVER, null);
-    assertThat(parentAndChild[1].name())
-      .isEqualTo("child");
+    Span[] parentAndChild = takeSpansWithKind(Span.Kind.SERVER, null);
+    assertParentEnclosesChild(parentAndChild[0], parentAndChild[1]);
+    assertThat(parentAndChild[1].name()).isEqualTo("child");
   }
 
   @Test

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -177,9 +177,9 @@ public abstract class ITHttpServer extends ITHttp {
   public void createsChildSpan() throws Exception {
     get("/child");
 
-    // We expect the last to report to be the parent
-    Span[] reportedSpans = assertSpansReportedKindInOrder(null, Span.Kind.SERVER);
-    assertChildEnclosedByParent(reportedSpans[0], reportedSpans[1]);
+    Span[] parentAndChild = takeParentAndChildSpansWithKind(Span.Kind.SERVER, null);
+    assertThat(parentAndChild[1].name())
+      .isEqualTo("child");
   }
 
   @Test

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -53,7 +53,6 @@ public abstract class ITHttpServer extends ITHttp {
   OkHttpClient client = new OkHttpClient();
 
   @Before public void setup() throws Exception {
-    Log.setLog(new Log4J2Log());
     httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE).build());
     init();
   }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -37,9 +37,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okhttp3.internal.http.HttpHeaders;
 import okio.Buffer;
-import org.eclipse.jetty.util.log.Log;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
@@ -527,7 +525,7 @@ public abstract class ITHttpServer extends ITHttp {
     request = request.newBuilder().header("test", testName.getMethodName()).build();
 
     try (Response response = client.newCall(request).execute()) {
-      if (!HttpHeaders.promisesBody(response)) return response;
+      if (response.body() == null) return response;
 
       // buffer response so tests can read it. Otherwise the finally block will drop it
       ResponseBody toReturn;

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
@@ -15,6 +15,7 @@ package brave.test.http;
 
 import brave.test.http.ServletContainer.ServerController;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.log.Log;
 import org.junit.After;
 
 /** Starts a jetty server which runs a servlet container */
@@ -22,6 +23,7 @@ public abstract class ITServletContainer extends ITHttpServer {
   final ServerController serverController;
 
   protected ITServletContainer(ServerController serverController) {
+    Log.setLog(new Log4J2Log());
     this.serverController = serverController;
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/Log4J2Log.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/Log4J2Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,10 +17,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.util.log.AbstractLogger;
 
-final class Log4J2Log extends AbstractLogger {
+public final class Log4J2Log extends AbstractLogger {
   final Logger logger;
 
-  Log4J2Log() {
+  public Log4J2Log() {
     this("org.eclipse.jetty.util.log");
   }
 

--- a/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/main/java/brave/httpasyncclient/TracingHttpAsyncClientBuilder.java
@@ -76,7 +76,7 @@ public final class TracingHttpAsyncClientBuilder extends HttpAsyncClientBuilder 
 
   final class HandleSend implements HttpRequestInterceptor {
     @Override public void process(HttpRequest request, HttpContext context) {
-      TraceContext parent = (TraceContext) context.removeAttribute(TraceContext.class.getName());
+      TraceContext parent = (TraceContext) context.getAttribute(TraceContext.class.getName());
 
       HttpRequestWrapper wrapper = new HttpRequestWrapper(request, context);
       Span span = handler.handleSendWithParent(wrapper, parent);

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -28,7 +28,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
   /**
    * Handle when the client doesn't actually make a client span
    *
-   * <p>See https://github.com/apache/incubator-zipkin-brave/issues/864
+   * <p>See https://github.com/openzipkin/brave/issues/864
    */
   @Test public void cacheControl() throws Exception {
     server.enqueue(new MockResponse()
@@ -42,7 +42,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
 
     assertThat(server.getRequestCount()).isEqualTo(1);
 
-    Span[] reportedSpans = assertSpansReportedKindInOrder(Span.Kind.CLIENT, null);
+    Span[] reportedSpans = takeSpansWithKind(Span.Kind.CLIENT, null);
     assertThat(reportedSpans[1].tags()).containsKey("http.cache_hit");
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -49,9 +49,10 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
     assertThat(server.getRequestCount()).isEqualTo(1);
 
     Span[] realAndCached = takeSpansWithKind(Span.Kind.CLIENT, null);
-    assertChildrenAreSequential(takeLocalSpan(), realAndCached[0], realAndCached[1]);
-    assertThat(realAndCached[1].tags()).containsKey("http.cache_hit");
+    Span parentSpan = takeLocalSpan();
+    assertThat(parentSpan.name()).isEqualTo("parent");
 
-    assertThat(takeLocalSpan().name()).isEqualTo("parent");
+    assertChildrenAreSequential(parentSpan, realAndCached[0], realAndCached[1]);
+    assertThat(realAndCached[1].tags()).containsKey("http.cache_hit");
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -49,7 +49,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
     assertThat(server.getRequestCount()).isEqualTo(1);
 
     Span[] realAndCached = takeSpansWithKind(Span.Kind.CLIENT, null);
-    assertSiblingsAreSequential(realAndCached[0], realAndCached[1]);
+    assertChildrenAreSequential(takeLocalSpan(), realAndCached[0], realAndCached[1]);
     assertThat(realAndCached[1].tags()).containsKey("http.cache_hit");
 
     assertThat(takeLocalSpan().name()).isEqualTo("parent");

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -116,8 +116,8 @@ poll
 +- processing N
 ```
 
-If this is not the desired behavior, users can customize it by setting `singleRootSpanOnReceiveBatch` to `false`. 
-This will create a root span `poll` for each record received. 
+If this is not the desired behavior, users can customize it by setting `singleRootSpanOnReceiveBatch` to `false`.
+This will create a root span `poll` for each record received.
 
 ```
 trace 1:
@@ -135,4 +135,4 @@ poll
 
 ## Notes
 * This tracer is only compatible with Kafka versions including headers support ( > 0.11.0).
-* More information about "Message Tracing" [here](https://github.com/apache/incubator-zipkin-website/blob/master/pages/instrumenting.md#message-tracing)
+* More information about "Message Tracing" [here](https://github.com/openzipkin/openzipkin.github.io/wiki/Messaging-instrumentation-abstraction)

--- a/instrumentation/kafka-streams/README.md
+++ b/instrumentation/kafka-streams/README.md
@@ -67,7 +67,7 @@ builder.stream(inputTopic)
        .to(outputTopic);
 ```
 
-For more details, [see here](https://github.com/apache/incubator-zipkin-brave/blob/master/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java).
+For more details, [see here](https://github.com/openzipkin/brave/blob/master/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java).
 
 To create a Kafka Streams with Tracing Client Supplier enabled, pass your topology and configuration like this:
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -95,6 +95,6 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    assertSpansReportedKindInAnyOrder(null, Span.Kind.CLIENT);
+    takeSpansWithKind(null, Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,12 +14,17 @@
 package brave.sparkjava;
 
 import brave.test.http.ITHttpServer;
+import brave.test.http.Log4J2Log;
 import okhttp3.Response;
+import org.eclipse.jetty.util.log.Log;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import spark.Spark;
 
 public class ITSparkTracing extends ITHttpServer {
+  public ITSparkTracing() {
+    Log.setLog(new Log4J2Log());
+  }
 
   @Override protected Response get(String path) throws Exception {
     if (path.toLowerCase().indexOf("async") == -1) return super.get(path);


### PR DESCRIPTION
This fixes a bug where httpasyncclient broke trace on redirect. It also fixes some minor issues.

 * Raises the global timeout to 20s
   * See https://github.com/line/armeria/pull/2615
 * Decouples assertions from reporting order
   * Allows libraries to backdate spans and report in any order
 * Fixes some out-of-date links notices when doing above
 * Eases classpath by decoupling from jetty and okhttp internals