### PR TITLE
Undeprecates StrictCurrentTraceContext

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
+++ b/brave-tests/src/test/java/brave/propagation/StrictCurrentTraceContextTest.java
@@ -27,7 +27,7 @@ public class StrictCurrentTraceContextTest extends CurrentTraceContextTest {
 
   static class BuilderSupplier implements Supplier<CurrentTraceContext.Builder> {
     @Override public CurrentTraceContext.Builder get() {
-      return StrictCurrentTraceContext.strictBuilder();
+      return new StrictCurrentTraceContext.Builder();
     }
   }
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -797,7 +797,7 @@ tracing = Tracing.newBuilder()
     .build();
 ```
 
-Besides logging, other tools are available. [StrictScopeDecorator](src/main/java/brave/propagation/StrictScopeDecorator.java) can
+Besides logging, other tools are available. [StrictCurrentTraceContext](src/main/java/brave/propagation/StrictCurrentTraceContext.java) can
 help find out when code is not closing scopes properly. This can be
 useful when writing or diagnosing custom instrumentation.
 
@@ -818,7 +818,7 @@ expensive and more precise `System.nanoTime()` function.
 
 ## Troubleshooting instrumentation
 Instrumentation problems can lead to scope leaks and orphaned data. When
-testing instrumentation, use [StrictScopeDecorator](src/main/java/brave/propagation/StrictScopeDecorator.java), as it will throw
+testing instrumentation, use [StrictCurrentTraceContext](src/main/java/brave/propagation/StrictCurrentTraceContext.java), as it will throw
 errors on known scoping problems.
 
 If you see data with the annotation `brave.flush`, you may have an
@@ -836,24 +836,23 @@ When writing unit tests, there are a few tricks that will make bugs
 easier to find:
 
 * Report spans into a concurrent queue, so you can read them in tests
-* Use `StrictScopeDecorator` to reveal subtle thread-related propagation bugs
+* Use `StrictCurrentTraceContext` to reveal subtle thread-related propagation bugs
 * Unconditionally cleanup `Tracing.current()`, to prevent leaks
 
 Here's an example setup for your unit test fixture:
 ```java
 ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
 
+StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create()
 Tracing tracing = Tracing.newBuilder()
-                 .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-                   .addScopeDecorator(StrictScopeDecorator.create())
-                   .build()
-                 )
+                 .currentTraceContext(currentTraceContext)
                  .spanReporter(spans::add)
                  .build();
 
   @After public void close() {
     Tracing current = Tracing.current();
     if (current != null) current.close();
+    currentTraceContext.clear();
   }
 ```
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -852,7 +852,7 @@ Tracing tracing = Tracing.newBuilder()
   @After public void close() {
     Tracing current = Tracing.current();
     if (current != null) current.close();
-    currentTraceContext.clear();
+    currentTraceContext.close();
   }
 ```
 

--- a/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
@@ -52,6 +52,7 @@ public final class StrictCurrentTraceContext extends CurrentTraceContext impleme
     @Override public Builder addScopeDecorator(ScopeDecorator scopeDecorator) {
       if (scopeDecorator instanceof StrictScopeDecorator) {
         strictScopeDecorator = (StrictScopeDecorator) scopeDecorator;
+        return this;
       }
       return (Builder) super.addScopeDecorator(scopeDecorator);
     }

--- a/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java
@@ -13,23 +13,84 @@
  */
 package brave.propagation;
 
+import brave.internal.Nullable;
+import java.io.Closeable;
+
 /**
  * Useful when developing instrumentation as state is enforced more strictly.
  *
  * <p>For example, it is instance scoped as opposed to static scoped, not inheritable and throws an
  * exception if a scope is closed on a different thread that it was opened on.
  *
- * @deprecated use {@linkplain StrictScopeDecorator}. This will be removed in Brave v6.
+ * @see StrictScopeDecorator
  */
