### PR TITLE
Adds CorrelationScopeDecorator.addDirtyName

### DIFF
--- a/brave/RATIONALE.md
+++ b/brave/RATIONALE.md
@@ -2,14 +2,20 @@
 
 ## CorrelationScopeDecorator
 
-### Why hold the initial value when `BaggageField.flushOnUpdate()`?
+### Why hold the initial values even when they match?
 
 The value read at the beginning of a scope is currently held when there's a
-chance the field can be updated later (`BaggageField.flushOnUpdate()`). This is
-because users generally expect data to be "cleaned up" when a scope completes,
-even if it was written mid-scope.
+chance the field can be updated later:
 
-Ex. https://github.com/spring-cloud/spring-cloud-sleuth/issues/1416
+* `CorrelationScopeDecorator.Builder.addDirtyName()`
+  * Always revert because someone else could have changed it (ex via `MDC`)
+* `BaggageField.flushOnUpdate()`
+  * Revert if only when we changed it (ex via `BaggageField.updateValue()`)
+
+This is because users generally expect data to be "cleaned up" when a scope
+completes, even if it was written mid-scope.
+
+https://github.com/spring-cloud/spring-cloud-sleuth/issues/1416
 
 If we delayed reading the value, until update, it could be different, due to
 nesting of scopes or out-of-band updates to the correlation context. Hence, we

--- a/brave/src/main/java/brave/baggage/BaggageField.java
+++ b/brave/src/main/java/brave/baggage/BaggageField.java
@@ -309,7 +309,7 @@ public final class BaggageField {
   public void updateValue(@Nullable TraceContext context, @Nullable String value) {
     if (context == null) return;
     if (this.context.updateValue(this, context, value) && flushOnUpdate) {
-      BaggageFieldFlushScope.flush(this, value);
+      CorrrelationFlushScope.flush(this, value);
     }
   }
 
@@ -323,7 +323,7 @@ public final class BaggageField {
   public void updateValue(TraceContextOrSamplingFlags extracted, @Nullable String value) {
     if (extracted == null) throw new NullPointerException("extracted == null");
     if (context.updateValue(this, extracted, value) && flushOnUpdate) {
-      BaggageFieldFlushScope.flush(this, value);
+      CorrrelationFlushScope.flush(this, value);
     }
   }
 

--- a/brave/src/main/java/brave/baggage/CorrelationScopeDecorator.java
+++ b/brave/src/main/java/brave/baggage/CorrelationScopeDecorator.java
@@ -20,6 +20,7 @@ import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import brave.propagation.TraceContext;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -87,6 +88,7 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
     final CorrelationContext context;
     // Don't allow mixed case of the same name!
     final Set<String> allNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    final Set<String> dirtyNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     final Map<BaggageField, String> fieldToNames = new LinkedHashMap<>();
 
     /** Internal constructor used by subtypes. */
@@ -98,9 +100,21 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
     }
 
     /**
+     * Returns an immutable copy of the currently configured {@linkplain #addDirtyName(String) dirty
+     * names}. This allows those who can't create the builder to reconfigure this builder.
+     *
+     * @see #clear()
+     * @since 5.11
+     */
+    public Set<String> dirtyNames() {
+      return Collections.unmodifiableSet(new LinkedHashSet<>(dirtyNames));
+    }
+
+    /**
      * Returns an immutable copy of the currently configured fields mapped to names for use in
      * correlation. This allows those who can't create the builder to reconfigure this builder.
      *
+     * @see #clear()
      * @since 5.11
      */
     public Map<BaggageField, String> fieldToNames() {
@@ -121,6 +135,7 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
      */
     public Builder clear() {
       allNames.clear();
+      dirtyNames.clear();
       fieldToNames.clear();
       return this;
     }
@@ -160,23 +175,46 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
       return this;
     }
 
+    /**
+     * Adds a name in the underlying context which is updated directly. The decorator will overwrite
+     * any underlying changes when the scope closes.
+     *
+     * <p>This is used when there are a mix of libraries controlling the same correlation field.
+     * For example, if SLF4J MDC can update the same field name.
+     *
+     * <p>This has a similar performance impact to {@link BaggageField#flushOnUpdate()}, as it
+     * requires tracking the field value even if there's no change detected.
+     *
+     * @since 5.11
+     */
+    public Builder addDirtyName(String name) {
+      name = validateName(name);
+      if (!allNames.contains(name)) {
+        throw new IllegalArgumentException("Correlation name not in use: " + name);
+      }
+      dirtyNames.add(name);
+      return this;
+    }
+
     /** @return {@link ScopeDecorator#NOOP} if no baggage fields were added. */
     public final ScopeDecorator build() {
       int fieldCount = fieldToNames.size();
       if (fieldCount == 0) return ScopeDecorator.NOOP;
       if (fieldCount == 1) {
         Entry<BaggageField, String> onlyEntry = fieldToNames.entrySet().iterator().next();
-        return new Single(context, onlyEntry.getKey(), onlyEntry.getValue());
+        return new Single(context, onlyEntry.getKey(), onlyEntry.getValue(), dirtyNames.size() > 0);
       }
       if (fieldCount > 32) throw new IllegalArgumentException("over 32 baggage fields");
       BaggageField[] fields = new BaggageField[fieldCount];
       String[] names = new String[fieldCount];
+      int dirty = 0;
       int i = 0;
       for (Entry<BaggageField, String> next : fieldToNames.entrySet()) {
         fields[i] = next.getKey();
         names[i++] = next.getValue();
+        if (dirtyNames.contains(next.getValue())) dirty = setBit(dirty, i);
       }
-      return new Multiple(context, fields, names);
+      return new Multiple(context, fields, names, dirty);
     }
   }
 
