### PR TITLE
Moves construct from trace context responsibility to MutableSpan

### DIFF
--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -88,9 +88,30 @@ public final class MutableSpan implements Cloneable {
   public MutableSpan() {
   }
 
+  /**
+   * Creates a new instance from the given context, and defaults in the span.
+   *
+   * <p><em>Note:</em> It is unexpected to have context properties also in the span defaults. The
+   * context will win in this case, as opposed to throwing an exception.
+   *
+   * @since 5.12
+   */
+  public MutableSpan(TraceContext context, @Nullable MutableSpan defaults) {
+    this(defaults != null ? defaults : EMPTY);
+    if (context == null) throw new NullPointerException("context == null");
+    traceId(context.traceIdString());
+    localRootId(context.localRootIdString());
+    parentId(context.parentIdString());
+    id(context.spanIdString());
+    flags = 0; // don't inherit flags from the span
+    if (context.debug()) setDebug();
+    if (context.shared()) setShared();
+  }
+
   /** @since 5.12 */
   public MutableSpan(MutableSpan toCopy) {
     if (toCopy == null) throw new NullPointerException("toCopy == null");
+    if (toCopy == EMPTY) return;
     traceId = toCopy.traceId;
     localRootId = toCopy.localRootId;
     parentId = toCopy.parentId;


### PR DESCRIPTION
This moves initializing from a given trace context from the internal
type `PendingSpans` to `MutableSpan` where it is easier to test, and
also can be used when we separate out orphan tracking to its own type.