### PR TITLE
Works around possibility to have an empty set of extra fields

### DIFF
--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -97,13 +97,12 @@ import java.util.Set;
  * String countryCode = ExtraFieldPropagation.get(span.context(), "country-code");
  * }</pre>
  */
-public final class ExtraFieldPropagation<K> implements Propagation<K> {
+public class ExtraFieldPropagation<K> implements Propagation<K> {
   /** Wraps an underlying propagation implementation, pushing one or more fields */
   public static Factory newFactory(Propagation.Factory delegate, String... fieldNames) {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
-    String[] validated = ensureLowerCase(new LinkedHashSet<>(Arrays.asList(fieldNames)));
-    return new Factory(delegate, validated, validated, new BitSet());
+    return newFactory(delegate, Arrays.asList(fieldNames));
   }
 
   /** Wraps an underlying propagation implementation, pushing one or more fields */
@@ -112,7 +111,8 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
     String[] validated = ensureLowerCase(new LinkedHashSet<>(fieldNames));
-    return new Factory(delegate, validated, validated, new BitSet());
+    return validated.length == 0
+      ? new Factory(delegate) : new RealFactory(delegate, validated, validated, new BitSet());
   }
 
   public static FactoryBuilder newFactoryBuilder(Propagation.Factory delegate) {
@@ -163,6 +163,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       return this;
     }
 
+    /** Returns a wrapper of the delegate if there are no fields to propagate. */
     public Factory build() {
       BitSet redacted = new BitSet();
       List<String> fields = new ArrayList<>(), keys = new ArrayList<>();
@@ -199,8 +200,10 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       for (i = 0; i < keyToField.length; i++) {
         keyToField[i] = keyToFieldList.get(i);
       }
-      return new Factory(delegate, fields.toArray(new String[0]), keys.toArray(new String[0]),
-        keyToField, redacted);
+      String[] validated = fields.toArray(new String[0]);
+      if (validated.length == 0) return new Factory(delegate);
+      return new RealFactory(delegate, validated, keys.toArray(new String[0]), keyToField,
+        redacted);
     }
   }
 
@@ -272,15 +275,39 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     PropagationFields.put(context, lowercase(name), value, Extra.class);
   }
 
-  public static final class Factory extends Propagation.Factory {
+  public static class Factory extends Propagation.Factory {
     final Propagation.Factory delegate;
+
+    Factory(Propagation.Factory delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public <K> ExtraFieldPropagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+      return new ExtraFieldPropagation<>(delegate, keyFactory);
+    }
+
+    @Override public boolean supportsJoin() {
+      return delegate.supportsJoin();
+    }
+
+    @Override public boolean requires128BitTraceId() {
+      return delegate.requires128BitTraceId();
+    }
+
+    @Override public TraceContext decorate(TraceContext context) {
+      return delegate.decorate(context);
+    }
+  }
+
+  public static final class RealFactory extends Factory {
     final String[] fieldNames;
     final String[] keyNames;
     final int[] keyToField;
     final BitSet redacted;
     final ExtraFactory extraFactory;
 
-    Factory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames, BitSet redacted) {
+    RealFactory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames,
+      BitSet redacted) {
       this(delegate, fieldNames, keyNames, keyToField(keyNames), redacted);
     }
 
@@ -294,22 +321,14 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       return result;
     }
 
-    Factory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames,
+    RealFactory(Propagation.Factory delegate, String[] fieldNames, String[] keyNames,
       int[] keyToField, BitSet redacted) {
-      this.delegate = delegate;
+      super(delegate);
       this.keyToField = keyToField;
       this.fieldNames = fieldNames;
       this.keyNames = keyNames;
       this.redacted = redacted;
       this.extraFactory = new ExtraFactory(fieldNames);
-    }
-
-    @Override public boolean supportsJoin() {
-      return delegate.supportsJoin();
-    }
-
-    @Override public boolean requires128BitTraceId() {
-      return delegate.requires128BitTraceId();
     }
 
     @Override
@@ -319,7 +338,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
       for (int i = 0; i < length; i++) {
         keys.add(keyFactory.create(keyNames[i]));
       }
-      return new ExtraFieldPropagation<>(this, keyFactory, keys, redacted);
+      return new RealExtraFieldPropagation<>(this, keyFactory, keys, redacted);
     }
 
     @Override public TraceContext decorate(TraceContext context) {
@@ -328,17 +347,10 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
     }
   }
 
-  final Factory factory;
   final Propagation<K> delegate;
-  final List<K> keys;
-  final BitSet redacted;
 
