### PR TITLE
Extracts WeakConcurrentMap from PendingSpans and uses for trackOrphans

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -10,3 +10,9 @@ by Google in the Guava Library:
   * Copyright (C) 2008 The Guava Authors
   * License: Apache License v2.0
   * Homepage: https://github.com/google/guava
+
+This product contains a modified portion of 'WeakConcurrentMap', distributed
+by Rafael Winterhalter in the weak-lock-free Library:
+
+  * License: Apache License v2.0
+  * Homepage: https://github.com/raphw/weak-lock-free

--- a/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
@@ -76,7 +76,7 @@ public class PendingSpansClassLoaderTest {
 
       GarbageCollectors.blockOnGC();
 
-      pendingSpans.reportOrphanedSpans();
+      pendingSpans.expungeStaleEntries();
     }
   }
 }

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -116,13 +116,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-invoker-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/brave/src/main/java/brave/RealScopedSpan.java
+++ b/brave/src/main/java/brave/RealScopedSpan.java
@@ -74,7 +74,7 @@ final class RealScopedSpan extends ScopedSpan {
 
   @Override public void finish() {
     scope.close();
-    if (!pendingSpans.remove(context)) return; // don't double-report
+    if (pendingSpans.remove(context) == null) return; // don't double-report
     state.finishTimestamp(clock.currentTimeMicroseconds());
     finishedSpanHandler.handle(context, state);
   }

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -144,7 +144,7 @@ final class RealSpan extends Span {
   }
 
   @Override public void finish(long timestamp) {
-    if (!pendingSpans.remove(context)) return;
+    if (pendingSpans.remove(context) == null) return;
     synchronized (state) {
       state.finishTimestamp(timestamp);
     }

--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -19,6 +19,7 @@ import brave.Tracer;
 import brave.internal.IpLiteral;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 
 /**
@@ -345,5 +346,17 @@ public final class MutableSpan implements Cloneable {
    */
   public void setShared() {
     shared = true;
+  }
+
+  @Override public int hashCode() {
+    return super.hashCode(); // quiet error-prone
+  }
+
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    // Hack that allows WeakConcurrentMap to lookup without allocating a new object.
+    if (o instanceof WeakReference) o = ((WeakReference) o).get();
+    if (!(o instanceof MutableSpan)) return false;
+    return super.equals(o); // not doing value-based comparison
   }
 }

--- a/brave/src/main/java/brave/internal/InternalPropagation.java
+++ b/brave/src/main/java/brave/internal/InternalPropagation.java
@@ -65,6 +65,12 @@ public abstract class InternalPropagation {
     List<Object> extra
   );
 
+  /**
+   * Allows you to decouple from the actual context, for example when it is a weak key. This is less
+   * allocations vs {@code context.toBuilder().build()}.
+   */
+  public abstract TraceContext shallowCopy(TraceContext context);
+
   /** {@link brave.propagation.TraceContext} is immutable so you need to read the result */
   public abstract TraceContext withExtra(TraceContext context, List<Object> immutableExtra);
 

--- a/brave/src/main/java/brave/internal/recorder/PendingSpan.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpan.java
@@ -15,6 +15,7 @@ package brave.internal.recorder;
 
 import brave.Clock;
 import brave.handler.MutableSpan;
