### PR TITLE
Starts making zipkin2.Span optional for external reporting

### DIFF
--- a/brave-tests/src/test/java/brave/TracerClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/TracerClassLoaderTest.java
@@ -13,6 +13,7 @@
  */
 package brave;
 
+import brave.internal.handler.ZipkinFinishedSpanHandler.LoggingReporter;
 import org.junit.Test;
 import zipkin2.Span;
 
@@ -26,7 +27,7 @@ public class TracerClassLoaderTest {
   // This test will clutter output; it is somewhat difficult to avoid that and still run the test
   static class UsingLoggingReporter implements Runnable {
     @Override public void run() {
-      Tracing.LoggingReporter reporter = new Tracing.LoggingReporter();
+      LoggingReporter reporter = new LoggingReporter();
       reporter.report(Span.newBuilder().traceId("a").id("b").build());
     }
   }

--- a/brave-tests/src/test/java/brave/internal/handler/ZipkinFinishedSpanHandlerClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/handler/ZipkinFinishedSpanHandlerClassLoaderTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave;
+package brave.internal.handler;
 
 import brave.internal.handler.ZipkinFinishedSpanHandler.LoggingReporter;
 import org.junit.Test;
@@ -19,7 +19,7 @@ import zipkin2.Span;
 
 import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
 
-public class TracerClassLoaderTest {
+public class ZipkinFinishedSpanHandlerClassLoaderTest {
   @Test public void unloadable_withLoggingReporter() {
     assertRunIsUnloadable(UsingLoggingReporter.class, getClass().getClassLoader());
   }

--- a/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
@@ -13,7 +13,9 @@
  */
 package brave.internal.recorder;
 
+import brave.ErrorParser;
 import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
 import brave.internal.InternalPropagation;
 import brave.internal.Platform;
 import brave.propagation.SamplingFlags;
@@ -51,7 +53,7 @@ public class PendingSpansClassLoaderTest {
 
   static class CreateAndRemove implements Runnable {
     @Override public void run() {
-      PendingSpans pendingSpans = new PendingSpans(
+      PendingSpans pendingSpans = new PendingSpans(new MutableSpan(), new ErrorParser(),
         Platform.get().clock(), FinishedSpanHandler.NOOP, true, new AtomicBoolean());
 
       TraceContext context = CONTEXT.toBuilder().build(); // intentionally make a copy
@@ -67,7 +69,7 @@ public class PendingSpansClassLoaderTest {
   static class OrphanedContext implements Runnable {
 
     @Override public void run() {
-      PendingSpans pendingSpans = new PendingSpans(
+      PendingSpans pendingSpans = new PendingSpans(new MutableSpan(), new ErrorParser(),
         Platform.get().clock(), FinishedSpanHandler.NOOP, true, new AtomicBoolean());
 
       TraceContext context = CONTEXT.toBuilder().build(); // intentionally make a copy

--- a/brave/src/main/java/brave/RealScopedSpan.java
+++ b/brave/src/main/java/brave/RealScopedSpan.java
@@ -74,8 +74,7 @@ final class RealScopedSpan extends ScopedSpan {
 
   @Override public void finish() {
     scope.close();
-    if (pendingSpans.remove(context) == null) return; // don't double-report
-    state.finishTimestamp(clock.currentTimeMicroseconds());
+    if (!pendingSpans.finish(context, 0L)) return; // don't double-report
     finishedSpanHandler.handle(context, state);
   }
 

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -140,13 +140,12 @@ final class RealSpan extends Span {
   }
 
   @Override public void finish() {
-    finish(clock.currentTimeMicroseconds());
+    finish(0L);
   }
 
   @Override public void finish(long timestamp) {
-    if (pendingSpans.remove(context) == null) return;
     synchronized (state) {
-      state.finishTimestamp(timestamp);
+      if (!pendingSpans.finish(context, timestamp)) return;
     }
     finishedSpanHandler.handle(context, state);
   }
@@ -156,7 +155,7 @@ final class RealSpan extends Span {
   }
 
   @Override public void flush() {
-    pendingSpans.remove(context);
+    if (!pendingSpans.flush(context)) return;
     finishedSpanHandler.handle(context, state);
   }
 

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
+import zipkin2.Endpoint;
 import zipkin2.reporter.Reporter;
 
 /**
@@ -137,7 +138,7 @@ public abstract class Tracing implements Closeable {
   public static final class Builder {
     String localServiceName = "unknown", localIp;
     int localPort; // zero means null
-    zipkin2.reporter.Reporter<zipkin2.Span> spanReporter;
+    Reporter<zipkin2.Span> spanReporter;
     Clock clock;
     Sampler sampler = Sampler.ALWAYS_SAMPLE;
     CurrentTraceContext currentTraceContext = CurrentTraceContext.Default.inheritable();
@@ -199,7 +200,7 @@ public abstract class Tracing implements Closeable {
      * #localPort(int)}. Will be removed in Brave v6.
      */
     @Deprecated
-    public Builder endpoint(zipkin2.Endpoint endpoint) {
+    public Builder endpoint(Endpoint endpoint) {
       if (endpoint == null) throw new NullPointerException("endpoint == null");
       this.localServiceName = endpoint.serviceName();
       this.localIp = endpoint.ipv6() != null ? endpoint.ipv6() : endpoint.ipv4();
@@ -208,9 +209,10 @@ public abstract class Tracing implements Closeable {
     }
 
     /**
-     * Controls how {@linkplain TraceContext#sampled() remote sampled} spans report to a {@code
-     * io.zipkin.reporter2:zipkin-reporter} destination. This input is usually a {@link
-     * zipkin2.reporter.AsyncReporter} which batches spans before reporting them.
+     * Controls how {@linkplain TraceContext#sampled() remote sampled} spans report to a
+     * <a href="https://github.com/openzipkin/zipkin-reporter-java">io.zipkin.reporter2:zipkin-reporter</a>destination.
+     * This input is usually a {@link zipkin2.reporter.AsyncReporter} which batches spans before
+     * reporting them.
      *
      * <p>For example, here's how to batch send spans via http:
      *
@@ -229,7 +231,7 @@ public abstract class Tracing implements Closeable {
      *
      * @see #addFinishedSpanHandler(FinishedSpanHandler)
      */
-    public Builder spanReporter(zipkin2.reporter.Reporter<zipkin2.Span> spanReporter) {
+    public Builder spanReporter(Reporter<zipkin2.Span> spanReporter) {
       if (spanReporter == null) throw new NullPointerException("spanReporter == null");
       this.spanReporter = spanReporter;
       return this;

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -15,6 +15,7 @@ package brave;
 
 import brave.baggage.BaggageField;
 import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
 import brave.internal.IpLiteral;
 import brave.internal.Nullable;
 import brave.internal.Platform;
@@ -34,10 +35,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import java.util.logging.Logger;
-import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Reporter;
-import zipkin2.reporter.Sender;
 
 /**
  * This provides utilities needed for trace instrumentation. For example, a {@link Tracer}.
@@ -139,7 +137,7 @@ public abstract class Tracing implements Closeable {
   public static final class Builder {
     String localServiceName = "unknown", localIp;
     int localPort; // zero means null
-    Reporter<zipkin2.Span> spanReporter;
+    zipkin2.reporter.Reporter<zipkin2.Span> spanReporter;
     Clock clock;
     Sampler sampler = Sampler.ALWAYS_SAMPLE;
     CurrentTraceContext currentTraceContext = CurrentTraceContext.Default.inheritable();
@@ -210,11 +208,9 @@ public abstract class Tracing implements Closeable {
     }
 
     /**
-     * Controls how spans are reported. Defaults to logging, but often an {@link AsyncReporter}
-     * which batches spans before sending to Zipkin.
-     *
-     * The {@link AsyncReporter} includes a {@link Sender}, which is a driver for transports like
-     * http, kafka and scribe.
+     * Controls how {@linkplain TraceContext#sampled() remote sampled} spans report to a {@code
+     * io.zipkin.reporter2:zipkin-reporter} destination. This input is usually a {@link
+     * zipkin2.reporter.AsyncReporter} which batches spans before reporting them.
      *
      * <p>For example, here's how to batch send spans via http:
      *
@@ -225,8 +221,15 @@ public abstract class Tracing implements Closeable {
      * }</pre>
      *
      * <p>See https://github.com/openzipkin/zipkin-reporter-java
+     *
+     * <h3>Relationship to {@link #addFinishedSpanHandler(FinishedSpanHandler)}</h3>
+     * There may only be one {@code spanReporter}. When present, this will be converted as the
+     * <em>last</em> {@link FinishedSpanHandler}. This ensures any customization or redaction
+     * happen before reporting to a {@code io.zipkin.reporter2:zipkin-reporter} destination.
+     *
+     * @see #addFinishedSpanHandler(FinishedSpanHandler)
      */
-    public Builder spanReporter(Reporter<zipkin2.Span> spanReporter) {
+    public Builder spanReporter(zipkin2.reporter.Reporter<zipkin2.Span> spanReporter) {
       if (spanReporter == null) throw new NullPointerException("spanReporter == null");
       this.spanReporter = spanReporter;
       return this;
@@ -315,26 +318,32 @@ public abstract class Tracing implements Closeable {
     }
 
     /**
-     * Similar to {@link #spanReporter(Reporter)} except it can read the trace context and create
-     * more efficient or completely different data structures. Importantly, the input is mutable for
-     * customization purposes.
-     *
-     * <p>These handlers execute before the {@link #spanReporter(Reporter) span reporter}, which
-     * means any mutations occur prior to Zipkin.
+     * Inputs receive {code (context, span)} pairs for every {@linkplain TraceContext#sampledLocal()
+     * locally sampled} span. The span is mutable for customization or redaction purposes and
+     * handlers execute in order: If any handler returns {code false}, the next will not see the
+     * span.
      *
      * <h3>Advanced notes</h3>
      *
-     * <p>This is named firehose as it can receive data even when spans are not sampled remotely.
-     * For example, {@link FinishedSpanHandler#alwaysSampleLocal()} will generate data for all
-     * traced requests while not affecting headers. This setting is often used for metrics
+     * <p>When {@link FinishedSpanHandler#alwaysSampleLocal()} is {@code true}, handlers here
+     * receive data even when spans are not sampled remotely. This setting is often used for metrics
      * aggregation.
      *
+     * <h3>Relationship to {@link #spanReporter(Reporter)}</h3>
+     * This is similar to {@link #spanReporter(zipkin2.reporter.Reporter)} except for a few things:
+     * <ul>
+     *   <li>This is decoupled from Zipkin types</li>
+     *   <li>This receives both {@linkplain TraceContext#sampled() remote} and {@linkplain TraceContext#sampledLocal() local} sampled spans</li>
+     *   <li>{@link MutableSpan} is mutable and has a raw {@link Throwable} error</li>
+     *   <li>{@link TraceContext} allows late lookup of {@linkplain BaggageField baggage}</li>
+     * </ul>
      *
-     * <p>Your handler can also be a custom span transport. When this is the case, set the {@link
-     * #spanReporter(Reporter) span reporter} to {@link Reporter#NOOP} to avoid redundant conversion
-     * overhead.
+     * <p>This is used to create more efficient or completely different data structures than what's
+     * provided in the {@code io.zipkin.reporter2:zipkin-reporter} library. For example, you can use
+     * a higher performance codec or disruptor, or you can forward to a vendor-specific trace exporter.
      *
      * @param handler skipped if {@link FinishedSpanHandler#NOOP} or already added
+     * @see #spanReporter(zipkin2.reporter.Reporter)
      * @see #alwaysReportSpans()
      * @see TraceContext#sampledLocal()
      */
@@ -390,27 +399,10 @@ public abstract class Tracing implements Closeable {
     }
 
     public Tracing build() {
-      if (clock == null) clock = Platform.get().clock();
-      if (localIp == null) localIp = Platform.get().linkLocalIp();
-      if (spanReporter == null) spanReporter = new LoggingReporter();
       return new Default(this);
     }
 
     Builder() {
-    }
-  }
-
-  static final class LoggingReporter implements Reporter<zipkin2.Span> {
-    final Logger logger = Logger.getLogger(Tracer.class.getName());
-
-    @Override public void report(zipkin2.Span span) {
-      if (span == null) throw new NullPointerException("span == null");
-      if (!logger.isLoggable(Level.INFO)) return;
-      logger.info(span.toString());
-    }
-
-    @Override public String toString() {
-      return "LoggingReporter{name=" + logger.getName() + "}";
     }
   }
 
@@ -425,7 +417,7 @@ public abstract class Tracing implements Closeable {
     final AtomicBoolean noop;
 
     Default(Builder builder) {
-      this.clock = builder.clock;
+      this.clock = builder.clock != null ? builder.clock : Platform.get().clock();
       this.errorParser = builder.errorParser;
       this.propagationFactory = builder.propagationFactory;
       this.stringPropagation = builder.propagationFactory.create(Propagation.KeyFactory.STRING);
@@ -433,9 +425,14 @@ public abstract class Tracing implements Closeable {
       this.sampler = builder.sampler;
       this.noop = new AtomicBoolean();
 
+      MutableSpan defaultSpan = new MutableSpan();
+      defaultSpan.localServiceName(builder.localServiceName);
+      defaultSpan.localIp(builder.localIp != null ? builder.localIp : Platform.get().linkLocalIp());
+      defaultSpan.localPort(builder.localPort);
+
       FinishedSpanHandler zipkinHandler = builder.spanReporter != Reporter.NOOP
-        ? new ZipkinFinishedSpanHandler(builder.spanReporter, errorParser,
-        builder.localServiceName, builder.localIp, builder.localPort, builder.alwaysReportSpans)
+        ? new ZipkinFinishedSpanHandler(defaultSpan, builder.spanReporter,
+        builder.alwaysReportSpans)
         : FinishedSpanHandler.NOOP;
 
       FinishedSpanHandler finishedSpanHandler =
@@ -453,11 +450,15 @@ public abstract class Tracing implements Closeable {
           zipkinReportingFinishedSpanHandler(orphanedSpanHandlers, zipkinHandler, noop);
       }
 
+      PendingSpans pendingSpans =
+        new PendingSpans(defaultSpan, errorParser, clock, orphanedSpanHandler, builder.trackOrphans,
+          noop);
+
       this.tracer = new Tracer(
         builder.clock,
         builder.propagationFactory,
         finishedSpanHandler,
-        new PendingSpans(clock, orphanedSpanHandler, builder.trackOrphans, noop),
+        pendingSpans,
         builder.sampler,
         builder.currentTraceContext,
         builder.traceId128Bit || propagationFactory.requires128BitTraceId(),

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -35,7 +35,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import zipkin2.Endpoint;
+import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Reporter;
 
 /**
@@ -200,7 +200,7 @@ public abstract class Tracing implements Closeable {
      * #localPort(int)}. Will be removed in Brave v6.
      */
     @Deprecated
-    public Builder endpoint(Endpoint endpoint) {
+    public Builder endpoint(zipkin2.Endpoint endpoint) {
       if (endpoint == null) throw new NullPointerException("endpoint == null");
       this.localServiceName = endpoint.serviceName();
       this.localIp = endpoint.ipv6() != null ? endpoint.ipv6() : endpoint.ipv4();
@@ -211,8 +211,7 @@ public abstract class Tracing implements Closeable {
     /**
      * Controls how {@linkplain TraceContext#sampled() remote sampled} spans report to a
      * <a href="https://github.com/openzipkin/zipkin-reporter-java">io.zipkin.reporter2:zipkin-reporter</a>destination.
-     * This input is usually a {@link zipkin2.reporter.AsyncReporter} which batches spans before
-     * reporting them.
+     * This input is usually a {@link AsyncReporter} which batches spans before reporting them.
      *
      * <p>For example, here's how to batch send spans via http:
      *
@@ -332,7 +331,7 @@ public abstract class Tracing implements Closeable {
      * aggregation.
      *
      * <h3>Relationship to {@link #spanReporter(Reporter)}</h3>
-     * This is similar to {@link #spanReporter(zipkin2.reporter.Reporter)} except for a few things:
+     * This is similar to {@link #spanReporter(Reporter)} except for a few things:
      * <ul>
      *   <li>This is decoupled from Zipkin types</li>
      *   <li>This receives both {@linkplain TraceContext#sampled() remote} and {@linkplain TraceContext#sampledLocal() local} sampled spans</li>
@@ -345,7 +344,7 @@ public abstract class Tracing implements Closeable {
      * a higher performance codec or disruptor, or you can forward to a vendor-specific trace exporter.
      *
      * @param handler skipped if {@link FinishedSpanHandler#NOOP} or already added
-     * @see #spanReporter(zipkin2.reporter.Reporter)
+     * @see #spanReporter(Reporter)
      * @see #alwaysReportSpans()
      * @see TraceContext#sampledLocal()
      */

--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -14,32 +14,40 @@
 package brave.handler;
 
 import brave.Span.Kind;
-import brave.Tag;
-import brave.Tracer;
+import brave.SpanCustomizer;
 import brave.internal.IpLiteral;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 
+import static brave.internal.InternalPropagation.FLAG_DEBUG;
+import static brave.internal.InternalPropagation.FLAG_SHARED;
+
 /**
  * This represents a span except for its {@link TraceContext}. It is mutable, for late adjustments.
  *
  * <p>While in-flight, the data is synchronized where necessary. When exposed to users, it can be
  * mutated without synchronization.
+ *
+ * @since 5.4
  */
 public final class MutableSpan implements Cloneable {
+  static final MutableSpan EMPTY = new MutableSpan();
 
+  /** @since 5.4 */
   public interface TagConsumer<T> {
     /** @see brave.Span#tag(String, String) */
     void accept(T target, String key, String value);
   }
 
+  /** @since 5.4 */
   public interface AnnotationConsumer<T> {
     /** @see brave.Span#annotate(long, String) */
     void accept(T target, long timestamp, String value);
   }
 
+  /** @since 5.4 */
   public interface TagUpdater {
     /**
      * Returns the same value, an updated one, or null to drop the tag.
@@ -49,6 +57,7 @@ public final class MutableSpan implements Cloneable {
     @Nullable String update(String key, String value);
   }
 
+  /** @since 5.4 */
   public interface AnnotationUpdater {
     /**
      * Returns the same value, an updated one, or null to drop the annotation.
@@ -63,7 +72,7 @@ public final class MutableSpan implements Cloneable {
    * like array allocation and object reference size.
    */
   Kind kind;
-  boolean shared;
+  int flags;
   long startTimestamp, finishTimestamp;
   String name, localServiceName, localIp, remoteServiceName, remoteIp;
   int localPort, remotePort;
@@ -74,77 +83,131 @@ public final class MutableSpan implements Cloneable {
   ArrayList<Object> annotations;
   Throwable error;
 
+  /** @since 5.4 */
   public MutableSpan() {
-    // this cheats because it will not need to grow unless there are more than 5 tags
-    tags = new ArrayList<>();
-    // lazy initialize annotations
   }
 
-  /** Returns true if there was no data added. Usually this indicates an instrumentation bug. */
-  public boolean isEmpty() {
-    return kind == null
-      && !shared
-      && startTimestamp == 0L
-      && finishTimestamp == 0L
-      && name == null
-      && localServiceName == null
-      && localIp == null
-      && remoteServiceName == null
-      && remoteIp == null
-      && localPort == 0
-      && remotePort == 0
-      && tags.isEmpty()
-      && annotations == null
-      && error == null;
+  /** @since 5.12 */
+  public MutableSpan(MutableSpan toCopy) {
+    if (toCopy == null) throw new NullPointerException("toCopy == null");
+    kind = toCopy.kind;
+    flags = toCopy.flags;
+    startTimestamp = toCopy.startTimestamp;
+    finishTimestamp = toCopy.finishTimestamp;
+    name = toCopy.name;
+    localServiceName = toCopy.localServiceName;
+    localIp = toCopy.localIp;
+    localPort = toCopy.localPort;
+    remoteServiceName = toCopy.remoteServiceName;
+    remoteIp = toCopy.remoteIp;
+    remotePort = toCopy.remotePort;
+    tags = toCopy.tags != null ? new ArrayList<>(toCopy.tags) : null;
+    annotations = toCopy.annotations != null ? new ArrayList<>(toCopy.annotations) : null;
+    error = toCopy.error;
   }
 
-  /** Returns the {@link brave.Span#name(String) span name} or null */
+  /**
+   * @since 5.4
+   * @deprecated Since 5.12 use {@link #equals(Object)} against a base value.
+   */
+  @Deprecated public boolean isEmpty() {
+    return equals(EMPTY);
+  }
+
+  /**
+   * Returns the {@linkplain brave.SpanCustomizer#name(String) span name} or {@code null}
+   *
+   * @since 5.4
+   */
   @Nullable public String name() {
     return name;
   }
 
-  /** @see brave.Span#name(String) */
+  /**
+   * Calling this overrides any previous value, such as{@link brave.SpanCustomizer#name(String)}.
+   *
+   * @see #name()
+   */
   public void name(String name) {
     if (name == null) throw new NullPointerException("name == null");
     this.name = name;
   }
 
-  /** Returns the {@link brave.Span#start(long) span start timestamp} or zero */
+  /**
+   * Returns the {@linkplain brave.Span#start(long) span start timestamp} or zero.
+   *
+   * @since 5.4
+   */
   public long startTimestamp() {
     return startTimestamp;
   }
 
-  /** @see brave.Span#start(long) */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Span#start(long)} or {@link
+   * brave.Tracer#startScopedSpan(String)}.
+   *
+   * @see #startTimestamp()
+   */
   public void startTimestamp(long startTimestamp) {
     this.startTimestamp = startTimestamp;
   }
 
-  /** Returns the {@link brave.Span#finish(long) span finish timestamp} or zero */
+  /**
+   * Returns the {@linkplain brave.Span#finish(long) span finish timestamp} or zero.
+   *
+   * @since 5.4
+   */
   public long finishTimestamp() {
     return finishTimestamp;
   }
 
-  /** @see brave.Span#finish(long) */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Span#finish(long)} or {@link
+   * brave.ScopedSpan#finish()}.
+   *
+   * @see #finishTimestamp()
+   */
   public void finishTimestamp(long finishTimestamp) {
     this.finishTimestamp = finishTimestamp;
   }
 
-  /** Returns the {@link brave.Span#kind(brave.Span.Kind) span kind} or null */
+  /**
+   * Returns the {@linkplain brave.Span#kind(brave.Span.Kind) span kind} or {@code null}.
+   *
+   * @since 5.4
+   */
   public Kind kind() {
     return kind;
   }
 
-  /** @see brave.Span#kind(brave.Span.Kind) */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Span#kind(Kind).
+   *
+   * @see #kind()
+   */
   public void kind(@Nullable Kind kind) {
     this.kind = kind;
   }
 
-  /** When null {@link brave.Tracing.Builder#localServiceName(String) default} is used. */
+  /**
+   * Returns the {@linkplain brave.Tracing.Builder#localIp(String) label of this node in the service
+   * graph} or {@code null}.
+   *
+   * <p><em>Note</em>: This is initialized from {@link brave.Tracing.Builder#localServiceName(String)}.
+   * {@linkplain FinishedSpanHandler handlers} that want to conditionally replace the value should
+   * compare against the same value given to the tracing component.
+   *
+   * @since 5.4
+   */
   @Nullable public String localServiceName() {
     return localServiceName;
   }
 
-  /** @see brave.Tracing.Builder#localServiceName(String) */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Tracing.Builder#localServiceName(String)}.
+   *
+   * @see #localServiceName()
+   */
   public void localServiceName(String localServiceName) {
     if (localServiceName == null || localServiceName.isEmpty()) {
       throw new NullPointerException("localServiceName is empty");
@@ -152,35 +215,72 @@ public final class MutableSpan implements Cloneable {
     this.localServiceName = localServiceName;
   }
 
-  /** When null {@link brave.Tracing.Builder#localIp(String) default} will be used for zipkin. */
+  /**
+   * Returns the {@linkplain brave.Tracing.Builder#localIp(String) primary IP address associated
+   * with this service} or {@code null}.
+   *
+   * <p><em>Note</em>: This is initialized from {@link brave.Tracing.Builder#localIp(String)}.
+   * {@linkplain FinishedSpanHandler handlers} that want to conditionally replace the value should
+   * compare against the same value given to the tracing component.
+   *
+   * @since 5.4
+   */
   @Nullable public String localIp() {
     return localIp;
   }
 
-  /** @see #localIp() */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Tracing.Builder#localIp(String)}.
+   *
+   * @see #localIp()
+   */
   public boolean localIp(@Nullable String localIp) {
     this.localIp = IpLiteral.ipOrNull(localIp);
     return localIp != null;
   }
 
-  /** When zero {@link brave.Tracing.Builder#localIp(String) default} will be used for zipkin. */
+  /**
+   * Returns the {@linkplain brave.Tracing.Builder#localPort(int) primary listen port associated
+   * with this service} or zero.
+   *
+   * <p><em>Note</em>: This is initialized from {@link brave.Tracing.Builder#localPort(int)}.
+   * {@linkplain FinishedSpanHandler handlers} that want to conditionally replace the value should
+   * compare against the same value given to the tracing component.
+   *
+   * @since 5.4
+   */
   public int localPort() {
     return localPort;
   }
 
-  /** @see #localPort() */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Tracing.Builder#localPort(int)}.
+   *
+   * @see #localPort()
+   */
   public void localPort(int localPort) {
     if (localPort > 0xffff) throw new IllegalArgumentException("invalid port " + localPort);
     if (localPort < 0) localPort = 0;
     this.localPort = localPort;
   }
 
-  /** @see brave.Span#remoteServiceName(String) */
+  /**
+   * Returns the {@linkplain brave.Span#remoteServiceName(String) primary label of the remote
+   * service} or {@code null}.
+   *
+   * @see #remoteIp()
+   * @see #remotePort()
+   * @since 5.4
+   */
   @Nullable public String remoteServiceName() {
     return remoteServiceName;
   }
 
-  /** @see brave.Span#remoteServiceName(String) */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Span#remoteServiceName(String)}.
+   *
+   * @see #remoteServiceName()
+   */
   public void remoteServiceName(String remoteServiceName) {
     if (remoteServiceName == null || remoteServiceName.isEmpty()) {
       throw new NullPointerException("remoteServiceName is empty");
@@ -189,26 +289,37 @@ public final class MutableSpan implements Cloneable {
   }
 
   /**
-   * The text representation of the primary IPv4 or IPv6 address associated with the remote side of
-   * this connection. Ex. 192.168.99.100 null if unknown.
+   * Returns the {@linkplain brave.Span#remoteIpAndPort(String, int) IP of the remote service} or
+   * {@code null}.
    *
-   * @see brave.Span#remoteIpAndPort(String, int)
+   * @see #remoteServiceName()
+   * @see #remotePort()
+   * @since 5.4
    */
   @Nullable public String remoteIp() {
     return remoteIp;
   }
 
   /**
-   * Port of the remote IP's socket or 0, if not known.
+   * Returns the {@linkplain brave.Span#remoteIpAndPort(String, int) port of the remote service} or
+   * zero.
    *
-   * @see java.net.InetSocketAddress#getPort()
-   * @see brave.Span#remoteIpAndPort(String, int)
+   * @see #remoteServiceName()
+   * @see #remoteIp()
+   * @since 5.4
    */
   public int remotePort() {
     return remotePort;
   }
 
-  /** @see brave.Span#remoteIpAndPort(String, int) */
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Span#remoteIpAndPort(String,
+   * int)}.
+   *
+   * @see #remoteServiceName()
+   * @see #remoteIp()
+   * @see #remotePort()
+   */
   public boolean remoteIpAndPort(@Nullable String remoteIp, int remotePort) {
     if (remoteIp == null) return false;
     this.remoteIp = IpLiteral.ipOrNull(remoteIp);
@@ -219,7 +330,120 @@ public final class MutableSpan implements Cloneable {
     return true;
   }
 
-  /** Returns true if an annotation with the given value exists in this span. */
+  /**
+   * Returns the {@linkplain brave.Span#error(Throwable) error} or {@code null}.
+   *
+   * @since 5.4
+   */
+  public Throwable error() {
+    return error;
+  }
+
+  /**
+   * Calling this overrides any previous value, such as {@link brave.Span#error(Throwable).
+   *
+   * @see #error()
+   */
+  public void error(@Nullable Throwable error) {
+    this.error = error;
+  }
+
+  /**
+   * Returns true if the context was {@linkplain TraceContext#debug() debug}.
+   *
+   * @since 5.4
+   */
+  public boolean debug() {
+    return (flags & FLAG_DEBUG) == FLAG_DEBUG;
+  }
+
+  /**
+   * Calling this is unexpected as it should only be initialized by {@link TraceContext#debug()}.
+   *
+   * @see #debug()
+   */
+  public void setDebug() {
+    flags |= FLAG_DEBUG;
+  }
+
+  /**
+   * Returns true if the context was {@linkplain TraceContext#shared() shared}.
+   *
+   * @since 5.4
+   */
+  public boolean shared() {
+    return (flags & FLAG_SHARED) == FLAG_SHARED;
+  }
+
+  /**
+   * Calling this is unexpected as it should only be initialized by {@link TraceContext#shared()}.
+   *
+   * @see #shared()
+   */
+  public void setShared() {
+    flags |= FLAG_SHARED;
+  }
+
+  /**
+   * Iterates over all {@linkplain SpanCustomizer#annotate(String) annotations} for purposes such as
+   * copying values.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * // During initialization, cache an annotation consumer function:
+   * annotationConsumer = (target, timestamp, value) -> target.add(tuple(timestamp, value));
+   *
+   * // Re-use that function while processing spans.
+   * List<Tuple<Long, String>> list = new ArrayList<>();
+   * span.forEachAnnotation(annotationConsumer, list);
+   * }</pre>
+   *
+   * @see #forEachAnnotation(AnnotationUpdater)
+   * @since 5.4
+   */
+  public <T> void forEachAnnotation(AnnotationConsumer<T> annotationConsumer, T target) {
+    if (annotations == null) return;
+    for (int i = 0, length = annotations.size(); i < length; i += 2) {
+      long timestamp = (long) annotations.get(i);
+      annotationConsumer.accept(target, timestamp, annotations.get(i + 1).toString());
+    }
+  }
+
+  /**
+   * Allows you to update or drop {@linkplain SpanCustomizer#annotate(String) annotations} for
+   * purposes such as redaction.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * // During initialization, cache an annotation updater function:
+   * annotationRedacter = (timestamp, value) -> badWords.contains(value) ? null : value;
+   *
+   * // Re-use that function while processing spans.
+   * span.forEachAnnotation(annotationRedacter);
+   * }</pre>
+   *
+   * @see #forEachAnnotation(AnnotationConsumer, Object)
+   * @since 5.4
+   */
+  public void forEachAnnotation(AnnotationUpdater annotationUpdater) {
+    if (annotations == null) return;
+    for (int i = 0, length = annotations.size(); i < length; i += 2) {
+      String value = annotations.get(i + 1).toString();
+      String newValue = annotationUpdater.update((long) annotations.get(i), value);
+      if (updateOrRemove(annotations, i, value, newValue)) {
+        length -= 2;
+        i -= 2;
+      }
+    }
+  }
+
+  /**
+   * Returns true if an annotation with the given value exists in this span.
+   *
+   * @see #forEachAnnotation(AnnotationConsumer, Object)
+   * @see #forEachAnnotation(AnnotationUpdater)
+   * @since 5.4
+   */
   public boolean containsAnnotation(String value) {
     if (value == null) throw new NullPointerException("value == null");
     if (annotations == null) return false;
@@ -230,7 +454,13 @@ public final class MutableSpan implements Cloneable {
     return false;
   }
 
-  /** @see brave.Span#annotate(String) */
+  /**
+   * Calling this adds an annotation, such as done in {@link brave.SpanCustomizer#annotate(String)}.
+   *
+   * @see #forEachAnnotation(AnnotationConsumer, Object)
+   * @see #forEachAnnotation(AnnotationUpdater)
+   * @since 5.4
+   */
   public void annotate(long timestamp, String value) {
     if (value == null) throw new NullPointerException("value == null");
     if (timestamp == 0L) return;
@@ -239,20 +469,16 @@ public final class MutableSpan implements Cloneable {
     annotations.add(value);
   }
 
-  /** @see brave.Span#error(Throwable) */
-  public Throwable error() {
-    return error;
-  }
-
-  /** @see brave.Span#error(Throwable) */
-  public void error(Throwable error) {
-    this.error = error;
-  }
-
-  /** Returns the last value associated with the key or null */
+  /**
+   * Returns the last {@linkplain brave.SpanCustomizer#tag(String, String) tag value} associated
+   * with the key or {@code null}.
+   *
+   * @since 5.4
+   */
   @Nullable public String tag(String key) {
     if (key == null) throw new NullPointerException("key == null");
     if (key.isEmpty()) throw new IllegalArgumentException("key is empty");
+    if (tags == null) return null;
     String result = null;
     for (int i = 0, length = tags.size(); i < length; i += 2) {
       if (key.equals(tags.get(i))) result = tags.get(i + 1);
@@ -261,31 +487,45 @@ public final class MutableSpan implements Cloneable {
   }
 
   /**
-   * @see brave.Span#tag(String, String)
-   * @see Tag#tag(Object, TraceContext, MutableSpan)
+   * Iterates over all {@linkplain SpanCustomizer#tag(String, String) tags} for purposes such as
+   * copying values.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * Map<String, String> tags = new LinkedHashMap<>();
+   * span.forEachTag(Map::put, tags);
+   * }</pre>
+   *
+   * @see #forEachTag(TagUpdater)
+   * @see #tag(String)
+   * @since 5.4
    */
-  public void tag(String key, String value) {
-    if (key == null) throw new NullPointerException("key == null");
-    if (key.isEmpty()) throw new IllegalArgumentException("key is empty");
-    if (value == null) throw new NullPointerException("value of " + key + " == null");
-    for (int i = 0, length = tags.size(); i < length; i += 2) {
-      if (key.equals(tags.get(i))) {
-        tags.set(i + 1, value);
-        return;
-      }
-    }
-    tags.add(key);
-    tags.add(value);
-  }
-
   public <T> void forEachTag(TagConsumer<T> tagConsumer, T target) {
+    if (tags == null) return;
     for (int i = 0, length = tags.size(); i < length; i += 2) {
       tagConsumer.accept(target, tags.get(i), tags.get(i + 1));
     }
   }
 
-  /** Allows you to update values for redaction purposes */
+  /**
+   * Allows you to update or drop {@linkplain SpanCustomizer#tag(String, String) tags} for purposes
+   * such as redaction.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * // During initialization, cache an tag updater function:
+   * tagRedacter = (key, value) -> badWords.contains(value) ? null : value;
+   *
+   * // Re-use that function while processing spans.
+   * span.forEachTag(tagRedacter);
+   * }</pre>
+   *
+   * @see #forEachTag(TagConsumer, Object)
+   * @see #tag(String)
+   * @since 5.4
+   */
   public void forEachTag(TagUpdater tagUpdater) {
+    if (tags == null) return;
     for (int i = 0, length = tags.size(); i < length; i += 2) {
       String value = tags.get(i + 1);
       String newValue = tagUpdater.update(tags.get(i), value);
@@ -297,27 +537,27 @@ public final class MutableSpan implements Cloneable {
   }
 
   /**
-   * Allows you to copy all data into a different target, such as a different span model or logs.
+   * Calling this overrides any previous value, such as {@link brave.SpanCustomizer#tag(String,
+   * String)}.
+   *
+   * @see #tag(String)
    */
-  public <T> void forEachAnnotation(AnnotationConsumer<T> annotationConsumer, T target) {
-    if (annotations == null) return;
-    for (int i = 0, length = annotations.size(); i < length; i += 2) {
-      long timestamp = (long) annotations.get(i);
-      annotationConsumer.accept(target, timestamp, annotations.get(i + 1).toString());
+  public void tag(String key, String value) {
+    if (key == null) throw new NullPointerException("key == null");
+    if (key.isEmpty()) throw new IllegalArgumentException("key is empty");
+    if (value == null) throw new NullPointerException("value of " + key + " == null");
+    if (tags == null) {
+      // this will not need to grow unless there are more than 5 tags
+      tags = new ArrayList<>();
     }
-  }
-
-  /** Allows you to update values for redaction purposes */
-  public void forEachAnnotation(AnnotationUpdater annotationUpdater) {
-    if (annotations == null) return;
-    for (int i = 0, length = annotations.size(); i < length; i += 2) {
-      String value = annotations.get(i + 1).toString();
-      String newValue = annotationUpdater.update((long) annotations.get(i), value);
-      if (updateOrRemove(annotations, i, value, newValue)) {
-        length -= 2;
-        i -= 2;
+    for (int i = 0, length = tags.size(); i < length; i += 2) {
+      if (key.equals(tags.get(i))) {
+        tags.set(i + 1, value);
+        return;
       }
     }
+    tags.add(key);
+    tags.add(value);
   }
 
   /** Returns true if the key/value was removed from the pair-indexed list at index {@code i} */
@@ -332,24 +572,42 @@ public final class MutableSpan implements Cloneable {
     return false;
   }
 
-  /** Returns true if the span ID is {@link #setShared() shared} with a remote client. */
-  public boolean shared() {
-    return shared;
-  }
-
-  /**
-   * Indicates we are contributing to a span started by another tracer (ex on a different host).
-   * Defaults to false.
-   *
-   * @see Tracer#joinSpan(TraceContext)
-   * @see zipkin2.Span#shared()
-   */
-  public void setShared() {
-    shared = true;
-  }
+  volatile int hashCode; // Lazily initialized and cached.
 
   @Override public int hashCode() {
-    return super.hashCode(); // quiet error-prone
+    int h = hashCode;
+    if (h == 0) {
+      h = 1000003;
+      h ^= kind == null ? 0 : kind.hashCode();
+      h *= 1000003;
+      h ^= flags;
+      h *= 1000003;
+      h ^= (int) ((startTimestamp >>> 32) ^ startTimestamp);
+      h *= 1000003;
+      h ^= (int) ((finishTimestamp >>> 32) ^ finishTimestamp);
+      h *= 1000003;
+      h ^= name == null ? 0 : name.hashCode();
+      h *= 1000003;
+      h ^= localServiceName == null ? 0 : localServiceName.hashCode();
+      h *= 1000003;
+      h ^= localIp == null ? 0 : localIp.hashCode();
+      h *= 1000003;
+      h ^= localPort;
+      h *= 1000003;
+      h ^= remoteServiceName == null ? 0 : remoteServiceName.hashCode();
+      h *= 1000003;
+      h ^= remoteIp == null ? 0 : remoteIp.hashCode();
+      h *= 1000003;
+      h ^= remotePort;
+      h *= 1000003;
+      h ^= tags == null ? 0 : tags.hashCode();
+      h *= 1000003;
+      h ^= annotations == null ? 0 : annotations.hashCode();
+      h *= 1000003;
+      h ^= error == null ? 0 : error.hashCode();
+      hashCode = h;
+    }
+    return h;
   }
 
   @Override public boolean equals(Object o) {
@@ -357,6 +615,25 @@ public final class MutableSpan implements Cloneable {
     // Hack that allows WeakConcurrentMap to lookup without allocating a new object.
     if (o instanceof WeakReference) o = ((WeakReference) o).get();
     if (!(o instanceof MutableSpan)) return false;
-    return super.equals(o); // not doing value-based comparison
+
+    MutableSpan that = (MutableSpan) o;
+    return kind == that.kind
+      && flags == that.flags
+      && startTimestamp == that.startTimestamp
+      && finishTimestamp == that.finishTimestamp
+      && equal(name, that.name)
+      && equal(localServiceName, that.localServiceName)
+      && equal(localIp, that.localIp)
+      && localPort == that.localPort
+      && equal(remoteServiceName, that.remoteServiceName)
+      && equal(remoteIp, that.remoteIp)
+      && remotePort == that.remotePort
+      && equal(tags, that.tags)
+      && equal(annotations, that.annotations)
+      && equal(error, that.error);
+  }
+
+  static boolean equal(@Nullable Object a, @Nullable Object b) {
+    return a == null ? b == null : a.equals(b); // Java 6 can't use Objects.equals()
   }
 }

--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -128,9 +128,8 @@ public final class MutableSpan implements Cloneable {
    *
    * @see #name()
    */
-  public void name(String name) {
-    if (name == null) throw new NullPointerException("name == null");
-    this.name = name;
+  public void name(@Nullable String name) {
+    this.name = name == null || name.isEmpty() ? null : name;
   }
 
   /**
@@ -208,9 +207,9 @@ public final class MutableSpan implements Cloneable {
    *
    * @see #localServiceName()
    */
-  public void localServiceName(String localServiceName) {
+  public void localServiceName(@Nullable String localServiceName) {
     if (localServiceName == null || localServiceName.isEmpty()) {
-      throw new NullPointerException("localServiceName is empty");
+      this.localServiceName = null;
     }
     this.localServiceName = localServiceName;
   }
@@ -281,9 +280,9 @@ public final class MutableSpan implements Cloneable {
    *
    * @see #remoteServiceName()
    */
-  public void remoteServiceName(String remoteServiceName) {
+  public void remoteServiceName(@Nullable String remoteServiceName) {
     if (remoteServiceName == null || remoteServiceName.isEmpty()) {
-      throw new NullPointerException("remoteServiceName is empty");
+      this.remoteServiceName = null;
     }
     this.remoteServiceName = remoteServiceName;
   }

--- a/brave/src/main/java/brave/internal/handler/MutableSpanConverter.java
+++ b/brave/src/main/java/brave/internal/handler/MutableSpanConverter.java
@@ -20,7 +20,6 @@ import brave.internal.Nullable;
 import java.util.Locale;
 import zipkin2.Endpoint;
 import zipkin2.Span;
-import zipkin2.Span.Builder;
 
 // internal until we figure out how the api should sit.
 public final class MutableSpanConverter {
@@ -49,7 +48,7 @@ public final class MutableSpanConverter {
     return h;
   }
 
-  void convert(MutableSpan span, Builder result) {
+  void convert(MutableSpan span, Span.Builder result) {
     result.name(span.name());
 
     long start = span.startTimestamp(), finish = span.finishTimestamp();
@@ -83,7 +82,8 @@ public final class MutableSpanConverter {
   }
 
   // avoid re-allocating an endpoint when we have the same data
-  void addLocalEndpoint(@Nullable String serviceName, @Nullable String ip, int port, Builder span) {
+  void addLocalEndpoint(@Nullable String serviceName, @Nullable String ip, int port,
+    Span.Builder span) {
     if (serviceName != null) serviceName = serviceName.toLowerCase(Locale.ROOT);
     if (hashEndpointParameters(serviceName, ip, port) == defaultEndpointHashCode) {
       span.localEndpoint(defaultEndpoint);
@@ -92,14 +92,14 @@ public final class MutableSpanConverter {
     }
   }
 
-  enum Consumer implements TagConsumer<Builder>, AnnotationConsumer<Builder> {
+  enum Consumer implements TagConsumer<Span.Builder>, AnnotationConsumer<Span.Builder> {
     INSTANCE;
 
-    @Override public void accept(Builder target, String key, String value) {
+    @Override public void accept(Span.Builder target, String key, String value) {
       target.putTag(key, value);
     }
 
-    @Override public void accept(Builder target, long timestamp, String value) {
+    @Override public void accept(Span.Builder target, long timestamp, String value) {
       target.addAnnotation(timestamp, value);
     }
   }

--- a/brave/src/main/java/brave/internal/handler/MutableSpanConverter.java
+++ b/brave/src/main/java/brave/internal/handler/MutableSpanConverter.java
@@ -71,13 +71,19 @@ public final class MutableSpanConverter {
   void addLocalEndpoint(@Nullable String serviceName, @Nullable String ip, int port,
     Span.Builder span) {
     if (serviceName != null) serviceName = serviceName.toLowerCase(Locale.ROOT);
-    if (equal(serviceName, defaultEndpoint.serviceName())
-      && (equal(ip, defaultEndpoint.ipv4()) || equal(ip, defaultEndpoint.ipv6()))
-      && port == defaultEndpoint.portAsInt()) {
+    if (equalsDefaultEndpoint(serviceName, ip, port)) {
       span.localEndpoint(defaultEndpoint);
     } else {
       span.localEndpoint(Endpoint.newBuilder().serviceName(serviceName).ip(ip).port(port).build());
     }
+  }
+
+  boolean equalsDefaultEndpoint(@Nullable String serviceName, @Nullable String ip, int port) {
+    return equal(serviceName, defaultEndpoint.serviceName())
+      // Brave only has one IP, but it shuffles into zipkin2.Endpoint based on its type
+      && ((defaultEndpoint.ipv4() != null && equal(ip, defaultEndpoint.ipv4())) ||
+      (defaultEndpoint.ipv6() != null && equal(ip, defaultEndpoint.ipv6())))
+      && port == defaultEndpoint.portAsInt();
   }
 
   enum Consumer implements TagConsumer<Span.Builder>, AnnotationConsumer<Span.Builder> {

--- a/brave/src/main/java/brave/internal/handler/MutableSpanConverter.java
+++ b/brave/src/main/java/brave/internal/handler/MutableSpanConverter.java
@@ -85,7 +85,8 @@ public final class MutableSpanConverter {
   void addLocalEndpoint(@Nullable String serviceName, @Nullable String ip, int port,
     Span.Builder span) {
     if (serviceName != null) serviceName = serviceName.toLowerCase(Locale.ROOT);
-    if (hashEndpointParameters(serviceName, ip, port) == defaultEndpointHashCode) {
+    if (hashEndpointParameters(serviceName, ip, port) == defaultEndpointHashCode
+      && equal(serviceName, defaultEndpoint.serviceName()) /* in case clash */) {
       span.localEndpoint(defaultEndpoint);
     } else {
       span.localEndpoint(Endpoint.newBuilder().serviceName(serviceName).ip(ip).port(port).build());
@@ -102,5 +103,9 @@ public final class MutableSpanConverter {
     @Override public void accept(Span.Builder target, long timestamp, String value) {
       target.addAnnotation(timestamp, value);
     }
+  }
+
+  static boolean equal(@Nullable Object a, @Nullable Object b) {
+    return a == null ? b == null : a.equals(b); // Java 6 can't use Objects.equals()
   }
 }

--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -14,6 +14,7 @@
 package brave.internal.recorder;
 
 import brave.Clock;
+import brave.ErrorParser;
 import brave.Tracer;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
@@ -36,12 +37,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingSpan> {
   @Nullable final WeakConcurrentMap<MutableSpan, Throwable> spanToCaller;
+  final MutableSpan defaultSpan;
+  final ErrorParser errorParser;
   final Clock clock;
   final FinishedSpanHandler orphanedSpanHandler;
   final AtomicBoolean noop;
 
-  public PendingSpans(Clock clock, FinishedSpanHandler orphanedSpanHandler, boolean trackOrphans,
-    AtomicBoolean noop) {
+  public PendingSpans(MutableSpan defaultSpan, ErrorParser errorParser, Clock clock,
+    FinishedSpanHandler orphanedSpanHandler,
+    boolean trackOrphans, AtomicBoolean noop) {
+    this.defaultSpan = defaultSpan;
+    this.errorParser = errorParser;
     this.clock = clock;
     this.orphanedSpanHandler = orphanedSpanHandler;
     this.spanToCaller = trackOrphans ? new WeakConcurrentMap<>() : null;
@@ -64,7 +70,8 @@ public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingS
     PendingSpan result = get(context);
     if (result != null) return result;
 
-    MutableSpan data = new MutableSpan();
+    MutableSpan data = new MutableSpan(defaultSpan);
+    if (context.debug()) data.setDebug();
     if (context.shared()) data.setShared();
 
     PendingSpan parentSpan = parent != null ? get(parent) : null;
@@ -103,9 +110,21 @@ public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingS
     remove(context);
   }
 
+  /** @see brave.Span#flush() */
+  public boolean flush(TraceContext context) {
+    PendingSpan last = remove(context);
+    if (last == null) return false;
+    maybeAddErrorTag(last.state);
+    return true;
+  }
+
   /** @see brave.Span#finish() */
-  @Override public PendingSpan remove(TraceContext context) {
-    return super.remove(context);
+  public boolean finish(TraceContext context, long timestamp) {
+    PendingSpan last = remove(context);
+    if (last == null) return false;
+    maybeAddErrorTag(last.state);
+    last.state.finishTimestamp(timestamp != 0L ? timestamp : last.clock.currentTimeMicroseconds());
+    return true;
   }
 
   /** Reports spans orphaned by garbage collection. */
@@ -123,7 +142,7 @@ public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingS
       assert value.context() == null : "unexpected for the weak referent to be present after GC!";
       if (flushTime == 0L) flushTime = clock.currentTimeMicroseconds();
 
-      boolean isEmpty = value.state.isEmpty();
+      boolean isEmpty = value.state.equals(defaultSpan);
       Throwable caller = spanToCaller != null ? spanToCaller.getIfPresent(value.state) : null;
 
       TraceContext context = value.backupContext;
@@ -136,8 +155,17 @@ public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingS
       }
       if (isEmpty) continue;
 
+      maybeAddErrorTag(value.state);
       value.state.annotate(flushTime, "brave.flush");
       orphanedSpanHandler.handle(context, value.state);
+    }
+  }
+
+  /** Legacy code never called {@link brave.Span#error(Throwable)}, so call here just in case. */
+  void maybeAddErrorTag(MutableSpan span) {
+    String errorTag = span.tag("error");
+    if (errorTag == null && span.error() != null) {
+      errorParser.error(span.error(), span);
     }
   }
 }

--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -44,8 +44,7 @@ public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingS
   final AtomicBoolean noop;
 
   public PendingSpans(MutableSpan defaultSpan, ErrorParser errorParser, Clock clock,
-    FinishedSpanHandler orphanedSpanHandler,
-    boolean trackOrphans, AtomicBoolean noop) {
+    FinishedSpanHandler orphanedSpanHandler, boolean trackOrphans, AtomicBoolean noop) {
     this.defaultSpan = defaultSpan;
     this.errorParser = errorParser;
     this.clock = clock;
@@ -163,9 +162,8 @@ public final class PendingSpans extends WeakConcurrentMap<TraceContext, PendingS
 
   /** Legacy code never called {@link brave.Span#error(Throwable)}, so call here just in case. */
   void maybeAddErrorTag(MutableSpan span) {
+    if (span.error() == null) return;
     String errorTag = span.tag("error");
-    if (errorTag == null && span.error() != null) {
-      errorParser.error(span.error(), span);
-    }
+    if (errorTag == null) errorParser.error(span.error(), span);
   }
 }

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -129,16 +129,14 @@ public class TracerTest {
   @Test public void localServiceName() {
     tracer = Tracing.newBuilder().localServiceName("my-foo").build().tracer();
 
-    assertThat(tracer).extracting(
-      "finishedSpanHandler.delegate.converter.localEndpoint.serviceName")
+    assertThat(tracer).extracting("pendingSpans.defaultSpan.localServiceName")
       .isEqualTo("my-foo");
   }
 
   @Test public void localServiceName_defaultIsUnknown() {
     tracer = Tracing.newBuilder().build().tracer();
 
-    assertThat(tracer).extracting(
-      "finishedSpanHandler.delegate.converter.localEndpoint.serviceName")
+    assertThat(tracer).extracting("pendingSpans.defaultSpan.localServiceName")
       .isEqualTo("unknown");
   }
 
@@ -146,8 +144,10 @@ public class TracerTest {
     Endpoint endpoint = Endpoint.newBuilder().ip("1.2.3.4").serviceName("my-bar").build();
     tracer = Tracing.newBuilder().localServiceName("my-foo").endpoint(endpoint).build().tracer();
 
-    assertThat(tracer).extracting("finishedSpanHandler.delegate.converter.localEndpoint")
-      .isEqualTo(endpoint);
+    MutableSpan defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("my-bar");
+    defaultSpan.localIp("1.2.3.4");
+    assertThat(tracer).extracting("pendingSpans.defaultSpan").isEqualTo(defaultSpan);
   }
 
   @Test public void newTrace_isRootSpan() {

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -15,6 +15,7 @@ package brave;
 
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
+import brave.internal.handler.ZipkinFinishedSpanHandler;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.Propagation;
 import brave.propagation.StrictCurrentTraceContext;
@@ -102,10 +103,10 @@ public class TracingTest {
     assertThat(zipkinSpans).isNotEmpty(); // ensures the assertions passed.
   }
 
-  @Test public void finishedSpanHandler_zipkinByDefault() {
+  @Test public void finishedSpanHandler_loggingByDefault() {
     try (Tracing tracing = Tracing.newBuilder().build()) {
       assertThat(tracing.tracer().finishedSpanHandler).extracting("delegate.spanReporter")
-        .isInstanceOf(Tracing.LoggingReporter.class);
+        .isInstanceOf(ZipkinFinishedSpanHandler.LoggingReporter.class);
     }
   }
 
@@ -114,7 +115,7 @@ public class TracingTest {
       .addFinishedSpanHandler(FinishedSpanHandler.NOOP)
       .build()) {
       assertThat(tracing.tracer().finishedSpanHandler).extracting("delegate.spanReporter")
-        .isInstanceOf(Tracing.LoggingReporter.class);
+        .isInstanceOf(ZipkinFinishedSpanHandler.LoggingReporter.class);
     }
   }
 

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -26,6 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -272,6 +274,178 @@ public class MutableSpanTest {
       MutableSpan span = new MutableSpan();
       span.setShared();
       assertThat(span.isEmpty()).isFalse();
+    }
+  }
+
+  static final Exception EX1 = new Exception(), EX2 = new Exception();
+
+  @Test public void equalsAndHashCode() {
+    // Not as good as property testing, but easier to see changes later when fields are added!
+    List<Supplier<MutableSpan>> permutations = asList(
+      MutableSpan::new,
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.kind(Span.Kind.CLIENT);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.kind(Span.Kind.SERVER);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.setDebug();
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.setShared();
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.startTimestamp(1L);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.startTimestamp(2L);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.finishTimestamp(1L);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.finishTimestamp(2L);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.name("foo");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.name("Foo");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.localServiceName("foo");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.localServiceName("Foo");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.localIp("1.2.3.4");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.localIp("::1");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.localPort(80);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.localPort(443);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.remoteServiceName("foo");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.remoteServiceName("Foo");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.remoteIpAndPort("1.2.3.4", 0);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.remoteIpAndPort("::1", 0);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.remoteIpAndPort("127.0.0.1", 80);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.remoteIpAndPort("127.0.0.1", 443);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.tag("error", "wasted");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.tag("error", "");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.annotate(1L, "wasted");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.annotate(2L, "wasted");
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.error(EX1);
+        return span;
+      },
+      () -> {
+        MutableSpan span = new MutableSpan();
+        span.error(EX2);
+        return span;
+      }
+    );
+
+    for (Supplier<MutableSpan> constructor : permutations) {
+      // same instance are equivalent
+      MutableSpan span = constructor.get();
+      assertThat(span).isEqualTo(span);
+      assertThat(span).hasSameHashCodeAs(span);
+
+      // same field are equivalent
+      assertThat(span).isEqualTo(constructor.get());
+      assertThat(span).hasSameHashCodeAs(constructor.get());
+
+      // This seems redundant, and mostly is, but the order of equals matters
+      List<Supplier<MutableSpan>> exceptMe = new ArrayList<>(permutations);
+      exceptMe.remove(constructor);
+      for (Supplier<MutableSpan> otherConstructor : exceptMe) {
+        MutableSpan other = otherConstructor.get();
+        assertThat(span)
+          .isNotSameAs(other) // sanity
+          .isNotEqualTo(other)
+          .extracting(MutableSpan::hashCode)
+          .isNotEqualTo(other.hashCode());
+      }
     }
   }
 

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -313,6 +313,8 @@ public class MutableSpanTest {
         span.annotate(1L, string);
         return span;
       }
+      // TODO: find two IPv6 literals whose string forms clash on hashCode
+      // bonus if there are actually IPv4 literals that clash on hashCode
     );
 
     for (Function<String, MutableSpan> factory : permutations) {

--- a/brave/src/test/java/brave/internal/handler/MutableSpanConverterTest.java
+++ b/brave/src/test/java/brave/internal/handler/MutableSpanConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,9 +13,9 @@
  */
 package brave.internal.handler;
 
-import brave.ErrorParser;
 import brave.Span.Kind;
 import brave.handler.MutableSpan;
+import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Annotation;
 import zipkin2.Endpoint;
@@ -27,38 +27,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 public class MutableSpanConverterTest {
-  MutableSpanConverter converter =
-    new MutableSpanConverter(new ErrorParser(), "fooService", "1.2.3.4", 80);
+  MutableSpan defaultSpan;
+  MutableSpanConverter converter;
 
-  @Test public void localEndpoint_default() {
-    // When span doesn't set local endpoint info
-    assertThat(convert(new MutableSpan()).localEndpoint())
-      .isEqualTo(converter.localEndpoint);
-
-    // When span sets to the same values
-    MutableSpan span = new MutableSpan();
-    span.localServiceName(converter.localServiceName);
-    span.localIp(converter.localIp);
-    span.localPort(converter.localPort);
-
-    assertThat(convert(span).localEndpoint())
-      .isEqualTo(converter.localEndpoint);
+  @Before public void setup() {
+    defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("fooService");
+    defaultSpan.localIp("1.2.3.4");
+    defaultSpan.localPort(80);
+    converter = new MutableSpanConverter(defaultSpan);
   }
 
-  @Test public void localEndpoint_default_whenIpNull() {
-    converter = new MutableSpanConverter(new ErrorParser(), "fooService", null, 80);
-
-    // When span doesn't set local endpoint info
+  @Test public void localEndpoint_null() {
+    // When a finished span handler clears the endpoint info
     assertThat(convert(new MutableSpan()).localEndpoint())
-      .isEqualTo(converter.localEndpoint);
+      .isNull();
+  }
 
+  @Test public void localEndpoint_sameAsDefault() {
     // When span sets to the same values
     MutableSpan span = new MutableSpan();
-    span.localServiceName(converter.localServiceName);
-    span.localPort(converter.localPort);
+    span.localServiceName(converter.defaultEndpoint.serviceName());
+    span.localIp(converter.defaultEndpoint.ipv4());
+    span.localPort(converter.defaultEndpoint.portAsInt());
 
     assertThat(convert(span).localEndpoint())
-      .isEqualTo(converter.localEndpoint);
+      .isSameAs(converter.defaultEndpoint);
+  }
+
+  @Test public void localEndpoint_notSameAsDefault() {
+    MutableSpan span = new MutableSpan();
+    span.localServiceName("fooService");
+    // missing IP address
+    span.localPort(80);
+
+    assertThat(convert(span).localEndpoint())
+      .isNotSameAs(converter.defaultEndpoint)
+      .isEqualTo(Endpoint.newBuilder().serviceName("fooService").port(80).build());
   }
 
   @Test public void localEndpoint_override() {
@@ -66,7 +71,7 @@ public class MutableSpanConverterTest {
     span.localServiceName("barService");
 
     assertThat(convert(span).localEndpoint())
-      .isEqualTo(Endpoint.newBuilder().serviceName("barService").ip("1.2.3.4").port(80).build());
+      .isEqualTo(Endpoint.newBuilder().serviceName("barService").build());
   }
 
   @Test public void minimumDurationIsOne() {
@@ -200,7 +205,7 @@ public class MutableSpanConverterTest {
     MutableSpan flushed = new MutableSpan();
     flushed.finishTimestamp(0L);
 
-    assertThat(convert(flushed)).extracting(s -> s.timestampAsLong(), s -> s.durationAsLong())
+    assertThat(convert(flushed)).extracting(Span::timestampAsLong, Span::durationAsLong)
       .allSatisfy(u -> assertThat(u).isEqualTo(0L));
   }
 

--- a/brave/src/test/java/brave/internal/handler/MutableSpanConverterTest.java
+++ b/brave/src/test/java/brave/internal/handler/MutableSpanConverterTest.java
@@ -32,7 +32,7 @@ public class MutableSpanConverterTest {
 
   @Before public void setup() {
     defaultSpan = new MutableSpan();
-    defaultSpan.localServiceName("fooService");
+    defaultSpan.localServiceName("Aa");
     defaultSpan.localIp("1.2.3.4");
     defaultSpan.localPort(80);
     converter = new MutableSpanConverter(defaultSpan);
@@ -53,6 +53,16 @@ public class MutableSpanConverterTest {
 
     assertThat(convert(span).localEndpoint())
       .isSameAs(converter.defaultEndpoint);
+  }
+
+  @Test public void localEndpoint_serviceNameHashCodeCollision() {
+    MutableSpan span = new MutableSpan();
+    span.localServiceName("BB");
+    span.localIp(converter.defaultEndpoint.ipv4());
+    span.localPort(converter.defaultEndpoint.portAsInt());
+
+    assertThat(convert(span).localEndpoint())
+      .isNotSameAs(converter.defaultEndpoint);
   }
 
   @Test public void localEndpoint_notSameAsDefault() {

--- a/brave/src/test/java/brave/internal/handler/MutableSpanConverterTest.java
+++ b/brave/src/test/java/brave/internal/handler/MutableSpanConverterTest.java
@@ -65,15 +65,44 @@ public class MutableSpanConverterTest {
       .isNotSameAs(converter.defaultEndpoint);
   }
 
-  @Test public void localEndpoint_notSameAsDefault() {
+  @Test public void localEndpoint_notSameAsDefault_missingIp() {
     MutableSpan span = new MutableSpan();
-    span.localServiceName("fooService");
+    span.localServiceName(converter.defaultEndpoint.serviceName());
     // missing IP address
-    span.localPort(80);
+    span.localPort(converter.defaultEndpoint.portAsInt());
 
-    assertThat(convert(span).localEndpoint())
-      .isNotSameAs(converter.defaultEndpoint)
-      .isEqualTo(Endpoint.newBuilder().serviceName("fooService").port(80).build());
+    assertThat(convert(span).localEndpoint().ipv4())
+      .isNull();
+  }
+
+  @Test public void localEndpoint_notSameAsDefault_differentIp() {
+    MutableSpan span = new MutableSpan();
+    span.localServiceName(converter.defaultEndpoint.serviceName());
+    span.localIp("2001:db8::c001");
+    span.localPort(converter.defaultEndpoint.portAsInt());
+
+    assertThat(convert(span).localEndpoint().ipv6())
+      .isEqualTo("2001:db8::c001");
+  }
+
+  @Test public void localEndpoint_notSameAsDefault_missingPort() {
+    MutableSpan span = new MutableSpan();
+    span.localServiceName(converter.defaultEndpoint.serviceName());
+    span.localIp(converter.defaultEndpoint.ipv4());
+    // missing port
+
+    assertThat(convert(span).localEndpoint().portAsInt())
+      .isZero();
+  }
+
+  @Test public void localEndpoint_notSameAsDefault_differentPort() {
+    MutableSpan span = new MutableSpan();
+    span.localServiceName(converter.defaultEndpoint.serviceName());
+    span.localIp(converter.defaultEndpoint.ipv4());
+    span.localPort(443);
+
+    assertThat(convert(span).localEndpoint().portAsInt())
+      .isEqualTo(443);
   }
 
   @Test public void localEndpoint_override() {

--- a/brave/src/test/java/brave/internal/handler/ZipkinFinishedSpanHandlerTest.java
+++ b/brave/src/test/java/brave/internal/handler/ZipkinFinishedSpanHandlerTest.java
@@ -48,21 +48,21 @@ public class ZipkinFinishedSpanHandlerTest {
       Span.newBuilder()
         .traceId("1")
         .id("2")
-        .localEndpoint(zipkinFinishedSpanHandler.converter.defaultEndpoint)
         .build()
     );
   }
 
   @Test public void reportsDebugSpan() {
     TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).debug(true).build();
-    zipkinFinishedSpanHandler.handle(context, new MutableSpan());
+    MutableSpan span = new MutableSpan();
+    span.setDebug();
+    zipkinFinishedSpanHandler.handle(context, span);
 
     assertThat(spans.get(0)).isEqualToComparingFieldByField(
       Span.newBuilder()
         .traceId("1")
         .id("2")
         .debug(true)
-        .localEndpoint(zipkinFinishedSpanHandler.converter.defaultEndpoint)
         .build()
     );
   }

--- a/brave/src/test/java/brave/internal/handler/ZipkinFinishedSpanHandlerTest.java
+++ b/brave/src/test/java/brave/internal/handler/ZipkinFinishedSpanHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  */
 package brave.internal.handler;
 
-import brave.ErrorParser;
 import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
@@ -34,8 +33,11 @@ public class ZipkinFinishedSpanHandlerTest {
   }
 
   void init(Reporter<Span> spanReporter, boolean alwaysReportSpans) {
-    zipkinFinishedSpanHandler = new ZipkinFinishedSpanHandler(spanReporter, new ErrorParser(),
-      "favistar", "1.2.3.4", 0, alwaysReportSpans);
+    MutableSpan defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("favistar");
+    defaultSpan.localIp("1.2.3.4");
+    zipkinFinishedSpanHandler = new ZipkinFinishedSpanHandler(defaultSpan, spanReporter,
+      alwaysReportSpans);
   }
 
   @Test public void reportsSampledSpan() {
@@ -46,7 +48,7 @@ public class ZipkinFinishedSpanHandlerTest {
       Span.newBuilder()
         .traceId("1")
         .id("2")
-        .localEndpoint(zipkinFinishedSpanHandler.converter.localEndpoint)
+        .localEndpoint(zipkinFinishedSpanHandler.converter.defaultEndpoint)
         .build()
     );
   }
@@ -60,7 +62,7 @@ public class ZipkinFinishedSpanHandlerTest {
         .traceId("1")
         .id("2")
         .debug(true)
-        .localEndpoint(zipkinFinishedSpanHandler.converter.localEndpoint)
+        .localEndpoint(zipkinFinishedSpanHandler.converter.defaultEndpoint)
         .build()
     );
   }

--- a/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
+++ b/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
@@ -13,6 +13,7 @@
  */
 package brave.internal.recorder;
 
+import brave.ErrorParser;
 import brave.GarbageCollectors;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
@@ -71,7 +72,10 @@ public class PendingSpansTest {
   }
 
   void init(FinishedSpanHandler zipkinFinishedSpanHandler, boolean trackOrphans) {
-    pendingSpans = new PendingSpans(() -> clock.incrementAndGet() * 1000L,
+    MutableSpan defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("favistar");
+    defaultSpan.localIp("1.2.3.4");
+    pendingSpans = new PendingSpans(defaultSpan, new ErrorParser(), () -> clock.incrementAndGet() * 1000L,
       zipkinFinishedSpanHandler, trackOrphans, new AtomicBoolean());
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/internal/handler/MutableSpanConverterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/handler/MutableSpanConverterBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/benchmarks/src/main/java/brave/internal/handler/MutableSpanConverterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/handler/MutableSpanConverterBenchmarks.java
@@ -13,7 +13,6 @@
  */
 package brave.internal.handler;
 
-import brave.ErrorParser;
 import brave.handler.MutableSpan;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -43,8 +42,7 @@ import static brave.handler.MutableSpanBenchmarks.newServerMutableSpan;
 @State(Scope.Thread)
 @Threads(1)
 public class MutableSpanConverterBenchmarks {
-  final MutableSpanConverter converter =
-    new MutableSpanConverter(new ErrorParser(), "unknown", "127.0.0.1", 0);
+  final MutableSpanConverter converter = new MutableSpanConverter(new MutableSpan());
   final MutableSpan serverMutableSpan = newServerMutableSpan();
   final MutableSpan bigClientMutableSpan = newBigClientMutableSpan();
 

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -18,6 +18,7 @@ import brave.ErrorParser;
 import brave.Tracing;
 import brave.TracingCustomizer;
 import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
@@ -66,8 +67,7 @@ public class TracingFactoryBeanTest {
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
-      .extracting("tracer.finishedSpanHandler.delegate.converter.localEndpoint")
-      .extracting("serviceName")
+      .extracting("tracer.pendingSpans.defaultSpan.localServiceName")
       .isEqualTo("brave-webmvc-example");
   }
 
@@ -84,12 +84,14 @@ public class TracingFactoryBeanTest {
       + "</bean>"
     );
 
+    MutableSpan defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("brave-webmvc-example");
+    defaultSpan.localIp("1.2.3.4");
+    defaultSpan.localPort(8080);
+
     assertThat(context.getBean("tracing", Tracing.class))
-      .extracting("tracer.finishedSpanHandler.delegate.converter.localEndpoint")
-      .isEqualTo(Endpoint.newBuilder()
-        .serviceName("brave-webmvc-example")
-        .ip("1.2.3.4")
-        .port(8080).build());
+      .extracting("tracer.pendingSpans.defaultSpan")
+      .isEqualTo(defaultSpan);
   }
 
   @Test public void endpoint() {
@@ -105,12 +107,14 @@ public class TracingFactoryBeanTest {
       + "</bean>"
     );
 
+    MutableSpan defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("brave-webmvc-example");
+    defaultSpan.localIp("1.2.3.4");
+    defaultSpan.localPort(8080);
+
     assertThat(context.getBean("tracing", Tracing.class))
-      .extracting("tracer.finishedSpanHandler.delegate.converter.localEndpoint")
-      .isEqualTo(Endpoint.newBuilder()
-        .serviceName("brave-webmvc-example")
-        .ip("1.2.3.4")
-        .port(8080).build());
+      .extracting("tracer.pendingSpans.defaultSpan")
+      .isEqualTo(defaultSpan);
   }
 
   @Test public void spanReporter() {


### PR DESCRIPTION
This migrates data formerly handled only by the zipkin reporter into
`MutableSpan`. To complete decoupling will take future pull requests
that add trace IDs to `MutableSpan` and make the logging reporter use
`MutableSpan` by default instead of zipkin types.