### PR TITLE
Decouples instrumentation-http-tests from servlet and okhttp 4

### DIFF
--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -45,17 +45,19 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+    </dependency>
+    <!-- Only subclasses of ITServletContainer need Jetty. -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -520,6 +520,7 @@ public abstract class ITHttpServer extends ITHttp {
   }
 
   /** like {@link #get(Request)} except doesn't throw unsupported on not found */
+  @SuppressWarnings("deprecation")
   Response call(Request request) throws IOException {
     // Particularly during async debugging, knowing which test invoked a request is helpful.
     request = request.newBuilder().header("test", testName.getMethodName()).build();
@@ -532,7 +533,8 @@ public abstract class ITHttpServer extends ITHttp {
       try (ResponseBody body = response.body()) {
         Buffer buffer = new Buffer();
         body.source().readAll(buffer);
-        toReturn = ResponseBody.create(buffer, body.contentType(), body.contentLength());
+        // allow deprecated method call as otherwise we pin the classpath to okhttp 4
+        toReturn = ResponseBody.create(body.contentType(), body.contentLength(), buffer);
       }
       return response.newBuilder().body(toReturn).build();
     }

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -75,6 +75,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
       <scope>test</scope>

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -58,6 +58,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
       <version>${jersey.version}</version>

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>brave-instrumentation-http-tests</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -57,6 +57,12 @@
       <artifactId>brave-instrumentation-http-tests</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- to mock System calls -->
     <dependency>


### PR DESCRIPTION
This decouples instrumentation-http-tests from servlet as many libraries
don't require it. This particularly helps removes Jetty classpath clash.

Also, this reduces the runtime version of OkHttp from v4 to v3, at the
expense of using a deprecated method.