@@ -189,11 +227,13 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
   static final class Single extends CorrelationScopeDecorator {
     final BaggageField field;
     final String name;
+    final boolean dirtyName;
 
-    Single(CorrelationContext context, BaggageField field, String name) {
+    Single(CorrelationContext context, BaggageField field, String name, boolean dirtyName) {
       super(context);
       this.field = field;
       this.name = name;
+      this.dirtyName = dirtyName;
     }
 
     @Override public Scope decorateScope(@Nullable TraceContext traceContext, Scope scope) {
@@ -205,6 +245,9 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
         dirty = !equal(valueToRevert, currentValue);
         if (dirty) context.update(name, currentValue);
       }
+
+      // If the underlying field might be updated, always revert the value
+      if (!dirty && dirtyName) dirty = true;
 
       if (!dirty && !field.flushOnUpdate()) return scope;
 
@@ -218,11 +261,13 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
   static final class Multiple extends CorrelationScopeDecorator {
     final BaggageField[] fields;
     final String[] names;
+    final int dirtyNames;
 
-    Multiple(CorrelationContext context, BaggageField[] fields, String[] names) {
+    Multiple(CorrelationContext context, BaggageField[] fields, String[] names, int dirtyNames) {
       super(context);
       this.fields = fields;
       this.names = names;
+      this.dirtyNames = dirtyNames;
     }
 
     @Override public Scope decorateScope(@Nullable TraceContext traceContext, Scope scope) {
@@ -246,6 +291,9 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
 
         valuesToRevert[i] = valueToRevert;
       }
+
+      // Always revert fields that could be updated in the context directly
+      dirty |= dirtyNames;
 
       if (dirty == 0 && flushOnUpdate == 0) return scope;
 

--- a/brave/src/main/java/brave/baggage/CorrelationScopeDecorator.java
+++ b/brave/src/main/java/brave/baggage/CorrelationScopeDecorator.java
@@ -211,8 +211,9 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
       int i = 0;
       for (Entry<BaggageField, String> next : fieldToNames.entrySet()) {
         fields[i] = next.getKey();
-        names[i++] = next.getValue();
+        names[i] = next.getValue();
         if (dirtyNames.contains(next.getValue())) dirty = setBit(dirty, i);
+        i++;
       }
       return new Multiple(context, fields, names, dirty);
     }
@@ -252,9 +253,9 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
       if (!dirty && !field.flushOnUpdate()) return scope;
 
       // If there was or could be a value update, we need to track values to revert.
-      BaggageFieldUpdateScope updateScope =
-        new BaggageFieldUpdateScope.Single(scope, context, field, name, valueToRevert, dirty);
-      return field.flushOnUpdate() ? new BaggageFieldFlushScope(updateScope) : updateScope;
+      CorrelationUpdateScope updateScope =
+        new CorrelationUpdateScope.Single(scope, context, field, name, valueToRevert, dirty);
+      return field.flushOnUpdate() ? new CorrrelationFlushScope(updateScope) : updateScope;
     }
   }
 
@@ -298,9 +299,9 @@ public abstract class CorrelationScopeDecorator implements ScopeDecorator {
       if (dirty == 0 && flushOnUpdate == 0) return scope;
 
       // If there was or could be a value update, we need to track values to revert.
-      BaggageFieldUpdateScope updateScope =
-        new BaggageFieldUpdateScope.Multiple(scope, context, fields, names, valuesToRevert, dirty);
-      return flushOnUpdate != 0 ? new BaggageFieldFlushScope(updateScope) : updateScope;
+      CorrelationUpdateScope updateScope =
+        new CorrelationUpdateScope.Multiple(scope, context, fields, names, valuesToRevert, dirty);
+      return flushOnUpdate != 0 ? new CorrrelationFlushScope(updateScope) : updateScope;
     }
   }
 

