### PR TITLE
Ports Kafka tests to ITRemote and fixes propagation bug

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -39,7 +39,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 final class TracingProducer<K, V> implements Producer<K, V> {
-
   final Producer<K, V> delegate;
   final KafkaTracing kafkaTracing;
   final CurrentTraceContext currentTraceContext;

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafka.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,35 +13,27 @@
  */
 package brave.kafka.clients;
 
-import brave.Tracing;
-import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.messaging.MessagingTracing;
+import brave.propagation.Propagation;
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import brave.test.ITRemote;
+import brave.test.util.AssertableCallback;
 import com.google.common.base.Charsets;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
-import org.junit.After;
-import zipkin2.Span;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-abstract class BaseTracingTest {
-  static String TRACE_ID = "463ac35c9f6413ad";
-  static String PARENT_ID = "463ac35c9f6413ab";
-  static String SPAN_ID = "48485a3953bb6124";
-  static String SAMPLED = "1";
-
+abstract class ITKafka extends ITRemote {
   String TEST_TOPIC = "myTopic";
   String TEST_KEY = "foo";
   String TEST_VALUE = "bar";
@@ -49,26 +41,12 @@ abstract class BaseTracingTest {
   ConsumerRecord<String, String> fakeRecord =
     new ConsumerRecord<>(TEST_TOPIC, 0, 1L, TEST_KEY, TEST_VALUE);
 
-  BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
-  Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-      .addScopeDecorator(StrictScopeDecorator.create())
-      .build())
-    .spanReporter(spans::add)
-    .build();
-  CurrentTraceContext current = tracing.currentTraceContext();
-  KafkaTracing kafkaTracing = KafkaTracing.create(tracing);
+  MessagingTracing messagingTracing = MessagingTracing.create(tracing);
+  KafkaTracing kafkaTracing = KafkaTracing.create(messagingTracing);
+  TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
 
-  @After public void tearDown() {
-    tracing.close();
-  }
-
-  static <K, V> void addB3MultiHeaders(ConsumerRecord<K, V> record) {
-    record.headers()
-      .add("X-B3-TraceId", TRACE_ID.getBytes(StandardCharsets.UTF_8))
-      .add("X-B3-ParentSpanId", PARENT_ID.getBytes(StandardCharsets.UTF_8))
-      .add("X-B3-SpanId", SPAN_ID.getBytes(StandardCharsets.UTF_8))
-      .add("X-B3-Sampled", SAMPLED.getBytes(StandardCharsets.UTF_8));
+  <K, V> void addB3MultiHeaders(ConsumerRecord<K, V> record) {
+    Propagation.B3_STRING.injector(KafkaPropagation.SETTER).inject(parent, record.headers());
   }
 
   static Set<Map.Entry<String, String>> lastHeaders(Headers headers) {
@@ -87,14 +65,20 @@ abstract class BaseTracingTest {
     return headers;
   }
 
-  /** Call this to block until a span was reported */
-  static Span takeSpan(BlockingQueue<Span> spans) throws InterruptedException {
-    Span result = spans.poll(3, TimeUnit.SECONDS);
-    assertThat(result)
-      .withFailMessage("span was not reported")
-      .isNotNull();
-    // ensure the span finished
-    assertThat(result.durationAsLong()).isPositive();
-    return result;
+  /** {@link #join()} waits for the callback to complete without any errors */
+  static final class BlockingCallback implements Callback {
+    final AssertableCallback<RecordMetadata> delegate = new AssertableCallback<>();
+
+    void join() {
+      delegate.join();
+    }
+
+    @Override public void onCompletion(RecordMetadata metadata, Exception exception) {
+      if (exception != null) {
+        delegate.onError(exception);
+      } else {
+        delegate.onSuccess(metadata);
+      }
+    }
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingCallbackTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,70 +24,72 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class TracingCallbackTest extends BaseTracingTest {
+public class TracingCallbackTest extends ITKafka {
   @Test public void onCompletion_shouldKeepContext_whenNotSampled() {
     Span span = tracing.tracer().nextSpan(TraceContextOrSamplingFlags.NOT_SAMPLED);
 
     Callback delegate =
       (metadata, exception) -> assertThat(tracing.tracer().currentSpan()).isEqualTo(span);
-    Callback tracingCallback = TracingCallback.create(delegate, span, current);
+    Callback tracingCallback = TracingCallback.create(delegate, span, currentTraceContext);
 
     tracingCallback.onCompletion(null, null);
   }
 
-  @Test public void on_completion_should_finish_span() throws InterruptedException {
+  @Test public void on_completion_should_finish_span() {
     Span span = tracing.tracer().nextSpan().start();
 
-    Callback tracingCallback = TracingCallback.create(null, span, current);
+    Callback tracingCallback = TracingCallback.create(null, span, currentTraceContext);
     tracingCallback.onCompletion(createRecordMetadata(), null);
 
-    assertThat(spans.take()).isNotNull();
+    reporter.takeLocalSpan();
   }
 
-  @Test public void on_completion_should_tag_if_exception() throws InterruptedException {
+  @Test public void on_completion_should_tag_if_exception() {
     Span span = tracing.tracer().nextSpan().start();
 
-    Callback tracingCallback = TracingCallback.create(null, span, current);
+    Callback tracingCallback = TracingCallback.create(null, span, currentTraceContext);
     tracingCallback.onCompletion(null, new Exception("Test exception"));
 
-    assertThat(spans.take().tags())
-      .containsEntry("error", "Test exception");
+    reporter.takeLocalSpanWithError("Test exception");
   }
 
-  @Test public void on_completion_should_forward_then_finish_span() throws InterruptedException {
+  @Test public void on_completion_should_forward_then_finish_span() {
     Span span = tracing.tracer().nextSpan().start();
 
     Callback delegate = mock(Callback.class);
-    Callback tracingCallback = TracingCallback.create(delegate, span, current);
+    Callback tracingCallback = TracingCallback.create(delegate, span, currentTraceContext);
     RecordMetadata md = createRecordMetadata();
     tracingCallback.onCompletion(md, null);
 
     verify(delegate).onCompletion(md, null);
-    assertThat(spans.take()).isNotNull();
+
+    reporter.takeLocalSpan();
   }
 
   @Test public void on_completion_should_have_span_in_scope() {
     Span span = tracing.tracer().nextSpan().start();
 
-    Callback delegate = (metadata, exception) -> assertThat(current.get()).isSameAs(span.context());
+    Callback delegate =
+      (metadata, exception) -> assertThat(currentTraceContext.get()).isSameAs(span.context());
 
-    TracingCallback.create(delegate, span, current).onCompletion(createRecordMetadata(), null);
+    TracingCallback.create(delegate, span, currentTraceContext)
+      .onCompletion(createRecordMetadata(), null);
+
+    reporter.takeLocalSpan();
   }
 
-  @Test public void on_completion_should_forward_then_tag_if_exception()
-    throws InterruptedException {
+  @Test public void on_completion_should_forward_then_tag_if_exception() {
     Span span = tracing.tracer().nextSpan().start();
 
     Callback delegate = mock(Callback.class);
-    Callback tracingCallback = TracingCallback.create(delegate, span, current);
+    Callback tracingCallback = TracingCallback.create(delegate, span, currentTraceContext);
     RecordMetadata md = createRecordMetadata();
     Exception e = new Exception("Test exception");
     tracingCallback.onCompletion(md, e);
 
     verify(delegate).onCompletion(md, e);
 
-    assertThat(spans.take().tags())
-      .containsEntry("error", "Test exception");
+    reporter.takeLocalSpanWithError("Test exception");
   }
 
   RecordMetadata createRecordMetadata() {

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingProducerTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/TracingProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package brave.kafka.clients;
 
-import brave.ScopedSpan;
+import brave.propagation.CurrentTraceContext.Scope;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,7 +26,7 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-public class TracingProducerTest extends BaseTracingTest {
+public class TracingProducerTest extends ITKafka {
   MockProducer<Object, String> mockProducer = new MockProducer<>();
   KafkaTracing kafkaTracing = KafkaTracing.create(tracing);
   TracingProducer<Object, String> tracingProducer =
@@ -43,47 +43,40 @@ public class TracingProducerTest extends BaseTracingTest {
     assertThat(headerKeys).containsOnly("b3");
   }
 
-  @Test public void should_add_b3_headers_when_other_headers_exist() throws InterruptedException {
+  @Test public void should_add_b3_headers_when_other_headers_exist() {
     ProducerRecord<Object, String> record = new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE);
     record.headers().add("tx-id", "1".getBytes());
     tracingProducer.send(record);
     mockProducer.completeNext();
 
-    Span producerSpan = takeSpan(spans);
+    Span producerSpan = reporter.takeRemoteSpan(Span.Kind.PRODUCER);
     assertThat(lastHeaders(mockProducer))
       .containsEntry("tx-id", "1")
       .containsEntry("b3", producerSpan.traceId() + "-" + producerSpan.id() + "-1");
   }
 
-  @Test public void should_inject_child_context() throws InterruptedException {
-    ScopedSpan scopedSpan = tracing.tracer().startScopedSpan("main");
-    tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE));
-    mockProducer.completeNext();
-    scopedSpan.finish();
+  @Test public void should_inject_child_context() {
+    try (Scope scope = currentTraceContext.newScope(parent)) {
+      tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE));
+      mockProducer.completeNext();
+    }
 
-    Span producerSpan = takeSpan(spans);
+    Span producerSpan = reporter.takeRemoteSpan(Span.Kind.PRODUCER);
+    assertChildOf(producerSpan, parent);
     assertThat(lastHeaders(mockProducer))
       .containsEntry("b3", producerSpan.traceId() + "-" + producerSpan.id() + "-1");
-
-    assertThat(producerSpan.parentId())
-      .isEqualTo(takeSpan(spans).id());
   }
 
-  @Test public void should_add_parent_trace_when_context_injected_on_headers()
-    throws InterruptedException {
-    brave.Span span = tracing.tracer().newTrace().start();
+  @Test public void should_add_parent_trace_when_context_injected_on_headers() {
     ProducerRecord<Object, String> record = new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE);
-    tracingProducer.injector.inject(span.context(), new KafkaProducerRequest(record));
+    tracingProducer.injector.inject(parent, new KafkaProducerRequest(record));
     tracingProducer.send(record);
     mockProducer.completeNext();
-    span.finish();
 
-    Span producerSpan = takeSpan(spans);
+    Span producerSpan = reporter.takeRemoteSpan(Span.Kind.PRODUCER);
+    assertChildOf(producerSpan, parent);
     assertThat(lastHeaders(mockProducer))
       .containsEntry("b3", producerSpan.traceId() + "-" + producerSpan.id() + "-1");
-
-    assertThat(producerSpan.parentId())
-      .isEqualTo(takeSpan(spans).id());
   }
 
   @Test public void should_call_wrapped_producer() {
@@ -96,17 +89,15 @@ public class TracingProducerTest extends BaseTracingTest {
     tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE));
     mockProducer.completeNext();
 
-    assertThat(spans)
-      .flatExtracting(Span::name)
-      .containsOnly("send");
+    assertThat(reporter.takeRemoteSpan(Span.Kind.PRODUCER).name())
+      .isEqualTo("send");
   }
 
   @Test public void send_should_tag_topic_and_key() {
     tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE));
     mockProducer.completeNext();
 
-    assertThat(spans)
-      .flatExtracting(s -> s.tags().entrySet())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.PRODUCER).tags())
       .containsOnly(entry("kafka.topic", TEST_TOPIC), entry("kafka.key", TEST_KEY));
   }
 
@@ -114,8 +105,7 @@ public class TracingProducerTest extends BaseTracingTest {
     tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, null, TEST_VALUE));
     mockProducer.completeNext();
 
-    assertThat(spans)
-      .flatExtracting(s -> s.tags().entrySet())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.PRODUCER).tags())
       .containsOnly(entry("kafka.topic", TEST_TOPIC));
   }
 
@@ -123,8 +113,7 @@ public class TracingProducerTest extends BaseTracingTest {
     tracingProducer.send(new ProducerRecord<>(TEST_TOPIC, new byte[1], TEST_VALUE));
     mockProducer.completeNext();
 
-    assertThat(spans)
-      .flatExtracting(s -> s.tags().entrySet())
+    assertThat(reporter.takeRemoteSpan(Span.Kind.PRODUCER).tags())
       .containsOnly(entry("kafka.topic", TEST_TOPIC));
   }
 }

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilter.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import brave.Span;
 import brave.Tracer;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import zipkin2.Call;
 
 import static brave.kafka.streams.KafkaStreamsTags.KAFKA_STREAMS_FILTERED_TAG;
 import static zipkin2.Call.propagateIfFatal;

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingProcessor.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import brave.Span;
 import brave.Tracer;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import zipkin2.Call;
 
 import static zipkin2.Call.propagateIfFatal;
 

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingTransformer.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import brave.Span;
 import brave.Tracer;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import zipkin2.Call;
 
 import static zipkin2.Call.propagateIfFatal;
 

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformer.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import brave.Span;
 import brave.Tracer;
 import org.apache.kafka.streams.kstream.ValueTransformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import zipkin2.Call;
 
 import static zipkin2.Call.propagateIfFatal;
 

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformerWithKey.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/TracingValueTransformerWithKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import brave.Span;
 import brave.Tracer;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import zipkin2.Call;
 
 import static zipkin2.Call.propagateIfFatal;
 


### PR DESCRIPTION
Note: there's significant opportunity for deduplication in the kafka tests right now. However, I'd like to conserve energy as some of it would be magically deduplicated if we do that messaging abstraction. It is also possible to do more deduping offline.

cc @jeqo @jorgheymans 