### PR TITLE
Allows subtypes of ITRemote to override the CurrentTraceContext

### DIFF
--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -29,6 +29,8 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
+    <!-- disable errorprone warning that "return this" is not synchronized! -->
+    <errorprone.args>-Xep:UnsynchronizedOverridesSynchronized:OFF</errorprone.args>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
We recently added enforcement of scopes as a test post-condition.
However, this broke a subtyping pattern used by Armeria.