### PR TITLE
Makes StrictScopeDecorator stricter without renaming it

### DIFF
--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -24,6 +24,7 @@ import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
@@ -73,7 +74,7 @@ public abstract class ITRemote {
   final StrictScopeDecorator strictScopeDecorator = StrictScopeDecorator.create();
 
   // field because this allows subclasses to initialize a field Tracing
-  protected final CurrentTraceContext currentTraceContext =
+  protected final ThreadLocalCurrentTraceContext currentTraceContext =
     ThreadLocalCurrentTraceContext.newBuilder()
       .addScopeDecorator(strictScopeDecorator)
       .build();
@@ -89,6 +90,11 @@ public abstract class ITRemote {
       .propagationFactory(propagationFactory)
       .currentTraceContext(currentTraceContext)
       .sampler(sampler);
+  }
+
+  /** Ensure any leaks present were caused by code invoked in the current method */
+  @Before public void clearThreadLocal() {
+    currentTraceContext.clear();
   }
 
   /**

--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -98,7 +98,20 @@ public abstract class ITRemote {
 
   /**
    * This closes the current instance of tracing, to prevent it from being accidentally visible to
-   * other test classes which call {@link Tracing#current()}. It also checks for scope leaks!
+   * other test classes which call {@link Tracing#current()}.
+   *
+   * <p>This also checks for scope leaks. It is important that you have closed all resources prior
+   * to this method call. Otherwise, in-flight request cleanup may be mistaken for scope leaks. This
+   * may involve blocking on completion, if using executors.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * @After @Override public void close() throws Exception {
+   *   executorService.shutdown();
+   *   executorService.awaitTermination(1, TimeUnit.SECONDS);
+   *   super.close();
+   * }
+   * }</pre>
    */
   @After public void close() throws Exception {
     Tracing current = Tracing.current();

--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,11 +15,25 @@ package brave.propagation;
 
 import brave.test.propagation.CurrentTraceContextTest;
 import java.util.function.Supplier;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadLocalCurrentTraceContextTest extends CurrentTraceContextTest {
 
   @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
     return CurrentSupplier.class;
+  }
+
+  /** Since the default thread-local is static, this helps code avoid leaks made by others. */
+  @Test public void clear_unleaks() {
+    currentTraceContext.newScope(context); // leak a scope
+
+    assertThat(currentTraceContext.get()).isEqualTo(context);
+
+    ((ThreadLocalCurrentTraceContext) currentTraceContext).clear();
+
+    assertThat(currentTraceContext.get()).isNull();
   }
 
   static class CurrentSupplier implements Supplier<CurrentTraceContext> {

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,9 +13,16 @@
  */
 package brave.propagation;
 
+import brave.Tracer;
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static java.lang.Thread.currentThread;
 
 /**
  * Useful when developing instrumentation as state is enforced more strictly.
@@ -30,38 +37,96 @@ import brave.propagation.CurrentTraceContext.ScopeDecorator;
  *                  ).build();
  * }</pre>
  */
-public final class StrictScopeDecorator implements ScopeDecorator {
-  public static ScopeDecorator create() {
+// Closeable so things like Spring will automatically execute it on shutdown and expose leaks!
+public final class StrictScopeDecorator implements ScopeDecorator, Closeable {
+  public static StrictScopeDecorator create() {
     return new StrictScopeDecorator();
   }
 
-  /** Identifies problems by throwing assertion errors when a scope is closed on a different thread. */
-  @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
-    return new StrictScope(scope, new Error(String.format("Thread %s opened scope for %s here:",
-      Thread.currentThread().getName(), currentSpan)));
+  final Queue<CallerStackTrace> currentCallers = new ConcurrentLinkedQueue<>();
+
+  /**
+   * Identifies problems by throwing {@link IllegalStateException} when a scope is closed on a
+   * different thread.
+   */
+  @Override public Scope decorateScope(@Nullable TraceContext context, Scope scope) {
+    CallerStackTrace caller = new CallerStackTrace(context);
+    StackTraceElement[] stackTrace = caller.getStackTrace();
+
+    // "new CallerStackTrace(context)" isn't the line we want to start the caller stack trace with
+    int i = 1;
+
+    // This skips internal utilities in this jar. Notably, this will not skip utilities outside it.
+    // For example, HTTP or messaging handlers will become the caller, as would wrappers over Brave,
+    // such as brave-opentracing. This is ok, as if they have bugs, they will show up as the caller!
+    while (i < stackTrace.length) {
+      String className = stackTrace[i].getClassName();
+      if (className.equals(Tracer.class.getName())
+        || className.endsWith("CurrentTraceContext") // subtypes with conventional names
+        || className.equals(ThreadLocalSpan.class.getName())) {
+        i++;
+      } else {
+        break;
+      }
+    }
+    int from = i;
+
+    stackTrace = Arrays.copyOfRange(stackTrace, from, stackTrace.length);
+    caller.setStackTrace(stackTrace);
+
+    return new StrictScope(scope, caller, currentCallers);
+  }
+
+  /**
+   * @throws IllegalStateException if any scopes were left unclosed.
+   * @since 5.11
+   */
+  @Override public void close() {
+    for (CallerStackTrace caller : currentCallers) {
+      // Sometimes unit test runners truncate the cause of the exception.
+      // This flattens the exception as the caller of close() isn't important vs the one that leaked
+      IllegalStateException toThrow = new IllegalStateException(
+        "Thread [" + caller.threadName + "] leaked a scope of " + caller.context + " here:");
+      toThrow.setStackTrace(caller.getStackTrace());
+      throw toThrow;
+    }
   }
 
   static final class StrictScope implements Scope {
     final Scope delegate;
-    final Throwable caller;
-    final long threadId = Thread.currentThread().getId();
+    final Queue<CallerStackTrace> currentCallers;
+    final CallerStackTrace caller;
 
-    StrictScope(Scope delegate, Throwable caller) {
+    StrictScope(Scope delegate, CallerStackTrace caller, Queue<CallerStackTrace> currentCallers) {
       this.delegate = delegate;
+      this.currentCallers = currentCallers;
       this.caller = caller;
+      this.currentCallers.add(caller);
     }
 
     @Override public void close() {
-      if (Thread.currentThread().getId() != threadId) {
-        throw new IllegalStateException(
-          "scope closed in a different thread: " + Thread.currentThread().getName(),
-          caller);
+      currentCallers.remove(caller);
+      if (currentThread().getId() != caller.threadId) {
+        throw new IllegalStateException(String.format(
+          "Thread [%s] opened scope, but thread [%s] closed it", caller.threadName,
+          currentThread().getName()), caller);
       }
       delegate.close();
     }
 
     @Override public String toString() {
-      return caller.toString();
+      return caller.getMessage();
+    }
+  }
+
+  static class CallerStackTrace extends Throwable {
+    final String threadName = currentThread().getName();
+    final long threadId = currentThread().getId();
+    final TraceContext context;
+
+    CallerStackTrace(@Nullable TraceContext context) {
+      super("Thread [" + currentThread().getName() + "] opened scope for " + context + " here:");
+      this.context = context;
     }
   }
 

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -50,6 +50,7 @@ public final class StrictScopeDecorator implements ScopeDecorator, Closeable {
    * different thread.
    */
   @Override public Scope decorateScope(@Nullable TraceContext context, Scope scope) {
+    if (scope == Scope.NOOP) return scope;
     CallerStackTrace caller = new CallerStackTrace(context);
     StackTraceElement[] stackTrace = caller.getStackTrace();
 

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 import static java.lang.Thread.currentThread;
 
@@ -80,6 +81,12 @@ public final class StrictScopeDecorator implements ScopeDecorator, Closeable {
   }
 
   /**
+   * This is useful in tests to help ensure scopes are not leaked by instrumentation.
+   *
+   * <p><em>Note:</em> It is important to close all resources prior to calling this, so that
+   * in-flight operations are not mistaken as scope leaks. If this raises an error, consider if a
+   * {@linkplain CurrentTraceContext#executor(Executor) wrapped executor} is still running.
+   *
    * @throws AssertionError if any scopes were left unclosed.
    * @since 5.11
    */
@@ -91,7 +98,7 @@ public final class StrictScopeDecorator implements ScopeDecorator, Closeable {
       // Sometimes unit test runners truncate the cause of the exception.
       // This flattens the exception as the caller of close() isn't important vs the one that leaked
       AssertionError toThrow = new AssertionError(
-        "Thread [" + caller.threadName + "] leaked a scope of " + caller.context + " here:");
+        "Thread [" + caller.threadName + "] opened a scope of " + caller.context + " here:");
       toThrow.setStackTrace(caller.getStackTrace());
       throw toThrow;
     }

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -78,14 +78,15 @@ public final class StrictScopeDecorator implements ScopeDecorator, Closeable {
   }
 
   /**
-   * @throws IllegalStateException if any scopes were left unclosed.
+   * @throws AssertionError if any scopes were left unclosed.
    * @since 5.11
    */
+  // AssertionError to ensure test runners render the stack trace
   @Override public void close() {
     for (CallerStackTrace caller : currentCallers) {
       // Sometimes unit test runners truncate the cause of the exception.
       // This flattens the exception as the caller of close() isn't important vs the one that leaked
-      IllegalStateException toThrow = new IllegalStateException(
+      AssertionError toThrow = new AssertionError(
         "Thread [" + caller.threadName + "] leaked a scope of " + caller.context + " here:");
       toThrow.setStackTrace(caller.getStackTrace());
       throw toThrow;

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -48,7 +48,8 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
 
   /**
    * This component is backed by a possibly static shared thread local. Call this to clear the
-   * reference when you are sure any residual state is due to a leak.
+   * reference when you are sure any residual state is due to a leak. This is generally only useful
+   * in tests.
    *
    * @since 5.11
    */

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -42,13 +42,27 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
     return new Builder().build();
   }
 
-  public static CurrentTraceContext.Builder newBuilder() {
+  public static Builder newBuilder() {
     return new Builder();
   }
 
-  static final class Builder extends CurrentTraceContext.Builder {
+  /**
+   * This component is backed by a possibly static shared thread local. Call this to clear the
+   * reference when you are sure any residual state is due to a leak.
+   *
+   * @since 5.11
+   */
+  public void clear() {
+    local.remove();
+  }
 
-    @Override public CurrentTraceContext build() {
+  /** @since 5.11 */ // overridden for covariance
+  public static final class Builder extends CurrentTraceContext.Builder {
+    @Override public Builder addScopeDecorator(ScopeDecorator scopeDecorator) {
+      return (Builder) super.addScopeDecorator(scopeDecorator);
+    }
+
+    @Override public ThreadLocalCurrentTraceContext build() {
       return new ThreadLocalCurrentTraceContext(this, DEFAULT);
     }
 

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
@@ -54,6 +54,12 @@ public class StrictScopeDecoratorTest {
     decorator.close(); // doesn't error
   }
 
+  @Test public void doesntDecorateNoop() {
+    assertThat(decorator.decorateScope(context, Scope.NOOP))
+      .isSameAs(Scope.NOOP);
+    decorator.close(); // doesn't error
+  }
+
   static class BusinessClass {
     final Tracing tracing;
     final ThreadLocalSpan threadLocalSpan;

--- a/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.propagation;
+
+import brave.ScopedSpan;
+import brave.Tracing;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import brave.sampler.SamplerFunctions;
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.Reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+public class StrictScopeDecoratorTest {
+  StrictScopeDecorator decorator = StrictScopeDecorator.create();
+  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
+    .addScopeDecorator(decorator)
+    .build();
+  Tracing tracing = Tracing.newBuilder()
+    .spanReporter(Reporter.NOOP)
+    .currentTraceContext(currentTraceContext)
+    .build();
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
+  BusinessClass businessClass = new BusinessClass(tracing, decorator, context);
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  @Test public void decorator_close_afterCorrectUsage() {
+    try (Scope ws = currentTraceContext.newScope(null)) {
+      try (Scope ws2 = currentTraceContext.newScope(context)) {
+      }
+    }
+
+    decorator.close(); // doesn't error
+  }
+
+  static class BusinessClass {
+    final Tracing tracing;
+    final ThreadLocalSpan threadLocalSpan;
+    final ScopeDecorator decorator;
+    final TraceContext context;
+
+    BusinessClass(Tracing tracing, ScopeDecorator decorator, TraceContext context) {
+      this.tracing = tracing;
+      this.threadLocalSpan = ThreadLocalSpan.create(tracing.tracer());
+      this.decorator = decorator;
+      this.context = context;
+    }
+
+    Closeable businessMethodAdHoc() {
+      return decorator.decorateScope(context, mock(Scope.class));
+    }
+
+    Closeable businessMethodNewScope() {
+      return tracing.currentTraceContext().newScope(context);
+    }
+
+    Closeable businessMethodMaybeScope() {
+      return tracing.currentTraceContext().maybeScope(context);
+    }
+
+    Closeable businessMethodWithSpanInScope() {
+      return tracing.tracer().withSpanInScope(tracing.tracer().nextSpan());
+    }
+
+    Closeable businessMethodStartScopedSpan() {
+      ScopedSpan span = tracing.tracer().startScopedSpan("foo");
+      return span::finish;
+    }
+
+    Closeable businessMethodStartScopedSpan_sampler() {
+      ScopedSpan span =
+        tracing.tracer().startScopedSpan("foo", SamplerFunctions.neverSample(), false);
+      return span::finish;
+    }
+
+    Closeable businessMethodStartScopedSpanWithParent() {
+      ScopedSpan span = tracing.tracer().startScopedSpanWithParent("foo", null);
+      return span::finish;
+    }
+
+    Closeable businessMethodThreadLocalSpan() {
+      threadLocalSpan.next();
+      return threadLocalSpan::remove;
+    }
+  }
+
+  @Test public void scope_close_onWrongThread_adHoc() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodAdHoc, "businessMethodAdHoc");
+  }
+
+  @Test public void decorator_close_withLeakedScope_adHoc() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodAdHoc, "businessMethodAdHoc");
+  }
+
+  @Test public void scope_close_onWrongThread_newScope() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodNewScope, "businessMethodNewScope");
+  }
+
+  @Test public void decorator_close_withLeakedScope_onWrongThread_newScope() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodNewScope,
+      "businessMethodNewScope");
+  }
+
+  @Test public void scope_close_onWrongThread_maybeScope() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodMaybeScope, "businessMethodMaybeScope");
+  }
+
+  @Test public void decorator_close_withLeakedScope_maybeScope() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodMaybeScope,
+      "businessMethodMaybeScope");
+  }
+
+  @Test public void scope_close_onWrongThread_withSpanInScope() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodWithSpanInScope,
+      "businessMethodWithSpanInScope");
+  }
+
+  @Test public void decorator_close_withLeakedScope_withSpanInScope() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodWithSpanInScope,
+      "businessMethodWithSpanInScope");
+  }
+
+  @Test public void scope_close_onWrongThread_startScopedSpan() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodStartScopedSpan,
+      "businessMethodStartScopedSpan");
+  }
+
+  @Test public void decorator_close_withLeakedScope_startScopedSpan() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodStartScopedSpan,
+      "businessMethodStartScopedSpan");
+  }
+
+  @Test public void scope_close_onWrongThread_startScopedSpan_sampler() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodStartScopedSpan_sampler,
+      "businessMethodStartScopedSpan_sampler");
+  }
+
+  @Test public void decorator_close_withLeakedScope_startScopedSpan_sampler() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodStartScopedSpan_sampler,
+      "businessMethodStartScopedSpan_sampler");
+  }
+
+  @Test public void scope_close_onWrongThread_startScopedSpanWithParent() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodStartScopedSpanWithParent,
+      "businessMethodStartScopedSpanWithParent");
+  }
+
+  @Test public void decorator_close_withLeakedScope_startScopedSpanWithParent() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodStartScopedSpanWithParent,
+      "businessMethodStartScopedSpanWithParent");
+  }
+
+  // ThreadLocalSpan by definition can't be closed on another thread
+  @Test(expected = AssertionError.class)
+  public void scope_close_onWrongThread_threadLocalSpan() throws Exception {
+    scope_close_onWrongThread(businessClass::businessMethodThreadLocalSpan,
+      "businessMethodThreadLocalSpan");
+  }
+
+  @Test public void decorator_close_withLeakedScope_threadLocalSpan() throws Exception {
+    decorator_close_withLeakedScope(businessClass::businessMethodThreadLocalSpan,
+      "businessMethodThreadLocalSpan");
+  }
+
+  void scope_close_onWrongThread(Supplier<Closeable> method, String methodName) throws Exception {
+    AtomicReference<Closeable> closeable = new AtomicReference<>();
+    Thread t1 = new Thread(() -> closeable.set(method.get()));
+    t1.setName("t1");
+    t1.start();
+    t1.join();
+
+    AtomicReference<Throwable> errorCatcher = new AtomicReference<>();
+
+    Thread t2 = new Thread(() -> {
+      try {
+        closeable.get().close();
+      } catch (Throwable t) {
+        errorCatcher.set(t);
+      }
+    });
+    t2.setName("t2");
+    t2.start();
+    t2.join();
+
+    assertThat(errorCatcher.get())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Thread [t1] opened scope, but thread [t2] closed it")
+      .satisfies(e -> assertThat(e.getCause().getMessage())
+        .matches("Thread \\[t1\\] opened scope for [0-9a-f]{16}/[0-9a-f]{16} here:"))
+      .satisfies(e -> assertStackTraceStartsWithMethod(e.getCause(), methodName));
+  }
+
+  void decorator_close_withLeakedScope(Supplier<Closeable> method, String methodName)
+    throws Exception {
+    Thread thread = new Thread(method::get);
+    thread.setName("t1");
+    thread.start();
+    thread.join();
+
+    assertThatThrownBy(decorator::close)
+      .isInstanceOf(IllegalStateException.class)
+      .satisfies(t -> assertThat(t.getMessage())
+        .matches("Thread \\[t1\\] leaked a scope of [0-9a-f]{16}/[0-9a-f]{16} here:"))
+      .hasNoCause()
+      .satisfies(t -> assertStackTraceStartsWithMethod(t, methodName));
+  }
+
+  static void assertStackTraceStartsWithMethod(Throwable throwable, String methodName) {
+    assertThat(throwable.getStackTrace()[0].getMethodName())
+      .isEqualTo(methodName);
+  }
+}

