### PR TITLE
Allows decoration of noop scopes

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/InheritableDefaultCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/InheritableDefaultCurrentTraceContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,26 +16,29 @@ package brave.propagation;
 import brave.test.propagation.CurrentTraceContextTest;
 import java.util.function.Supplier;
 import org.junit.Before;
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 
-public class DefaultCurrentTraceContextTest extends CurrentTraceContextTest {
+import static brave.propagation.CurrentTraceContext.Default.INHERITABLE;
 
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+public class InheritableDefaultCurrentTraceContextTest extends CurrentTraceContextTest {
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
-      return CurrentTraceContext.Default.create();
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
+      return new ThreadLocalCurrentTraceContext.Builder(INHERITABLE);
     }
   }
 
-  @Test public void is_inheritable() throws Exception {
-    super.is_inheritable(CurrentTraceContext.Default.inheritable());
+  @Test(expected = ComparisonFailure.class)
+  public void isnt_inheritable() throws Exception {
+    super.isnt_inheritable();
   }
 
   @Before public void ensureNoOtherTestsTaint() {
-    CurrentTraceContext.Default.INHERITABLE.set(null);
+    INHERITABLE.set(null);
     CurrentTraceContext.Default.DEFAULT.set(null);
   }
 }

--- a/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
@@ -21,14 +21,13 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StrictCurrentTraceContextTest extends CurrentTraceContextTest {
-
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
-      return new StrictCurrentTraceContext();
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
+      return StrictCurrentTraceContext.strictBuilder();
     }
   }
 

--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextTest.java
@@ -20,9 +20,8 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadLocalCurrentTraceContextTest extends CurrentTraceContextTest {
-
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
   /** Since the default thread-local is static, this helps code avoid leaks made by others. */
@@ -36,9 +35,9 @@ public class ThreadLocalCurrentTraceContextTest extends CurrentTraceContextTest 
     assertThat(currentTraceContext.get()).isNull();
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
-      return ThreadLocalCurrentTraceContext.newBuilder().build();
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
+      return ThreadLocalCurrentTraceContext.newBuilder();
     }
   }
 }