+import brave.internal.InternalPropagation;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import java.lang.ref.WeakReference;
@@ -30,12 +31,13 @@ import java.lang.ref.WeakReference;
 public final class PendingSpan extends WeakReference<TraceContext> {
   final MutableSpan state;
   final TickClock clock;
-  volatile Throwable caller;
+  final TraceContext backupContext; // only used on abandon
 
   PendingSpan(TraceContext context, MutableSpan state, TickClock clock) {
     super(context);
     this.state = state;
     this.clock = clock;
+    this.backupContext = InternalPropagation.instance.shallowCopy(context);
   }
 
   /** Returns the context for this span unless it was cleared due to GC. */

--- a/brave/src/main/java/brave/internal/weaklockfree/WeakConcurrentMap.java
+++ b/brave/src/main/java/brave/internal/weaklockfree/WeakConcurrentMap.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.weaklockfree;
+
+import brave.internal.Nullable;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * This borrows heavily from Rafael Winterhalter's {@code com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap}
+ * with the following major changes:
+ *
+ * <p>The biggest change is this removes LatentKey. Instead it relies on keys known to have a
+ * stable {@link #hashCode} and who are {@linkplain #equals(Object) equal to} a weak reference of
+ * itself. We allow lookups using externally created contexts, yet don't want to incur overhead of
+ * key allocation or classloader problems sharing keys with a thread local.
+ *
+ * <p>Other changes mostly remove features (to reduce the bytecode size) and address style:
+ * <ul>
+ *   <li>Inline expunction only as we have no thread to use anyway</li>
+ *   <li>Removes methods we don't need such as iteration</li>
+ *   <li>Stylistic changes including different javadoc and removal of private modifiers</li>
+ *   <li>toString: derived only from keys</li>
+ * </ul>
+ *
+ * <p>See https://github.com/raphw/weak-lock-free
+ */
+public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> {
+  final ConcurrentMap<WeakKey<K>, V> target = new ConcurrentHashMap<>();
+
+  @Nullable public V getIfPresent(K key) {
+    if (key == null) throw new NullPointerException("key == null");
+    expungeStaleEntries();
+
+    return target.get(key);
+  }
+
+  /** Replaces the entry with the indicated key and returns the old value or {@code null}. */
+  @Nullable public V putIfProbablyAbsent(K key, V value) {
+    if (key == null) throw new NullPointerException("key == null");
+    if (value == null) throw new NullPointerException("value == null");
+    expungeStaleEntries();
+
+    return target.putIfAbsent(new WeakKey<>(key, this), value);
+  }
+
+  /** Removes the entry with the indicated key and returns the old value or {@code null}. */
+  @Nullable public V remove(K key) {
+    if (key == null) throw new NullPointerException("key == null");
+    expungeStaleEntries();
+
+    return target.remove(key);
+  }
+
+  /** Cleans all unused references. */
+  protected void expungeStaleEntries() {
+    Reference<?> reference;
+    while ((reference = poll()) != null) {
+      removeStaleEntry(reference);
+    }
+  }
+
+  protected V removeStaleEntry(Reference<?> reference) {
+    return target.remove(reference);
+  }
+
+  // This comment was directly verbatim from https://github.com/raphw/weak-lock-free/blob/dcbd2fa0d30571bb3ed187a42cb75323a5569d5b/src/main/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMap.java#L273-L302
+  /*
+   * Why this works:
+   * ---------------
+   *
+   * Note that this map only supports reference equality for keys and uses system hash codes. Also, for the
+   * WeakKey instances to function correctly, we are voluntarily breaking the Java API contract for
+   * hashCode/equals of these instances.
+   *
+   *
+   * System hash codes are immutable and can therefore be computed prematurely and are stored explicitly
+   * within the WeakKey instances. This way, we always know the correct hash code of a key and always
+   * end up in the correct bucket of our target map. This remains true even after the weakly referenced
+   * key is collected.
+   *
+   * If we are looking up the value of the current key via WeakConcurrentMap::get or any other public
+   * API method, we know that any value associated with this key must still be in the map as the mere
+   * existence of this key makes it ineligible for garbage collection. Therefore, looking up a value
+   * using another WeakKey wrapper guarantees a correct result.
+   *
+   * If we are looking up the map entry of a WeakKey after polling it from the reference queue, we know
+   * that the actual key was already collected and calling WeakKey::get returns null for both the polled
+   * instance and the instance within the map. Since we explicitly stored the identity hash code for the
+   * referenced value, it is however trivial to identify the correct bucket. From this bucket, the first
+   * weak key with a null reference is removed. Due to hash collision, we do not know if this entry
+   * represents the weak key. However, we do know that the reference queue polls at least as many weak
+   * keys as there are stale map entries within the target map. If no key is ever removed from the map
+   * explicitly, the reference queue eventually polls exactly as many weak keys as there are stale entries.
+   *
+   * Therefore, we can guarantee that there is no memory leak.
+   */
+  static final class WeakKey<T> extends WeakReference<T> {
+    final int hashCode;
+
+    WeakKey(T key, ReferenceQueue<? super T> queue) {
+      super(key, queue);
+      this.hashCode = key.hashCode(); // cache as hashCode is used for all future operations
+    }
+
+    @Override public int hashCode() {
+      return hashCode;
+    }
+
+    @Override public String toString() {
+      T value = get();
+      return value != null ? value.toString() : "ClearedReference()";
+    }
+
+    /**
+     * While a lookup key will invoke equals against this, the visa versa is not true. This methos
+     * is only used inside the target map to resolve hash code collisions.
+     */
+    @Override public boolean equals(Object o) { // resolves hash code collisions
+      if (o == this) return true;
+      assert o instanceof WeakReference : "Bug: unexpected input to equals";
+      return equal(get(), ((WeakReference) o).get());
+    }
+  }
+
+  @Override public String toString() {
+    Class<?> thisClass = getClass();
+    while (thisClass.getSimpleName().isEmpty()) {
+      thisClass = thisClass.getSuperclass();
+    }
+    expungeStaleEntries(); // Clean up so that only present references show up (unless race lost)
+    return thisClass.getSimpleName() + target.keySet();
+  }
+
+  static boolean equal(@Nullable Object a, @Nullable Object b) {
+    return a == null ? b == null : a.equals(b); // Java 6 can't use Objects.equals()
+  }
+}

--- a/brave/src/main/java/brave/internal/weaklockfree/WeakConcurrentMap.java
+++ b/brave/src/main/java/brave/internal/weaklockfree/WeakConcurrentMap.java
@@ -127,7 +127,7 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> {
     }
 
     /**
-     * While a lookup key will invoke equals against this, the visa versa is not true. This methos
+     * While a lookup key will invoke equals against this, the visa versa is not true. This method
      * is only used inside the target map to resolve hash code collisions.
      */
     @Override public boolean equals(Object o) { // resolves hash code collisions

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -41,6 +41,10 @@ public class SamplingFlags {
         return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extra);
       }
 
+      @Override public TraceContext shallowCopy(TraceContext context) {
+        return context.shallowCopy();
+      }
+
       @Override public TraceContext withExtra(TraceContext context, List<Object> extra) {
         return context.withExtra(extra);
       }

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -489,6 +489,10 @@ public final class TraceContext extends SamplingFlags {
     }
   }
 
+  TraceContext shallowCopy() {
+    return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extra);
+  }
+
   TraceContext withExtra(List<Object> extra) {
     return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extra);
   }