--- a/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
@@ -227,7 +227,7 @@ public class StrictScopeDecoratorTest {
     assertThatThrownBy(decorator::close)
       .isInstanceOf(AssertionError.class)
       .satisfies(t -> assertThat(t.getMessage())
-        .matches("Thread \\[t1\\] leaked a scope of [0-9a-f]{16}/[0-9a-f]{16} here:"))
+        .matches("Thread \\[t1\\] opened a scope of [0-9a-f]{16}/[0-9a-f]{16} here:"))
       .hasNoCause()
       .satisfies(t -> assertStackTraceStartsWithMethod(t, methodName));
   }

--- a/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
@@ -219,7 +219,7 @@ public class StrictScopeDecoratorTest {
     thread.join();
 
     assertThatThrownBy(decorator::close)
-      .isInstanceOf(IllegalStateException.class)
+      .isInstanceOf(AssertionError.class)
       .satisfies(t -> assertThat(t.getMessage())
         .matches("Thread \\[t1\\] leaked a scope of [0-9a-f]{16}/[0-9a-f]{16} here:"))
       .hasNoCause()

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -60,12 +60,12 @@ public abstract class ITHttpClient<C> extends ITRemote {
   protected Extractor<RecordedRequest> extractor =
     propagationFactory.create(Propagation.KeyFactory.STRING).extractor(RecordedRequest::getHeader);
 
-  @Before public void setup() {
+  @Before public void setup() throws IOException {
     client = newClient(server.getPort());
   }
 
   /** Make sure the client you return has retries disabled. */
-  protected abstract C newClient(int port);
+  protected abstract C newClient(int port) throws IOException;
 
   protected abstract void closeClient(C client) throws IOException;
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -73,6 +73,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
 
   protected abstract void post(C client, String pathIncludingQuery, String body) throws IOException;
 
+  /** Closes the client prior to calling {@link ITRemote#close()} */
   @Override @After public void close() throws Exception {
     closeClient(client);
     super.close();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -51,6 +51,12 @@ import static brave.sampler.Sampler.NEVER_SAMPLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ITHttpServer extends ITRemote {
+  public static final IllegalStateException NOT_READY_ISE = new IllegalStateException("not ready") {
+    @Override public Throwable fillInStackTrace() {
+      return this; // don't fill logs as we are only testing
+    }
+  };
+
   OkHttpClient client = new OkHttpClient();
   protected HttpTracing httpTracing = HttpTracing.create(tracing);
 
@@ -440,12 +446,9 @@ public abstract class ITHttpServer extends ITRemote {
   }
 
   /**
-   * Some synchronous frameworks have limited means to adjust the HTTP status code upon raising an
-   * exception. When this is the case, use the following built-in exception:
-   *
-   * <p><pre>{@code
-   *   throw new UnavailableException("not ready", 1); // implies 503
-   * }</pre>
+   * Throw {@link ITHttpServer#NOT_READY_ISE} inside your controller unless you cannot control the
+   * HTTP status code. When this is the case, you may be able to use a wrapped exception such as
+   * {@link ITServletContainer#NOT_READY_UE} instead.
    */
   @Test public void httpStatusCodeTagMatchesResponse_onException() throws IOException {
     httpStatusCodeTagMatchesResponse("/exception", ".+");

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -83,7 +83,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
       req.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 503);
       // TODO: org.eclipse.jetty.server.HttpChannelState.onError() clobbers ^^ and hard-codes
       // status based on servlet types.
-      throw new UnavailableException("not ready", 1 /* temporary implies 503 */);
+      throw NOT_READY_UE;
     }
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
@@ -102,7 +102,7 @@ public abstract class ITServlet3Container extends ITServlet25Container {
         @Override public void onStartAsync(AsyncEvent event) {
         }
       });
-      throw new IllegalStateException("not ready");
+      throw NOT_READY_ISE;
     }
   }
 
@@ -142,7 +142,7 @@ public abstract class ITServlet3Container extends ITServlet25Container {
       if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
 
       if (req.getAttribute("dispatched") != null) {
-        throw new IllegalStateException("not ready");
+        throw NOT_READY_ISE;
       }
 
       req.setAttribute("dispatched", Boolean.TRUE);

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
@@ -14,12 +14,20 @@
 package brave.test.http;
 
 import brave.test.http.ServletContainer.ServerController;
+import javax.servlet.UnavailableException;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.log.Log;
 import org.junit.After;
 
 /** Starts a jetty server which runs a servlet container */
 public abstract class ITServletContainer extends ITHttpServer {
+  public static final UnavailableException NOT_READY_UE =
+    new UnavailableException("not ready", 1 /* temporary implies 503 */) {
+      @Override public Throwable fillInStackTrace() {
+        return this; // don't fill logs as we are only testing
+      }
+    };
+
   final ServerController serverController;
 
   protected ITServletContainer(ServerController serverController) {

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TestResource.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/TestResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
 
 import static brave.test.ITRemote.EXTRA_KEY;
+import static brave.test.http.ITHttpServer.NOT_READY_ISE;
 
 @Path("")
 public class TestResource { // public for resteasy to inject
@@ -74,14 +75,14 @@ public class TestResource { // public for resteasy to inject
   @GET
   @Path("exception")
   public Response notReady() {
-    throw new WebApplicationException(new IllegalStateException("not ready"), 503);
+    throw new WebApplicationException(NOT_READY_ISE, 503);
   }
 
   @GET
   @Path("exceptionAsync")
   public void notReadyAsync(@Suspended AsyncResponse response) {
     new Thread(() -> response.resume(
-      new WebApplicationException(new IllegalStateException("not ready"), 503)
+      new WebApplicationException(NOT_READY_ISE, 503)
     )).start();
   }
 }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/TestResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 import org.glassfish.jersey.server.ManagedAsync;
 
 import static brave.test.ITRemote.EXTRA_KEY;
+import static brave.test.http.ITHttpServer.NOT_READY_ISE;
 
 @Path("")
 public class TestResource {
@@ -111,14 +112,14 @@ public class TestResource {
   @GET
   @Path("exception")
   public Response notReady() {
-    throw new WebApplicationException(new IllegalStateException("not ready"), 503);
+    throw new WebApplicationException(NOT_READY_ISE, 503);
   }
 
   @GET
   @Path("exceptionAsync")
   public void notReadyAsync(@Suspended AsyncResponse response) {
     Thread thread = new Thread(() -> response.resume(
-      new WebApplicationException(new IllegalStateException("not ready"), 503)
+      new WebApplicationException(NOT_READY_ISE, 503)
     ));
     thread.start();
     try {

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
@@ -51,10 +51,10 @@ public class KafkaTracingTest extends ITKafka {
 
   @Test public void nextSpan_should_create_span_with_extra_keys() {
     addB3MultiHeaders(fakeRecord);
-    fakeRecord.headers().add("user-id", "user1".getBytes());
+    fakeRecord.headers().add(EXTRA_KEY, "user1".getBytes());
 
     Span span = kafkaTracing.nextSpan(fakeRecord);
-    assertThat(ExtraFieldPropagation.get(span.context(), "user-id")).contains("user1");
+    assertThat(ExtraFieldPropagation.get(span.context(), EXTRA_KEY)).contains("user1");
   }
 
   @Test public void nextSpan_should_tag_topic_and_key_when_no_incoming_context() {

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/pom.xml
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/pom.xml
@@ -56,6 +56,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- MockWebServer uses JUL -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>@log4j.version@</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -80,6 +92,12 @@
           <includes>
             <include>**/IT*.java</include>
           </includes>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
+            </java.util.logging.manager>
+          </systemPropertyVariables>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/resources/log4j2.properties
+++ b/instrumentation/okhttp3/src/it/okhttp3_v3/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -16,6 +16,7 @@ package brave.okhttp3;
 import brave.test.http.ITHttpAsyncClient;
 import brave.test.util.AssertableCallback;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -25,23 +26,29 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.junit.After;
 
 public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
+  ExecutorService executorService = new Dispatcher().executorService();
+  Dispatcher dispatcher = new Dispatcher(currentTraceContext.executorService(executorService));
+
+  @After @Override public void close() throws Exception {
+    executorService.shutdownNow();
+    super.close();
+  }
 
   @Override protected Call.Factory newClient(int port) {
     return new OkHttpClient.Builder()
       .connectTimeout(1, TimeUnit.SECONDS)
       .readTimeout(1, TimeUnit.SECONDS)
       .retryOnConnectionFailure(false)
-      .dispatcher(
-        new Dispatcher(currentTraceContext.executorService(new Dispatcher().executorService())
-      ))
+      .dispatcher(dispatcher)
       .addNetworkInterceptor(TracingInterceptor.create(httpTracing))
       .build();
   }
 
   @Override protected void closeClient(Call.Factory client) {
-    ((OkHttpClient) client).dispatcher().executorService().shutdownNow();
+    // done in close()
   }
 
   @Override protected void get(Call.Factory client, String pathIncludingQuery)

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -33,7 +33,8 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
   Dispatcher dispatcher = new Dispatcher(currentTraceContext.executorService(executorService));
 
   @After @Override public void close() throws Exception {
-    executorService.shutdownNow();
+    executorService.shutdown();
+    executorService.awaitTermination(1, TimeUnit.SECONDS);
     super.close();
   }
 

--- a/instrumentation/okhttp3/src/test/resources/log4j2.properties
+++ b/instrumentation/okhttp3/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/sparkjava/src/test/java/brave/sparkjava/TestApplication.java
+++ b/instrumentation/sparkjava/src/test/java/brave/sparkjava/TestApplication.java
@@ -19,6 +19,7 @@ import spark.Spark;
 import spark.servlet.SparkApplication;
 
 import static brave.test.ITRemote.EXTRA_KEY;
+import static brave.test.http.ITHttpServer.NOT_READY_ISE;
 
 public class TestApplication implements SparkApplication {
   @Override public void init() {
@@ -35,7 +36,7 @@ public class TestApplication implements SparkApplication {
     });
     Spark.get("/exception", (req, res) -> {
       res.status(503);
-      throw new IllegalStateException("not ready");
+      throw NOT_READY_ISE;
     });
 
     // TODO: we need matchUri: https://github.com/perwendel/spark/issues/959

--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -93,6 +93,8 @@
             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
             </java.util.logging.manager>
           </systemPropertyVariables>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -15,8 +15,8 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>@project.groupId@</groupId>
@@ -56,6 +56,25 @@
       <version>@httpclient.version@</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- MockWebServer uses JUL -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>@log4j.version@</version>
+    </dependency>
+    <!-- Spring uses commons logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -70,6 +89,10 @@
           <includes>
             <include>**/IT*.java</include>
           </includes>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
+            </java.util.logging.manager>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-web/src/it/spring3/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-web/src/it/spring3/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/spring-web/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-web/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2019 The OpenZipkin Authors
+    Copyright 2013-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -78,6 +78,20 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>@mockito.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Spring uses commons logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/servlet25/pom.xml
@@ -119,6 +119,8 @@
           <includes>
             <include>**/IT*.java</include>
           </includes>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-webmvc/src/it/servlet25/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-webmvc/src/it/servlet25/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/spring-webmvc/src/it/spring25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/spring25/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2019 The OpenZipkin Authors
+    Copyright 2013-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -78,6 +78,20 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>@mockito.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Spring uses commons logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/instrumentation/spring-webmvc/src/it/spring25/pom.xml
+++ b/instrumentation/spring-webmvc/src/it/spring25/pom.xml
@@ -107,6 +107,8 @@
           <includes>
             <include>**/IT*.java</include>
           </includes>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
     </plugins>

--- a/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -103,7 +103,7 @@ public class ITSpanCustomizingHandlerInterceptor extends ITServletContainer {
 
     @RequestMapping(value = "/exception")
     public void notReady() throws UnavailableException {
-      throw new UnavailableException("not ready", 1 /* temporary implies 503 */);
+      throw NOT_READY_UE;
     }
   }
 

--- a/instrumentation/spring-webmvc/src/it/spring25/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-webmvc/src/it/spring25/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import static brave.test.http.ITServletContainer.NOT_READY_UE;
+
 @Controller class Servlet25TestController {
   final Tracer tracer;
 
@@ -63,7 +65,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
   @ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE)
   @RequestMapping(value = "/exception")
   public ResponseEntity<Void> notReady() throws UnavailableException {
-    throw new UnavailableException("not ready", 1 /* temporary implies 503 */);
+    throw NOT_READY_UE;
   }
 
   @RequestMapping(value = "/items/{itemId}")

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import static brave.test.http.ITServletContainer.NOT_READY_UE;
+
 @Controller class Servlet3TestController extends Servlet25TestController {
 
   @Autowired Servlet3TestController(HttpTracing httpTracing) {
@@ -38,7 +40,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
   @RequestMapping(value = "/exceptionAsync")
   public Callable<ResponseEntity<Void>> notReadyAsync() {
     return () -> {
-      throw new IllegalStateException("not ready");
+      throw NOT_READY_UE;
     };
   }
 

--- a/instrumentation/spring-webmvc/src/test/resources/log4j2.properties
+++ b/instrumentation/spring-webmvc/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -78,7 +78,7 @@ public class ITVertxWebTracing extends ITHttpServer {
       ctx.response().end("happy");
     });
     router.route("/exception").handler(ctx -> {
-      ctx.fail(503, new IllegalStateException("not ready"));
+      ctx.fail(503, NOT_READY_ISE);
     });
     router.route("/items/:itemId").handler(ctx -> {
       ctx.response().end(ctx.request().getParam("itemId"));
@@ -95,7 +95,7 @@ public class ITVertxWebTracing extends ITHttpServer {
     });
     router.mountSubRouter("/nested", subrouter);
     router.route("/exceptionAsync").handler(ctx -> {
-      ctx.request().endHandler(v -> ctx.fail(503, new IllegalStateException("not ready")));
+      ctx.request().endHandler(v -> ctx.fail(503, NOT_READY_ISE));
     });
 
     Handler<RoutingContext> routingContextHandler =

--- a/pom.xml
+++ b/pom.xml
@@ -561,6 +561,8 @@
             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
             </java.util.logging.manager>
           </systemPropertyVariables>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <plugin>
@@ -573,6 +575,8 @@
             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
             </java.util.logging.manager>
           </systemPropertyVariables>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -561,8 +561,6 @@
             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
             </java.util.logging.manager>
           </systemPropertyVariables>
-          <!-- Ensure scope leak cause ends up in the console -->
-          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <plugin>
@@ -575,8 +573,6 @@
             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager
             </java.util.logging.manager>
           </systemPropertyVariables>
-          <!-- Ensure scope leak cause ends up in the console -->
-          <trimStackTrace>false</trimStackTrace>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This fixes some fuzz in tests, but notably makes `StrictScopeDecorator`
`Closeable`. In doing so, this will expose any instrumentation that
leaked scopes as opposed to before which could only show if something
closed on the wrong thread.

This type was only ever documented for development, so there should be
no harm in updating this in a way that could OOM in extreme leak
circumstances (due to hard references).