--- a/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecoratorBuilder.java
+++ b/brave/src/main/java/brave/internal/propagation/CorrelationFieldScopeDecoratorBuilder.java
@@ -133,7 +133,7 @@ public abstract class CorrelationFieldScopeDecoratorBuilder<B extends Correlatio
     }
 
     @Override public Scope decorateScope(TraceContext traceContext, Scope scope) {
-      if (scope == Scope.NOOP) return scope;
+      if (scope == Scope.NOOP) return scope; // we only scope fields constant in the context
 
       String previousValue = context.get(name);
       if (!update(traceContext, getter, name, previousValue)) {
@@ -167,7 +167,7 @@ public abstract class CorrelationFieldScopeDecoratorBuilder<B extends Correlatio
     }
 
     @Override public Scope decorateScope(TraceContext traceContext, Scope scope) {
-      if (scope == Scope.NOOP) return scope;
+      if (scope == Scope.NOOP) return scope; // we only scope fields constant in the context
 
       String[] previousValues = new String[names.length];
       boolean changed = false;

--- a/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,12 +23,13 @@ package brave.propagation;
  */
 @Deprecated
 public final class StrictCurrentTraceContext extends ThreadLocalCurrentTraceContext {
-  static final CurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
-    ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(new StrictScopeDecorator());
+  static Builder strictBuilder() {
+    return new Builder(new ThreadLocal<>()).addScopeDecorator(new StrictScopeDecorator());
+  }
 
   public StrictCurrentTraceContext() { // Preserve historical public ctor
     // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
     // intentionally not static to make explicit when instrumentation need per thread semantics
-    super(SCOPE_DECORATING_BUILDER, new ThreadLocal<>());
+    super(strictBuilder());
   }
 }

--- a/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
+++ b/brave/src/main/java/brave/propagation/StrictScopeDecorator.java
@@ -52,7 +52,8 @@ public final class StrictScopeDecorator implements ScopeDecorator, Closeable {
    * different thread.
    */
   @Override public Scope decorateScope(@Nullable TraceContext context, Scope scope) {
-    if (scope == Scope.NOOP) return scope;
+    if (scope == Scope.NOOP) return scope; // don't track no-op scopes as they cannot leak
+
     CallerStackTrace caller = new CallerStackTrace(context);
     StackTraceElement[] stackTrace = caller.getStackTrace();
 

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -39,11 +39,11 @@ import brave.internal.Nullable;
  */
 public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not final for backport
   public static CurrentTraceContext create() {
-    return new Builder().build();
+    return new Builder(DEFAULT).build();
   }
 
   public static Builder newBuilder() {
-    return new Builder();
+    return new Builder(DEFAULT);
   }
 
   /**
@@ -59,15 +59,18 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
 
   /** @since 5.11 */ // overridden for covariance
   public static final class Builder extends CurrentTraceContext.Builder {
+    final ThreadLocal<TraceContext> local;
+
+    Builder(ThreadLocal<TraceContext> local) {
+      this.local = local;
+    }
+
     @Override public Builder addScopeDecorator(ScopeDecorator scopeDecorator) {
       return (Builder) super.addScopeDecorator(scopeDecorator);
     }
 
     @Override public ThreadLocalCurrentTraceContext build() {
-      return new ThreadLocalCurrentTraceContext(this, DEFAULT);
-    }
-
-    Builder() {
+      return new ThreadLocalCurrentTraceContext(this);
     }
   }
 
@@ -76,13 +79,10 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
   @SuppressWarnings("ThreadLocalUsage") // intentional: to support multiple Tracer instances
   final ThreadLocal<TraceContext> local;
 
-  ThreadLocalCurrentTraceContext(
-    CurrentTraceContext.Builder builder,
-    ThreadLocal<TraceContext> local
-  ) {
+  ThreadLocalCurrentTraceContext(Builder builder) {
     super(builder);
-    if (local == null) throw new NullPointerException("local == null");
-    this.local = local;
+    if (builder.local == null) throw new NullPointerException("local == null");
+    local = builder.local;
   }
 
   @Override public TraceContext get() {

--- a/brave/src/test/java/brave/internal/propagation/CorrelationFieldScopeDecoratorBuilderTest.java
+++ b/brave/src/test/java/brave/internal/propagation/CorrelationFieldScopeDecoratorBuilderTest.java
@@ -63,7 +63,7 @@ public class CorrelationFieldScopeDecoratorBuilderTest {
     ExtraFieldPropagation.set(context, "user-id", "romeo");
   }
 
-  @Test public void noop() {
+  @Test public void doesntDecorateNoop() {
     assertThat(decorator.decorateScope(context, Scope.NOOP)).isSameAs(Scope.NOOP);
     assertThat(onlyExtraFieldDecorator.decorateScope(context, Scope.NOOP)).isSameAs(Scope.NOOP);
     assertThat(withExtraFieldDecorator.decorateScope(context, Scope.NOOP)).isSameAs(Scope.NOOP);

--- a/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/propagation/StrictScopeDecoratorTest.java
@@ -55,8 +55,8 @@ public class StrictScopeDecoratorTest {
   }
 
   @Test public void doesntDecorateNoop() {
-    assertThat(decorator.decorateScope(context, Scope.NOOP))
-      .isSameAs(Scope.NOOP);
+    assertThat(decorator.decorateScope(context, Scope.NOOP)).isSameAs(Scope.NOOP);
+    assertThat(decorator.decorateScope(null, Scope.NOOP)).isSameAs(Scope.NOOP);
     decorator.close(); // doesn't error
   }
 

--- a/context/jfr/src/main/java/brave/context/jfr/JfrScopeDecorator.java
+++ b/context/jfr/src/main/java/brave/context/jfr/JfrScopeDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,14 +53,16 @@ public final class JfrScopeDecorator implements ScopeDecorator {
     return new JfrScopeDecorator();
   }
 
-  @Override public Scope decorateScope(@Nullable TraceContext currentSpan, Scope scope) {
+  @Override public Scope decorateScope(@Nullable TraceContext context, Scope scope) {
+    if (scope == Scope.NOOP) return scope; // we only scope fields constant in the context
+
     ScopeEvent event = new ScopeEvent();
     if (!event.isEnabled()) return scope;
 
-    if (currentSpan != null) {
-      event.traceId = currentSpan.traceIdString();
-      event.parentId = currentSpan.parentIdString();
-      event.spanId = currentSpan.spanIdString();
+    if (context != null) {
+      event.traceId = context.traceIdString();
+      event.parentId = context.parentIdString();
+      event.spanId = context.spanIdString();
     }
 
     event.begin();

--- a/context/jfr/src/test/java/brave/context/jfr/JfrScopeDecoratorTest.java
+++ b/context/jfr/src/test/java/brave/context/jfr/JfrScopeDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package brave.context.jfr;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
@@ -40,6 +41,7 @@ public class JfrScopeDecoratorTest {
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
+  ScopeDecorator decorator = JfrScopeDecorator.create();
   CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
     .addScopeDecorator(StrictScopeDecorator.create())
     .addScopeDecorator(JfrScopeDecorator.create())
@@ -76,6 +78,11 @@ public class JfrScopeDecoratorTest {
         tuple("0000000000000001", "0000000000000001", "0000000000000002"),
         tuple("0000000000000002", null, "0000000000000003")
       );
+  }
+
+  @Test public void doesntDecorateNoop() {
+    assertThat(decorator.decorateScope(context, Scope.NOOP)).isSameAs(Scope.NOOP);
+    assertThat(decorator.decorateScope(null, Scope.NOOP)).isSameAs(Scope.NOOP);
   }
 
   /**

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCCurrentTraceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package brave.context.log4j12;
 
 import brave.internal.Nullable;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import org.apache.log4j.MDC;
 
@@ -27,31 +26,44 @@ import org.apache.log4j.MDC;
  */
 @Deprecated
 public final class MDCCurrentTraceContext extends CurrentTraceContext {
-  static final CurrentTraceContext.Builder SCOPE_DECORATING_BUILDER =
-    ThreadLocalCurrentTraceContext.newBuilder().addScopeDecorator(MDCScopeDecorator.create());
-
   public static MDCCurrentTraceContext create() {
     return create(CurrentTraceContext.Default.inheritable());
   }
 
   public static MDCCurrentTraceContext create(CurrentTraceContext delegate) {
     if (delegate == null) throw new NullPointerException("delegate == null");
-    return new MDCCurrentTraceContext(delegate);
+    return new Builder(delegate).build();
+  }
+
+  static final class Builder extends CurrentTraceContext.Builder {
+    final CurrentTraceContext delegate;
+
+    Builder(CurrentTraceContext delegate) {
+      this.delegate = delegate;
+      addScopeDecorator(MDCScopeDecorator.create());
+    }
+
+    @Override public MDCCurrentTraceContext build() {
+      return new MDCCurrentTraceContext(this);
+    }
   }
 
   final CurrentTraceContext delegate;
 
-  MDCCurrentTraceContext(CurrentTraceContext delegate) {
-    super(SCOPE_DECORATING_BUILDER);
-    this.delegate = delegate;
+  MDCCurrentTraceContext(Builder builder) {
+    super(builder);
+    delegate = builder.delegate;
   }
 
   @Override public TraceContext get() {
     return delegate.get();
   }
 
-  @Override public Scope newScope(@Nullable TraceContext currentSpan) {
-    Scope scope = delegate.newScope(currentSpan);
-    return decorateScope(currentSpan, scope);
+  @Override public Scope newScope(@Nullable TraceContext context) {
+    return decorateScope(context, delegate.newScope(context));
+  }
+
+  @Override public Scope maybeScope(TraceContext context) {
+    return decorateScope(context, delegate.maybeScope(context));
   }
 }

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCCurrentTraceContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,23 +26,18 @@ import static brave.context.log4j12.MDCScopeDecoratorTest.assumeMDCWorks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
-
   public MDCCurrentTraceContextTest() {
     assumeMDCWorks();
   }
 
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
-      return MDCCurrentTraceContext.create();
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
+      return new MDCCurrentTraceContext.Builder(CurrentTraceContext.Default.create());
     }
-  }
-
-  @Test public void is_inheritable() throws Exception {
-    super.is_inheritable(currentTraceContext);
   }
 
   @Test(expected = ComparisonFailure.class) // Log4J 1.2.x MDC is inheritable by default

--- a/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
+++ b/context/log4j12/src/test/java/brave/context/log4j12/MDCScopeDecoratorTest.java
@@ -29,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
-
   public MDCScopeDecoratorTest() {
     assumeMDCWorks();
   }
@@ -49,17 +48,16 @@ public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
     }
   }
 
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
       return ThreadLocalCurrentTraceContext.newBuilder()
         .addScopeDecorator(MDCScopeDecorator.newBuilder()
           .addExtraField(EXTRA_FIELD)
-          .build())
-        .build();
+          .build());
     }
   }
 

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextCurrentTraceContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,14 +23,13 @@ import org.apache.logging.log4j.ThreadContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadContextCurrentTraceContextTest extends CurrentTraceContextTest {
-
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
-      return ThreadContextCurrentTraceContext.create(CurrentTraceContext.Default.create());
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
+      return new ThreadContextCurrentTraceContext.Builder(CurrentTraceContext.Default.create());
     }
   }
 

--- a/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
+++ b/context/log4j2/src/test/java/brave/context/log4j2/ThreadContextScopeDecoratorTest.java
@@ -25,18 +25,16 @@ import org.apache.logging.log4j.ThreadContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadContextScopeDecoratorTest extends CurrentTraceContextTest {
-
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
       return ThreadLocalCurrentTraceContext.newBuilder()
         .addScopeDecorator(ThreadContextScopeDecorator.newBuilder()
           .addExtraField(EXTRA_FIELD)
-          .build())
-        .build();
+          .build());
     }
   }
 

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCCurrentTraceContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,14 +23,13 @@ import org.slf4j.MDC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCCurrentTraceContextTest extends CurrentTraceContextTest {
-
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
-      return MDCCurrentTraceContext.create(CurrentTraceContext.Default.create());
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
+      return new MDCCurrentTraceContext.Builder(CurrentTraceContext.Default.create());
     }
   }
 

--- a/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
+++ b/context/slf4j/src/test/java/brave/context/slf4j/MDCScopeDecoratorTest.java
@@ -25,17 +25,16 @@ import org.slf4j.MDC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MDCScopeDecoratorTest extends CurrentTraceContextTest {
-  @Override protected Class<? extends Supplier<CurrentTraceContext>> currentSupplier() {
-    return CurrentSupplier.class;
+  @Override protected Class<? extends Supplier<CurrentTraceContext.Builder>> builderSupplier() {
+    return BuilderSupplier.class;
   }
 
-  static class CurrentSupplier implements Supplier<CurrentTraceContext> {
-    @Override public CurrentTraceContext get() {
+  static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
+    @Override public CurrentTraceContext.Builder get() {
       return ThreadLocalCurrentTraceContext.newBuilder()
         .addScopeDecorator(MDCScopeDecorator.newBuilder()
           .addExtraField(EXTRA_FIELD)
-          .build())
-        .build();
+          .build());
     }
   }
 


### PR DESCRIPTION
`CurrentTraceContext.maybeScope()` is used frequently in reactive
instrumentation. It is implemented by comparing identity fields in the
trace context, and conditionally returning a new scope if they changed.
This optimization saves thread local and MDC decoration overhead.

Formerly, scope decorators were written to pay attention to `Scope.NOOP`
inputs, but the implementation never allowed a hook that would make that
the case. This prevents features like late updates from working as
decoration only happens when identity fields occurred. Now, even when
identity fields are the same, decorators are able to re-evaluate.