### PR TITLE
Reverts defensiveness in generic params and shares a buffer

### DIFF
--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -40,6 +40,17 @@ public class ThreadLocalCurrentTraceContextClassLoaderTest {
       try (Scope scope = current.newScope(TraceContext.newBuilder().traceId(1).spanId(1).build())) {
 
       }
+    }
+  }
+
+  @Test public void leakedNullScope() {
+    assertRunIsUnloadable(LeakedNullScope.class, getClass().getClassLoader());
+  }
+
+  static class LeakedNullScope implements Runnable {
+    @Override public void run() {
+      CurrentTraceContext current = ThreadLocalCurrentTraceContext.newBuilder().build();
+      current.newScope(null);
     }
   }
 

--- a/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/propagation/ThreadLocalCurrentTraceContextClassLoaderTest.java
@@ -55,8 +55,12 @@ public class ThreadLocalCurrentTraceContextClassLoaderTest {
   }
 
   /**
-   * TODO: While it is an instrumentation bug to leak a scope, we should be tolerant, for example
-   * considering weak references or similar.
+   * TODO: While it is an instrumentation bug to leak a scope, we should be tolerant.
+   *
+   * <p>The current design problem is we don't know a reference type we can use that clears when
+   * the classloader is unloaded, regardless of GC. For example, having {@link Scope} extend {@link
+   * java.lang.ref.WeakReference} to hold the value to revert. This would only help if GC happened
+   * prior to the classloader unload, which would be an odd thing to rely on.
    */
   @Test(expected = AssertionError.class) public void leakedScope_preventsUnloading() {
     assertRunIsUnloadable(LeakedScope.class, getClass().getClassLoader());

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -49,8 +49,7 @@ import zipkin2.reporter.Sender;
  * for example via spring or when mocking.
  */
 public abstract class Tracing implements Closeable {
-  // AtomicReference<Object> instead of AtomicReference<Tracing> to ensure unloadable
-  static final AtomicReference<Object> CURRENT = new AtomicReference<>();
+  static final AtomicReference<Tracing> CURRENT = new AtomicReference<>();
 
   public static Builder newBuilder() {
     return new Builder();

--- a/brave/src/main/java/brave/internal/HexCodec.java
+++ b/brave/src/main/java/brave/internal/HexCodec.java
@@ -82,7 +82,7 @@ public final class HexCodec {
 
   /** Inspired by {@code okio.Buffer.writeLong} */
   public static String toLowerHex(long v) {
-    char[] data = RecyclableBuffers.idBuffer();
+    char[] data = RecyclableBuffers.parseBuffer();
     writeHexLong(data, 0, v);
     return new String(data, 0, 16);
   }

--- a/brave/src/main/java/brave/internal/RecyclableBuffers.java
+++ b/brave/src/main/java/brave/internal/RecyclableBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,18 +15,18 @@ package brave.internal;
 
 public final class RecyclableBuffers {
 
-  private static final ThreadLocal<char[]> ID_BUFFER = new ThreadLocal<>();
+  private static final ThreadLocal<char[]> PARSE_BUFFER = new ThreadLocal<>();
 
   /**
    * Returns a {@link ThreadLocal} reused {@code char[]} for use when decoding bytes into an ID hex
    * string. The buffer should be immediately copied into a {@link String} after decoding within the
    * same method.
    */
-  public static char[] idBuffer() {
-    char[] idBuffer = ID_BUFFER.get();
+  public static char[] parseBuffer() {
+    char[] idBuffer = PARSE_BUFFER.get();
     if (idBuffer == null) {
-      idBuffer = new char[32];
-      ID_BUFFER.set(idBuffer);
+      idBuffer = new char[32 + 1 + 16 + 3 + 16]; // traceid128-spanid-1-parentid
+      PARSE_BUFFER.set(idBuffer);
     }
     return idBuffer;
   }

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -15,6 +15,7 @@ package brave.propagation;
 
 import brave.internal.Nullable;
 import brave.internal.Platform;
+import brave.internal.RecyclableBuffers;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
@@ -71,7 +72,7 @@ public final class B3SingleFormat {
    * with the client.
    */
   public static String writeB3SingleFormatWithoutParentId(TraceContext context) {
-    char[] buffer = getCharBuffer();
+    char[] buffer = RecyclableBuffers.parseBuffer();
     int length = writeB3SingleFormat(context, 0L, buffer);
     return new String(buffer, 0, length);
   }
@@ -81,7 +82,7 @@ public final class B3SingleFormat {
    * array or byte buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatWithoutParentIdAsBytes(TraceContext context) {
-    char[] buffer = getCharBuffer();
+    char[] buffer = RecyclableBuffers.parseBuffer();
     int length = writeB3SingleFormat(context, 0L, buffer);
     return asciiToNewByteArray(buffer, length);
   }
@@ -95,7 +96,7 @@ public final class B3SingleFormat {
    * reuses a client's span ID, prefer {@link #writeB3SingleFormatWithoutParentId(TraceContext)}.
    */
   public static String writeB3SingleFormat(TraceContext context) {
-    char[] buffer = getCharBuffer();
+    char[] buffer = RecyclableBuffers.parseBuffer();
     int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
     return new String(buffer, 0, length);
   }
@@ -105,7 +106,7 @@ public final class B3SingleFormat {
    * buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatAsBytes(TraceContext context) {
-    char[] buffer = getCharBuffer();
+    char[] buffer = RecyclableBuffers.parseBuffer();
     int length = writeB3SingleFormat(context, context.parentIdAsLong(), buffer);
     return asciiToNewByteArray(buffer, length);
   }
@@ -341,17 +342,6 @@ public final class B3SingleFormat {
       result[i] = (byte) buffer[i];
     }
     return result;
-  }
-
-  static final ThreadLocal<char[]> CHAR_BUFFER = new ThreadLocal<>();
-
-  static char[] getCharBuffer() {
-    char[] charBuffer = CHAR_BUFFER.get();
-    if (charBuffer == null) {
-      charBuffer = new char[FORMAT_MAX_LENGTH];
-      CHAR_BUFFER.set(charBuffer);
-    }
-    return charBuffer;
   }
 
   B3SingleFormat() {

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -78,11 +78,13 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
 
   @SuppressWarnings("ThreadLocalUsage") // intentional: to support multiple Tracer instances
   final ThreadLocal<TraceContext> local;
+  final RevertToNullScope revertToNull;
 
   ThreadLocalCurrentTraceContext(Builder builder) {
     super(builder);
     if (builder.local == null) throw new NullPointerException("local == null");
     local = builder.local;
+    revertToNull = new RevertToNullScope(local);
   }
 
   @Override public TraceContext get() {
@@ -92,15 +94,27 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
   @Override public Scope newScope(@Nullable TraceContext currentSpan) {
     final TraceContext previous = local.get();
     local.set(currentSpan);
-    Scope result = new ThreadLocalScope(local, previous);
+    Scope result = previous != null ? new RevertToPreviousScope(local, previous) : revertToNull;
     return decorateScope(currentSpan, result);
   }
 
-  static final class ThreadLocalScope implements Scope {
+  static final class RevertToNullScope implements Scope {
+    final ThreadLocal<TraceContext> local;
+
+    RevertToNullScope(ThreadLocal<TraceContext> local) {
+      this.local = local;
+    }
+
+    @Override public void close() {
+      local.set(null);
+    }
+  }
+
+  static final class RevertToPreviousScope implements Scope {
     final ThreadLocal<TraceContext> local;
     final TraceContext previous;
 
-    ThreadLocalScope(ThreadLocal<TraceContext> local, TraceContext previous) {
+    RevertToPreviousScope(ThreadLocal<TraceContext> local, TraceContext previous) {
       this.local = local;
       this.previous = previous;
     }

--- a/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/ThreadLocalCurrentTraceContext.java
@@ -92,12 +92,21 @@ public class ThreadLocalCurrentTraceContext extends CurrentTraceContext { // not
   @Override public Scope newScope(@Nullable TraceContext currentSpan) {
     final TraceContext previous = local.get();
     local.set(currentSpan);
-    class ThreadLocalScope implements Scope {
-      @Override public void close() {
-        local.set(previous);
-      }
-    }
-    Scope result = new ThreadLocalScope();
+    Scope result = new ThreadLocalScope(local, previous);
     return decorateScope(currentSpan, result);
+  }
+
+  static final class ThreadLocalScope implements Scope {
+    final ThreadLocal<TraceContext> local;
+    final TraceContext previous;
+
+    ThreadLocalScope(ThreadLocal<TraceContext> local, TraceContext previous) {
+      this.local = local;
+      this.previous = previous;
+    }
+
+    @Override public void close() {
+      local.set(previous);
+    }
   }
 }

--- a/brave/src/main/java/brave/propagation/TraceIdContext.java
+++ b/brave/src/main/java/brave/propagation/TraceIdContext.java
@@ -60,10 +60,10 @@ public final class TraceIdContext extends SamplingFlags {
 
   static String toTraceIdString(long traceIdHigh, long traceId) {
     if (traceIdHigh != 0) {
-      char[] result = RecyclableBuffers.idBuffer();
+      char[] result = RecyclableBuffers.parseBuffer();
       writeHexLong(result, 0, traceIdHigh);
       writeHexLong(result, 16, traceId);
-      return new String(result);
+      return new String(result, 0, 32);
     }
     return toLowerHex(traceId);
   }

--- a/instrumentation/http/src/main/java/brave/http/HttpTracing.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpTracing.java
@@ -31,8 +31,7 @@ import static brave.http.HttpSampler.toHttpRequestSampler;
  */
 // Not final as it previously was not. This allows mocks and similar.
 public class HttpTracing implements Closeable {
-  // AtomicReference<Object> instead of AtomicReference<HttpTracing> to ensure unloadable
-  static final AtomicReference<Object> CURRENT = new AtomicReference<>();
+  static final AtomicReference<HttpTracing> CURRENT = new AtomicReference<>();
 
   public static HttpTracing create(Tracing tracing) {
     return newBuilder(tracing).build();

--- a/instrumentation/messaging/src/main/java/brave/messaging/MessagingTracing.java
+++ b/instrumentation/messaging/src/main/java/brave/messaging/MessagingTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,8 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @since 5.9
  */
 public class MessagingTracing implements Closeable {
-  // AtomicReference<Object> instead of AtomicReference<MessagingTracing> to ensure unloadable
-  static final AtomicReference<Object> CURRENT = new AtomicReference<>();
+  static final AtomicReference<MessagingTracing> CURRENT = new AtomicReference<>();
 
   /** @since 5.9 */
   public static MessagingTracing create(Tracing tracing) {

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,8 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @since 5.8
  */
 public class RpcTracing implements Closeable {
-  // AtomicReference<Object> instead of AtomicReference<RpcTracing> to ensure unloadable
-  static final AtomicReference<Object> CURRENT = new AtomicReference<>();
+  static final AtomicReference<RpcTracing> CURRENT = new AtomicReference<>();
 
   /** @since 5.8 */
   public static RpcTracing create(Tracing tracing) {


### PR DESCRIPTION
it was a relic of an older JDK, or complete fantasy. This reverts it.

This also fixes where we accidentally didn't share a buffer.

Thanks @felixbarny for mentioning this..