@@ -526,7 +530,7 @@ public final class TraceContext extends SamplingFlags {
    */
   @Override public boolean equals(Object o) {
     if (o == this) return true;
-    // Hack that allows PendingSpans to lookup without allocating a new object.
+    // Hack that allows WeakConcurrentMap to lookup without allocating a new object.
     if (o instanceof WeakReference) o = ((WeakReference) o).get();
     if (!(o instanceof TraceContext)) return false;
     TraceContext that = (TraceContext) o;

--- a/brave/src/test/java/brave/internal/weaklockfree/WeakConcurrentMapTest.java
+++ b/brave/src/test/java/brave/internal/weaklockfree/WeakConcurrentMapTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.weaklockfree;
+
+import brave.GarbageCollectors;
+import brave.internal.weaklockfree.WeakConcurrentMap.WeakKey;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WeakConcurrentMapTest {
+
+  static class TestKey {
+    final String key;
+
+    TestKey(String key) {
+      this.key = key;
+    }
+
+    @Override public int hashCode() {
+      return key.hashCode();
+    }
+
+    @Override public boolean equals(Object o) {
+      if (o == this) return true;
+      // Hack that allows WeakConcurrentMap to lookup without allocating a new object.
+      if (o instanceof WeakReference) o = ((WeakReference) o).get();
+      if (!(o instanceof TestKey)) return false;
+      return key.equals(((TestKey) o).key);
+    }
+
+    @Override public String toString() {
+      return key;
+    }
+  }
+
+  WeakConcurrentMap<TestKey, Object> map = new WeakConcurrentMap<>();
+  TestKey key = new TestKey("a");
+
+  @Test public void getOrCreate_whenSomeReferencesAreCleared() {
+    map.putIfProbablyAbsent(key, "1");
+    pretendGCHappened();
+    map.putIfProbablyAbsent(key, "1");
+
+    // we'd expect two distinct entries..
+    assertThat(map.target.keySet())
+      .extracting(WeakReference::get)
+      .containsExactlyInAnyOrder(null, key);
+  }
+
+  @Test public void remove_clearsReference() {
+    map.putIfProbablyAbsent(key, "1");
+    map.remove(key);
+
+    assertThat(map.target).isEmpty();
+    assertThat(map.poll()).isNull();
+  }
+
+  @Test
+  public void remove_okWhenDoesntExist() {
+    map.remove(key);
+  }
+
+  @Test
+  public void remove_resolvesHashCodeCollisions() {
+    // intentionally clash on hashCode, but not equals
+    TestKey key1 = new TestKey("a") {
+      @Override public int hashCode() {
+        return 1;
+      }
+    };
+    TestKey key2 = new TestKey("b") {
+      @Override public int hashCode() {
+        return 1;
+      }
+    };
+
+    // sanity check
+    assertThat(key1.hashCode()).isEqualTo(key2.hashCode());
+    assertThat(key1).isNotEqualTo(key2);
+
+    map.putIfProbablyAbsent(key1, "1");
+    assertThat(map.putIfProbablyAbsent(key2, "2")).isNull();
+
+    map.remove(key1);
+
+    assertThat(map.target.keySet()).extracting(o -> ((Reference) o).get())
+      .containsOnly(key2);
+  }
+
+  /** mainly ensures internals aren't dodgy on null */
+  @Test public void remove_whenSomeReferencesAreCleared() {
+    map.putIfProbablyAbsent(key, "1");
+    pretendGCHappened();
+    map.remove(key);
+
+    assertThat(map.target.keySet()).extracting(WeakReference::get)
+      .hasSize(1)
+      .containsNull();
+  }
+
+  @Test public void weakKey_equalToItself() {
+    WeakKey<TestKey> key = new WeakKey<>(new TestKey("a"), map);
+    assertThat(key).isEqualTo(key);
+    key.clear();
+    assertThat(key).isEqualTo(key);
+  }
+
+  @Test public void weakKey_equalToEquivalent() {
+    WeakKey<TestKey> key = new WeakKey<>(new TestKey("a"), map);
+    WeakKey<TestKey> key2 = new WeakKey<>(new TestKey("a"), map);
+    assertThat(key).isEqualTo(key2);
+    key.clear();
+    assertThat(key).isNotEqualTo(key2);
+    key2.clear();
+    assertThat(key).isEqualTo(key2);
+  }
+
+  /** Debugging should show what the spans are, as well any references pending clear. */
+  @Test public void toString_saysWhatReferentsAre() {
+    assertThat(map.toString())
+      .isEqualTo("WeakConcurrentMap[]");
+
+    map.putIfProbablyAbsent(key, "1");
+
+    assertThat(map.toString())
+      .isEqualTo("WeakConcurrentMap[" + key.key + "]");
+
+    pretendGCHappened();
+
+    assertThat(map.toString())
+      .isEqualTo("WeakConcurrentMap[ClearedReference()]");
+  }
+
+  /**
+   * This is a customized version of https://github.com/raphw/weak-lock-free/blob/master/src/test/java/com/blogspot/mydailyjava/weaklockfree/WeakConcurrentMapTest.java
+   */
+  @Test
+  public void expungeStaleEntries_afterGC() {
+    TestKey key1 = new TestKey("a");
+    Object value1 = new Object();
+    map.putIfProbablyAbsent(key1, value1);
+    TestKey key2 = new TestKey("b");
+    Object value2 = new Object();
+    map.putIfProbablyAbsent(key2, value2);
+    TestKey key3 = new TestKey("c");
+    Object value3 = new Object();
+    map.putIfProbablyAbsent(key3, value3);
+    TestKey key4 = new TestKey("d");
+    Object value4 = new Object();
+    map.putIfProbablyAbsent(key4, value4);
+    TestKey key5 = new TestKey("e");
+    Object value5 = new Object();
+    map.putIfProbablyAbsent(key5, value5);
+
+    // By clearing strong references in this test, we are left with the weak ones in the map
+    key1 = key2 = key5 = null;
+    GarbageCollectors.blockOnGC();
+
+    // After GC, we expect that the weak references of key1 and key2 to be cleared
+    assertThat(map.target.keySet()).extracting(WeakReference::get)
+      .usingFieldByFieldElementComparator()
+      .containsExactlyInAnyOrder(null, null, key3, key4, null);
+
+    map.expungeStaleEntries();
+
+    // After reporting, we expect no the weak references of null
+    assertThat(map.target.keySet()).extracting(WeakReference::get)
+      .containsExactlyInAnyOrder(key3, key4);
+  }
+
+  /** In reality, this clears a reference even if it is strongly held by the test! */
+  void pretendGCHappened() {
+    map.target.keySet().iterator().next().clear();
+  }
+}

--- a/instrumentation/http/src/main/java/brave/http/HttpTracing.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpTracing.java
@@ -379,7 +379,7 @@ public class HttpTracing implements Closeable {
    * @since 5.9
    */
   @Nullable public static HttpTracing current() {
-    return (HttpTracing) CURRENT.get();
+    return CURRENT.get();
   }
 
   /** @since 5.9 */

--- a/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpRuleSamplerTest.java
@@ -168,6 +168,6 @@ public class HttpRuleSamplerTest {
 
   // empty may sound unintuitive, but it allows use of the same type when always deferring
   @Test public void noRulesOk() {
-    HttpRuleSampler.<Boolean>newBuilder().build();
+    HttpRuleSampler.newBuilder().build();
   }
 }

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageProducer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageProducer.java
@@ -117,7 +117,7 @@ public class ITJms_2_0_TracingMessageProducer extends ITJms_1_1_TracingMessagePr
       .build();
          JMSContext context = JmsTracing.create(messagingTracing)
            .connectionFactory(((ArtemisJmsTestRule) jms).factory)
-           .createContext(JMSContext.AUTO_ACKNOWLEDGE);
+           .createContext(JMSContext.AUTO_ACKNOWLEDGE)
     ) {
       context.createProducer().send(jms.queue, "foo");
     }

--- a/instrumentation/messaging/src/main/java/brave/messaging/MessagingTracing.java
+++ b/instrumentation/messaging/src/main/java/brave/messaging/MessagingTracing.java
@@ -145,7 +145,7 @@ public class MessagingTracing implements Closeable {
    * @since 5.9
    */
   @Nullable public static MessagingTracing current() {
-    return (MessagingTracing) CURRENT.get();
+    return CURRENT.get();
   }
 
   /** @since 5.9 */

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
@@ -145,7 +145,7 @@ public class RpcTracing implements Closeable {
    * @since 5.9
    */
   @Nullable public static RpcTracing current() {
-    return (RpcTracing) CURRENT.get();
+    return CURRENT.get();
   }
 
   /** @since 5.9 */


### PR DESCRIPTION
This formalizes that PendingSpans was derived from weaklockfree, pulling
it up so that we can decouple orphan handling in the future.

This also fixes attribution which was in the source, but not NOTICE
before. Sorry @raphw (though not sure you noticed.. pun intended)

Finally, this does a fair amount of simplification on the orphan path.
Most importantly, we pre-emptively fork the context as opposed to
copying most of its values for the orphan path.