### PR TITLE
Extracts TestSpanReporter and narrows exceptions in integration tests

### DIFF
--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -14,7 +14,6 @@
 package brave.test;
 
 import brave.Tracing;
-import brave.internal.Nullable;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.ExtraFieldPropagation;
@@ -24,19 +23,12 @@ import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import org.junit.After;
-import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
-import org.junit.runner.Description;
 import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,55 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p><pre><ul>
  *   <li>{@link StrictScopeDecorator} double-checks threads don't leak contexts</li>
- *   <li>Span reporting double-checks the span was de-scoped on finish, to prevent leaks</li>
- *   <li>Spans report into a concurrent blocking queue to prevent assertions race conditions</li>
- *   <li>After tests complete, the queue is strictly checked to catch redundant span reporting</li>
+ *   <li>{@link TestSpanReporter} helps avoid race conditions or accidental errors</li>
  * </ul></pre>
- *
- * <p>As a blocking queue is used, {@linkplain #takeSpan() take a span} to perform assertions on
- * it.
- *
- * <pre>{@code
- * Span span = takeSpan();
- * assertThat(span.traceId()).isEqualTo(traceId);
- * }</pre>
- *
- * <em>All spans reported must be taken before the test completes!</em>
- *
- * <h3>Debugging test failures</h3>
- *
- * <p>If a test hangs, likely {@link BlockingQueue#take()} is being called when a span wasn't
- * reported. An exception or bug could cause this (for example, the error handling route not calling
- * {@link brave.Span#finish()}).
- *
- * <p>If a test fails on {@link After}, it can mean that your test created a span, but didn't
- * {@link BlockingQueue#take()} it off the queue. If you are testing something that creates a span,
- * you may not want to verify each one. In this case, at least take them similar to below:
- *
- * <p><pre>{@code
- * for (int i = 0; i < 10; i++) takeSpan(); // we expected 10 spans
- * }</pre>
- *
- * <h3>This code looks hard.. why are we using a concurrent queue? My client is easy</h3>
- *
- * <p>Some client instrumentation are fully synchronous (everything on the main thread).
- * Testing such instrumentation could be easier, ex reporting into a list. Some other race-detecting
- * features may feel overkill in this case.
- *
- * <p>Consider though, this is a base class for all remote instrumentation: servers (always report
- * off main thread) and asynchronous clients (often report off main). Also, even blocking clients
- * can execute their "on headers received" hook on a separate thread! Even if the client you are
- * working on does everything on the same thread, a small change could invalidate that assumption.
- * If something written to work on one thread is suddenly working on two threads, tests can fail
- * "randomly", perhaps not until an unrelated change to JRE. When tests fail, they also make it
- * impossible to release new code until we disable the test or fix it. Bugs or race conditions
- * instrumentation can be very time consuming to solve. For example, they can appear as "flakes" in
- * CI servers such as Travis, which can be near impossible to debug.
- *
- * <p>Bottom-line is that we accept that strict tests are harder up front, and not necessary for a
- * few types of blocking client instrumentation. However, the majority of remote instrumentation
- * have to concern themselves with multi-threaded behavior and if we always do, the chances of
- * builds breaking are less.
  */
 public abstract class ITRemote {
   /**
@@ -108,6 +53,7 @@ public abstract class ITRemote {
    * needed even in a an overloaded CI server or extreme garbage collection pause.
    */
   @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(20)); // max per method
+  @Rule public TestSpanReporter reporter = new TestSpanReporter();
   @Rule public TestName testName = new TestName();
 
   public static final String EXTRA_KEY = "user-id";
@@ -123,14 +69,6 @@ public abstract class ITRemote {
     return tracing.propagationFactory().decorate(result);
   }
 
-  /**
-   * When testing servers or asynchronous clients, spans are reported on a worker thread. In order
-   * to read them on the main thread, we use a concurrent queue. As some implementations report
-   * after a response is sent, we use a blocking queue to prevent race conditions in tests.
-   */
-  BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
-  boolean ignoreAnySpans;
-
   // field because this allows subclasses to initialize a field Tracing
   protected final CurrentTraceContext currentTraceContext =
     ThreadLocalCurrentTraceContext.newBuilder()
@@ -142,56 +80,12 @@ public abstract class ITRemote {
 
   protected Tracing tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
 
-  /**
-   * Call this before throwing an {@link AssumptionViolatedException}, when there's a chance a span
-   * was reported.
-   *
-   * <p>This was made for detecting features in HTTP server testing via 404. When 404 itself is
-   * instrumented, post-conditions would otherwise fail from not consuming the associated span.
-   */
-  protected void ignoreAnySpans() {
-    ignoreAnySpans = true;
-  }
-
-  /**
-   * This is hidden because the historical takeSpan() method led to numerous bugs. For example,
-   * tests passed even though the span asserted against wasn't the intended one (local vs remote).
-   * Also, tests passed even though there was an error inside the span. Even error tests have passed
-   * for the wrong reason (ex setup failure not the error raised in instrumentation).
-   */
-  Span doTakeSpan(@Nullable String errorTag, boolean flushed) throws InterruptedException {
-    Span result = spans.poll(3, TimeUnit.SECONDS);
-    assertThat(result)
-      .withFailMessage("Span was not reported")
-      .isNotNull();
-
-    assertThat(result.timestampAsLong())
-      .withFailMessage("Expected a timestamp: %s", result)
-      .isNotZero();
-
-    if (errorTag != null) {
-      // Some exception messages are multi-line
-      Pattern regex = Pattern.compile(errorTag, Pattern.DOTALL);
-      assertThat(result.tags().get("error"))
-        .withFailMessage("Expected %s to have an error tag matching %s", result, errorTag)
-        .matches(regex);
-    } else {
-      assertThat(result.tags().get("error"))
-        .withFailMessage("Expected %s to have no error tag", result)
-        .isNull();
-    }
-
-    if (flushed) {
-      assertThat(result.durationAsLong())
-        .withFailMessage("Expected no duration: %s", result)
-        .isZero();
-    } else {
-      assertThat(result.durationAsLong())
-        .withFailMessage("Expected a duration: %s", result)
-        .isNotZero();
-    }
-
-    return result;
+  protected Tracing.Builder tracingBuilder(Sampler sampler) {
+    return Tracing.newBuilder()
+      .spanReporter(reporter)
+      .propagationFactory(propagationFactory)
+      .currentTraceContext(currentTraceContext)
+      .sampler(sampler);
   }
 
   /**
@@ -203,77 +97,7 @@ public abstract class ITRemote {
     if (current != null) current.close();
   }
 
-  /**
-   * On close, we check that all spans have been verified by the test. This ensures bad behavior
-   * such as duplicate reporting doesn't occur. The impact is that every span must at least be
-   * {@link #doTakeSpan(String, boolean)} before the end of each method.
-   */
-  @Rule public TestRule assertSpansEmpty = new TestWatcher() {
-    // only check success path to avoid masking assertion errors or exceptions
-    @Override protected void succeeded(Description description) {
-      if (ignoreAnySpans) return;
-      try {
-        assertThat(spans.poll(100, TimeUnit.MILLISECONDS))
-          .withFailMessage("Span remaining in queue. Check for redundant reporting")
-          .isNull();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new AssertionError(e);
-      }
-    }
-  };
-
-  /**
-   * Blocks until a local span was reported. We define a local span as one with a timestamp and no
-   * duration, kind, or remote endpoint. This will fail if there's an "error" tag. If you expect a
-   * failure, use {@link #takeLocalSpanWithError(String)} instead.
-   */
-  protected Span takeLocalSpan() throws InterruptedException {
-    Span local = doTakeSpan(null, false);
-    assertLocalSpan(local);
-    return local;
-  }
-
-  /** Like {@link #takeLocalSpan()} except an error tag must match the given value. */
-  protected Span takeLocalSpanWithError(String errorTag) throws InterruptedException {
-    Span result = doTakeSpan(errorTag, false);
-    assertLocalSpan(result);
-    return result;
-  }
-
-  private void assertLocalSpan(Span local) {
-    assertThat(local.kind())
-      .withFailMessage("Expected %s to have no kind", local)
-      .isNull();
-    assertThat(local.remoteEndpoint())
-      .withFailMessage("Expected %s to have no remote endpoint", local)
-      .isNull();
-  }
-
-  /**
-   * Blocks until a remote span was reported. We define a remote span as one with a timestamp,
-   * duration and kind. This will fail if there's an "error" tag. If you expect a failure, use
-   * {@link #takeRemoteSpanWithError(Span.Kind, String)} instead.
-   */
-  protected Span takeRemoteSpan(Span.Kind kind) throws InterruptedException {
-    Span result = doTakeSpan(null, false);
-    assertRemoteSpan(result, kind);
-    return result;
-  }
-
-  /** Like {@link #takeRemoteSpan(Span.Kind)} except an error tag must match the given value. */
-  protected Span takeRemoteSpanWithError(Span.Kind kind, String errorTag)
-    throws InterruptedException {
-    Span result = doTakeSpan(errorTag, false);
-    assertRemoteSpan(result, kind);
-    return result;
-  }
-
-  void assertRemoteSpan(Span span, Span.Kind kind) {
-    assertThat(span.kind())
-      .withFailMessage("Expected %s to have kind=%s", span, kind)
-      .isEqualTo(kind);
-  }
+  // Assertions below here can eventually move to a new type
 
   /**
    * Ensures the inputs are parent and child, the parent starts before the child, and the duration
@@ -342,13 +166,5 @@ public abstract class ITRemote {
     assertThat(child.parentId())
       .withFailMessage("Expected to have parent ID(%s): %s", parent.id(), child)
       .isEqualTo(parent.id());
-  }
-
-  protected Tracing.Builder tracingBuilder(Sampler sampler) {
-    return Tracing.newBuilder()
-      .spanReporter(spans::add)
-      .propagationFactory(propagationFactory)
-      .currentTraceContext(currentTraceContext)
-      .sampler(sampler);
   }
 }

--- a/brave-tests/src/main/java/brave/test/TestSpanReporter.java
+++ b/brave-tests/src/main/java/brave/test/TestSpanReporter.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test;
+
+import brave.internal.Nullable;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.junit.After;
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is a special span reporter for remote integration tests. It has a few features to ensure
+ * tests cover common instrumentation bugs. Most of this optimizes for instrumentation occurring on
+ * a different thread than main (which does the assertions).
+ *
+ * <p><pre><ul>
+ *   <li>Spans report into a concurrent blocking queue to prevent assertions race conditions</li>
+ *   <li>After tests complete, the queue is strictly checked to catch redundant span reporting</li>
+ * </ul></pre>
+ *
+ * <p>As a blocking queue is used, {@linkplain #takeLocalSpan()} take a span} to perform assertions
+ * on it.
+ *
+ * <pre>{@code
+ * Span span = takeLocalSpan();
+ * assertThat(span.traceId()).isEqualTo(traceId);
+ * }</pre>
+ *
+ * <em>All spans reported must be taken before the test completes!</em>
+ *
+ * <h3>Debugging test failures</h3>
+ *
+ * <p>If a test hangs, likely {@link BlockingQueue#take()} is being called when a span wasn't
+ * reported. An exception or bug could cause this (for example, the error handling route not calling
+ * {@link brave.Span#finish()}).
+ *
+ * <p>If a test fails on {@link After}, it can mean that your test created a span, but didn't
+ * {@link BlockingQueue#take()} it off the queue. If you are testing something that creates a span,
+ * you may not want to verify each one. In this case, at least take them similar to below:
+ *
+ * <p><pre>{@code
+ * for (int i = 0; i < 10; i++) takeLocalSpan(); // we expected 10 spans
+ * }</pre>
+ *
+ * <h3>This code looks hard.. why are we using a concurrent queue? My client is easy</h3>
+ *
+ * <p>Some client instrumentation are fully synchronous (everything on the main thread).
+ * Testing such instrumentation could be easier, ex reporting into a list. Some other race-detecting
+ * features may feel overkill in this case.
+ *
+ * <p>Consider though, this is a base class for all remote instrumentation: servers (always report
+ * off main thread) and asynchronous clients (often report off main). Also, even blocking clients
+ * can execute their "on headers received" hook on a separate thread! Even if the client you are
+ * working on does everything on the same thread, a small change could invalidate that assumption.
+ * If something written to work on one thread is suddenly working on two threads, tests can fail
+ * "randomly", perhaps not until an unrelated change to JRE. When tests fail, they also make it
+ * impossible to release new code until we disable the test or fix it. Bugs or race conditions
+ * instrumentation can be very time consuming to solve. For example, they can appear as "flakes" in
+ * CI servers such as Travis, which can be near impossible to debug.
+ *
+ * <p>Bottom-line is that we accept that strict tests are harder up front, and not necessary for a
+ * few types of blocking client instrumentation. However, the majority of remote instrumentation
+ * have to concern themselves with multi-threaded behavior and if we always do, the chances of
+ * builds breaking are less.
+ */
+public final class TestSpanReporter extends TestWatcher implements Reporter<Span> {
+  /**
+   * When testing servers or asynchronous clients, spans are reported on a worker thread. In order
+   * to read them on the main thread, we use a concurrent queue. As some implementations report
+   * after a response is sent, we use a blocking queue to prevent race conditions in tests.
+   */
+  BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+  boolean ignoreAnySpans;
+
+  /**
+   * Call this before throwing an {@link AssumptionViolatedException}, when there's a chance a span
+   * was reported.
+   *
+   * <p>This was made for detecting features in HTTP server testing via 404. When 404 itself is
+   * instrumented, post-conditions would otherwise fail from not consuming the associated span.
+   */
+  public void ignoreAnySpans() {
+    ignoreAnySpans = true;
+  }
+
+  /**
+   * On close, we check that all spans have been verified by the test. This ensures bad behavior
+   * such as duplicate reporting doesn't occur. The impact is that every span must at least be
+   * {@link #doTakeSpan(String, boolean)} before the end of each method.
+   */
+  // only check success path to avoid masking assertion errors or exceptions
+  @Override protected void succeeded(Description description) {
+    if (ignoreAnySpans) return;
+    try {
+      assertThat(spans.poll(100, TimeUnit.MILLISECONDS))
+        .withFailMessage("Span remaining in queue. Check for redundant reporting")
+        .isNull();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * Blocks until a local span was reported. We define a local span as one with a timestamp and no
+   * duration, kind, or remote endpoint. This will fail if there's an "error" tag. If you expect a
+   * failure, use {@link #takeLocalSpanWithError(String)} instead.
+   */
+  public Span takeLocalSpan() {
+    Span local = doTakeSpan(null, false);
+    assertLocalSpan(local);
+    return local;
+  }
+
+  /** Like {@link #takeLocalSpan()} except an error tag must match the given value. */
+  public Span takeLocalSpanWithError(String errorTag) {
+    Span result = doTakeSpan(errorTag, false);
+    assertLocalSpan(result);
+    return result;
+  }
+
+  private void assertLocalSpan(Span local) {
+    assertThat(local.kind())
+      .withFailMessage("Expected %s to have no kind", local)
+      .isNull();
+    assertThat(local.remoteEndpoint())
+      .withFailMessage("Expected %s to have no remote endpoint", local)
+      .isNull();
+  }
+
+  /**
+   * Blocks until a remote span was reported. We define a remote span as one with a timestamp,
+   * duration and kind. This will fail if there's an "error" tag. If you expect a failure, use
+   * {@link #takeRemoteSpanWithError(Span.Kind, String)} instead.
+   */
+  public Span takeRemoteSpan(Span.Kind kind) {
+    Span result = doTakeSpan(null, false);
+    assertRemoteSpan(result, kind);
+    return result;
+  }
+
+  /** Like {@link #takeRemoteSpan(Span.Kind)} except an error tag must match the given value. */
+  public Span takeRemoteSpanWithError(Span.Kind kind, String errorTag) {
+    Span result = doTakeSpan(errorTag, false);
+    assertRemoteSpan(result, kind);
+    return result;
+  }
+
+  void assertRemoteSpan(Span span, Span.Kind kind) {
+    assertThat(span.kind())
+      .withFailMessage("Expected %s to have kind=%s", span, kind)
+      .isEqualTo(kind);
+  }
+
+  /**
+   * This is hidden because the historical takeSpan() method led to numerous bugs. For example,
+   * tests passed even though the span asserted against wasn't the intended one (local vs remote).
+   * Also, tests passed even though there was an error inside the span. Even error tests have passed
+   * for the wrong reason (ex setup failure not the error raised in instrumentation).
+   */
+  Span doTakeSpan(@Nullable String errorTag, boolean flushed) {
+    Span result;
+    try {
+      result = spans.poll(3, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+
+    assertThat(result)
+      .withFailMessage("Span was not reported")
+      .isNotNull();
+
+    assertThat(result.timestampAsLong())
+      .withFailMessage("Expected a timestamp: %s", result)
+      .isNotZero();
+
+    if (errorTag != null) {
+      // Some exception messages are multi-line
+      Pattern regex = Pattern.compile(errorTag, Pattern.DOTALL);
+      assertThat(result.tags().get("error"))
+        .withFailMessage("Expected %s to have an error tag matching %s", result, errorTag)
+        .matches(regex);
+    } else {
+      assertThat(result.tags().get("error"))
+        .withFailMessage("Expected %s to have no error tag", result)
+        .isNull();
+    }
+
+    if (flushed) {
+      assertThat(result.durationAsLong())
+        .withFailMessage("Expected no duration: %s", result)
+        .isZero();
+    } else {
+      assertThat(result.durationAsLong())
+        .withFailMessage("Expected a duration: %s", result)
+        .isNotZero();
+    }
+
+    return result;
+  }
+
+  @Override public void report(Span span) {
+    spans.add(span);
+  }
+}

--- a/brave-tests/src/main/java/brave/test/util/AssertableCallback.java
+++ b/brave-tests/src/main/java/brave/test/util/AssertableCallback.java
@@ -79,7 +79,8 @@ public final class AssertableCallback<V> extends CountDownLatch implements
     countDown();
   }
 
-  public ObjectAssert<V> assertThatSuccess() {
+  /** Returns the value after performing state checks */
+  @Nullable public V join() {
     awaitUninterruptably();
 
     if (onSuccessCount.get() > 0) {
@@ -91,7 +92,7 @@ public final class AssertableCallback<V> extends CountDownLatch implements
         .withFailMessage("Both onSuccess and onError were signaled")
         .hasValue(0);
 
-      return assertThat(result == NULL_SENTINEL ? null : (V) result);
+      return result == NULL_SENTINEL ? null : (V) result;
     } else if (onErrorCount.get() > 0) {
       assertThat(error)
         .withFailMessage("onError signaled with null")
@@ -100,9 +101,15 @@ public final class AssertableCallback<V> extends CountDownLatch implements
       throw new AssertionError("expected onSuccess, but received onError(" + error + ")",
         (Throwable) error);
     }
-    return null;
+    throw new AssertionError("unexpected state");
   }
 
+  // TODO: not actually used as we don't need to verify http status code or otherwise yet
+  public ObjectAssert<V> assertThatSuccess() {
+    return assertThat(join());
+  }
+
+  // TODO: not actually used as we have no async error tests, yet
   public AbstractThrowableAssert<?, ? extends Throwable> assertThatError() {
     awaitUninterruptably();
 

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/internal/TraceContextFlowableSubscriber.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/internal/TraceContextFlowableSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package brave.context.rxjava2.internal;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
-import io.reactivex.Flowable;
 import io.reactivex.FlowableSubscriber;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
@@ -70,8 +70,13 @@ class TestServer {
     return service.getProtocol().getPort();
   }
 
-  TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
-    return requestQueue.poll(3, TimeUnit.SECONDS);
+  TraceContextOrSamplingFlags takeRequest() {
+    try {
+      return requestQueue.poll(3, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
   }
 
   String ip() {

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TracingResponseCallbackTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TracingResponseCallbackTest.java
@@ -27,27 +27,27 @@ public class TracingResponseCallbackTest extends ITTracingFilter {
     init();
   }
 
-  @Test public void done_should_finish_span() throws Exception {
+  @Test public void done_should_finish_span() {
     Span span = tracing.tracer().nextSpan().start();
 
     ResponseCallback tracingResponseCallback =
       TracingResponseCallback.create(null, span, currentTraceContext);
     tracingResponseCallback.done(null);
 
-    takeLocalSpan();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void caught_should_tag() throws Exception {
+  @Test public void caught_should_tag() {
     Span span = tracing.tracer().nextSpan().start();
 
     ResponseCallback tracingResponseCallback =
       TracingResponseCallback.create(null, span, currentTraceContext);
     tracingResponseCallback.caught(new Exception("Test exception"));
 
-    takeLocalSpanWithError("Test exception");
+    reporter.takeLocalSpanWithError("Test exception");
   }
 
-  @Test public void done_should_forward_then_finish_span() throws Exception {
+  @Test public void done_should_forward_then_finish_span() {
     Span span = tracing.tracer().nextSpan().start();
 
     ResponseCallback delegate = mock(ResponseCallback.class);
@@ -58,10 +58,10 @@ public class TracingResponseCallbackTest extends ITTracingFilter {
     tracingResponseCallback.done(result);
 
     verify(delegate).done(result);
-    takeLocalSpan();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void done_should_have_span_in_scope() throws Exception {
+  @Test public void done_should_have_span_in_scope() {
     Span span = tracing.tracer().nextSpan().start();
 
     ResponseCallback delegate = new ResponseCallback() {
@@ -77,10 +77,10 @@ public class TracingResponseCallbackTest extends ITTracingFilter {
     TracingResponseCallback.create(delegate, span, currentTraceContext)
       .done(new Object());
 
-    takeLocalSpan();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void caught_should_forward_then_tag() throws Exception {
+  @Test public void caught_should_forward_then_tag() {
     Span span = tracing.tracer().nextSpan().start();
 
     ResponseCallback delegate = new ResponseCallback() {
@@ -96,6 +96,6 @@ public class TracingResponseCallbackTest extends ITTracingFilter {
     TracingResponseCallback.create(delegate, span, currentTraceContext)
       .caught(new Exception("Test exception"));
 
-    takeLocalSpanWithError("Test exception");
+    reporter.takeLocalSpanWithError("Test exception");
   }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/test/Unsupported.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/test/Unsupported.java
@@ -23,9 +23,9 @@ public abstract class Unsupported {
    * better as a tag. It should be considered a deprecated practice. This method only exists to
    * support Dubbo, exposed to avoid exposing the raw span queue protected.
    */
-  public static Span takeOneWayRpcSpan(ITRemote itRemote, Span.Kind kind) throws Exception {
-    Span span = itRemote.doTakeSpan(null, true);
-    itRemote.assertRemoteSpan(span, kind);
+  public static Span takeOneWayRpcSpan(ITRemote itRemote, Span.Kind kind) {
+    Span span = itRemote.reporter.doTakeSpan(null, true);
+    itRemote.reporter.assertRemoteSpan(span, kind);
     return span;
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -75,8 +75,13 @@ class TestServer {
     return service.getProtocol().getPort();
   }
 
-  TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
-    return requestQueue.poll(3, TimeUnit.SECONDS);
+  TraceContextOrSamplingFlags takeRequest() {
+    try {
+      return requestQueue.poll(3, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
   }
 
   String ip() {

--- a/instrumentation/dubbo/src/test/java/brave/test/Unsupported.java
+++ b/instrumentation/dubbo/src/test/java/brave/test/Unsupported.java
@@ -23,9 +23,9 @@ public abstract class Unsupported {
    * better as a tag. It should be considered a deprecated practice. This method only exists to
    * support Dubbo, exposed to avoid exposing the raw span queue protected.
    */
-  public static Span takeOneWayRpcSpan(ITRemote itRemote, Span.Kind kind) throws Exception {
-    Span span = itRemote.doTakeSpan(null, true);
-    itRemote.assertRemoteSpan(span, kind);
+  public static Span takeOneWayRpcSpan(ITRemote itRemote, Span.Kind kind) {
+    Span span = itRemote.reporter.doTakeSpan(null, true);
+    itRemote.reporter.assertRemoteSpan(span, kind);
     return span;
   }
 }

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
@@ -63,17 +63,27 @@ class TestServer {
     server.start();
   }
 
-  void stop() throws InterruptedException {
+  void stop() {
     server.shutdown();
-    server.awaitTermination();
+    try {
+      server.awaitTermination();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
   }
 
   int port() {
     return server.getPort();
   }
 
-  TraceContextOrSamplingFlags takeRequest() throws InterruptedException {
-    return requestQueue.poll(3, TimeUnit.SECONDS);
+  TraceContextOrSamplingFlags takeRequest() {
+    try {
+      return requestQueue.poll(3, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
   }
 
   void enqueueDelay(long millis) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -33,6 +33,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.Sampler;
 import brave.sampler.SamplerFunction;
 import brave.test.ITRemote;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -66,11 +67,11 @@ public abstract class ITHttpClient<C> extends ITRemote {
   /** Make sure the client you return has retries disabled. */
   protected abstract C newClient(int port);
 
-  protected abstract void closeClient(C client) throws Exception;
+  protected abstract void closeClient(C client) throws IOException;
 
-  protected abstract void get(C client, String pathIncludingQuery) throws Exception;
+  protected abstract void get(C client, String pathIncludingQuery) throws IOException;
 
-  protected abstract void post(C client, String pathIncludingQuery, String body) throws Exception;
+  protected abstract void post(C client, String pathIncludingQuery, String body) throws IOException;
 
   @Override @After public void close() throws Exception {
     closeClient(client);
@@ -84,10 +85,10 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext extracted = extract(takeRequest());
     assertThat(extracted.sampled()).isTrue();
     assertThat(extracted.parentIdString()).isNull();
-    assertSameIds(takeRemoteSpan(Span.Kind.CLIENT), extracted);
+    assertSameIds(reporter.takeRemoteSpan(Span.Kind.CLIENT), extracted);
   }
 
-  @Test public void propagatesChildOfCurrentSpan() throws Exception {
+  @Test public void propagatesChildOfCurrentSpan() throws IOException {
     server.enqueue(new MockResponse());
 
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
@@ -98,11 +99,11 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext extracted = extract(takeRequest());
     assertThat(extracted.sampled()).isTrue();
     assertChildOf(extracted, parent);
-    assertSameIds(takeRemoteSpan(Span.Kind.CLIENT), extracted);
+    assertSameIds(reporter.takeRemoteSpan(Span.Kind.CLIENT), extracted);
   }
 
   /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
-  @Test public void propagatesUnsampledContext() throws Exception {
+  @Test public void propagatesUnsampledContext() throws IOException {
     server.enqueue(new MockResponse());
 
     TraceContext parent = newTraceContext(SamplingFlags.NOT_SAMPLED);
@@ -115,7 +116,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertChildOf(extracted, parent);
   }
 
-  @Test public void propagatesExtra() throws Exception {
+  @Test public void propagatesExtra() throws IOException {
     server.enqueue(new MockResponse());
 
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
@@ -127,10 +128,10 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext extracted = extract(takeRequest());
     assertThat(ExtraFieldPropagation.get(extracted, EXTRA_KEY)).isEqualTo("joey");
 
-    takeRemoteSpan(Span.Kind.CLIENT);
+    reporter.takeRemoteSpan(Span.Kind.CLIENT);
   }
 
-  @Test public void propagatesExtra_unsampled() throws Exception {
+  @Test public void propagatesExtra_unsampled() throws IOException {
     server.enqueue(new MockResponse());
 
     TraceContext parent = newTraceContext(SamplingFlags.NOT_SAMPLED);
@@ -143,10 +144,10 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertThat(ExtraFieldPropagation.get(extracted, EXTRA_KEY)).isEqualTo("joey");
   }
 
-  @Test public void customSampler() throws Exception {
+  @Test public void customSampler() throws IOException {
     String path = "/foo";
 
-    close();
+    closeClient(client);
 
     SamplerFunction<HttpRequest> sampler = HttpRuleSampler.newBuilder()
       .putRule(pathStartsWith(path), Sampler.NEVER_SAMPLE)
@@ -162,7 +163,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
   }
 
   /** This prevents confusion as a blocking client should end before, the start of the next span. */
-  @Test public void clientTimestampAndDurationEnclosedByParent() throws Exception {
+  @Test public void clientTimestampAndDurationEnclosedByParent() throws IOException {
     server.enqueue(new MockResponse());
 
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
@@ -174,42 +175,42 @@ public abstract class ITHttpClient<C> extends ITRemote {
     }
     long finish = clock.currentTimeMicroseconds();
 
-    Span clientSpan = takeRemoteSpan(Span.Kind.CLIENT);
+    Span clientSpan = reporter.takeRemoteSpan(Span.Kind.CLIENT);
     assertChildOf(clientSpan, parent);
     assertSpanInInterval(clientSpan, start, finish);
   }
 
-  @Test public void reportsClientKindToZipkin() throws Exception {
+  @Test public void reportsClientKindToZipkin() throws IOException {
     server.enqueue(new MockResponse());
     get(client, "/foo");
 
-    takeRemoteSpan(Span.Kind.CLIENT);
+    reporter.takeRemoteSpan(Span.Kind.CLIENT);
   }
 
   @Test
-  public void reportsServerAddress() throws Exception {
+  public void reportsServerAddress() throws IOException {
     server.enqueue(new MockResponse());
     get(client, "/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.CLIENT).remoteEndpoint())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.CLIENT).remoteEndpoint())
       .isEqualTo(Endpoint.newBuilder()
         .ip("127.0.0.1")
         .port(server.getPort()).build()
       );
   }
 
-  @Test public void defaultSpanNameIsMethodName() throws Exception {
+  @Test public void defaultSpanNameIsMethodName() throws IOException {
     server.enqueue(new MockResponse());
     get(client, "/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.CLIENT).name())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.CLIENT).name())
       .isEqualTo("get");
   }
 
-  @Test public void readsRequestAtResponseTime() throws Exception {
+  @Test public void readsRequestAtResponseTime() throws IOException {
     String uri = "/foo/bar?z=2&yAA=1";
 
-    close();
+    closeClient(client);
     httpTracing = httpTracing.toBuilder()
       .clientResponseParser((response, context, span) -> {
         span.tag("http.url", response.request().url()); // just the path is tagged by default
@@ -220,14 +221,14 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    assertThat(takeRemoteSpan(Span.Kind.CLIENT).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.CLIENT).tags())
       .containsEntry("http.url", url(uri));
   }
 
-  @Test public void supportsPortableCustomization() throws Exception {
+  @Test public void supportsPortableCustomization() throws IOException {
     String uri = "/foo/bar?z=2&yAA=1";
 
-    close();
+    closeClient(client);
     httpTracing = httpTracing.toBuilder()
       .clientRequestParser((request, context, span) -> {
         span.name(request.method().toLowerCase() + " " + request.path());
@@ -244,7 +245,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    Span span = takeRemoteSpan(Span.Kind.CLIENT);
+    Span span = reporter.takeRemoteSpan(Span.Kind.CLIENT);
     assertThat(span.name())
       .isEqualTo("get /foo/bar");
 
@@ -257,10 +258,10 @@ public abstract class ITHttpClient<C> extends ITRemote {
       .containsEntry("response_customizer.is_span", "false");
   }
 
-  @Deprecated @Test public void supportsDeprecatedPortableCustomization() throws Exception {
+  @Deprecated @Test public void supportsDeprecatedPortableCustomization() throws IOException {
     String uri = "/foo/bar?z=2&yAA=1";
 
-    close();
+    closeClient(client);
     httpTracing = httpTracing.toBuilder()
       .clientParser(new HttpClientParser() {
         @Override
@@ -285,7 +286,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    Span span = takeRemoteSpan(Span.Kind.CLIENT);
+    Span span = reporter.takeRemoteSpan(Span.Kind.CLIENT);
     assertThat(span.name())
       .isEqualTo("get /foo/bar");
 
@@ -299,16 +300,16 @@ public abstract class ITHttpClient<C> extends ITRemote {
       .containsEntry("response_customizer.is_span", "false");
   }
 
-  @Test public void addsStatusCodeWhenNotOk() throws Exception {
+  @Test public void addsStatusCodeWhenNotOk() {
     server.enqueue(new MockResponse().setResponseCode(400));
 
     try {
       get(client, "/foo");
-    } catch (Exception e) {
+    } catch (IOException e) {
       // some clients think 400 is an error
     }
 
-    assertThat(takeRemoteSpanWithError(Span.Kind.CLIENT, "400").tags())
+    assertThat(reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, "400").tags())
       .containsEntry("http.status_code", "400");
   }
 
@@ -320,12 +321,12 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
     try (Scope scope = currentTraceContext.newScope(parent)) {
       get(client, "/foo");
-    } catch (RuntimeException e) {
+    } catch (IOException e) {
       // some think 404 is an exception
     }
 
-    Span initial = takeRemoteSpan(Span.Kind.CLIENT);
-    Span redirected = takeRemoteSpanWithError(Span.Kind.CLIENT, "404");
+    Span initial = reporter.takeRemoteSpan(Span.Kind.CLIENT);
+    Span redirected = reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, "404");
 
     for (Span child : Arrays.asList(initial, redirected)) {
       assertChildOf(child, parent);
@@ -337,7 +338,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertThat(redirected.tags().get("http.path")).isEqualTo("/bar");
   }
 
-  @Test public void post() throws Exception {
+  @Test public void post() throws IOException {
     String path = "/post";
     String body = "body";
     server.enqueue(new MockResponse());
@@ -347,25 +348,25 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertThat(takeRequest().getBody().readUtf8())
       .isEqualTo(body);
 
-    assertThat(takeRemoteSpan(Span.Kind.CLIENT).name())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.CLIENT).name())
       .isEqualTo("post");
   }
 
-  @Test public void httpPathTagExcludesQueryParams() throws Exception {
+  @Test public void httpPathTagExcludesQueryParams() throws IOException {
     String path = "/foo?z=2&yAA=1";
 
     server.enqueue(new MockResponse());
     get(client, path);
 
-    assertThat(takeRemoteSpan(Span.Kind.CLIENT).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.CLIENT).tags())
       .containsEntry("http.path", "/foo");
   }
 
-  @Test public void finishedSpanHandlerSeesException() throws Exception {
+  @Test public void finishedSpanHandlerSeesException() throws IOException {
     finishedSpanHandlerSeesException(get());
   }
 
-  @Test public void errorTag_onTransportException() throws Exception {
+  @Test public void errorTag_onTransportException() {
     checkReportsSpanOnTransportException(get());
   }
 
@@ -380,9 +381,9 @@ public abstract class ITHttpClient<C> extends ITRemote {
    * This ensures custom finished span handlers can see the actual exception thrown, not just the
    * "error" tag value.
    */
-  void finishedSpanHandlerSeesException(Callable<Void> get) throws Exception {
+  void finishedSpanHandlerSeesException(Callable<Void> get) throws IOException {
     AtomicReference<Throwable> caughtThrowable = new AtomicReference<>();
-    close();
+    closeClient(client);
     httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE)
       .addFinishedSpanHandler(new FinishedSpanHandler() {
         @Override public boolean handle(TraceContext context, MutableSpan span) {
@@ -397,7 +398,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertThat(caughtThrowable.get()).isNotNull();
   }
 
-  Span checkReportsSpanOnTransportException(Callable<Void> get) throws InterruptedException {
+  Span checkReportsSpanOnTransportException(Callable<Void> get) {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
     try {
@@ -406,7 +407,8 @@ public abstract class ITHttpClient<C> extends ITRemote {
       // ok, but the span should include an error!
     }
 
-    return takeRemoteSpanWithError(Span.Kind.CLIENT, ".+"); // We don't know the transport exception
+    // We don't know the transport exception
+    return reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, ".+");
   }
 
   protected String url(String pathIncludingQuery) {
@@ -414,8 +416,13 @@ public abstract class ITHttpClient<C> extends ITRemote {
   }
 
   /** Ensures a timeout receiving a request happens before the method timeout */
-  protected RecordedRequest takeRequest() throws InterruptedException {
-    return server.takeRequest(3, TimeUnit.SECONDS);
+  protected RecordedRequest takeRequest() {
+    try {
+      return server.takeRequest(3, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
   }
 
   protected TraceContext extract(RecordedRequest request) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -138,7 +138,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
         .isEqualTo("abcdefg");
     }
 
-    takeRemoteSpan(Span.Kind.SERVER);
+    reporter.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   // copies the header to the response
@@ -172,7 +172,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
         .isEqualTo("abcdefg");
     }
 
-    takeRemoteSpan(Span.Kind.SERVER);
+    reporter.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   // Shows how a framework can layer on "http.route" logic
@@ -200,7 +200,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
     get("/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.SERVER).name())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.SERVER).name())
       .isEqualTo("get /foo");
   }
 
@@ -228,7 +228,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
     get("/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("foo", "bar");
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
@@ -48,13 +48,13 @@ public abstract class ITServlet3Container extends ITServlet25Container {
   @Test public void forward() throws Exception {
     get("/forward");
 
-    takeRemoteSpan(Span.Kind.SERVER);
+    reporter.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Test public void forwardAsync() throws Exception {
     get("/forwardAsync");
 
-    takeRemoteSpan(Span.Kind.SERVER);
+    reporter.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   static class ForwardServlet extends HttpServlet {

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -16,6 +16,7 @@ package brave.httpclient;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
+import java.io.IOException;
 import java.util.Arrays;
 import okhttp3.mockwebserver.MockResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -34,7 +35,7 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
    *
    * <p>See https://github.com/openzipkin/brave/issues/864
    */
-  @Test public void cacheControl() throws Exception {
+  @Test public void cacheControl() throws IOException {
     server.enqueue(new MockResponse()
       .addHeader("Content-Type", "text/plain")
       .addHeader("Cache-Control", "max-age=600, stale-while-revalidate=1200")
@@ -48,8 +49,8 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
 
     assertThat(server.getRequestCount()).isEqualTo(1);
 
-    Span real = takeRemoteSpan(Span.Kind.CLIENT);
-    Span cached = takeLocalSpan();
+    Span real = reporter.takeRemoteSpan(Span.Kind.CLIENT);
+    Span cached = reporter.takeLocalSpan();
     assertThat(cached.tags()).containsKey("http.cache_hit");
 
     for (Span child : Arrays.asList(real, cached)) {

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -44,13 +44,13 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
   }
 
   @Override protected void post(CloseableHttpClient client, String pathIncludingQuery, String body)
-    throws Exception {
+    throws IOException {
     HttpPost post = new HttpPost(URI.create(url(pathIncludingQuery)));
     post.setEntity(new StringEntity(body));
     consume(client.execute(post).getEntity());
   }
 
-  @Test public void currentSpanVisibleToUserFilters() throws Exception {
+  @Test public void currentSpanVisibleToUserFilters() throws IOException {
     server.enqueue(new MockResponse());
     closeClient(client);
 
@@ -65,6 +65,6 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeRemoteSpan(Span.Kind.CLIENT);
+    reporter.takeRemoteSpan(Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -67,7 +67,7 @@ public class ITSpanCustomizingContainerFilter extends ITServletContainer {
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
@@ -42,7 +42,7 @@ public class ITSpanCustomizingApplicationEventListener extends ITServletContaine
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }
@@ -52,7 +52,7 @@ public class ITSpanCustomizingApplicationEventListener extends ITServletContaine
   @Test public void managedAsync() throws Exception {
     get("/managedAsync");
 
-    takeRemoteSpan(Span.Kind.SERVER);
+    reporter.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -38,7 +38,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }
@@ -48,7 +48,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
     Response response = get("/managedAsync");
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    takeRemoteSpan(Span.Kind.SERVER);
+    reporter.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/jms/src/test/java/brave/jms/ArtemisJmsTestRule.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ArtemisJmsTestRule.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.jms.Connection;
 import javax.jms.JMSContext;
+import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.QueueConnection;
 import javax.jms.TopicConnection;
@@ -46,26 +47,29 @@ class ArtemisJmsTestRule extends JmsTestRule {
     return factory.createContext(JMSContext.AUTO_ACKNOWLEDGE);
   }
 
-  @Override Connection newConnection() throws Exception {
+  @Override Connection newConnection() throws JMSException {
     if (!started.getAndSet(true)) resource.start();
     return factory.createConnection();
   }
 
-  @Override QueueConnection newQueueConnection() throws Exception {
+  @Override QueueConnection newQueueConnection() throws JMSException {
     if (!started.getAndSet(true)) resource.start();
     return factory.createQueueConnection();
   }
 
-  @Override TopicConnection newTopicConnection() throws Exception {
+  @Override TopicConnection newTopicConnection() throws JMSException {
     if (!started.getAndSet(true)) resource.start();
     return factory.createTopicConnection();
   }
 
-  @Override void setReadOnlyProperties(Message message, boolean readOnlyProperties)
-    throws Exception {
-    Field propertiesReadOnly = ActiveMQMessage.class.getDeclaredField("propertiesReadOnly");
-    propertiesReadOnly.setAccessible(true);
-    propertiesReadOnly.set(message, readOnlyProperties);
+  @Override void setReadOnlyProperties(Message message, boolean readOnlyProperties) {
+    try {
+      Field propertiesReadOnly = ActiveMQMessage.class.getDeclaredField("propertiesReadOnly");
+      propertiesReadOnly.setAccessible(true);
+      propertiesReadOnly.set(message, readOnlyProperties);
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
   }
 
   @Override public void after() {

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms.java
@@ -13,6 +13,7 @@
  */
 package brave.jms;
 
+import brave.messaging.MessagingTracing;
 import brave.test.ITRemote;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
@@ -21,17 +22,21 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 
 public abstract class ITJms extends ITRemote {
-  JmsTracing jmsTracing = JmsTracing.create(tracing);
+  MessagingTracing messagingTracing = MessagingTracing.create(tracing);
+  JmsTracing jmsTracing = JmsTracing.create(messagingTracing);
 
-  static Map<String, String> propertiesToMap(Message headers) throws Exception {
-    Map<String, String> result = new LinkedHashMap<>();
-
-    Enumeration<String> names = headers.getPropertyNames();
-    while (names.hasMoreElements()) {
-      String name = names.nextElement();
-      result.put(name, headers.getStringProperty(name));
+  static Map<String, String> propertiesToMap(Message headers) {
+    try {
+      Map<String, String> result = new LinkedHashMap<>();
+      Enumeration<String> names = headers.getPropertyNames();
+      while (names.hasMoreElements()) {
+        String name = names.nextElement();
+        result.put(name, headers.getStringProperty(name));
+      }
+      return result;
+    } catch (JMSException e) {
+      throw new AssertionError(e);
     }
-    return result;
   }
 
   interface JMSRunnable {

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import brave.messaging.MessagingTracing;
 import brave.sampler.Sampler;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
+import javax.jms.JMSException;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
@@ -31,11 +32,11 @@ public class ITJms_2_0_TracingMessageConsumer extends ITJms_1_1_TracingMessageCo
   }
 
   // Inability to encode "b3" on a received BytesMessage only applies to ActiveMQ 5.x
-  @Test public void receive_resumesTrace_bytes() throws Exception {
+  @Test public void receive_resumesTrace_bytes() throws JMSException {
     receive_resumesTrace(() -> messageProducer.send(bytesMessage), messageConsumer);
   }
 
-  @Test public void receive_customSampler() throws Exception {
+  @Test public void receive_customSampler() throws JMSException {
     queueReceiver.close();
 
     MessagingRuleSampler consumerSampler = MessagingRuleSampler.newBuilder()

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTestRule.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTestRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -62,15 +62,16 @@ public abstract class JmsTestRule extends ExternalResource {
     return message;
   }
 
-  abstract void setReadOnlyProperties(Message message, boolean readOnlyProperties) throws Exception;
+  abstract void setReadOnlyProperties(Message message, boolean readOnlyProperties)
+    throws JMSException;
 
-  abstract Connection newConnection() throws Exception;
+  abstract Connection newConnection() throws JMSException;
 
-  abstract QueueConnection newQueueConnection() throws Exception;
+  abstract QueueConnection newQueueConnection() throws JMSException;
 
-  abstract TopicConnection newTopicConnection() throws Exception;
+  abstract TopicConnection newTopicConnection() throws JMSException;
 
-  @Override public void before() throws Exception {
+  @Override public void before() throws JMSException {
     connection = newConnection();
     connection.start();
     // Pass redundant info as we can't user default method in activeMQ
@@ -112,17 +113,17 @@ public abstract class JmsTestRule extends ExternalResource {
       super(testName);
     }
 
-    @Override Connection newConnection() throws Exception {
+    @Override Connection newConnection() throws JMSException {
       return new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
         .createConnection();
     }
 
-    @Override QueueConnection newQueueConnection() throws Exception {
+    @Override QueueConnection newQueueConnection() throws JMSException {
       return new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
         .createQueueConnection();
     }
 
-    @Override TopicConnection newTopicConnection() throws Exception {
+    @Override TopicConnection newTopicConnection() throws JMSException {
       return new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
         .createTopicConnection();
     }

--- a/instrumentation/jms/src/test/java/brave/jms/MessageParserTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/MessageParserTest.java
@@ -13,6 +13,7 @@
  */
 package brave.jms;
 
+import javax.jms.JMSException;
 import javax.jms.Queue;
 import javax.jms.Topic;
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class MessageParserTest {
     assertThat(MessageParser.channelKind(null)).isNull();
   }
 
-  @Test public void channelKind_queueAndTopic_queueOnQueueName() throws Exception {
+  @Test public void channelKind_queueAndTopic_queueOnQueueName() throws JMSException {
     QueueAndTopic destination = mock(QueueAndTopic.class);
     when(destination.getQueueName()).thenReturn("queue-foo");
 
@@ -39,7 +40,7 @@ public class MessageParserTest {
       .isEqualTo("queue");
   }
 
-  @Test public void channelKind_queueAndTopic_topicOnNoQueueName() throws Exception {
+  @Test public void channelKind_queueAndTopic_topicOnNoQueueName() throws JMSException {
     QueueAndTopic destination = mock(QueueAndTopic.class);
     when(destination.getTopicName()).thenReturn("topic-foo");
 
@@ -51,7 +52,7 @@ public class MessageParserTest {
     assertThat(MessageParser.channelName(null)).isNull();
   }
 
-  @Test public void channelName_queueAndTopic_queueOnQueueName() throws Exception {
+  @Test public void channelName_queueAndTopic_queueOnQueueName() throws JMSException {
     QueueAndTopic destination = mock(QueueAndTopic.class);
     when(destination.getQueueName()).thenReturn("queue-foo");
 
@@ -59,7 +60,7 @@ public class MessageParserTest {
       .isEqualTo("queue-foo");
   }
 
-  @Test public void channelName_queueAndTopic_topicOnNoQueueName() throws Exception {
+  @Test public void channelName_queueAndTopic_topicOnNoQueueName() throws JMSException {
     QueueAndTopic destination = mock(QueueAndTopic.class);
     when(destination.getTopicName()).thenReturn("topic-foo");
 

--- a/instrumentation/jms/src/test/java/brave/jms/TracingCompletionListenerTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/TracingCompletionListenerTest.java
@@ -43,7 +43,7 @@ public class TracingCompletionListenerTest extends ITJms {
     // post-conditions validate no span was reported
   }
 
-  @Test public void on_completion_should_finish_span() throws Exception {
+  @Test public void on_completion_should_finish_span() {
     Message message = mock(Message.class);
     Span span = tracing.tracer().nextSpan().start();
 
@@ -51,10 +51,10 @@ public class TracingCompletionListenerTest extends ITJms {
       TracingCompletionListener.create(mock(CompletionListener.class), span, currentTraceContext);
     tracingCompletionListener.onCompletion(message);
 
-    takeLocalSpan();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void on_exception_should_tag_if_exception() throws Exception {
+  @Test public void on_exception_should_tag_if_exception() {
     Message message = mock(Message.class);
     Span span = tracing.tracer().nextSpan().start();
 
@@ -62,10 +62,10 @@ public class TracingCompletionListenerTest extends ITJms {
       TracingCompletionListener.create(mock(CompletionListener.class), span, currentTraceContext);
     tracingCompletionListener.onException(message, new Exception("Test exception"));
 
-    takeLocalSpanWithError("Test exception");
+    reporter.takeLocalSpanWithError("Test exception");
   }
 
-  @Test public void on_completion_should_forward_then_finish_span() throws Exception {
+  @Test public void on_completion_should_forward_then_finish_span() {
     Message message = mock(Message.class);
     Span span = tracing.tracer().nextSpan().start();
 
@@ -76,10 +76,10 @@ public class TracingCompletionListenerTest extends ITJms {
 
     verify(delegate).onCompletion(message);
 
-    takeLocalSpan();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void on_completion_should_have_span_in_scope() throws Exception {
+  @Test public void on_completion_should_have_span_in_scope() {
     Message message = mock(Message.class);
     Span span = tracing.tracer().nextSpan().start();
 
@@ -95,10 +95,10 @@ public class TracingCompletionListenerTest extends ITJms {
 
     TracingCompletionListener.create(delegate, span, currentTraceContext).onCompletion(message);
 
-    takeLocalSpan();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void on_exception_should_forward_then_tag() throws Exception {
+  @Test public void on_exception_should_forward_then_tag() {
     Message message = mock(Message.class);
     Span span = tracing.tracer().nextSpan().start();
 
@@ -110,6 +110,6 @@ public class TracingCompletionListenerTest extends ITJms {
 
     verify(delegate).onException(message, e);
 
-    takeLocalSpanWithError("Test exception");
+    reporter.takeLocalSpanWithError("Test exception");
   }
 }

--- a/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/test/java/brave/netty/http/ITNettyHttpTracing.java
@@ -32,7 +32,7 @@ public class ITNettyHttpTracing extends ITHttpServer {
   EventLoopGroup workerGroup;
   int port;
 
-  @Override protected void init() throws Exception {
+  @Override protected void init() {
     stop();
     bossGroup = new NioEventLoopGroup(1);
     workerGroup = new NioEventLoopGroup();
@@ -51,8 +51,13 @@ public class ITNettyHttpTracing extends ITHttpServer {
         }
       });
 
-    Channel ch = b.bind(0).sync().channel();
-    port = ((InetSocketAddress) ch.localAddress()).getPort();
+    try {
+      Channel ch = b.bind(0).sync().channel();
+      port = ((InetSocketAddress) ch.localAddress()).getPort();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
   }
 
   @Override

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -54,7 +54,7 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
   }
 
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
-    throws Exception {
+    throws IOException {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery))
       // intentionally deprecated method so that the v3.x tests can compile
       .post(RequestBody.create(MediaType.parse("text/plain"), body)).build())
@@ -75,7 +75,7 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
       });
   }
 
-  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+  @Test public void currentSpanVisibleToUserInterceptors() throws IOException {
     server.enqueue(new MockResponse());
     closeClient(client);
 
@@ -94,6 +94,6 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeRemoteSpan(Span.Kind.CLIENT);
+    reporter.takeRemoteSpan(Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -51,7 +51,7 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
   }
 
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
-    throws Exception {
+    throws IOException {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery))
       // intentionally deprecated method so that the v3.x tests can compile
       .post(RequestBody.create(MediaType.parse("text/plain"), body)).build())

--- a/instrumentation/rpc/src/test/java/brave/rpc/features/ExampleTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/features/ExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package brave.rpc.features;
 
 import brave.Tracing;
 import brave.rpc.RpcRuleSampler;
-import brave.rpc.RpcServerRequest;
 import brave.rpc.RpcTracing;
 import brave.sampler.RateLimitingSampler;
 import brave.sampler.Sampler;

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/ITSparkTracing.java
@@ -15,6 +15,7 @@ package brave.sparkjava;
 
 import brave.test.http.ITHttpServer;
 import brave.test.http.Log4J2Log;
+import java.io.IOException;
 import okhttp3.Response;
 import org.eclipse.jetty.util.log.Log;
 import org.junit.After;
@@ -26,13 +27,13 @@ public class ITSparkTracing extends ITHttpServer {
     Log.setLog(new Log4J2Log());
   }
 
-  @Override protected Response get(String path) throws Exception {
+  @Override protected Response get(String path) throws IOException {
     if (path.toLowerCase().indexOf("async") == -1) return super.get(path);
     throw new AssumptionViolatedException(
       "ignored until https://github.com/perwendel/spark/issues/208");
   }
 
-  @Override protected void init() throws Exception {
+  @Override protected void init() throws IOException {
     stop();
 
     SparkTracing spark = SparkTracing.create(httpTracing);
@@ -51,14 +52,9 @@ public class ITSparkTracing extends ITHttpServer {
     return "http://localhost:4567" + path;
   }
 
-  /**
-   * Spark stop asynchronously but share one class Instance, so AddressAlreadyUsed Exception may
-   * happen. See:https://github.com/perwendel/spark/issues/705 . Just sleep 1 second to avoid this
-   * happens, after Spark.awaitStopped add,I will fix it.
-   */
   @After
-  public void stop() throws InterruptedException {
+  public void stop() {
     Spark.stop();
-    Thread.sleep(1000);
+    Spark.awaitStop();
   }
 }

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -75,7 +75,7 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    takeRemoteSpan(Span.Kind.CLIENT);
+    reporter.takeRemoteSpan(Span.Kind.CLIENT);
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -44,8 +44,8 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     return configureClient(TracingClientHttpRequestInterceptor.create(httpTracing));
   }
 
-  @Override protected void closeClient(ClientHttpRequestFactory client) throws Exception {
-    ((HttpComponentsClientHttpRequestFactory) client).destroy();
+  @Override protected void closeClient(ClientHttpRequestFactory client) {
+    // unnecessary to cleanup as the IT runs in a sub-process
   }
 
   @Override protected void get(ClientHttpRequestFactory client, String pathIncludingQuery) {
@@ -60,7 +60,7 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     restTemplate.postForObject(url(uri), content, String.class);
   }
 
-  @Test public void currentSpanVisibleToUserInterceptors() throws Exception {
+  @Test public void currentSpanVisibleToUserInterceptors() throws InterruptedException {
     server.enqueue(new MockResponse());
 
     RestTemplate restTemplate = new RestTemplate(client);

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
@@ -40,7 +40,7 @@ public abstract class BaseITSpanCustomizingHandlerInterceptor extends ITServletC
   @Test public void addsControllerTags() throws Exception {
     get("/foo");
 
-    Span span = takeRemoteSpan(Span.Kind.SERVER);
+    Span span = reporter.takeRemoteSpan(Span.Kind.SERVER);
     assertThat(span.tags())
       .containsKeys("mvc.controller.class", "mvc.controller.method");
     assertThat(span.tags().get("mvc.controller.class"))

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
@@ -42,7 +42,7 @@ public class ITSpanCustomizingAsyncHandlerInterceptor extends ITServletContainer
   @Test public void addsControllerTags() throws Exception {
     get("/foo");
 
-    assertThat(takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("mvc.controller.class", "Servlet3TestController")
       .containsEntry("mvc.controller.method", "foo");
   }

--- a/spring-beans/src/test/java/brave/spring/beans/ExtraFieldPropagationFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/ExtraFieldPropagationFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import brave.propagation.ExtraFieldCustomizer;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.After;
 import org.junit.Test;
 

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,11 +18,9 @@ import brave.ErrorParser;
 import brave.Tracing;
 import brave.TracingCustomizer;
 import brave.handler.FinishedSpanHandler;
-import brave.propagation.CurrentTraceContext;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
-import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.Endpoint;


### PR DESCRIPTION
The Kafka ITs use two tracing instances at the same time. This extracts
`TestSpanReporter` from `ITRemote` so that it is possible to drive two
instrumentations at the same time.

This also narrows exception handling as `Exception` masked some test
setup problems.