### PR TITLE
Adds Tag, Tags and HttpTags

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -109,6 +109,22 @@ version.
 span.tag("clnt/finagle.version", "6.36.0");
 ```
 
+The `Tag` type is a helper that works with all variants of `Span`. For
+common or expensive tags, consider implementing `Tag` or re-using a
+built-in one.
+
+Here's an example of a potentially expensive tag:
+```java
+SUMMARY_TAG = new Tag<Summarizer>("summary") {
+  @Override protected String parseValue(Summarizer input, TraceContext context) {
+    return input.computeSummary();
+  }
+}
+
+// This works for any variant of span
+SUMMARY_TAG.tag(summarizer, span);
+```
+
 When exposing the ability to customize spans to third parties, prefer
 `brave.SpanCustomizer` as opposed to `brave.Span`. The former is simpler to
 understand and test, and doesn't tempt users with span lifecycle hooks.

--- a/brave/src/main/java/brave/ErrorParser.java
+++ b/brave/src/main/java/brave/ErrorParser.java
@@ -15,7 +15,11 @@ package brave;
 
 import brave.handler.MutableSpan;
 
-/** This is a simplified type used for parsing errors. It only allows annotations or tags. */
+/**
+ * This is a simplified type used for parsing errors. It only allows annotations or tags.
+ *
+ * @see Tags#ERROR
+ */
 // This implementation works with SpanCustomizer, MutableSpan and ScopedSpan, which don't share a
 // common interface, yet both support tag and annotations.
 public class ErrorParser {

--- a/brave/src/main/java/brave/ScopedSpan.java
+++ b/brave/src/main/java/brave/ScopedSpan.java
@@ -33,10 +33,11 @@ import brave.propagation.TraceContext;
  * }
  * }</pre>
  *
- * <p>Usage notes: All methods return {@linkplain ScopedSpan} for chaining, but the instance is
- * always the same. Also, this type is intended for in-process synchronous code. Do not leak this
- * onto another thread: it is not thread-safe. For advanced features or remote commands, use {@link
- * Span} instead.
+ * <h3>Usage notes</h3>
+ * All methods return {@linkplain ScopedSpan} for chaining, but the instance is always the same.
+ * Also, this type is intended for in-process synchronous code. Do not leak this onto another
+ * thread: it is not thread-safe. For advanced features or remote commands, use {@link Span}
+ * instead.
  *
  * @since 4.19
  */

--- a/brave/src/main/java/brave/Span.java
+++ b/brave/src/main/java/brave/Span.java
@@ -18,7 +18,7 @@ import brave.propagation.TraceContext;
 import zipkin2.Endpoint;
 
 /**
- * Used to model the latency of an operation.
+ * Subtype of {@link SpanCustomizer} which can capture latency and remote context of an operation.
  *
  * Here's a typical example of synchronous tracing from perspective of the span:
  * <pre>{@code
@@ -37,8 +37,9 @@ import zipkin2.Endpoint;
  *
  * <p>This captures duration of {@link #start()} until {@link #finish()} is called.
  *
- * <p>Note: All methods return {@linkplain Span} for chaining, but the instance is always the same.
- * Also, when only tracing in-process operations, consider {@link ScopedSpan}: a simpler api.
+ * <h3>Usage notes</h3>
+ * All methods return {@linkplain Span} for chaining, but the instance is always the same. Also,
+ * when only tracing in-process operations, consider {@link ScopedSpan}: a simpler api.
  */
 // Design note: this does not require a builder as the span is mutable anyway. Having a single
 // mutation interface is less code to maintain. Those looking to prepare a span before starting it

--- a/brave/src/main/java/brave/SpanCustomizer.java
+++ b/brave/src/main/java/brave/SpanCustomizer.java
@@ -17,18 +17,11 @@ package brave;
  * Simple interface users can customize a span with. For example, this can add custom tags useful in
  * looking up spans.
  *
- * <p>This type is safer to expose directly to users than {@link Span} or {@link ScopedSpan}, as it
- * has no hooks that can affect the span lifecycle.
+ * <h3>Usage notes</h3>
+ * This type is safer to expose directly to users than {@link Span}, as it has no hooks that can
+ * affect the span lifecycle.
  *
- * <p>While unnecessary when tagging constants, guard potentially expensive operations on the
- * {@link NoopSpanCustomizer} type.
- *
- * <p>Ex.
- * <pre>{@code
- * if (!(customizer instanceof NoopSpanCustomizer)) {
- *   customizer.tag("summary", computeSummary());
- * }
- * }</pre>
+ * @see Tag
  */
 // Note: this is exposed to users. We cannot add methods to this until Java 8 is required or we do a
 // major version bump
@@ -45,8 +38,22 @@ public interface SpanCustomizer {
    * "your_app.version" would let you lookup spans by version. A tag "sql.query" isn't searchable,
    * but it can help in debugging when viewing a trace.
    *
+   * <p><em>Note:</em>To guard potentially expensive parsing, implement {@link Tag} instead, which
+   * avoids parsing into a no-op span.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * SUMMARY_TAG = new Tag<Summarizer>("summary") {
+   *   @Override protected String parseValue(Summarizer input, TraceContext context) {
+   *     return input.computeSummary();
+   *   }
+   * }
+   * SUMMARY_TAG.tag(span);
+   * }</pre>
+   *
    * @param key Name used to lookup spans, such as "your_app.version".
    * @param value String value, cannot be <code>null</code>.
+   * @see Tag#tag(Object, SpanCustomizer)
    */
   SpanCustomizer tag(String key, String value);
 

--- a/brave/src/main/java/brave/Tag.java
+++ b/brave/src/main/java/brave/Tag.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave;
+
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.internal.Nullable;
+import brave.internal.Platform;
+import brave.propagation.TraceContext;
+
+import static brave.internal.Throwables.propagateIfFatal;
+
+/**
+ * This is a centralized type to parse a tag into any variant of a span. This also avoids the
+ * clutter of checking null or guarding on exceptions.
+ *
+ * Here's an example of a potentially expensive tag:
+ * <pre>{@code
+ * SUMMARY_TAG = new Tag<Summarizer>("summary") {
+ *   @Override protected String parseValue(Summarizer input, TraceContext context) {
+ *     return input.computeSummary();
+ *   }
+ * }
+ * SUMMARY_TAG.tag(span);
+ * }</pre>
+ *
+ * @see Tags
+ * @see SpanCustomizer#tag(String, String)
+ * @see ScopedSpan#tag(String, String)
+ * @see MutableSpan#tag(String, String)
+ * @since 5.11
+ */
+public abstract class Tag<I> {
+  public final String key() {
+    return key;
+  }
+
+  /**
+   * Override to change what data from the input are parsed into the span modeling it. Any
+   * exceptions will be logged and ignored.
+   *
+   * @return possibly nullable result. Note: empty string is a valid tag value!
+   * @since 5.11
+   */
+  @Nullable protected abstract String parseValue(I input, @Nullable TraceContext context);
+
+  /**
+   * {@linkplain SpanCustomizer#tag(String, String) Tags} the value parsed from the {@code input}
+   * when non-null and the span is not no-op.
+   *
+   * @since 5.11
+   */
+  // ex void parse(HttpRequest request, TraceContext context, SpanCustomizer span);
+  public final void tag(I input, TraceContext context, SpanCustomizer span) {
+    if (input == null) throw new NullPointerException("input == null");
+    if (context == null) throw new NullPointerException("context == null");
+    if (span == null) throw new NullPointerException("span == null");
+    if (span == NoopSpanCustomizer.INSTANCE) return;
+    tag(span, input, context);
+  }
+
+  /**
+   * {@linkplain SpanCustomizer#tag(String, String) Tags} the value parsed from the {@code input}
+   * when non-null and the span is not no-op.
+   *
+   * @since 5.11
+   */
+  public final void tag(I input, SpanCustomizer span) {
+    if (input == null) throw new NullPointerException("input == null");
+    if (span == null) throw new NullPointerException("span == null");
+    TraceContext context = null;
+    if (span instanceof Span) {
+      Span asSpan = (Span) span;
+      if (asSpan.isNoop()) return;
+      context = asSpan.context();
+    } else if (span == NoopSpanCustomizer.INSTANCE) {
+      return;
+    }
+    tag(span, input, context);
+  }
+
+  /**
+   * {@linkplain MutableSpan#tag(String, String) Tags} the value parsed from the {@code input} when
+   * non-null.
+   *
+   * @see FinishedSpanHandler#handle(TraceContext, MutableSpan)
+   * @since 5.11
+   */
+  public final void tag(I input, TraceContext context, MutableSpan span) {
+    if (input == null) throw new NullPointerException("input == null");
+    if (span == null) throw new NullPointerException("span == null");
+    tag(span, input, context);
+  }
+
+  final String key;
+
+  /** @since 5.11 */
+  protected Tag(String key) {
+    this.key = validateNonEmpty("key", key);
+  }
+
+  @Override public String toString() {
+    return getClass().getSimpleName() + "{" + key + "}";
+  }
+
+  final void tag(Object span, I input, @Nullable TraceContext context) {
+    String value;
+    try {
+      value = parseValue(input, context);
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      Platform.get().log("Error parsing tag value of input %s", input, e);
+      return;
+    }
+    if (value == null) return;
+    if (span instanceof SpanCustomizer) {
+      ((SpanCustomizer) span).tag(key, value);
+    } else if (span instanceof MutableSpan) {
+      ((MutableSpan) span).tag(key, value);
+    }
+  }
+
+  protected static String validateNonEmpty(String label, String value) {
+    if (value == null) throw new NullPointerException(label + " == null");
+    value = value.trim();
+    if (value.isEmpty()) throw new IllegalArgumentException(label + " is empty");
+    return value;
+  }
+}

--- a/brave/src/main/java/brave/Tags.java
+++ b/brave/src/main/java/brave/Tags.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave;
+
+import brave.propagation.TraceContext;
+
+/**
+ * Standard tags used in parsers
+ *
+ * @since 5.11
+ */
+public final class Tags {
+  /**
+   * This tags "error" as the message or simple name of the throwable.
+   *
+   * @see Span#error(Throwable)
+   * @since 5.11
+   */
+  public static final Tag<Throwable> ERROR = new Tag<Throwable>("error") {
+    @Override protected String parseValue(Throwable input, TraceContext context) {
+      String message = input.getMessage();
+      if (message == null) message = input.getClass().getSimpleName();
+      return message;
+    }
+  };
+
+  Tags() {
+  }
+}

--- a/brave/src/main/java/brave/handler/FinishedSpanHandler.java
+++ b/brave/src/main/java/brave/handler/FinishedSpanHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package brave.handler;
 
 import brave.Span;
+import brave.Tag;
 import brave.Tracer;
 import brave.internal.recorder.PendingSpans;
 import brave.propagation.TraceContext;
@@ -67,6 +68,7 @@ public abstract class FinishedSpanHandler {
    * @return true retains the span, and should almost always be used. false drops the span, making
    * it invisible to later handlers such as Zipkin.
    * @see #supportsOrphans() If you are scrubbing personal information, consider supporting orphans.
+   * @see Tag#tag(Object, TraceContext, MutableSpan)
    */
   public abstract boolean handle(TraceContext context, MutableSpan span);
 

--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -14,6 +14,7 @@
 package brave.handler;
 
 import brave.Span.Kind;
+import brave.Tag;
 import brave.Tracer;
 import brave.internal.IpLiteral;
 import brave.internal.Nullable;
@@ -258,7 +259,10 @@ public final class MutableSpan implements Cloneable {
     return result;
   }
 
-  /** @see brave.Span#tag(String, String) */
+  /**
+   * @see brave.Span#tag(String, String)
+   * @see Tag#tag(Object, TraceContext, MutableSpan)
+   */
   public void tag(String key, String value) {
     if (key == null) throw new NullPointerException("key == null");
     if (key.isEmpty()) throw new IllegalArgumentException("key is empty");

--- a/brave/src/test/java/brave/TagTest.java
+++ b/brave/src/test/java/brave/TagTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave;
+
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import java.util.function.BiFunction;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class TagTest {
+  Span span = mock(Span.class);
+  ScopedSpan scopedSpan = mock(ScopedSpan.class);
+  SpanCustomizer customizer = mock(SpanCustomizer.class);
+  MutableSpan mutableSpan = new MutableSpan();
+  BiFunction<Object, TraceContext, String> parseValue = mock(BiFunction.class);
+
+  Object input = new Object();
+  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+  Tag<Object> tag = new Tag<Object>("key") {
+    @Override protected String parseValue(Object input, TraceContext context) {
+      return parseValue.apply(input, context);
+    }
+  };
+
+  @Before public void setup() {
+    when(span.context()).thenReturn(context);
+    when(scopedSpan.context()).thenReturn(context);
+  }
+
+  @Test public void trimsKey() {
+    assertThat(new Tag<Object>(" x-foo  ") {
+      @Override protected String parseValue(Object input, TraceContext context) {
+        return null;
+      }
+    }.key()).isEqualTo("x-foo");
+  }
+
+  @Test public void key_invalid() {
+    assertThatThrownBy(() -> new Tag<Object>(null) {
+      @Override protected String parseValue(Object input, TraceContext context) {
+        return null;
+      }
+    }).isInstanceOf(NullPointerException.class);
+
+    assertThatThrownBy(() -> new Tag<Object>("") {
+      @Override protected String parseValue(Object input, TraceContext context) {
+        return null;
+      }
+    }).isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() -> new Tag<Object>("   ") {
+      @Override protected String parseValue(Object input, TraceContext context) {
+        return null;
+      }
+    }).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test public void tag_span() {
+    when(parseValue.apply(input, context)).thenReturn("value");
+
+    tag.tag(input, span);
+
+    verify(span).context();
+    verify(span).isNoop();
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(span).tag("key", "value");
+    verifyNoMoreInteractions(span); // doesn't tag twice
+  }
+
+  @Test public void tag_span_empty() {
+    when(parseValue.apply(input, context)).thenReturn("");
+
+    tag.tag(input, span);
+
+    verify(span).context();
+    verify(span).isNoop();
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(span).tag("key", "");
+    verifyNoMoreInteractions(span); // doesn't tag twice
+  }
+
+  @Test public void tag_span_doesntParseNoop() {
+    when(span.isNoop()).thenReturn(true);
+
+    verifyNoMoreInteractions(parseValue); // parsing is lazy
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void tag_span_ignoredErrorParsing() {
+    when(parseValue.apply(input, context)).thenThrow(new Error());
+
+    tag.tag(input, span);
+
+    verify(span).context();
+    verify(span).isNoop();
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void tag_scopedSpan() {
+    when(parseValue.apply(input, context)).thenReturn("value");
+
+    tag.tag(input, scopedSpan);
+
+    verify(scopedSpan).context();
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(scopedSpan).tag("key", "value");
+    verifyNoMoreInteractions(scopedSpan); // doesn't tag twice
+  }
+
+  @Test public void tag_scopedSpan_empty() {
+    when(parseValue.apply(input, context)).thenReturn("");
+
+    tag.tag(input, scopedSpan);
+
+    verify(scopedSpan).context();
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(scopedSpan).tag("key", "");
+    verifyNoMoreInteractions(scopedSpan); // doesn't tag twice
+  }
+
+  @Test public void tag_scopedSpan_doesntParseNoop() {
+    when(scopedSpan.isNoop()).thenReturn(true);
+
+    verifyNoMoreInteractions(parseValue); // parsing is lazy
+    verifyNoMoreInteractions(scopedSpan);
+  }
+
+  @Test public void tag_scopedSpan_ignoredErrorParsing() {
+    when(parseValue.apply(input, context)).thenThrow(new Error());
+
+    tag.tag(input, scopedSpan);
+
+    verify(scopedSpan).context();
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verifyNoMoreInteractions(scopedSpan);
+  }
+
+  @Test public void tag_customizer() {
+    when(parseValue.apply(input, null)).thenReturn("value");
+
+    tag.tag(input, customizer);
+
+    verify(parseValue).apply(input, null);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(customizer).tag("key", "value");
+    verifyNoMoreInteractions(customizer); // doesn't tag twice
+  }
+
+  @Test public void tag_customizer_empty() {
+    when(parseValue.apply(input, null)).thenReturn("");
+
+    tag.tag(input, customizer);
+
+    verify(parseValue).apply(input, null);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(customizer).tag("key", "");
+    verifyNoMoreInteractions(customizer); // doesn't tag twice
+  }
+
+  @Test public void tag_customizer_doesntParseNoop() {
+    tag.tag(input, context, NoopSpanCustomizer.INSTANCE);
+
+    verifyNoMoreInteractions(parseValue); // parsing is lazy
+  }
+
+  @Test public void tag_customizer_ignoredErrorParsing() {
+    when(parseValue.apply(input, null)).thenThrow(new Error());
+
+    tag.tag(input, customizer);
+
+    verify(parseValue).apply(input, null);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verifyNoMoreInteractions(customizer);
+  }
+
+  @Test public void tag_customizer_withContext() {
+    when(parseValue.apply(input, context)).thenReturn("value");
+
+    tag.tag(input, context, customizer);
+
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(customizer).tag("key", "value");
+    verifyNoMoreInteractions(customizer); // doesn't tag twice
+  }
+
+  @Test public void tag_customizer_withContext_empty() {
+    when(parseValue.apply(input, context)).thenReturn("");
+
+    tag.tag(input, context, customizer);
+
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verify(customizer).tag("key", "");
+    verifyNoMoreInteractions(customizer); // doesn't tag twice
+  }
+
+  @Test public void tag_customizer_withContext_doesntParseNoop() {
+    tag.tag(input, context, NoopSpanCustomizer.INSTANCE);
+
+    verifyNoMoreInteractions(parseValue); // parsing is lazy
+  }
+
+  @Test public void tag_customizer_withContext_ignoredErrorParsing() {
+    when(parseValue.apply(input, context)).thenThrow(new Error());
+
+    tag.tag(input, context, customizer);
+
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+    verifyNoMoreInteractions(customizer);
+  }
+
+  @Test public void tag_mutableSpan() {
+    when(parseValue.apply(input, context)).thenReturn("value");
+
+    tag.tag(input, context, mutableSpan);
+
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+
+    MutableSpan expected = new MutableSpan();
+    expected.tag("key", "value");
+    assertThat(mutableSpan).isEqualToComparingFieldByField(expected);
+  }
+
+  @Test public void tag_mutableSpan_empty() {
+    when(parseValue.apply(input, context)).thenReturn("");
+
+    tag.tag(input, context, mutableSpan);
+
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+
+    MutableSpan expected = new MutableSpan();
+    expected.tag("key", "");
+    assertThat(mutableSpan).isEqualToComparingFieldByField(expected);
+  }
+
+  @Test public void tag_mutableSpan_ignoredErrorParsing() {
+    when(parseValue.apply(input, context)).thenThrow(new Error());
+
+    tag.tag(input, context, mutableSpan);
+
+    verify(parseValue).apply(input, context);
+    verifyNoMoreInteractions(parseValue); // doesn't parse twice
+
+    assertThat(mutableSpan.isEmpty()).isTrue();
+  }
+}

--- a/brave/src/test/java/brave/TagTest.java
+++ b/brave/src/test/java/brave/TagTest.java
@@ -124,6 +124,7 @@ public class TagTest {
 
     tag.tag(input, scopedSpan);
 
+    verify(scopedSpan).isNoop();
     verify(scopedSpan).context();
     verify(parseValue).apply(input, context);
     verifyNoMoreInteractions(parseValue); // doesn't parse twice
@@ -136,6 +137,7 @@ public class TagTest {
 
     tag.tag(input, scopedSpan);
 
+    verify(scopedSpan).isNoop();
     verify(scopedSpan).context();
     verify(parseValue).apply(input, context);
     verifyNoMoreInteractions(parseValue); // doesn't parse twice
@@ -155,6 +157,7 @@ public class TagTest {
 
     tag.tag(input, scopedSpan);
 
+    verify(scopedSpan).isNoop();
     verify(scopedSpan).context();
     verify(parseValue).apply(input, context);
     verifyNoMoreInteractions(parseValue); // doesn't parse twice

--- a/brave/src/test/java/brave/TagsTest.java
+++ b/brave/src/test/java/brave/TagsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+
+/** This only tests things not already covered in {@link TagTest} */
+@RunWith(MockitoJUnitRunner.class)
+public class TagsTest {
+  @Mock SpanCustomizer span;
+
+  @Test public void error() {
+    Tags.ERROR.tag(new RuntimeException("this cake is a lie"), span);
+
+    verify(span).tag("error", "this cake is a lie");
+  }
+
+  @Test public void error_noMessage() {
+    Tags.ERROR.tag(new RuntimeException(), span);
+
+    verify(span).tag("error", "RuntimeException");
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -22,6 +22,7 @@ import brave.http.HttpClientParser;
 import brave.http.HttpRequest;
 import brave.http.HttpResponseParser;
 import brave.http.HttpRuleSampler;
+import brave.http.HttpTags;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.ExtraFieldPropagation;
@@ -214,7 +215,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     closeClient(client);
     httpTracing = httpTracing.toBuilder()
       .clientResponseParser((response, context, span) -> {
-        span.tag("http.url", response.request().url()); // just the path is tagged by default
+        HttpTags.URL.tag(response.request(), span); // just the path is tagged by default
       })
       .build();
 
@@ -233,7 +234,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     httpTracing = httpTracing.toBuilder()
       .clientRequestParser((request, context, span) -> {
         span.name(request.method().toLowerCase() + " " + request.path());
-        span.tag("http.url", request.url()); // just the path is tagged by default
+        HttpTags.URL.tag(request, span); // just the path is tagged by default
         span.tag("request_customizer.is_span", (span instanceof brave.Span) + "");
       })
       .clientResponseParser((response, context, span) -> {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -22,6 +22,7 @@ import brave.http.HttpRequestParser;
 import brave.http.HttpResponseParser;
 import brave.http.HttpRuleSampler;
 import brave.http.HttpServerParser;
+import brave.http.HttpTags;
 import brave.http.HttpTracing;
 import brave.propagation.B3SingleFormat;
 import brave.propagation.ExtraFieldPropagation;
@@ -244,7 +245,7 @@ public abstract class ITHttpServer extends ITRemote {
   @Test public void readsRequestAtResponseTime() throws IOException {
     httpTracing = httpTracing.toBuilder()
       .serverResponseParser((response, context, span) -> {
-        span.tag("http.url", response.request().url()); // just the path is tagged by default
+        HttpTags.URL.tag(response.request(), span); // just the path is tagged by default
       })
       .build();
     init();
@@ -260,7 +261,7 @@ public abstract class ITHttpServer extends ITRemote {
     httpTracing = httpTracing.toBuilder()
       .serverRequestParser((request, context, span) -> {
         span.name(request.method().toLowerCase() + " " + request.path());
-        span.tag("http.url", request.url()); // just the path is tagged by default
+        HttpTags.URL.tag(request, span); // just the path is tagged by default
         span.tag("request_customizer.is_span", (span instanceof brave.Span) + "");
       })
       .serverResponseParser((response, context, span) -> {
@@ -380,7 +381,7 @@ public abstract class ITHttpServer extends ITRemote {
 
   final HttpRequestParser addHttpUrlTag = (request, context, span) -> {
     HttpRequestParser.DEFAULT.parse(request, context, span);
-    span.tag("http.url", request.url()); // just the path is tagged by default
+    HttpTags.URL.tag(request, span); // just the path is tagged by default
   };
 
   /** If http route is supported, then the span name should include it */

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -30,7 +30,7 @@ For example, to add a non-default tag for HTTP clients, you can do this:
 httpTracing = httpTracing.toBuilder()
     .clientRequestParser((req, context, span) -> {
       HttpClientRequestParser.DEFAULT.parse(req, context, span);
-      span.tag("http.url", req.url()); // add the url in addition to defaults
+      HttpTags.URL.tag(req, context, span); // add the url in addition to defaults
     })
     .build();
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequest.java
@@ -57,6 +57,8 @@ public abstract class HttpRequest extends Request {
    * <p>It is part of the <a href="https://tools.ietf.org/html/rfc7231#section-4.1">HTTP RFC</a>
    * that an HTTP method is case-sensitive. Do not downcase results. If you do, not only will
    * integration tests fail, but you will surprise any consumers who expect compliant results.
+   *
+   * @see HttpTags#METHOD
    */
   public abstract String method();
 
@@ -69,6 +71,7 @@ public abstract class HttpRequest extends Request {
    *
    * @see #url()
    * @see HttpResponse#route()
+   * @see HttpTags#PATH
    */
   @Nullable public abstract String path();
 
@@ -83,6 +86,7 @@ public abstract class HttpRequest extends Request {
    * needed.
    *
    * @see HttpRequest#path()
+   * @see HttpTags#ROUTE
    * @since 5.10
    */
   @Nullable public String route() {
@@ -97,6 +101,7 @@ public abstract class HttpRequest extends Request {
    *
    * @see #path()
    * @see HttpResponse#route()
+   * @see HttpTags#URL
    */
   @Nullable public abstract String url();
 

--- a/instrumentation/http/src/main/java/brave/http/HttpRequestParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequestParser.java
@@ -26,7 +26,7 @@ import brave.propagation.TraceContext;
  * httpTracing = httpTracing.toBuilder()
  *   .clientRequestParser((request, context, span) -> {
  *     span.name(spanName(adapter, request)); // default span name
- *     span.tag("http.url", request.url()); // the whole url, not just the path
+ *     HttpTags.URL.tag(req, context, span); // the whole url, not just the path
  *   }).build();
  * }</pre>
  *
@@ -62,9 +62,8 @@ public interface HttpRequestParser {
     @Override public void parse(HttpRequest req, TraceContext context, SpanCustomizer span) {
       String name = spanName(req, context);
       if (name != null) span.name(name);
-      span.tag("http.method", req.method());
-      String path = req.path();
-      if (path != null) span.tag("http.path", path);
+      HttpTags.METHOD.tag(req, context, span);
+      HttpTags.PATH.tag(req, context, span);
     }
 
     /**

--- a/instrumentation/http/src/main/java/brave/http/HttpTags.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpTags.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.SpanCustomizer;
+import brave.Tag;
+import brave.propagation.TraceContext;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Standard tags used in {@linkplain HttpRequestParser request} and {@linkplain HttpResponseParser
+ * response parsers}.
+ *
+ * @see HttpRequestParser
+ * @see HttpResponseParser
+ * @since 5.11
+ */
+public final class HttpTags {
+  /** In worst case, holds 500 strings corresponding to all valid status codes. */
+  static final Map<Integer, String> CACHED_STATUS_CODES = new ConcurrentHashMap<>();
+
+  /**
+   * This tags "http.method" as the value of  {@link HttpRequest#method()}, such as "GET" or
+   * "POST".
+   *
+   * @see HttpRequest#method()
+   * @see HttpRequestParser#parse(HttpRequest, TraceContext, SpanCustomizer)
+   * @see HttpResponse#request()
+   * @since 5.11
+   */
+  public static final Tag<HttpRequest> METHOD = new Tag<HttpRequest>("http.method") {
+    @Override protected String parseValue(HttpRequest input, TraceContext context) {
+      return input.method();
+    }
+  };
+
+  /**
+   * This tags "http.path" as the value of  {@link HttpRequest#path()}. Ex. "/objects/abcd-ff"
+   *
+   * @see HttpRequest#path()
+   * @see #ROUTE
+   * @see HttpRequestParser#parse(HttpRequest, TraceContext, SpanCustomizer)
+   * @see HttpResponse#request()
+   * @since 5.11
+   */
+  public static final Tag<HttpRequest> PATH = new Tag<HttpRequest>("http.path") {
+    @Override protected String parseValue(HttpRequest input, TraceContext context) {
+      return input.path();
+    }
+  };
+
+  /**
+   * This tags "http.route" as the value of {@link HttpRequest#route()}. Ex "/users/{userId}" or ""
+   * (empty string) if routing is supported, but there was no match.
+   *
+   * @see HttpRequest#route()
+   * @see #PATH
+   * @see HttpRequestParser#parse(HttpRequest, TraceContext, SpanCustomizer)
+   * @see HttpResponse#request()
+   * @since 5.11
+   */
+  public static final Tag<HttpRequest> ROUTE = new Tag<HttpRequest>("http.route") {
+    @Override protected String parseValue(HttpRequest input, TraceContext context) {
+      return input.route();
+    }
+  };
+
+  /**
+   * This tags "http.url" as the value of {@link HttpRequest#url()}. Unlike {@link #PATH}, this
+   * includes the scheme, host and query parameters.
+   *
+   * <p>Ex. "https://mybucket.s3.amazonaws.com/objects/abcd-ff?X-Amz-Algorithm=AWS4-HMAC-SHA256..."
+   *
+   * <p>Combined with {@link #METHOD}, you can understand the fully-qualified request line.
+   *
+   * <p><em>Caution:</em>This may include private data or be of considerable length.
+   *
+   * @see HttpRequest#url()
+   * @see #PATH
+   * @see HttpRequestParser#parse(HttpRequest, TraceContext, SpanCustomizer)
+   * @see HttpResponse#request()
+   * @since 5.11
+   */
+  public static final Tag<HttpRequest> URL = new Tag<HttpRequest>("http.url") {
+    @Override protected String parseValue(HttpRequest input, TraceContext context) {
+      return input.url();
+    }
+  };
+
+  /**
+   * This tags "http.status_code" as the value of {@link HttpResponse#statusCode()}, when a valid
+   * status code (100 - 599).
+   *
+   * @see HttpResponse#statusCode()
+   * @see HttpResponseParser#parse(HttpResponse, TraceContext, SpanCustomizer)
+   * @since 5.11
+   */
+  public static final Tag<HttpResponse> STATUS_CODE = new Tag<HttpResponse>("http.status_code") {
+    @Override protected String parseValue(HttpResponse input, TraceContext context) {
+      int statusCode = input.statusCode();
+      return statusCodeString(statusCode);
+    }
+  };
+
+  /**
+   * Creates a tag for the given {@linkplain HttpRequest#header(String) HTTP request header}.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * USER_AGENT = HttpTags.requestHeader("User-Agent");
+   * }</pre>
+   *
+   * @see HttpRequest#header(String)
+   * @see HttpResponse#request()
+   * @since 5.11
+   */
+  public static Tag<HttpRequest> requestHeader(String headerName) {
+    return requestHeader(headerName, headerName);
+  }
+
+  /**
+   * Like {@link #requestHeader(String)}, except controls the tag key used.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * USER_AGENT = HttpTags.requestHeader("http.user_agent", "User-Agent");
+   * }</pre>
+   *
+   * @see HttpRequest#header(String)
+   * @see HttpResponse#request()
+   * @since 5.11
+   */
+  public static Tag<HttpRequest> requestHeader(String key, String headerName) {
+    return new Tag<HttpRequest>(key) {
+      String name = validateNonEmpty("headerName", headerName);
+
+      @Override protected String parseValue(HttpRequest input, TraceContext context) {
+        return input.header(name);
+      }
+    };
+  }
+
+  static String statusCodeString(int statusCode) {
+    if (statusCode < 100 || statusCode > 599) return null; // not a valid status code
+    String cached = CACHED_STATUS_CODES.get(statusCode); // try to avoid allocating a string
+    if (cached != null) return cached;
+    String result = String.valueOf(statusCode);
+    CACHED_STATUS_CODES.put(statusCode, result); // lost race is unimportant
+    return result;
+  }
+
+  HttpTags() {
+  }
+}

--- a/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientHandlerTest.java
@@ -146,6 +146,8 @@ public class HttpClientHandlerTest {
 
   @Test public void handleReceive_finishesSpanEvenIfUnwrappedNull() {
     brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
+    when(span.customizer()).thenReturn(span);
 
     handler.handleReceive(mock(HttpClientResponse.class), null, span);
 
@@ -158,6 +160,7 @@ public class HttpClientHandlerTest {
 
   @Test public void handleReceive_finishesSpanEvenIfUnwrappedNull_withError() {
     brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
     when(span.customizer()).thenReturn(span);
 
     Exception error = new RuntimeException("peanuts");

--- a/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpHandlerTest.java
@@ -59,6 +59,7 @@ public class HttpHandlerTest {
 
   @Test public void handleStart_parsesTagsWithCustomizer() {
     brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
     brave.SpanCustomizer spanCustomizer = mock(brave.SpanCustomizer.class);
     when(request.spanKind()).thenReturn(Span.Kind.SERVER);
     when(request.method()).thenReturn("GET");

--- a/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerHandlerTest.java
@@ -16,6 +16,7 @@ package brave.http;
 import brave.Span;
 import brave.SpanCustomizer;
 import brave.Tracing;
+import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import brave.sampler.SamplerFunction;
 import brave.sampler.SamplerFunctions;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class HttpServerHandlerTest {
   List<zipkin2.Span> spans = new ArrayList<>();
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
 
   HttpTracing httpTracing;
   HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
@@ -116,6 +118,8 @@ public class HttpServerHandlerTest {
 
   @Test public void handleSend_finishesSpanEvenIfUnwrappedNull() {
     brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
+    when(span.customizer()).thenReturn(span);
 
     handler.handleSend(mock(HttpServerResponse.class), null, span);
 
@@ -128,6 +132,7 @@ public class HttpServerHandlerTest {
 
   @Test public void handleSend_finishesSpanEvenIfUnwrappedNull_withError() {
     brave.Span span = mock(brave.Span.class);
+    when(span.context()).thenReturn(context);
     when(span.customizer()).thenReturn(span);
 
     Exception error = new RuntimeException("peanuts");

--- a/instrumentation/http/src/test/java/brave/http/HttpTagsTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpTagsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.http;
+
+import brave.SpanCustomizer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/** This only tests things not already covered in {@code brave.TagTest} */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpTagsTest {
+  @Mock SpanCustomizer span;
+  @Mock HttpRequest request;
+  @Mock HttpResponse response;
+
+  @Test public void method() {
+    when(request.method()).thenReturn("GET");
+    HttpTags.METHOD.tag(request, span);
+
+    verify(span).tag("http.method", "GET");
+  }
+
+  @Test public void method_null() {
+    HttpTags.METHOD.tag(request, span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void path() {
+    when(request.path()).thenReturn("/objects/abcd-ff");
+    HttpTags.PATH.tag(request, span);
+
+    verify(span).tag("http.path", "/objects/abcd-ff");
+  }
+
+  @Test public void path_null() {
+    HttpTags.PATH.tag(request, span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void route() {
+    when(request.route()).thenReturn("/items/:itemId");
+    HttpTags.ROUTE.tag(request, span);
+
+    verify(span).tag("http.route", "/items/:itemId");
+  }
+
+  @Test public void route_null() {
+    HttpTags.ROUTE.tag(request, span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void url() {
+    when(request.url()).thenReturn("https://zipkin.io");
+    HttpTags.URL.tag(request, span);
+
+    verify(span).tag("http.url", "https://zipkin.io");
+  }
+
+  @Test public void url_null() {
+    HttpTags.URL.tag(request, span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void requestHeader() {
+    when(request.header("User-Agent")).thenReturn("Mozilla/5.0");
+    HttpTags.requestHeader("User-Agent").tag(request, span);
+
+    verify(span).tag("User-Agent", "Mozilla/5.0");
+  }
+
+  @Test public void requestHeader_renamed() {
+    when(request.header("User-Agent")).thenReturn("Mozilla/5.0");
+    HttpTags.requestHeader("http.user_agent", "User-Agent").tag(request, span);
+
+    verify(span).tag("http.user_agent", "Mozilla/5.0");
+  }
+
+  @Test public void requestHeader_null() {
+    HttpTags.requestHeader("User-Agent").tag(request, span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void status_code() {
+    when(response.statusCode()).thenReturn(200);
+    HttpTags.STATUS_CODE.tag(response, span);
+
+    verify(span).tag("http.status_code", "200");
+  }
+
+  @Test public void status_code_zero() {
+    HttpTags.STATUS_CODE.tag(response, span);
+
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void status_code_invalid() {
+    when(response.statusCode()).thenReturn(600);
+    HttpTags.STATUS_CODE.tag(response, span);
+
+    verifyNoMoreInteractions(span);
+  }
+}

--- a/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
+++ b/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
@@ -261,6 +261,7 @@ public final class JmsTracing {
   void tagQueueOrTopic(MessagingRequest request, SpanCustomizer span) {
     String channelName = request.channelName();
     if (channelName == null) return;
+    // TODO: TAG
 
     String channelKind = request.channelKind();
     if ("queue".equals(channelKind)) {

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -15,6 +15,7 @@ package brave.vertx.web;
 
 import brave.Tracing;
 import brave.http.HttpRequestParser;
+import brave.http.HttpTags;
 import brave.propagation.ExtraFieldPropagation;
 import brave.test.http.ITHttpServer;
 import io.vertx.core.Handler;
@@ -139,7 +140,7 @@ public class ITVertxWebTracing extends ITHttpServer {
   void handlesReroute(String path) throws IOException {
     httpTracing = httpTracing.toBuilder().serverRequestParser((request, context, span) -> {
       HttpRequestParser.DEFAULT.parse(request, context, span);
-      span.tag("http.url", request.url()); // just the path is logged by default
+      HttpTags.URL.tag(request, span); // just the path is logged by default
     }).build();
     init();
 


### PR DESCRIPTION
This adds a long overdue feature to ease support of tagging spans. `Tag`
bakes in all logic needed to add a tag to a `Span`, `ScopedSpan`,
`SpanCustomizer` or `MutableSpan` leaving the user left only to decide
what the key is and how to parse it.

This also takes care of error handling and obviation of parsing into a
no-op span.

Here's an example of a potentially expensive tag:
```java
SUMMARY_TAG = new Tag<Summarizer>("summary") {
  @Override protected String parseValue(Summarizer input, TraceContext context) {
    return input.computeSummary();
  }
}

// This works for any variant of span
SUMMARY_TAG.tag(summarizer, span);
```

We need to solve a common case for `BaggageField` which is to add that
as a span tag. This is the best time to fix this problem.

The closest type we have is `ErrorParser` as that does a similar
dispatch. Externally, the closest is [OpenTracing Tag](https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/tag/Tag.java).

Our approach is different notably as we seal everything except how to
parse the value. This helps avoid leaking exceptions or accidentally
adding null values.