### PR TITLE
align javax.annotation-api 1.3.1, 1.3.2 to 1.3.2 

### DIFF
--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -49,7 +49,7 @@
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <scope>provided</scope>
-      <version>1.3.1</version>
+      <version>1.3.2</version>
     </dependency>
     <!-- For Inject -->
     <dependency>


### PR DESCRIPTION
align library versions to avoid inconsistent API behaviors. (Or unify library version by removing explicitly declared version tag in _instrumentation/jaxrs2/pom.xml_ 