### PR TITLE
Uses the same parent reference internally for clock lookups

### DIFF
--- a/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,16 +14,36 @@
 package brave.internal.recorder;
 
 import brave.handler.FinishedSpanHandler;
-import brave.handler.MutableSpan;
+import brave.internal.InternalPropagation;
 import brave.internal.Platform;
+import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
 import brave.test.util.GarbageCollectors;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
+import static brave.internal.InternalPropagation.FLAG_LOCAL_ROOT;
+import static brave.internal.InternalPropagation.FLAG_SAMPLED;
+import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
 
 public class PendingSpansClassLoaderTest {
+  static {
+    SamplingFlags.NOT_SAMPLED.toString(); // ensure InternalPropagation is wired for tests
+  }
+
+  // PendingSpans should always be passed a trace context instantiated by the Tracer. This fakes
+  // a local root span, so that we don't have to depend on the Tracer to run these tests.
+  static final TraceContext CONTEXT = InternalPropagation.instance.newTraceContext(
+    FLAG_SAMPLED_SET | FLAG_SAMPLED | FLAG_LOCAL_ROOT,
+    0L,
+    1L,
+    2L,
+    0L,
+    1L,
+    Collections.emptyList()
+  );
 
   @Test public void unloadable_afterCreateAndRemove() {
     assertRunIsUnloadable(CreateAndRemove.class, getClass().getClassLoader());
@@ -31,15 +51,11 @@ public class PendingSpansClassLoaderTest {
 
   static class CreateAndRemove implements Runnable {
     @Override public void run() {
-      PendingSpans pendingSpans =
-        new PendingSpans(Platform.get().clock(), new FinishedSpanHandler() {
-          @Override public boolean handle(TraceContext context, MutableSpan span) {
-            return true;
-          }
-        }, true, new AtomicBoolean());
+      PendingSpans pendingSpans = new PendingSpans(
+        Platform.get().clock(), FinishedSpanHandler.NOOP, true, new AtomicBoolean());
 
-      TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
-      pendingSpans.getOrCreate(context, true);
+      TraceContext context = CONTEXT.toBuilder().build(); // intentionally make a copy
+      pendingSpans.getOrCreate(null, context, true);
       pendingSpans.remove(context);
     }
   }
@@ -51,15 +67,11 @@ public class PendingSpansClassLoaderTest {
   static class OrphanedContext implements Runnable {
 
     @Override public void run() {
-      PendingSpans pendingSpans =
-        new PendingSpans(Platform.get().clock(), new FinishedSpanHandler() {
-          @Override public boolean handle(TraceContext context, MutableSpan span) {
-            return true;
-          }
-        }, true, new AtomicBoolean());
+      PendingSpans pendingSpans = new PendingSpans(
+        Platform.get().clock(), FinishedSpanHandler.NOOP, true, new AtomicBoolean());
 
-      TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
-      pendingSpans.getOrCreate(context, true);
+      TraceContext context = CONTEXT.toBuilder().build(); // intentionally make a copy
+      pendingSpans.getOrCreate(null, context, true);
       context = null; // orphan the context
 
       GarbageCollectors.blockOnGC();

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -93,7 +93,7 @@ public abstract class Tracing implements Closeable {
    * @param context references a potentially unstarted span you'd like a clock correlated with
    */
   public final Clock clock(TraceContext context) {
-    return tracer().pendingSpans.getOrCreate(context, false).clock();
+    return tracer().pendingSpans.getOrCreate(null, context, false).clock();
   }
 
   abstract public ErrorParser errorParser();
@@ -104,7 +104,7 @@ public abstract class Tracing implements Closeable {
    * <p>This object should not be cached.
    */
   @Nullable public static Tracing current() {
-    return (Tracing) CURRENT.get();
+    return CURRENT.get();
   }
 
   /**


### PR DESCRIPTION
While using the parent context in PendingSpans here only neatens clock
lookup, it is a key feature needed to complete `SpanHandler` as it
ensure we can see a consistent parent ref when allocating a new context.

Depends on #1149
See #1148