### PR TITLE
Allows correlation fields to not match `BaggageField` names

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -379,6 +379,16 @@ tracingBuilder.propagationFactory(BaggagePropagation.newFactoryBuilder(B3Propaga
                                                                  .build())
 ```
 
+#### Field mapping
+Your log correlation properties may not be the same as the baggage field names. You can
+override them in the builder as needed.
+
+Ex. If your log property is %X{trace-id}, you can do this:
+```java
+builder.clear(); // traceId is a default field!
+builder.addField(BaggageFields.TRACE_ID, "trace-id");
+```
+
 ### Appropriate usage
 
 Brave is an infrastructure library: you will create lock-in if you expose its apis into

--- a/brave/src/main/java/brave/baggage/BaggageFieldFlushScope.java
+++ b/brave/src/main/java/brave/baggage/BaggageFieldFlushScope.java
@@ -51,12 +51,14 @@ final class BaggageFieldFlushScope extends AtomicBoolean implements Scope {
     Set<CorrelationContext> syncedContexts = new LinkedHashSet<>();
     for (Object o : updateScopeStack()) {
       BaggageFieldUpdateScope next = ((BaggageFieldUpdateScope) o);
+      String name = next.name(field);
+      if (name == null) continue;
 
       // Since this is a static method, it could be called with different tracers on the stack.
       // This synchronizes the context if we haven't already.
       if (!syncedContexts.contains(next.context)) {
-        if (!equal(next.context.getValue(field.name()), value)) {
-          next.context.update(field.name, value);
+        if (!equal(next.context.getValue(name), value)) {
+          next.context.update(name, value);
         }
         syncedContexts.add(next.context);
       }

--- a/brave/src/main/java/brave/baggage/BaggageFields.java
+++ b/brave/src/main/java/brave/baggage/BaggageFields.java
@@ -43,9 +43,9 @@ public final class BaggageFields {
    * @since 5.11
    */
   public static final BaggageField TRACE_ID = BaggageField.newBuilder("traceId")
-    .internalContext(new TraceIdStorage()).build();
+    .internalContext(new TraceId()).build();
 
-  static final class TraceIdStorage extends BaggageContext.ReadOnly {
+  static final class TraceId extends BaggageContext.ReadOnly {
     @Override public String getValue(BaggageField field, TraceContextOrSamplingFlags extracted) {
       if (extracted.context() != null) return getValue(field, extracted.context());
       if (extracted.traceIdContext() != null) return extracted.traceIdContext().traceIdString();
@@ -64,9 +64,9 @@ public final class BaggageFields {
    * @since 5.11
    */
   public static final BaggageField PARENT_ID = BaggageField.newBuilder("parentId")
-    .internalContext(new ParentIdStorage()).build();
+    .internalContext(new ParentId()).build();
 
-  static final class ParentIdStorage extends BaggageContext.ReadOnly {
+  static final class ParentId extends BaggageContext.ReadOnly {
     @Override public String getValue(BaggageField field, TraceContextOrSamplingFlags extracted) {
       if (extracted.context() != null) return getValue(field, extracted.context());
       return null;
@@ -84,9 +84,9 @@ public final class BaggageFields {
    * @since 5.11
    */
   public static final BaggageField SPAN_ID = BaggageField.newBuilder("spanId")
-    .internalContext(new SpanIdStorage()).build();
+    .internalContext(new SpanId()).build();
 
-  static final class SpanIdStorage extends BaggageContext.ReadOnly {
+  static final class SpanId extends BaggageContext.ReadOnly {
     @Override public String getValue(BaggageField field, TraceContextOrSamplingFlags extracted) {
       if (extracted.context() != null) return getValue(field, extracted.context());
       return null;
@@ -106,9 +106,9 @@ public final class BaggageFields {
    * @since 5.11
    */
   public static final BaggageField SAMPLED = BaggageField.newBuilder("sampled")
-    .internalContext(new SampledStorage()).build();
+    .internalContext(new Sampled()).build();
 
-  static final class SampledStorage extends BaggageContext.ReadOnly {
+  static final class Sampled extends BaggageContext.ReadOnly {
     @Override public String getValue(BaggageField field, TraceContextOrSamplingFlags extracted) {
       return getValue(extracted.sampled());
     }
@@ -133,13 +133,14 @@ public final class BaggageFields {
    * @since 5.11
    */
   public static BaggageField constant(String name, @Nullable String value) {
-    return BaggageField.newBuilder(name).internalContext(new ConstantStorage(value)).build();
+    if (name == null) throw new NullPointerException("name == null");
+    return BaggageField.newBuilder(name).internalContext(new Constant(value)).build();
   }
 
-  static final class ConstantStorage extends BaggageContext.ReadOnly {
+  static final class Constant extends BaggageContext.ReadOnly {
     @Nullable final String value;
 
-    ConstantStorage(String value) {
+    Constant(String value) {
       this.value = value;
     }
 

--- a/brave/src/main/java/brave/baggage/BaggagePropagation.java
+++ b/brave/src/main/java/brave/baggage/BaggagePropagation.java
@@ -102,7 +102,7 @@ public class BaggagePropagation<K> implements Propagation<K> {
      * @since 5.11
      */
     public Map<BaggageField, Set<String>> fieldToKeyNames() {
-      return Collections.unmodifiableMap(fieldToKeyNames);
+      return Collections.unmodifiableMap(new LinkedHashMap<>(fieldToKeyNames));
     }
 
     /**
@@ -171,7 +171,12 @@ public class BaggagePropagation<K> implements Propagation<K> {
         allKeyNames.add(lcName);
         lcKeyNames.add(lcName);
       }
-      if (lcKeyNames.isEmpty()) lcKeyNames.add(field.lcName);
+
+      if (lcKeyNames.isEmpty()) { // add the default name
+        allKeyNames.add(field.lcName);
+        lcKeyNames.add(field.lcName);
+      }
+
       fieldToKeyNames.put(field, Collections.unmodifiableSet(lcKeyNames));
       return this;
     }

--- a/brave/src/test/java/brave/baggage/BaggagePropagationTest.java
+++ b/brave/src/test/java/brave/baggage/BaggagePropagationTest.java
@@ -22,6 +22,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,6 +77,22 @@ public class BaggagePropagationTest {
     assertThatThrownBy(() -> builder.addRemoteField(BaggageField.create("userId"), "baggage"))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Propagation key already in use: baggage");
+  }
+
+  @Test public void name_clear_and_add() {
+    BaggagePropagation.FactoryBuilder builder = newFactoryBuilder(B3Propagation.FACTORY);
+    builder.addRemoteField(vcapRequestId, "request-id", "request_id");
+    builder.addRemoteField(amznTraceId).build();
+
+    Map<BaggageField, Set<String>> saved = builder.fieldToKeyNames();
+    builder.clear();
+    saved.forEach(builder::addRemoteField);
+
+    assertThat(builder)
+      .usingRecursiveComparison()
+      .isEqualTo(newFactoryBuilder(B3Propagation.FACTORY)
+        .addRemoteField(vcapRequestId, "request-id", "request_id")
+        .addRemoteField(amznTraceId));
   }
 
   @Test public void inject_baggage() {

--- a/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
+++ b/context/log4j12/src/main/java/brave/context/log4j12/MDCScopeDecorator.java
@@ -69,7 +69,7 @@ public final class MDCScopeDecorator {
    */
   @Deprecated public static CurrentTraceContext.ScopeDecorator create() {
     return new Builder()
-      .clearFields()
+      .clear()
       .addField(BaggageFields.TRACE_ID)
       .addField(BaggageFields.PARENT_ID)
       .addField(BaggageFields.SPAN_ID)

--- a/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
+++ b/context/log4j2/src/main/java/brave/context/log4j2/ThreadContextScopeDecorator.java
@@ -69,7 +69,7 @@ public final class ThreadContextScopeDecorator {
    */
   @Deprecated public static CurrentTraceContext.ScopeDecorator create() {
     return new Builder()
-      .clearFields()
+      .clear()
       .addField(BaggageFields.TRACE_ID)
       .addField(BaggageFields.PARENT_ID)
       .addField(BaggageFields.SPAN_ID)

--- a/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
+++ b/context/slf4j/src/main/java/brave/context/slf4j/MDCScopeDecorator.java
@@ -70,7 +70,7 @@ public final class MDCScopeDecorator {
    */
   @Deprecated public static CurrentTraceContext.ScopeDecorator create() {
     return new Builder()
-      .clearFields()
+      .clear()
       .addField(BaggageFields.TRACE_ID)
       .addField(BaggageFields.PARENT_ID)
       .addField(BaggageFields.SPAN_ID)

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/CurrentTraceContextBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/CurrentTraceContextBenchmarks.java
@@ -43,13 +43,13 @@ public class CurrentTraceContextBenchmarks {
   static final CurrentTraceContext base = ThreadLocalCurrentTraceContext.create();
   static final CurrentTraceContext log4j2OnlyTraceId = ThreadLocalCurrentTraceContext.newBuilder()
     .addScopeDecorator(ThreadContextScopeDecorator.newBuilder()
-      .clearFields()
+      .clear()
       .addField(BaggageFields.TRACE_ID)
       .build())
     .build();
   static final CurrentTraceContext log4j2OnlyBaggage = ThreadLocalCurrentTraceContext.newBuilder()
     .addScopeDecorator(ThreadContextScopeDecorator.newBuilder()
-      .clearFields()
+      .clear()
       .addField(BAGGAGE_FIELD)
       .build())
     .build();

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -70,3 +70,22 @@ with trace headers:
   <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
     <property name="propagationFactory" ref="propagationFactory"/>
 ```
+
+Here's an example of adding only the trace ID as the correlation property "X-B3-TraceId":
+
+```xml
+<util:constant id="traceId" static-field="brave.baggage.BaggageFields.TRACE_ID"/>
+<bean id="correlationDecorator" class="brave.spring.beans.CorrelationScopeDecoratorFactoryBean">
+  <property name="builder">
+    <bean class="brave.context.log4j12.MDCScopeDecorator" factory-method="newBuilder"/>
+  </property>
+  <property name="mappedFields">
+    <list>
+      <bean class="brave.spring.beans.MappedBaggageField">
+        <property name="field" ref="traceId"/>
+        <property name="name" value="X-B3-TraceId"/>
+      </bean>
+    </list>
+  </property>
+</bean>
+```

--- a/spring-beans/src/main/java/brave/spring/beans/CorrelationScopeDecoratorFactoryBean.java
+++ b/spring-beans/src/main/java/brave/spring/beans/CorrelationScopeDecoratorFactoryBean.java
@@ -16,6 +16,7 @@ package brave.spring.beans;
 import brave.baggage.BaggageField;
 import brave.baggage.CorrelationScopeCustomizer;
 import brave.baggage.CorrelationScopeDecorator;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import java.util.List;
 import org.springframework.beans.factory.FactoryBean;
 
@@ -23,14 +24,20 @@ import org.springframework.beans.factory.FactoryBean;
 public class CorrelationScopeDecoratorFactoryBean implements FactoryBean {
   CorrelationScopeDecorator.Builder builder;
   List<BaggageField> fields;
+  List<MappedBaggageField> mappedFields;
   List<CorrelationScopeCustomizer> customizers;
 
-  @Override public CorrelationScopeDecorator getObject() {
+  @Override public ScopeDecorator getObject() {
     if (builder == null) throw new NullPointerException("builder == null");
+    if (fields != null || mappedFields != null) builder.clear();
     if (fields != null) {
-      builder.clearFields();
       for (BaggageField field : fields) {
         builder.addField(field);
+      }
+    }
+    if (mappedFields != null) {
+      for (MappedBaggageField mappedFields : mappedFields) {
+        builder.addField(mappedFields.field, mappedFields.name);
       }
     }
     if (customizers != null) {
@@ -39,8 +46,8 @@ public class CorrelationScopeDecoratorFactoryBean implements FactoryBean {
     return builder.build();
   }
 
-  @Override public Class<? extends CorrelationScopeDecorator> getObjectType() {
-    return CorrelationScopeDecorator.class;
+  @Override public Class<? extends ScopeDecorator> getObjectType() {
+    return ScopeDecorator.class;
   }
 
   @Override public boolean isSingleton() {
@@ -53,6 +60,10 @@ public class CorrelationScopeDecoratorFactoryBean implements FactoryBean {
 
   public void setFields(List<BaggageField> fields) {
     this.fields = fields;
+  }
+
+  public void setMappedFields(List<MappedBaggageField> mappedFields) {
+    this.mappedFields = mappedFields;
   }
 
   public void setCustomizers(List<CorrelationScopeCustomizer> customizers) {

--- a/spring-beans/src/main/java/brave/spring/beans/MappedBaggageField.java
+++ b/spring-beans/src/main/java/brave/spring/beans/MappedBaggageField.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.spring.beans;
+
+import brave.baggage.BaggageField;
+
+public class MappedBaggageField {
+  BaggageField field;
+  String name;
+
+  public void setField(BaggageField field) {
+    this.field = field;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/spring-beans/src/test/java/brave/spring/beans/CorrelationScopeDecoratorFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/CorrelationScopeDecoratorFactoryBeanTest.java
@@ -88,6 +88,29 @@ public class CorrelationScopeDecoratorFactoryBeanTest {
       .containsExactly(BaggageFields.TRACE_ID, BaggageFields.SPAN_ID);
   }
 
+  @Test public void mappedFields() {
+    context = new XmlBeans(""
+      + "<util:constant id=\"traceId\" static-field=\"brave.baggage.BaggageFields.TRACE_ID\"/>\n"
+      + "<bean id=\"correlationDecorator\" class=\"brave.spring.beans.CorrelationScopeDecoratorFactoryBean\">\n"
+      + "  <property name=\"builder\">\n"
+      + "    <bean class=\"brave.context.log4j12.MDCScopeDecorator\" factory-method=\"newBuilder\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"mappedFields\">\n"
+      + "    <list>\n"
+      + "      <bean class=\"brave.spring.beans.MappedBaggageField\">\n"
+      + "        <property name=\"field\" ref=\"traceId\"/>\n"
+      + "        <property name=\"name\" value=\"X-B3-TraceId\"/>\n"
+      + "      </bean>\n"
+      + "    </list>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("correlationDecorator", CorrelationScopeDecorator.class))
+      .extracting("field")
+      .isEqualTo(BaggageFields.TRACE_ID);
+  }
+
   public static final CorrelationScopeCustomizer
     CUSTOMIZER_ONE = mock(CorrelationScopeCustomizer.class);
   public static final CorrelationScopeCustomizer

--- a/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
@@ -15,7 +15,7 @@ package brave.spring.beans;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContextCustomizer;
-import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.After;
 import org.junit.Test;
 
@@ -44,7 +44,8 @@ public class CurrentTraceContextFactoryBeanTest {
 
     assertThat(context.getBean("currentTraceContext", CurrentTraceContext.class))
       .extracting("scopeDecorators")
-      .satisfies(e -> assertThat((List) e).isNotEmpty());
+      .asInstanceOf(InstanceOfAssertFactories.ARRAY)
+      .isNotEmpty();
   }
 
   public static final CurrentTraceContextCustomizer


### PR DESCRIPTION
This helps port code which formerly added different naming conventions
for span IDs.

Ex. If your log property is %X{trace-id}, you can do this:
```java
builder.clear(); // traceId is a default field!
builder.addField(BaggageFields.TRACE_ID, "trace-id");
```