### PR TITLE
Ensures currentSpan, toSpan and joinSpan use existing context references

### DIFF
--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -101,6 +101,8 @@ final class NoopSpan extends Span {
     return isEqualToNoopOrLazySpan(context, o);
   }
 
+  // We don't compare a RealSpan vs a NoopSpan as they can never equal each other.
+  // RealSpan's are always locally sampled and Noop ones are always not.
   static boolean isEqualToNoopOrLazySpan(TraceContext context, Object o) {
     if (o instanceof LazySpan) {
       return context.equals(((LazySpan) o).context);

--- a/brave/src/main/java/brave/NoopSpan.java
+++ b/brave/src/main/java/brave/NoopSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,10 +92,22 @@ final class NoopSpan extends Span {
     return "NoopSpan(" + context + ")";
   }
 
+  /**
+   * This also matches equals against a lazy span. The rationale is least surprise to the user, as
+   * code should not act differently given an instance of lazy or {@link NoopSpan}.
+   */
   @Override public boolean equals(Object o) {
     if (o == this) return true;
-    if (!(o instanceof NoopSpan)) return false;
-    return context.equals(((NoopSpan) o).context);
+    return isEqualToNoopOrLazySpan(context, o);
+  }
+
+  static boolean isEqualToNoopOrLazySpan(TraceContext context, Object o) {
+    if (o instanceof LazySpan) {
+      return context.equals(((LazySpan) o).context);
+    } else if (o instanceof NoopSpan) {
+      return context.equals(((NoopSpan) o).context);
+    }
+    return false;
   }
 
   @Override public int hashCode() {

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -152,11 +152,11 @@ final class RealSpan extends Span {
   }
 
   @Override public void abandon() {
-    pendingSpans.remove(context);
+    pendingSpans.abandon(context);
   }
 
   @Override public void flush() {
-    abandon();
+    pendingSpans.remove(context);
     finishedSpanHandler.handle(context, state);
   }
 

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -173,6 +173,8 @@ final class RealSpan extends Span {
     return isEqualToRealOrLazySpan(context, o);
   }
 
+  // We don't compare a RealSpan vs a NoopSpan as they can never equal each other.
+  // RealSpan's are always locally sampled and Noop ones are always not.
   static boolean isEqualToRealOrLazySpan(TraceContext context, Object o) {
     if (o instanceof LazySpan) {
       return context.equals(((LazySpan) o).context);

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -180,26 +180,22 @@ public class Tracer {
    */
   public final Span joinSpan(TraceContext context) {
     if (context == null) throw new NullPointerException("context == null");
-    long spanId = context.spanId();
+    if (!supportsJoin) return newChild(context);
 
-    TraceContext decorated;
-    if (!supportsJoin) {
-      decorated = decorateContext(context, spanId);
-    } else {
+    // set shared flag if not already done
+    if (!context.shared()) {
       int flags = InternalPropagation.instance.flags(context);
       flags |= FLAG_SHARED;
-      decorated = decorateContext(
-        flags,
-        context.traceIdHigh(),
-        context.traceId(),
-        context.localRootId(),
-        context.parentIdAsLong(),
-        spanId,
-        context.extra()
-      );
+      context = InternalPropagation.instance.withFlags(context, flags);
     }
 
-    return _toSpan(decorated);
+    return toSpan(context);
+  }
+
+  /** Returns an equivalent context if exists in the pending map */
+  TraceContext swapForPendingContext(TraceContext context) {
+    PendingSpan pendingSpan = pendingSpans.get(context);
+    return pendingSpan != null ? pendingSpan.context() : null;
   }
 
   /**
@@ -369,12 +365,27 @@ public class Tracer {
     return _toSpan(decorateContext(flags, traceIdHigh, traceId, localRootId, spanId, 0L, extra));
   }
 
-  /** Converts the context to a Span object after decorating it for propagation */
+  /**
+   * Converts the context to a Span object after decorating it for propagation.
+   *
+   * <p>This api is not advised for routine use. It is better to hold a reference to a span created
+   * elsewhere vs rely on implicit lookups.
+   */
   public Span toSpan(TraceContext context) {
-    if (context == null) throw new NullPointerException("context == null");
-    if (isDecorated(context)) return _toSpan(context);
+    // Re-use a pending context if present: This ensures reference consistency on Span.context()
+    TraceContext pendingContext = swapForPendingContext(context);
+    if (pendingContext != null) return _toSpan(pendingContext);
 
-    return _toSpan(decorateContext(
+    // There are a few known scenarios for the context to be absent from the pending map:
+    // * Created by a separate tracer (localRootId set)
+    // * Resurrected span from a garbage collection (localRootId set)
+    // * Ad-hoc usage of TraceContext.Builder (localRootId not set, as only settable internally)
+    //
+    // The first two scenarios are currently indistinguishable from eachother. If we had a way to
+    // tell if the current tracer already decorated the context, we could avoid re-decorating it
+    // here in the case of resurrection. This is an edge case anyway and decoration should be
+    // idempotent. Hence, we decorate unconditionally at this point.
+    TraceContext decorated = decorateContext(
       InternalPropagation.instance.flags(context),
       context.traceIdHigh(),
       context.traceId(),
@@ -382,14 +393,20 @@ public class Tracer {
       context.parentIdAsLong(),
       context.spanId(),
       context.extra()
-    ));
+    );
+
+    return _toSpan(decorated);
   }
 
-  Span _toSpan(TraceContext decorated) {
-    if (isNoop(decorated)) return new NoopSpan(decorated);
+  Span _toSpan(TraceContext context) {
+    if (isNoop(context)) return new NoopSpan(context);
     // allocate a mutable span in case multiple threads call this method.. they'll use the same data
-    PendingSpan pendingSpan = pendingSpans.getOrCreate(decorated, false);
-    return new RealSpan(decorated, pendingSpans, pendingSpan.state(), pendingSpan.clock(),
+    PendingSpan pendingSpan = pendingSpans.getOrCreate(context, false);
+    TraceContext pendingContext = pendingSpan.context();
+    // A lost race of Tracer.toSpan(context) is the only known situation where "context" won't be
+    // the same as pendingSpan.context()
+    if (pendingContext != null) context = pendingContext;
+    return new RealSpan(context, pendingSpans, pendingSpan.state(), pendingSpan.clock(),
       finishedSpanHandler);
   }
 
@@ -464,21 +481,6 @@ public class Tracer {
   @Nullable public Span currentSpan() {
     TraceContext context = currentTraceContext.get();
     if (context == null) return null;
-
-    if (!isDecorated(context)) { // It wasn't initialized by our tracer, so we must decorate.
-      context = decorateContext(
-        InternalPropagation.instance.flags(context),
-        context.traceIdHigh(),
-        context.traceId(),
-        context.localRootId(),
-        context.parentIdAsLong(),
-        context.spanId(),
-        context.extra()
-      );
-    }
-
-    if (isNoop(context)) return new NoopSpan(context);
-
     // Returns a lazy span to reduce overhead when tracer.currentSpan() is invoked just to see if
     // one exists, or when the result is never used.
     return new LazySpan(this, context);
@@ -548,8 +550,8 @@ public class Tracer {
 
   /**
    * Like {@link #nextSpan(SamplerFunction, Object)} except this controls the parent context
-   * explicitly. This is useful when an invocation context is propagated manually, commonly
-   * the case with asynchronous client frameworks.
+   * explicitly. This is useful when an invocation context is propagated manually, commonly the case
+   * with asynchronous client frameworks.
    *
    * @param samplerFunction invoked if there's no {@link CurrentTraceContext#get() current trace}
    * @param arg parameter to {@link SamplerFunction#trySample(Object)}
@@ -586,15 +588,16 @@ public class Tracer {
     return newScopedSpan(name, context);
   }
 
-  ScopedSpan newScopedSpan(String name, TraceContext context) {
-    Scope scope = currentTraceContext.newScope(context);
-    if (isNoop(context)) return new NoopScopedSpan(context, scope);
+  ScopedSpan newScopedSpan(String name, TraceContext decoratedContext) {
+    Scope scope = currentTraceContext.newScope(decoratedContext);
+    if (isNoop(decoratedContext)) return new NoopScopedSpan(decoratedContext, scope);
 
-    PendingSpan pendingSpan = pendingSpans.getOrCreate(context, true);
+    PendingSpan pendingSpan = pendingSpans.getOrCreate(decoratedContext, true);
     Clock clock = pendingSpan.clock();
     MutableSpan state = pendingSpan.state();
     state.name(name);
-    return new RealScopedSpan(context, scope, state, clock, pendingSpans, finishedSpanHandler);
+    return new RealScopedSpan(
+      decoratedContext, scope, state, clock, pendingSpans, finishedSpanHandler);
   }
 
   /** A span remains in the scope it was bound to until close is called. */
@@ -631,15 +634,6 @@ public class Tracer {
     int flags = InternalPropagation.instance.flags(context);
     if ((flags & FLAG_SAMPLED_LOCAL) == FLAG_SAMPLED_LOCAL) return false;
     return (flags & FLAG_SAMPLED) != FLAG_SAMPLED;
-  }
-
-  /**
-   * To save overhead, we shouldn't re-decorate a context on operations such as {@link
-   * #toSpan(TraceContext)} or {@link #currentSpan()}. As the {@link TraceContext#localRootId()} can
-   * only be set internally, we use this as a signal that we've already decorated.
-   */
-  static boolean isDecorated(TraceContext context) {
-    return context.localRootId() != 0L;
   }
 
   /** Generates a new 64-bit ID, taking care to dodge zero which can be confused with absent */

--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -378,13 +378,13 @@ public class Tracer {
 
     // There are a few known scenarios for the context to be absent from the pending map:
     // * Created by a separate tracer (localRootId set)
-    // * Resurrected span from a garbage collection (localRootId set)
+    // * Recreating the same trace context after it was garbage collected (localRootId set)
     // * Ad-hoc usage of TraceContext.Builder (localRootId not set, as only settable internally)
     //
-    // The first two scenarios are currently indistinguishable from eachother. If we had a way to
+    // The first two scenarios are currently indistinguishable from each other. If we had a way to
     // tell if the current tracer already decorated the context, we could avoid re-decorating it
-    // here in the case of resurrection. This is an edge case anyway and decoration should be
-    // idempotent. Hence, we decorate unconditionally at this point.
+    // in the case of recreation. This is an edge case anyway and decoration should be idempotent.
+    // Hence, we decorate unconditionally here.
     TraceContext decorated = decorateContext(
       InternalPropagation.instance.flags(context),
       context.traceIdHigh(),

--- a/brave/src/main/java/brave/internal/recorder/PendingSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpan.java
@@ -20,10 +20,12 @@ import brave.propagation.TraceContext;
 import java.lang.ref.WeakReference;
 
 /**
- * This includes a weak reference of the trace context, which allows externalized forms of the trace
- * context to be swapped for the one in use.
+ * This is the value of a map entry in {@link PendingSpans}, whose key is a weak reference to {@link
+ * #context()}.
  *
- * <p>This is a weak reference to ensure that {@link PendingSpans} can clean up on GC.
+ * <p>{@link #context()} is cached so that externalized forms of a trace context to be swapped for
+ * the one in use. It is a weak reference as otherwise it would prevent the corresponding map key
+ * from being garbage collected.
  */
 public final class PendingSpan extends WeakReference<TraceContext> {
   final MutableSpan state;

--- a/brave/src/main/java/brave/internal/recorder/PendingSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,15 +15,30 @@ package brave.internal.recorder;
 
 import brave.Clock;
 import brave.handler.MutableSpan;
+import brave.internal.Nullable;
+import brave.propagation.TraceContext;
+import java.lang.ref.WeakReference;
 
-public final class PendingSpan {
+/**
+ * This includes a weak reference of the trace context, which allows externalized forms of the trace
+ * context to be swapped for the one in use.
+ *
+ * <p>This is a weak reference to ensure that {@link PendingSpans} can clean up on GC.
+ */
+public final class PendingSpan extends WeakReference<TraceContext> {
   final MutableSpan state;
   final TickClock clock;
   volatile Throwable caller;
 
-  PendingSpan(MutableSpan state, TickClock clock) {
+  PendingSpan(TraceContext context, MutableSpan state, TickClock clock) {
+    super(context);
     this.state = state;
     this.clock = clock;
+  }
+
+  /** Returns the context for this span unless it was cleared due to GC. */
+  @Nullable public TraceContext context() {
+    return get();
   }
 
   /** Returns the state currently accumulated for this trace ID and span ID */

--- a/brave/src/test/java/brave/NoopSpanTest.java
+++ b/brave/src/test/java/brave/NoopSpanTest.java
@@ -13,6 +13,7 @@
  */
 package brave;
 
+import brave.Tracer.SpanInScope;
 import brave.sampler.Sampler;
 import org.junit.After;
 import org.junit.Test;
@@ -59,5 +60,23 @@ public class NoopSpanTest {
     span.finish();
     span.abandon();
     span.flush();
+  }
+
+  @Test public void equals_lazySpan_sameContext() {
+    Span current;
+    try (SpanInScope ws = tracer.withSpanInScope(span)) {
+      current = tracer.currentSpan();
+    }
+
+    assertThat(span).isEqualTo(current);
+  }
+
+  @Test public void equals_lazySpan_notSameContext() {
+    Span current;
+    try (SpanInScope ws = tracer.withSpanInScope(tracer.newTrace())) {
+      current = tracer.currentSpan();
+    }
+
+    assertThat(span).isNotEqualTo(current);
   }
 }

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -13,7 +13,7 @@
  */
 package brave;
 
-import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -201,18 +201,18 @@ public class RealSpanTest {
     assertThat(one).isNotEqualTo(two);
   }
 
-  @Test public void equals_realSpan_sameContext() {
+  @Test public void equals_lazySpan_sameContext() {
     Span current;
-    try (CurrentTraceContext.Scope ws = tracing.currentTraceContext().newScope(context)) {
+    try (Scope ws = tracing.currentTraceContext().newScope(context)) {
       current = tracing.tracer().currentSpan();
     }
 
     assertThat(tracing.tracer().toSpan(context)).isEqualTo(current);
   }
 
-  @Test public void equals_realSpan_notSameContext() {
+  @Test public void equals_lazySpan_notSameContext() {
     Span current;
-    try (CurrentTraceContext.Scope ws = tracing.currentTraceContext().newScope(context2)) {
+    try (Scope ws = tracing.currentTraceContext().newScope(context2)) {
       current = tracing.tracer().currentSpan();
     }
 


### PR DESCRIPTION
Before, `Tracer.currentSpan`, `toSpan` and `joinSpan` either didn't
decorate external contexts (in no-op) or needlessly recreated context
instances when a span was already present in the pending map.i

This not only adds overhead, but interferes with our ability to track
the difference between a newly allocated span vs incidental changes to
an existing one due to use of `currentSpan`, `toSpan` or `joinSpan`.

This change is necessary to support `SpanHandler` when powered by
identity maps.

See #1148