### PR TITLE
Adds example of custom trace ID parsing

### DIFF
--- a/brave/src/test/java/brave/features/propagation/CustomTraceIdPropagation.java
+++ b/brave/src/test/java/brave/features/propagation/CustomTraceIdPropagation.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.features.propagation;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This is an example where a load balancer is sending a B3 compatible trace ID, but using a
+ * different header name. In ideal case, the load balancer just switches to use B3 single format.
+ * This is an example of a hack you can do when it can't.
+ *
+ * <p>See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1106
+ * <p>See https://github.com/openzipkin/b3-propagation
+ */
+public final class CustomTraceIdPropagation<K> implements Propagation<K> {
+  public static Propagation.Factory create(Propagation.Factory delegate, String customTraceIdName) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    if (customTraceIdName == null) throw new NullPointerException("customTraceIdName == null");
+    if (!delegate.create(KeyFactory.STRING).keys().contains("b3")) {
+      throw new IllegalArgumentException("delegate must implement B3 propagation");
+    }
+    return new Factory(delegate, customTraceIdName);
+  }
+
+  static final class Factory extends Propagation.Factory {
+    final Propagation.Factory delegate;
+    final String customTraceIdName;
+
+    /**
+     * @param delegate some configuration of {@link B3Propagation#newFactoryBuilder()}
+     * @param customTraceIdName something not "b3"
+     */
+    Factory(Propagation.Factory delegate, String customTraceIdName) {
+      this.delegate = delegate;
+      this.customTraceIdName = customTraceIdName;
+    }
+
+    @Override public boolean supportsJoin() {
+      return delegate.supportsJoin();
+    }
+
+    @Override public boolean requires128BitTraceId() {
+      return delegate.requires128BitTraceId();
+    }
+
+    @Override public TraceContext decorate(TraceContext context) {
+      return delegate.decorate(context);
+    }
+
+    @Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+      return new CustomTraceIdPropagation<>(this, keyFactory);
+    }
+  }
+
+  final Propagation<K> delegate;
+  final K b3Key, b3TraceIdKey, customTraceIdKey;
+  final List<K> allKeys;
+
+  CustomTraceIdPropagation(Factory factory, KeyFactory<K> keyFactory) {
+    this.delegate = factory.delegate.create(keyFactory);
+    this.b3Key = keyFactory.create("b3");
+    this.b3TraceIdKey = keyFactory.create("X-B3-TraceId");
+    this.customTraceIdKey = keyFactory.create(factory.customTraceIdName);
+    List<K> allKeys = new ArrayList<>(delegate.keys());
+    allKeys.add(customTraceIdKey);
+    this.allKeys = Collections.unmodifiableList(allKeys);
+  }
+
+  @Override public List<K> keys() {
+    return allKeys;
+  }
+
+  @Override public <C> TraceContext.Extractor<C> extractor(Propagation.Getter<C, K> getter) {
+    return delegate.extractor(new Getter<>(getter, b3Key, b3TraceIdKey, customTraceIdKey));
+  }
+
+  @Override public <C> TraceContext.Injector<C> injector(Propagation.Setter<C, K> setter) {
+    return delegate.injector(setter);
+  }
+
+  static final class Getter<C, K> implements Propagation.Getter<C, K> {
+    final Propagation.Getter<C, K> delegate;
+    private final K b3Key, b3TraceIdKey, customTraceIdKey;
+
+    Getter(Propagation.Getter<C, K> delegate, K b3Key, K b3TraceIdKey, K customTraceIdKey) {
+      this.delegate = delegate;
+      this.b3Key = b3Key;
+      this.b3TraceIdKey = b3TraceIdKey;
+      this.customTraceIdKey = customTraceIdKey;
+    }
+
+    @Override public String get(C carrier, K key) {
+      if (key.equals(b3Key)) {
+        // Don't override a valid B3 context
+        String b3 = delegate.get(carrier, key);
+        if (b3 != null) return b3;
+        if (delegate.get(carrier, b3TraceIdKey) != null) return null;
+
+        // At this point, we know this is not a valid B3 context, check for a valid custom trace ID
+        String customTraceId = delegate.get(carrier, customTraceIdKey);
+        if (customTraceId == null) return null;
+
+        // We still expect the trace ID to be of valid length.
+        int traceIdLength = customTraceId.length();
+        if (traceIdLength < 16 || traceIdLength > 32) return null;
+
+        // Synthesize a B3 single header out of the custom trace ID.
+        // If invalid characters exist, the default parser will fail leniently.
+        StringBuilder builder = new StringBuilder();
+        for (int traceIdPad = 32 - traceIdLength; traceIdPad > 0; traceIdPad--) {
+          builder.append('0');
+        }
+        builder.append(customTraceId).append('-');
+
+        int spanIdIndex = traceIdLength > 16 ? traceIdLength - 16 : 0;
+        builder.append(customTraceId.substring(spanIdIndex));
+        return builder.toString();
+      }
+      return delegate.get(carrier, key);
+    }
+  }
+}

