### PR TITLE
Actually don't check SingletonList as comment says.

### DIFF
--- a/brave/src/main/java/brave/internal/Lists.java
+++ b/brave/src/main/java/brave/internal/Lists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/main/java/brave/internal/Lists.java
+++ b/brave/src/main/java/brave/internal/Lists.java
@@ -29,19 +29,19 @@ public final class Lists {
     return mutable;
   }
 
-  public static List<Object> ensureImmutable(List<Object> extra) {
-    if (isImmutable(extra)) return extra;
+  public static List<Object> ensureImmutable(List<Object> list) {
+    if (list.isEmpty()) return Collections.emptyList();
     // Faster to make a copy than check the type to see if it is already a singleton list
-    if (extra.size() == 1) return Collections.singletonList(extra.get(0));
-    return Collections.unmodifiableList(new ArrayList<>(extra));
+    if (list.size() == 1) return Collections.singletonList(list.get(0));
+    if (isImmutable(list)) return list;
+    return Collections.unmodifiableList(new ArrayList<>(list));
   }
 
   static boolean isImmutable(List<Object> extra) {
-    if (extra == Collections.EMPTY_LIST) return true;
+    if (extra == Collections.emptyList()) return true;
     // avoid copying datastructure by trusting certain names.
     String simpleName = extra.getClass().getSimpleName();
-    return simpleName.equals("SingletonList")
-      || simpleName.startsWith("Unmodifiable")
+    return simpleName.startsWith("Unmodifiable")
       || simpleName.contains("Immutable");
   }
 

--- a/brave/src/main/java/brave/internal/Lists.java
+++ b/brave/src/main/java/brave/internal/Lists.java
@@ -38,9 +38,11 @@ public final class Lists {
   }
 
   static boolean isImmutable(List<Object> extra) {
-    if (extra == Collections.emptyList()) return true;
+    assert extra.size() > 1;  // Handled by caller.
     // avoid copying datastructure by trusting certain names.
     String simpleName = extra.getClass().getSimpleName();
+    // We don't need to check EMPTY_LIST or SingletonList here since our only caller handles them
+    // without type-checking.
     return simpleName.startsWith("Unmodifiable")
       || simpleName.contains("Immutable");
   }

--- a/brave/src/test/java/brave/internal/ListsTest.java
+++ b/brave/src/test/java/brave/internal/ListsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/brave/internal/ListsTest.java
+++ b/brave/src/test/java/brave/internal/ListsTest.java
@@ -57,20 +57,25 @@ public class ListsTest {
       .isSameAs(list);
   }
 
-  @Test public void ensureImmutable_doesntCopySingletonList() {
+  @Test public void ensureImmutable_returnsEmptyListForMutableInput() {
+    List<Object> list = new ArrayList<>();
+    assertThat(Lists.ensureImmutable(list)).isSameAs(Collections.emptyList());
+  }
+
+  @Test public void ensureImmutable_singletonListStaysSingleton() {
     List<Object> list = Collections.singletonList("foo");
-    assertThat(Lists.ensureImmutable(list))
-      .isSameAs(list);
+    assertThat(Lists.ensureImmutable(list).getClass().getSimpleName())
+      .isEqualTo("SingletonList");
   }
 
   @Test public void ensureImmutable_doesntCopyUnmodifiableList() {
-    List<Object> list = Collections.unmodifiableList(Arrays.asList("foo"));
+    List<Object> list = Collections.unmodifiableList(Arrays.asList("foo", "bar"));
     assertThat(Lists.ensureImmutable(list))
       .isSameAs(list);
   }
 
   @Test public void ensureImmutable_doesntCopyImmutableList() {
-    List<Object> list = ImmutableList.of("foo");
+    List<Object> list = ImmutableList.of("foo", "bar");
     assertThat(Lists.ensureImmutable(list))
       .isSameAs(list);
   }


### PR DESCRIPTION
Noticed implementation does not reflect the comment "Faster to make a copy than check the type to see if it is already a singleton list". I haven't actually benchmarked this but it seems to make sense. Alternatively I can revert the code changes and remove the comment, let me know.

Additionally optimizes for an empty mutable list parameter.