-@Deprecated
-public final class StrictCurrentTraceContext extends ThreadLocalCurrentTraceContext {
-  static Builder strictBuilder() {
-    return new Builder(new ThreadLocal<>()).addScopeDecorator(new StrictScopeDecorator());
+public final class StrictCurrentTraceContext extends CurrentTraceContext implements Closeable {
+  /** @since 5.11 */
+  public static StrictCurrentTraceContext create() {
+    return new StrictCurrentTraceContext();
   }
 
-  public StrictCurrentTraceContext() { // Preserve historical public ctor
+  /** @since 5.11 */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends CurrentTraceContext.Builder {
     // intentionally not inheritable to ensure instrumentation propagation doesn't accidentally work
     // intentionally not static to make explicit when instrumentation need per thread semantics
-    super(strictBuilder());
+    final ThreadLocal<TraceContext> local = new ThreadLocal<>();
+    CurrentTraceContext delegate = new ThreadLocalCurrentTraceContext.Builder(local).build();
+    StrictScopeDecorator strictScopeDecorator = new StrictScopeDecorator();
+
+    @Override public StrictCurrentTraceContext build() {
+      delegate = new ThreadLocalCurrentTraceContext.Builder(local)
+        .addScopeDecorator(strictScopeDecorator)
+        .build();
+      return new StrictCurrentTraceContext(this);
+    }
+
+    @Override public Builder addScopeDecorator(ScopeDecorator scopeDecorator) {
+      if (scopeDecorator instanceof StrictScopeDecorator) {
+        strictScopeDecorator = (StrictScopeDecorator) scopeDecorator;
+      }
+      return (Builder) super.addScopeDecorator(scopeDecorator);
+    }
+
+    Builder() {
+    }
+  }
+
+  final CurrentTraceContext delegate;
+  final StrictScopeDecorator strictScopeDecorator;
+
+  public StrictCurrentTraceContext() { // Preserve historical public ctor
+    this(new Builder());
+  }
+
+  StrictCurrentTraceContext(Builder builder) {
+    super(builder);
+    delegate = builder.delegate;
+    strictScopeDecorator = builder.strictScopeDecorator;
+  }
+
+  @Override public TraceContext get() {
+    return delegate.get();
+  }
+
+  @Override public Scope newScope(@Nullable TraceContext context) {
+    return decorateScope(context, delegate.newScope(context));
+  }
+
+  @Override public Scope maybeScope(TraceContext context) {
+    return decorateScope(context, delegate.maybeScope(context));
+  }
+
+  /**
+   * Calls {@link StrictScopeDecorator#close()}
+   *
+   * @since 5.11
+   */
+  @Override public void close() {
+    strictScopeDecorator.close();
   }
 }

--- a/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/CurrentSpanCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package brave;
 
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
@@ -24,10 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 public class CurrentSpanCustomizerTest {
-
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::add)
     .build();
   CurrentSpanCustomizer spanCustomizer = CurrentSpanCustomizer.create(tracing);

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,8 +14,7 @@
 package brave;
 
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -38,9 +37,7 @@ public class CurrentTraceContextExecutorServiceTest {
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
 
   // override default so that it isn't inheritable
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
-    .build();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   ExecutorService executor = currentTraceContext.executorService(wrappedExecutor);
 
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(1).build();

--- a/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
+++ b/brave/src/test/java/brave/CurrentTraceContextExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,8 +14,7 @@
 package brave;
 
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -32,9 +31,7 @@ public class CurrentTraceContextExecutorTest {
   // Ensures one at-a-time, but also on a different thread
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
   // override default so that it isn't inheritable
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
-    .build();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
 
   Executor executor = currentTraceContext.executor(wrappedExecutor);
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(1).build();

--- a/brave/src/test/java/brave/LazySpanTest.java
+++ b/brave/src/test/java/brave/LazySpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 package brave;
 
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LazySpanTest {
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::add)
     .build();
 

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  */
 package brave;
 
-import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
 import org.junit.After;
 import org.junit.Test;
@@ -22,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class NoopSpanTest {
   Tracer tracer = Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE)
-    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
     .clock(() -> {
       throw new AssertionError();
     })

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -23,7 +23,7 @@ import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import brave.propagation.SamplingFlags;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.propagation.TraceIdContext;
@@ -50,7 +50,7 @@ public class TracerTest {
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).shared(true).build();
   List<zipkin2.Span> spans = new ArrayList<>();
   Propagation.Factory propagationFactory = B3Propagation.FACTORY;
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.create();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   Tracer tracer = Tracing.newBuilder()
     .spanReporter(new Reporter<zipkin2.Span>() {
       @Override public void report(zipkin2.Span span) {

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -17,6 +17,7 @@ import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.Propagation;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import java.util.ArrayList;
@@ -46,7 +47,9 @@ public class TracingTest {
    * sampled status, and be missing a parent when their parent tracer is in noop.
    */
   @Test public void setNoop_dropsDataButDoesntAffectSampling() {
-    try (Tracing tracing = Tracing.newBuilder().spanReporter(spans::add).build()) {
+    try (Tracing tracing = Tracing.newBuilder()
+      .currentTraceContext(StrictCurrentTraceContext.create())
+      .spanReporter(spans::add).build()) {
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
 
       tracing.setNoop(true);

--- a/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
+++ b/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
@@ -15,7 +15,7 @@ package brave.features.advanced;
 
 import brave.Clock;
 import brave.Tracing;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CustomScopedClockTracingTest {
   List<Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::add)
     .build();
 

--- a/brave/src/test/java/brave/features/async/OneWaySpanTest.java
+++ b/brave/src/test/java/brave/features/async/OneWaySpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,7 @@ package brave.features.async;
 
 import brave.Span;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -48,16 +47,12 @@ public class OneWaySpanTest {
   /** Use different tracers for client and server as usually they are on different hosts. */
   Tracing clientTracing = Tracing.newBuilder()
     .localServiceName("client")
-    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-      .addScopeDecorator(StrictScopeDecorator.create())
-      .build())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::add)
     .build();
   Tracing serverTracing = Tracing.newBuilder()
     .localServiceName("server")
-    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-      .addScopeDecorator(StrictScopeDecorator.create())
-      .build())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::add)
     .build();
 

--- a/brave/src/test/java/brave/features/handler/DefaultTagsTest.java
+++ b/brave/src/test/java/brave/features/handler/DefaultTagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import brave.ScopedSpan;
 import brave.Tracing;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.entry;
 public class DefaultTagsTest {
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .addFinishedSpanHandler(new FinishedSpanHandler() {
       @Override public boolean handle(TraceContext context, MutableSpan span) {
         if (context.isLocalRoot()) {

--- a/brave/src/test/java/brave/features/handler/RedactingFinishedSpanHandlerTest.java
+++ b/brave/src/test/java/brave/features/handler/RedactingFinishedSpanHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.handler.MutableSpan.AnnotationUpdater;
 import brave.handler.MutableSpan.TagUpdater;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -86,6 +87,7 @@ public class RedactingFinishedSpanHandlerTest {
   };
 
   Tracing tracing = Tracing.newBuilder()
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .addFinishedSpanHandler(redacter)
     .addFinishedSpanHandler(markFinished)
     .spanReporter(spans::add)

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,8 +16,6 @@ package brave.features.opentracing;
 import brave.Tracing;
 import brave.propagation.B3Propagation;
 import brave.propagation.ExtraFieldPropagation;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMapAdapter;
@@ -39,9 +37,6 @@ import static org.assertj.core.data.MapEntry.entry;
 public class OpenTracingAdapterTest {
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing brave = Tracing.newBuilder()
-    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-      .addScopeDecorator(StrictScopeDecorator.create())
-      .build())
     .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "client-id"))
     .spanReporter(spans::add).build();
 

--- a/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
+++ b/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package brave.features.sampler;
 import brave.ScopedSpan;
 import brave.Tracer;
 import brave.Tracing;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.sampler.DeclarativeSampler;
 import brave.sampler.Sampler;
 import brave.sampler.SamplerFunction;
@@ -54,6 +55,7 @@ public class AspectJSamplerTest {
 
   @Before public void clear() {
     tracing.set(Tracing.newBuilder()
+      .currentTraceContext(StrictCurrentTraceContext.create())
       .spanReporter(spans::add)
       .sampler(new Sampler() {
         @Override public boolean isSampled(long traceId) {

--- a/brave/src/test/java/brave/internal/ExtraFactoryTest.java
+++ b/brave/src/test/java/brave/internal/ExtraFactoryTest.java
@@ -17,6 +17,7 @@ import brave.ScopedSpan;
 import brave.Tracing;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.List;
 import org.junit.Before;
@@ -27,7 +28,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class ExtraFactoryTest<E, F extends ExtraFactory<E>> {
-
   protected F factory;
   protected Propagation.Factory propagationFactory;
   protected TraceContext context;
@@ -92,6 +92,7 @@ public abstract class ExtraFactoryTest<E, F extends ExtraFactory<E>> {
   @Test public void toSpan_selfLinksContext() {
     try (Tracing t = Tracing.newBuilder()
       .spanReporter(Reporter.NOOP)
+      .currentTraceContext(StrictCurrentTraceContext.create())
       .propagationFactory(propagationFactory)
       .build()) {
       ScopedSpan parent = t.tracer().startScopedSpan("parent");

--- a/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
+++ b/brave/src/test/java/brave/internal/PropagationFieldsFactoryTest.java
@@ -17,6 +17,7 @@ import brave.ScopedSpan;
 import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.SamplingFlags;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import org.junit.Test;
@@ -266,6 +267,7 @@ public abstract class PropagationFieldsFactoryTest<K, V, P extends PropagationFi
   /** Ensures we don't accidentally use console logging, which is default */
   Tracing withNoopSpanReporter() {
     return Tracing.newBuilder()
+      .currentTraceContext(StrictCurrentTraceContext.create())
       .spanReporter(Reporter.NOOP)
       .propagationFactory(propagationFactory)
       .build();

--- a/brave/src/test/java/brave/propagation/ThreadLocalSpanTest.java
+++ b/brave/src/test/java/brave/propagation/ThreadLocalSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,10 +23,9 @@ import zipkin2.Span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadLocalSpanTest {
-
   List<Span> spans = new ArrayList<>();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::add)
     .build();
 

--- a/context/jfr/src/test/java/brave/context/jfr/JfrScopeDecoratorTest.java
+++ b/context/jfr/src/test/java/brave/context/jfr/JfrScopeDecoratorTest.java
@@ -16,8 +16,7 @@ package brave.context.jfr;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.CurrentTraceContext.ScopeDecorator;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.nio.file.Path;
 import java.util.List;
@@ -42,8 +41,7 @@ public class JfrScopeDecoratorTest {
 
   ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
   ScopeDecorator decorator = JfrScopeDecorator.create();
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.newBuilder()
     .addScopeDecorator(JfrScopeDecorator.create())
     .build();
 

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingMatrixTest.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingMatrixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,7 @@ package brave.context.rxjava2;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
@@ -67,9 +66,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * CurrentTraceContextAssemblyTrackingTest} so they don't get lost!
  */
 public class CurrentTraceContextAssemblyTrackingMatrixTest {
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
-    .build();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   CurrentTraceContext throwingCurrentTraceContext = new CurrentTraceContext() {
     @Override public TraceContext get() {
       return subscribeContext;

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingTest.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/CurrentTraceContextAssemblyTrackingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,8 +16,7 @@ package brave.context.rxjava2;
 import brave.context.rxjava2.CurrentTraceContextAssemblyTracking.SavedHooks;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import hu.akarnokd.rxjava2.debug.RxJavaAssemblyException;
 import hu.akarnokd.rxjava2.debug.RxJavaAssemblyTracking;
@@ -33,9 +32,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CurrentTraceContextAssemblyTrackingTest {
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
-    .build();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   TraceContext assemblyContext = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
 
   @Before public void setup() {

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/NotYetSupportedTest.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/NotYetSupportedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,7 @@ package brave.context.rxjava2;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
@@ -35,9 +34,7 @@ import org.reactivestreams.Subscriber;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class NotYetSupportedTest {
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
-    .build();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   TraceContext assemblyContext = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
   TraceContext subscribeContext = assemblyContext.toBuilder().parentId(1L).spanId(2L).build();
 

--- a/context/rxjava2/src/test/java/brave/context/rxjava2/features/ITRetrofitRxJava2.java
+++ b/context/rxjava2/src/test/java/brave/context/rxjava2/features/ITRetrofitRxJava2.java
@@ -16,8 +16,7 @@ package brave.context.rxjava2.features;
 import brave.context.rxjava2.CurrentTraceContextAssemblyTracking;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -50,9 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** This tests that propagation isn't lost when passing through an untraced system. */
 public class ITRetrofitRxJava2 {
   TraceContext context1 = TraceContext.newBuilder().traceId(1L).spanId(1L).build();
-  CurrentTraceContext currentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-    .addScopeDecorator(StrictScopeDecorator.create())
-    .build();
+  CurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   CurrentTraceContextAssemblyTracking contextTracking;
 
   @Rule public MockWebServer server = new MockWebServer();

--- a/instrumentation/http-tests/src/test/java/brave/http/features/RequestSamplingTest.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/RequestSamplingTest.java
@@ -15,8 +15,7 @@ package brave.http.features;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import okhttp3.Call;
@@ -43,9 +42,7 @@ public class RequestSamplingTest {
   ConcurrentLinkedDeque<zipkin2.Span> spans = new ConcurrentLinkedDeque<>();
   Tracing tracing = Tracing.newBuilder()
     .localServiceName("server")
-    .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-      .addScopeDecorator(StrictScopeDecorator.create())
-      .build())
+    .currentTraceContext(StrictCurrentTraceContext.create())
     .spanReporter(spans::push)
     .build();
   HttpTracing httpTracing = HttpTracing.newBuilder(tracing)


### PR DESCRIPTION
`StrictCurrentTraceContext` can help reduce flakiness in environments
that run multiple concurrent tests from different classes at the same
time. This unflaking is due to an unshared thread local.

Even if thread local isn't the cause of flakiness, this can help those
trying to debug flakey things rule it out!