-  ExtraFieldPropagation(Factory factory, Propagation.KeyFactory<K> keyFactory, List<K> keys,
-    BitSet redacted) {
-    this.factory = factory;
-    this.delegate = factory.delegate.create(keyFactory);
-    this.keys = keys;
-    this.redacted = redacted;
+  ExtraFieldPropagation(Propagation.Factory factory, Propagation.KeyFactory<K> keyFactory) {
+    this.delegate = factory.create(keyFactory);
   }
 
   /**
@@ -348,7 +360,7 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   // This is here to support extraction from carriers missing a get field by name function. The only
   // known example is OpenTracing TextMap https://github.com/opentracing/opentracing-java/issues/305
   public List<K> extraKeys() {
-    return keys;
+    return Collections.emptyList();
   }
 
   /**
@@ -361,19 +373,45 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   }
 
   @Override public <C> Injector<C> injector(Setter<C, K> setter) {
-    return new ExtraFieldInjector<>(this, setter);
+    return delegate.injector(setter);
   }
 
   @Override public <C> Extractor<C> extractor(Getter<C, K> getter) {
-    return new ExtraFieldExtractor<>(this, getter);
+    return delegate.extractor(getter);
+  }
+
+  static final class RealExtraFieldPropagation<K> extends ExtraFieldPropagation<K> {
+    final RealFactory factory;
+    final List<K> keys;
+    final BitSet redacted;
+
+    RealExtraFieldPropagation(RealFactory factory, Propagation.KeyFactory<K> keyFactory,
+      List<K> keys, BitSet redacted) {
+      super(factory.delegate, keyFactory);
+      this.factory = factory;
+      this.keys = keys;
+      this.redacted = redacted;
+    }
+
+    @Override public List<K> extraKeys() {
+      return keys;
+    }
+
+    @Override public <C> Injector<C> injector(Setter<C, K> setter) {
+      return new ExtraFieldInjector<>(this, setter);
+    }
+
+    @Override public <C> Extractor<C> extractor(Getter<C, K> getter) {
+      return new ExtraFieldExtractor<>(this, getter);
+    }
   }
 
   static final class ExtraFieldInjector<C, K> implements Injector<C> {
-    final ExtraFieldPropagation<K> propagation;
+    final RealExtraFieldPropagation<K> propagation;
     final Injector<C> delegate;
     final Propagation.Setter<C, K> setter;
 
-    ExtraFieldInjector(ExtraFieldPropagation<K> propagation, Setter<C, K> setter) {
+    ExtraFieldInjector(RealExtraFieldPropagation<K> propagation, Setter<C, K> setter) {
       this.propagation = propagation;
       this.delegate = propagation.delegate.injector(setter);
       this.setter = setter;
@@ -397,11 +435,11 @@ public final class ExtraFieldPropagation<K> implements Propagation<K> {
   }
 
   static final class ExtraFieldExtractor<C, K> implements Extractor<C> {
-    final ExtraFieldPropagation<K> propagation;
+    final RealExtraFieldPropagation<K> propagation;
     final Extractor<C> delegate;
     final Propagation.Getter<C, K> getter;
 
-    ExtraFieldExtractor(ExtraFieldPropagation<K> propagation, Getter<C, K> getter) {
+    ExtraFieldExtractor(RealExtraFieldPropagation<K> propagation, Getter<C, K> getter) {
       this.propagation = propagation;
       this.delegate = propagation.delegate.extractor(getter);
       this.getter = getter;

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -106,13 +106,11 @@ public class ExtraFieldPropagation<K> implements Propagation<K> {
   }
 
   /** Wraps an underlying propagation implementation, pushing one or more fields */
-  public static Factory newFactory(Propagation.Factory delegate,
-    Collection<String> fieldNames) {
+  public static Factory newFactory(Propagation.Factory delegate, Collection<String> fieldNames) {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (fieldNames == null) throw new NullPointerException("fieldNames == null");
-    String[] validated = ensureLowerCase(new LinkedHashSet<>(fieldNames));
-    return validated.length == 0
-      ? new Factory(delegate) : new RealFactory(delegate, validated, validated, new BitSet());
+    String[] validated = ensureLowerCaseFieldNames(new LinkedHashSet<>(fieldNames));
+    return new RealFactory(delegate, validated, validated, new BitSet());
   }
 
   public static FactoryBuilder newFactoryBuilder(Propagation.Factory delegate) {
@@ -159,7 +157,7 @@ public class ExtraFieldPropagation<K> implements Propagation<K> {
       if (prefix == null) throw new NullPointerException("prefix == null");
       if (prefix.isEmpty()) throw new IllegalArgumentException("prefix is empty");
       if (fieldNames == null) throw new NullPointerException("fieldNames == null");
-      prefixedNames.put(prefix, ensureLowerCase(new LinkedHashSet<>(fieldNames)));
+      prefixedNames.put(prefix, ensureLowerCaseFieldNames(new LinkedHashSet<>(fieldNames)));
       return this;
     }
 
@@ -459,15 +457,15 @@ public class ExtraFieldPropagation<K> implements Propagation<K> {
     }
   }
 
-  static String[] ensureLowerCase(Collection<String> names) {
-    if (names.isEmpty()) throw new IllegalArgumentException("names is empty");
-    Iterator<String> nextName = names.iterator();
-    String[] result = new String[names.size()];
+  static String[] ensureLowerCaseFieldNames(Collection<String> fieldNames) {
+    if (fieldNames.isEmpty()) throw new IllegalArgumentException("no field names");
+    Iterator<String> nextName = fieldNames.iterator();
+    String[] result = new String[fieldNames.size()];
     for (int i = 0; nextName.hasNext(); i++) {
       String name = nextName.next();
-      if (name == null) throw new NullPointerException("names[" + i + "] == null");
+      if (name == null) throw new NullPointerException("fieldNames[" + i + "] == null");
       name = name.trim();
-      if (name.isEmpty()) throw new IllegalArgumentException("names[" + i + "] is empty");
+      if (name.isEmpty()) throw new IllegalArgumentException("fieldNames[" + i + "] is empty");
       result[i] = name.toLowerCase(Locale.ROOT);
     }
     return result;

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -198,10 +198,10 @@ public class ExtraFieldPropagation<K> implements Propagation<K> {
       for (i = 0; i < keyToField.length; i++) {
         keyToField[i] = keyToFieldList.get(i);
       }
-      String[] validated = fields.toArray(new String[0]);
-      if (validated.length == 0) return new Factory(delegate);
-      return new RealFactory(delegate, validated, keys.toArray(new String[0]), keyToField,
-        redacted);
+
+      if (fields.isEmpty()) return new Factory(delegate);
+      return new RealFactory(delegate, fields.toArray(new String[0]), keys.toArray(new String[0]),
+        keyToField, redacted);
     }
   }
 
@@ -297,7 +297,7 @@ public class ExtraFieldPropagation<K> implements Propagation<K> {
     }
   }
 
-  public static final class RealFactory extends Factory {
+  static final class RealFactory extends Factory {
     final String[] fieldNames;
     final String[] keyNames;
     final int[] keyToField;

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -14,6 +14,7 @@
 package brave.propagation;
 
 import brave.Tracing;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.ExtraFieldPropagation.Extra;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -22,9 +23,11 @@ import java.util.TreeMap;
 import org.junit.Before;
 import org.junit.Test;
 
+import static brave.propagation.ExtraFieldPropagation.newFactoryBuilder;
 import static brave.propagation.Propagation.KeyFactory.STRING;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 public class ExtraFieldPropagationTest {
@@ -107,10 +110,56 @@ public class ExtraFieldPropagationTest {
     TraceContext context = extractWithAmazonTraceId();
 
     try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build();
-         CurrentTraceContext.Scope scope = t.currentTraceContext().newScope(context)) {
+         Scope scope = t.currentTraceContext().newScope(context)) {
       assertThat(ExtraFieldPropagation.get("x-amzn-trace-id"))
         .isEqualTo(awsTraceId);
     }
+  }
+
+  @Test public void emptyFields_disallowed() {
+    assertThatThrownBy(() -> ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, ""))
+      .hasMessage("fieldNames[0] is empty");
+
+    assertThatThrownBy(() -> ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, asList("")))
+      .hasMessage("fieldNames[0] is empty");
+
+    assertThatThrownBy(() -> newFactoryBuilder(B3Propagation.FACTORY).addField("").build())
+      .hasMessage("fieldName is empty");
+
+    assertThatThrownBy(() -> newFactoryBuilder(B3Propagation.FACTORY).addRedactedField("").build())
+      .hasMessage("fieldName is empty");
+
+    assertThatThrownBy(
+      () -> newFactoryBuilder(B3Propagation.FACTORY).addPrefixedFields("foo", asList("")).build())
+      .hasMessage("fieldNames[0] is empty");
+  }
+
+  // We formerly enforced presence of field names in the factory's factory method
+  @Test public void noFields_newFactory_disallowed() {
+    assertThatThrownBy(() -> ExtraFieldPropagation.newFactory(B3Propagation.FACTORY))
+      .hasMessage("no field names");
+
+    assertThatThrownBy(() -> ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, asList()))
+      .hasMessage("no field names");
+  }
+
+  // We formerly accepted .build() when no fields were present
+  @Test public void noFields_newFactoryBuilder_wrapsDelegate() {
+    factory = newFactoryBuilder(B3Propagation.FACTORY).build();
+    initialize();
+
+    // check nothing throws on no-op
+    ExtraFieldPropagation.set(context, "userid", "bob");
+    assertThat(ExtraFieldPropagation.get(context, "userid")).isNull();
+
+    assertThat(extractor.extract(Collections.emptyMap()).extra())
+      .isEmpty();
+
+    injector.inject(context, carrier);
+    TraceContext extractedContext = extractor.extract(carrier).context();
+    assertThat(extractedContext)
+      .usingRecursiveComparison()
+      .isEqualTo(context);
   }
 
   @Test public void current_get_null_if_no_current_context() {
@@ -127,7 +176,7 @@ public class ExtraFieldPropagationTest {
 
   @Test public void current_set() {
     try (Tracing t = Tracing.newBuilder().propagationFactory(factory).build();
-         CurrentTraceContext.Scope scope = t.currentTraceContext().newScope(context)) {
+         Scope scope = t.currentTraceContext().newScope(context)) {
       ExtraFieldPropagation.set("x-amzn-trace-id", awsTraceId);
 
       assertThat(ExtraFieldPropagation.get("x-amzn-trace-id"))
@@ -167,7 +216,7 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void inject_prefixed() {
-    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+    factory = newFactoryBuilder(B3Propagation.FACTORY)
       .addField("x-vcap-request-id")
       .addPrefixedFields("baggage-", asList("country-code"))
       .build();
@@ -217,7 +266,7 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void extract_prefixed() {
-    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+    factory = newFactoryBuilder(B3Propagation.FACTORY)
       .addField("x-vcap-request-id")
       .addPrefixedFields("baggage-", asList("country-code"))
       .build();
@@ -289,7 +338,7 @@ public class ExtraFieldPropagationTest {
   @Test public void extract_field_multiple_prefixes() {
     // switch to case insensitive as this example is about http :P
     carrier = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+    factory = newFactoryBuilder(B3Propagation.FACTORY)
       .addField("userId")
       .addField("sessionId")
       .addPrefixedFields("baggage-", asList("userId", "sessionId"))
@@ -311,7 +360,7 @@ public class ExtraFieldPropagationTest {
 
   /** Redaction only applies outbound. Inbound parsing should be unaffected */
   @Test public void extract_redactedField() {
-    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+    factory = newFactoryBuilder(B3Propagation.FACTORY)
       .addRedactedField("userid")
       .addField("sessionid")
       .build();
@@ -331,7 +380,7 @@ public class ExtraFieldPropagationTest {
 
   /** Redaction prevents named fields from being written downstream. */
   @Test public void inject_redactedField() {
-    factory = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+    factory = newFactoryBuilder(B3Propagation.FACTORY)
       .addRedactedField("userid")
       .addField("sessionid")
       .build();
@@ -348,7 +397,7 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void inject_field_multiple_prefixes() {
-    factory = ExtraFieldPropagation.newFactoryBuilder(B3SinglePropagation.FACTORY)
+    factory = newFactoryBuilder(B3SinglePropagation.FACTORY)
       .addField("userId")
       .addField("sessionId")
       .addPrefixedFields("baggage-", asList("userId", "sessionId"))
@@ -374,13 +423,13 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void deduplicates() {
-    assertThat(ExtraFieldPropagation.newFactoryBuilder(B3SinglePropagation.FACTORY)
+    assertThat(newFactoryBuilder(B3SinglePropagation.FACTORY)
       .addField("country-code")
       .addPrefixedFields("baggage-", asList("country-code"))
       .addPrefixedFields("baggage_", asList("country-code"))
       .build())
       .usingRecursiveComparison().isEqualTo(
-      ExtraFieldPropagation.newFactoryBuilder(B3SinglePropagation.FACTORY)
+      newFactoryBuilder(B3SinglePropagation.FACTORY)
         .addField("country-code").addField("country-code")
         .addPrefixedFields("baggage-", asList("country-code", "country-code"))
         .addPrefixedFields("baggage_", asList("country-code", "country-code"))

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -68,15 +68,17 @@ public class ExtraFieldPropagationTest {
   }
 
   @Test public void downcasesNames() {
-    ExtraFieldPropagation.Factory factory = ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,
-      "X-FOO");
+    ExtraFieldPropagation.RealFactory factory =
+      (ExtraFieldPropagation.RealFactory) ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,
+        "X-FOO");
     assertThat(factory.fieldNames)
       .containsExactly("x-foo");
   }
 
   @Test public void trimsNames() {
-    ExtraFieldPropagation.Factory factory = ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,
-      " x-foo  ");
+    ExtraFieldPropagation.RealFactory factory =
+      (ExtraFieldPropagation.RealFactory) ExtraFieldPropagation.newFactory(B3Propagation.FACTORY,
+        " x-foo  ");
     assertThat(factory.fieldNames)
       .containsExactly("x-foo");
   }


### PR DESCRIPTION
We didn't eagerly validate `ExtraFieldPropagation`, that it had any
fields at all. This leads to late bugs where an exception is thrown for
trying to inject nothing.

As they type `ExtraFieldPropagation` has public methods in use, this
doesn't change signatures. Rather, it creates a wrapper in the case
nothing exists.

WIP as some unit tests are due.