--- a/brave/src/main/java/brave/baggage/CorrelationUpdateScope.java
+++ b/brave/src/main/java/brave/baggage/CorrelationUpdateScope.java
@@ -23,10 +23,10 @@ import static brave.baggage.CorrelationScopeDecorator.isSet;
 import static brave.baggage.CorrelationScopeDecorator.setBit;
 
 /** Handles reverting potentially late value updates to baggage fields. */
-abstract class BaggageFieldUpdateScope extends AtomicBoolean implements Scope {
+abstract class CorrelationUpdateScope extends AtomicBoolean implements Scope {
   CorrelationContext context;
 
-  BaggageFieldUpdateScope(CorrelationContext context) {
+  CorrelationUpdateScope(CorrelationContext context) {
     this.context = context;
   }
 
@@ -43,7 +43,7 @@ abstract class BaggageFieldUpdateScope extends AtomicBoolean implements Scope {
    */
   abstract void handleUpdate(BaggageField field, @Nullable String value);
 
-  static final class Single extends BaggageFieldUpdateScope {
+  static final class Single extends CorrelationUpdateScope {
     final Scope delegate;
     final BaggageField field;
     final String name;
@@ -83,7 +83,7 @@ abstract class BaggageFieldUpdateScope extends AtomicBoolean implements Scope {
     }
   }
 
-  static final class Multiple extends BaggageFieldUpdateScope {
+  static final class Multiple extends CorrelationUpdateScope {
     final Scope delegate;
     final BaggageField[] fields;
     final String[] names;

--- a/brave/src/main/java/brave/baggage/CorrrelationFlushScope.java
+++ b/brave/src/main/java/brave/baggage/CorrrelationFlushScope.java
@@ -23,10 +23,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static brave.baggage.CorrelationScopeDecorator.equal;
 
 /** Sets up thread locals if they are needed to support {@link BaggageField#flushOnUpdate()} */
-final class BaggageFieldFlushScope extends AtomicBoolean implements Scope {
-  final BaggageFieldUpdateScope updateScope;
+final class CorrrelationFlushScope extends AtomicBoolean implements Scope {
+  final CorrelationUpdateScope updateScope;
 
-  BaggageFieldFlushScope(BaggageFieldUpdateScope updateScope) {
+  CorrrelationFlushScope(CorrelationUpdateScope updateScope) {
     this.updateScope = updateScope;
     pushCurrentUpdateScope(updateScope);
   }
@@ -50,7 +50,7 @@ final class BaggageFieldFlushScope extends AtomicBoolean implements Scope {
 
     Set<CorrelationContext> syncedContexts = new LinkedHashSet<>();
     for (Object o : updateScopeStack()) {
-      BaggageFieldUpdateScope next = ((BaggageFieldUpdateScope) o);
+      CorrelationUpdateScope next = ((CorrelationUpdateScope) o);
       String name = next.name(field);
       if (name == null) continue;
 
@@ -79,11 +79,11 @@ final class BaggageFieldFlushScope extends AtomicBoolean implements Scope {
     return stack;
   }
 
-  static void pushCurrentUpdateScope(BaggageFieldUpdateScope updateScope) {
+  static void pushCurrentUpdateScope(CorrelationUpdateScope updateScope) {
     updateScopeStack().push(updateScope);
   }
 
-  static void popCurrentUpdateScope(BaggageFieldUpdateScope expected) {
+  static void popCurrentUpdateScope(CorrelationUpdateScope expected) {
     Object popped = updateScopeStack().pop();
     assert equal(popped, expected) :
       "Misalignment: popped updateScope " + popped + " !=  expected " + expected;

--- a/brave/src/test/java/brave/baggage/CorrelationScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/baggage/CorrelationScopeDecoratorTest.java
@@ -23,6 +23,7 @@ import brave.propagation.TraceContext;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -80,6 +81,15 @@ public class CorrelationScopeDecoratorTest {
     .clear()
     .addField(FLUSHABLE_BAGGAGE_FIELD, "flushed")
     .build();
+  ScopeDecorator withDirtyFieldDecorator = new TestBuilder()
+    .addField(BAGGAGE_FIELD, "dirty")
+    .addDirtyName("dirty")
+    .build();
+  ScopeDecorator onlyDirtyFieldDecorator = new TestBuilder()
+    .clear()
+    .addField(BAGGAGE_FIELD, "dirty")
+    .addDirtyName("dirty")
+    .build();
 
   @Before public void before() {
     map.clear();
@@ -93,20 +103,59 @@ public class CorrelationScopeDecoratorTest {
       .hasMessage("Field already added: bp");
   }
 
-  @Test public void name_clear_and_add() {
+  @Test public void dirtyMustBeAName() {
     CorrelationScopeDecorator.Builder builder = new TestBuilder();
-    Map<BaggageField, String> saved = builder.fieldToNames();
+
+    assertThatThrownBy(() -> builder.addDirtyName("dirty"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Correlation name not in use: dirty");
+  }
+
+  @Test public void name_clear_and_add() {
+    CorrelationScopeDecorator.Builder builder = new TestBuilder()
+      .addField(BAGGAGE_FIELD, "dirty")
+      .addDirtyName("dirty");
+
+    Map<BaggageField, String> fieldToNames = builder.fieldToNames();
+    Set<String> dirtyNames = builder.dirtyNames();
+
     builder.clear();
-    saved.keySet().forEach(builder::addField);
+
+    fieldToNames.forEach(builder::addField);
+    dirtyNames.forEach(builder::addDirtyName);
 
     assertThat(builder)
       .usingRecursiveComparison()
-      .isEqualTo(new TestBuilder());
+      .isEqualTo(new TestBuilder()
+        .addField(BAGGAGE_FIELD, "dirty")
+        .addDirtyName("dirty"));
   }
 
   @Test public void doesntDecorateNoop() {
     assertThat(decorator.decorateScope(context, Scope.NOOP)).isSameAs(Scope.NOOP);
     assertThat(decorator.decorateScope(null, Scope.NOOP)).isSameAs(Scope.NOOP);
+  }
+
+  @Test public void decoratesNoop_matchingDirtyField() {
+    BAGGAGE_FIELD.updateValue(context, "romeo");
+    map.put("dirty", "romeo");
+
+    decoratesNoop_dirtyField();
+  }
+
+  @Test public void decoratesNoop_matchingNullDirtyField() {
+    decoratesNoop_dirtyField();
+  }
+
+  /**
+   * All dirty fields should be reverted at the end of the scope, because end-users can interfere
+   * with the underlying context in the middle of the scope. (ex. MDC.put)
+   */
+  void decoratesNoop_dirtyField() {
+    assertThat(withDirtyFieldDecorator.decorateScope(context, Scope.NOOP))
+      .isNotSameAs(Scope.NOOP);
+    assertThat(onlyDirtyFieldDecorator.decorateScope(context, Scope.NOOP))
+      .isNotSameAs(Scope.NOOP);
   }
 
   /** Fields that don't flush inside a s have no value and no value of the underlying context. */

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -79,9 +79,9 @@ Here's an example of adding only the trace ID as the correlation property "X-B3-
   <property name="builder">
     <bean class="brave.context.log4j12.MDCScopeDecorator" factory-method="newBuilder"/>
   </property>
-  <property name="mappedFields">
+  <property name="fields">
     <list>
-      <bean class="brave.spring.beans.MappedBaggageField">
+      <bean class="brave.spring.beans.CorrelationField">
         <property name="field" ref="traceId"/>
         <property name="name" value="X-B3-TraceId"/>
       </bean>

--- a/spring-beans/src/main/java/brave/spring/beans/CorrelationField.java
+++ b/spring-beans/src/main/java/brave/spring/beans/CorrelationField.java
@@ -15,9 +15,10 @@ package brave.spring.beans;
 
 import brave.baggage.BaggageField;
 
-public class MappedBaggageField {
+public class CorrelationField {
   BaggageField field;
   String name;
+  boolean dirty;
 
   public void setField(BaggageField field) {
     this.field = field;
@@ -25,5 +26,9 @@ public class MappedBaggageField {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public void setDirty(boolean dirty) {
+    this.dirty = dirty;
   }
 }

--- a/spring-beans/src/test/java/brave/spring/beans/CorrelationScopeDecoratorFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/CorrelationScopeDecoratorFactoryBeanTest.java
@@ -70,34 +70,14 @@ public class CorrelationScopeDecoratorFactoryBeanTest {
 
   @Test public void fields() {
     context = new XmlBeans(""
+      + "<util:constant id=\"traceId\" static-field=\"brave.baggage.BaggageFields.TRACE_ID\"/>\n"
       + "<bean id=\"correlationDecorator\" class=\"brave.spring.beans.CorrelationScopeDecoratorFactoryBean\">\n"
       + "  <property name=\"builder\">\n"
       + "    <bean class=\"brave.context.log4j12.MDCScopeDecorator\" factory-method=\"newBuilder\"/>\n"
       + "  </property>\n"
       + "  <property name=\"fields\">\n"
       + "    <list>\n"
-      + "      <util:constant static-field=\"brave.baggage.BaggageFields.TRACE_ID\"/>\n"
-      + "      <util:constant static-field=\"brave.baggage.BaggageFields.SPAN_ID\"/>\n"
-      + "    </list>\n"
-      + "  </property>"
-      + "</bean>"
-    );
-
-    assertThat(context.getBean("correlationDecorator", CorrelationScopeDecorator.class))
-      .extracting("fields").asInstanceOf(InstanceOfAssertFactories.ARRAY)
-      .containsExactly(BaggageFields.TRACE_ID, BaggageFields.SPAN_ID);
-  }
-
-  @Test public void mappedFields() {
-    context = new XmlBeans(""
-      + "<util:constant id=\"traceId\" static-field=\"brave.baggage.BaggageFields.TRACE_ID\"/>\n"
-      + "<bean id=\"correlationDecorator\" class=\"brave.spring.beans.CorrelationScopeDecoratorFactoryBean\">\n"
-      + "  <property name=\"builder\">\n"
-      + "    <bean class=\"brave.context.log4j12.MDCScopeDecorator\" factory-method=\"newBuilder\"/>\n"
-      + "  </property>\n"
-      + "  <property name=\"mappedFields\">\n"
-      + "    <list>\n"
-      + "      <bean class=\"brave.spring.beans.MappedBaggageField\">\n"
+      + "      <bean class=\"brave.spring.beans.CorrelationField\">\n"
       + "        <property name=\"field\" ref=\"traceId\"/>\n"
       + "        <property name=\"name\" value=\"X-B3-TraceId\"/>\n"
       + "      </bean>\n"

--- a/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/CurrentTraceContextFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
`CorrelationScopeDecorator.addDirtyName()` indicates a correlation property
which could be updated without Brave knowing about it. When set, we will
always revert its value on scope close, even if it incurs performance
overhead to track the value.

The value read at the beginning of a scope is currently held when there's a
chance the field can be updated later:

* `CorrelationScopeDecorator.Builder.addDirtyName()`
  * Always revert because someone else could have changed it (ex via `MDC`)
* `BaggageField.flushOnUpdate()`
  * Revert if only when we changed it (ex via `BaggageField.updateValue()`)

This is because users generally expect data to be "cleaned up" when a scope
completes, even if it was written mid-scope.

https://github.com/spring-cloud/spring-cloud-sleuth/issues/1416