### PR TITLE
Uses SpanCustomizer as a base for all running spans

### DIFF
--- a/brave/src/main/java/brave/ErrorParser.java
+++ b/brave/src/main/java/brave/ErrorParser.java
@@ -25,11 +25,6 @@ public class ErrorParser {
     }
   };
 
-  /** Used to parse errors on a subtype of {@linkplain ScopedSpan} */
-  public final void error(Throwable error, ScopedSpan scopedSpan) {
-    error(error, (Object) scopedSpan);
-  }
-
   /** Used to parse errors on a subtype of {@linkplain SpanCustomizer} */
   public final void error(Throwable error, SpanCustomizer customizer) {
     error(error, (Object) customizer);
@@ -54,8 +49,6 @@ public class ErrorParser {
   protected final void annotate(Object span, String value) {
     if (span instanceof SpanCustomizer) {
       ((SpanCustomizer) span).annotate(value);
-    } else if (span instanceof ScopedSpan) {
-      ((ScopedSpan) span).annotate(value);
     }
   }
 
@@ -63,8 +56,6 @@ public class ErrorParser {
   protected final void tag(Object span, String key, String message) {
     if (span instanceof SpanCustomizer) {
       ((SpanCustomizer) span).tag(key, message);
-    } else if (span instanceof ScopedSpan) {
-      ((ScopedSpan) span).tag(key, message);
     } else if (span instanceof MutableSpan) {
       ((MutableSpan) span).tag(key, message);
     }

--- a/brave/src/main/java/brave/NoopScopedSpan.java
+++ b/brave/src/main/java/brave/NoopScopedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 
 final class NoopScopedSpan extends ScopedSpan {
-
   final TraceContext context;
   final Scope scope;
 
@@ -34,11 +33,15 @@ final class NoopScopedSpan extends ScopedSpan {
     return context;
   }
 
-  @Override public ScopedSpan annotate(String value) {
+  @Override public ScopedSpan name(String name) {
     return this;
   }
 
   @Override public ScopedSpan tag(String key, String value) {
+    return this;
+  }
+
+  @Override public ScopedSpan annotate(String value) {
     return this;
   }
 

--- a/brave/src/main/java/brave/RealScopedSpan.java
+++ b/brave/src/main/java/brave/RealScopedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,6 @@ import brave.propagation.TraceContext;
 
 /** This wraps the public api and guards access to a mutable span. */
 final class RealScopedSpan extends ScopedSpan {
-
   final TraceContext context;
   final Scope scope;
   final MutableSpan state;
@@ -53,13 +52,18 @@ final class RealScopedSpan extends ScopedSpan {
     return context;
   }
 
-  @Override public ScopedSpan annotate(String value) {
-    state.annotate(clock.currentTimeMicroseconds(), value);
+  @Override public ScopedSpan name(String name) {
+    state.name(name);
     return this;
   }
 
   @Override public ScopedSpan tag(String key, String value) {
     state.tag(key, value);
+    return this;
+  }
+
+  @Override public ScopedSpan annotate(String value) {
+    state.annotate(clock.currentTimeMicroseconds(), value);
     return this;
   }
 

--- a/brave/src/main/java/brave/ScopedSpan.java
+++ b/brave/src/main/java/brave/ScopedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,43 +37,60 @@ import brave.propagation.TraceContext;
  * always the same. Also, this type is intended for in-process synchronous code. Do not leak this
  * onto another thread: it is not thread-safe. For advanced features or remote commands, use {@link
  * Span} instead.
+ *
+ * @since 4.19
  */
-public abstract class ScopedSpan {
-
+public abstract class ScopedSpan implements SpanCustomizer {
   /**
    * When true, no recording will take place, so no data is reported on finish. However, the trace
    * context is in scope until {@link #finish()} is called.
+   *
+   * @since 4.19
    */
   public abstract boolean isNoop();
 
-  /** Returns the trace context associated with this span */
+  /**
+   * Returns the trace context associated with this span
+   *
+   * @since 4.19
+   */
   // This api is exposed as there's always a context in scope by definition, and the context is
   // needed for methods like ExtraFieldPropagation.set
   public abstract TraceContext context();
 
   /**
-   * Associates an event that explains latency with the current system time.
+   * {@inheritDoc}
    *
-   * @param value A short tag indicating the event, like "finagle.retry"
+   * @since 5.11
    */
-  public abstract ScopedSpan annotate(String value);
+  @Override public abstract ScopedSpan name(String name);
 
   /**
-   * Tags give your span context for search, viewing and analysis. For example, a key
-   * "your_app.version" would let you lookup spans by version. A tag "sql.query" isn't searchable,
-   * but it can help in debugging when viewing a trace.
+   * {@inheritDoc}
    *
-   * @param key Name used to lookup spans, such as "your_app.version".
-   * @param value String value, cannot be <code>null</code>.
+   * @since 4.19
    */
-  public abstract ScopedSpan tag(String key, String value);
+  @Override public abstract ScopedSpan tag(String key, String value);
 
-  /** Adds tags depending on the configured {@link Tracing#errorParser() error parser} */
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.19
+   */
+  @Override public abstract ScopedSpan annotate(String value);
+
+  /**
+   * Adds tags depending on the configured {@link Tracing#errorParser() error parser}   *
+   *
+   * @since 4.19
+   */
   public abstract ScopedSpan error(Throwable throwable);
 
   /**
    * Closes the {@link CurrentTraceContext#newScope(TraceContext) scope} associated with this span,
    * then reports the span complete, assigning the most precise duration possible.
+   *
+   * @since 4.19
    */
   public abstract void finish();
 

--- a/brave/src/main/java/brave/SpanCustomizer.java
+++ b/brave/src/main/java/brave/SpanCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,8 +17,8 @@ package brave;
  * Simple interface users can customize a span with. For example, this can add custom tags useful in
  * looking up spans.
  *
- * <p>This type is safer to expose directly to users than {@link Span}, as it has no hooks that
- * can affect the span lifecycle.
+ * <p>This type is safer to expose directly to users than {@link Span} or {@link ScopedSpan}, as it
+ * has no hooks that can affect the span lifecycle.
  *
  * <p>While unnecessary when tagging constants, guard potentially expensive operations on the
  * {@link NoopSpanCustomizer} type.

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -793,6 +793,17 @@ public class TracerTest {
       .isPositive();
   }
 
+  @Test public void startScopedSpan_overrideName() {
+    ScopedSpan scoped = tracer.startScopedSpan("foo");
+    try {
+      scoped.name("bar");
+    } finally {
+      scoped.finish();
+    }
+
+    assertThat(spans.get(0).name()).isEqualTo("bar");
+  }
+
   @Test public void useSpanAfterFinished_doesNotCauseBraveFlush() {
     simulateInProcessPropagation(tracer, tracer);
     GarbageCollectors.blockOnGC();


### PR DESCRIPTION
This simplifies concepts and code by retrofitting `ScopedSpan` as a
`SpanCustomizer`. In doing so, it makes hierarchies easier as everything
that can affect a current span can use a `SpanCustomizer` to do so.

This implicitly allows renaming of a `ScopedSpan` which can be done
anyway via `Tracer.currentSpan()`

Thanks to @anuraaga for the idea.