--- a/brave/src/test/java/brave/features/propagation/CustomTraceIdPropagation.java
+++ b/brave/src/test/java/brave/features/propagation/CustomTraceIdPropagation.java
@@ -25,7 +25,6 @@ import java.util.List;
  * different header name. In ideal case, the load balancer just switches to use B3 single format.
  * This is an example of a hack you can do when it can't.
  *
- * <p>See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1106
  * <p>See https://github.com/openzipkin/b3-propagation
  */
 public final class CustomTraceIdPropagation<K> implements Propagation<K> {

--- a/brave/src/test/java/brave/features/propagation/HackedTraceIdTest.java
+++ b/brave/src/test/java/brave/features/propagation/HackedTraceIdTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.features.propagation;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
+import brave.propagation.Propagation.KeyFactory;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContext.Extractor;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This shows how people constrained to only propagating a trace ID can stash numerical data into
+ * the trace ID. For example, a load balancer can set some bit flags like this.
+ *
+ * <p>Rumor has it that Twitter used to do this for embedding device information to ensure a
+ * specific device couldn't absorb the entire random space. It isn't known if the amount of bits
+ * stolen was a nibble or a byte.
+ */
+public class HackedTraceIdTest {
+  String customTraceIdName = "trace_id";
+  // CustomTraceIdPropagation.Factory substitutes for B3Propagation.FACTORY in real config.
+  Propagation.Factory propagationFactory =
+    new CustomTraceIdPropagation.Factory(B3Propagation.FACTORY, customTraceIdName);
+  Propagation<String> propagation = propagationFactory.create(KeyFactory.STRING);
+  Extractor<Map<String, String>> extractor = propagation.extractor(Map::get);
+  Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+  // Let's say environment number zero is invalid, and its desired value is 3
+  // There are at least 3 ways to embed this!
+  @Test public void testFormatThatEmbedsEnvironmentNumber() {
+    // Lead with single-digit, then pad-right zeros until the real trace ID.
+    //
+    // This is not great because it limits to 9 environment numbers. However, parsing is easy
+    // as you look only at the first character.
+    headers.put(customTraceIdName, "3000000000000000e457b5a2e4d86bd1");
+    assertThat(extractor.extract(headers).context())
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("3000000000000000e457b5a2e4d86bd1"))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("e457b5a2e4d86bd1"));
+    headers.put(customTraceIdName, "3000000000000000");
+    assertThat(extractor.extract(headers).context())
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("3000000000000000"))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("3000000000000000"));
+
+    // Use the upper 64-bits (left 16 hex) as the environment ID
+    //
+    // This allows a lot of env numbers, and is easy to parse. This still gives 64-bit trace IDs
+    headers.put(customTraceIdName, "0000000000000003e457b5a2e4d86bd1");
+    assertThat(extractor.extract(headers).context())
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("0000000000000003e457b5a2e4d86bd1"))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("e457b5a2e4d86bd1"));
+    headers.put(customTraceIdName, "3e457b5a2e4d86bd1");
+    assertThat(extractor.extract(headers).context())
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("0000000000000003e457b5a2e4d86bd1"))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("e457b5a2e4d86bd1"));
+
+    // Steal the upper nibble (first hex character) of the 64-bit trace ID as the environment ID
+    //
+    // This allows 15 env numbers, and is easy to parse. It allows 60-bits for the trace ID, which
+    // is good enough for most sites.
+    String customTraceIdString = "3457b5a2e4d86bd1";
+    headers.put(customTraceIdName, customTraceIdString);
+    TraceContext extractedContext = extractor.extract(headers).context();
+    assertThat(extractedContext)
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo(customTraceIdString))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo(customTraceIdString))
+      .satisfies(c -> assertThat((c.traceId() >>> 64 - 4L) & 0xf).isEqualTo(3));
+  }
+
+  @Test public void testB3SingleWins() {
+    headers.put("b3", "1111111111111111-2222222222222222");
+    headers.put(customTraceIdName, "1000000000000000e457b5a2e4d86bd1");
+    assertThat(extractor.extract(headers).context())
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("1111111111111111"))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("2222222222222222"));
+  }
+
+  @Test public void testB3MultiWins() {
+    headers.put("X-B3-TraceId", "1111111111111111");
+    headers.put("X-B3-SpanId", "2222222222222222");
+    headers.put(customTraceIdName, "1000000000000000e457b5a2e4d86bd1");
+    assertThat(extractor.extract(headers).context())
+      .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("1111111111111111"))
+      .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("2222222222222222"));
+  }
+
+  @Test public void invalidTraceIdsDontCrash() {
+    //Arrays.asList(
+    //  "",
+    //  "1",
+    //  "12222222222222222",
+    //
+    //)
+
+  }
+}

--- a/brave/src/test/java/brave/features/propagation/HackedTraceIdTest.java
+++ b/brave/src/test/java/brave/features/propagation/HackedTraceIdTest.java
@@ -100,14 +100,4 @@ public class HackedTraceIdTest {
       .satisfies(c -> assertThat(c.traceIdString()).isEqualTo("1111111111111111"))
       .satisfies(c -> assertThat(c.spanIdString()).isEqualTo("2222222222222222"));
   }
-
-  @Test public void invalidTraceIdsDontCrash() {
-    //Arrays.asList(
-    //  "",
-    //  "1",
-    //  "12222222222222222",
-    //
-    //)
-
-  }
 }

--- a/brave/src/test/java/brave/features/propagation/HackedTraceIdTest.java
+++ b/brave/src/test/java/brave/features/propagation/HackedTraceIdTest.java
@@ -31,12 +31,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>Rumor has it that Twitter used to do this for embedding device information to ensure a
  * specific device couldn't absorb the entire random space. It isn't known if the amount of bits
  * stolen was a nibble or a byte.
+ *
+ * <p>See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1106
  */
 public class HackedTraceIdTest {
   String customTraceIdName = "trace_id";
   // CustomTraceIdPropagation.Factory substitutes for B3Propagation.FACTORY in real config.
   Propagation.Factory propagationFactory =
-    new CustomTraceIdPropagation.Factory(B3Propagation.FACTORY, customTraceIdName);
+    CustomTraceIdPropagation.create(B3Propagation.FACTORY, customTraceIdName);
   Propagation<String> propagation = propagationFactory.create(KeyFactory.STRING);
   Extractor<Map<String, String>> extractor = propagation.extractor(Map::get);
   Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);


### PR DESCRIPTION
This shows how people constrained to only propagating a trace ID can stash numerical data into
the trace ID. For example, a load balancer can set some bit flags like this.

Rumor has it that Twitter used to do this for embedding device information to ensure a
specific device couldn't absorb the entire random space. It isn't known if the amount of bits
stolen was a nibble or a byte.

See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1106