### PR TITLE
Replaces "carrier" with "request"

### DIFF
--- a/brave-tests/src/main/java/brave/test/propagation/PropagationSetterTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/PropagationSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,49 +18,49 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class PropagationSetterTest<C, K> {
+public abstract class PropagationSetterTest<R, K> {
   protected abstract Propagation.KeyFactory<K> keyFactory();
 
-  protected abstract C carrier();
+  protected abstract R request();
 
-  protected abstract Propagation.Setter<C, K> setter();
+  protected abstract Propagation.Setter<R, K> setter();
 
-  protected abstract Iterable<String> read(C carrier, K key);
+  protected abstract Iterable<String> read(R request, K key);
 
   @Test public void set() throws Exception {
     K key = keyFactory().create("X-B3-TraceId");
-    setter().put(carrier(), key, "48485a3953bb6124");
+    setter().put(request(), key, "48485a3953bb6124");
 
-    assertThat(read(carrier(), key))
+    assertThat(read(request(), key))
       .containsExactly("48485a3953bb6124");
   }
 
   @Test public void set128() throws Exception {
     K key = keyFactory().create("X-B3-TraceId");
-    setter().put(carrier(), key, "463ac35c9f6413ad48485a3953bb6124");
+    setter().put(request(), key, "463ac35c9f6413ad48485a3953bb6124");
 
-    assertThat(read(carrier(), key))
+    assertThat(read(request(), key))
       .containsExactly("463ac35c9f6413ad48485a3953bb6124");
   }
 
   @Test public void setTwoKeys() throws Exception {
     K key1 = keyFactory().create("X-B3-TraceId");
     K key2 = keyFactory().create("X-B3-SpanId");
-    setter().put(carrier(), key1, "463ac35c9f6413ad48485a3953bb6124");
-    setter().put(carrier(), key2, "48485a3953bb6124");
+    setter().put(request(), key1, "463ac35c9f6413ad48485a3953bb6124");
+    setter().put(request(), key2, "48485a3953bb6124");
 
-    assertThat(read(carrier(), key1))
+    assertThat(read(request(), key1))
       .containsExactly("463ac35c9f6413ad48485a3953bb6124");
-    assertThat(read(carrier(), key2))
+    assertThat(read(request(), key2))
       .containsExactly("48485a3953bb6124");
   }
 
   @Test public void reset() throws Exception {
     K key = keyFactory().create("X-B3-TraceId");
-    setter().put(carrier(), key, "48485a3953bb6124");
-    setter().put(carrier(), key, "463ac35c9f6413ad");
+    setter().put(request(), key, "48485a3953bb6124");
+    setter().put(request(), key, "463ac35c9f6413ad");
 
-    assertThat(read(carrier(), key))
+    assertThat(read(request(), key))
       .containsExactly("463ac35c9f6413ad");
   }
 }

--- a/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,7 +41,7 @@ public abstract class PropagationTest<K> {
    * There's currently no standard API to just inject sampling flags, as IDs are intended to be
    * propagated.
    */
-  protected abstract void inject(Map<K, String> carrier, SamplingFlags samplingFlags);
+  protected abstract void inject(Map<K, String> request, SamplingFlags samplingFlags);
 
   protected Map<K, String> map = new LinkedHashMap<>();
   MapEntry<K> mapEntry = new MapEntry<>();
@@ -147,12 +147,12 @@ public abstract class PropagationTest<K> {
     public MapEntry() {
     }
 
-    @Override public void put(Map<K, String> carrier, K key, String value) {
-      carrier.put(key, value);
+    @Override public void put(Map<K, String> request, K key, String value) {
+      request.put(key, value);
     }
 
-    @Override public String get(Map<K, String> carrier, K key) {
-      return carrier.get(key);
+    @Override public String get(Map<K, String> request, K key) {
+      return request.get(key);
     }
   }
 

--- a/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3PropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,11 +43,11 @@ public class B3PropagationTest extends PropagationTest<String> {
     if (debug != null) map.put("X-B3-Flags", debug ? "1" : "0");
   }
 
-  @Override protected void inject(Map<String, String> carrier, SamplingFlags flags) {
+  @Override protected void inject(Map<String, String> request, SamplingFlags flags) {
     if (flags.debug()) {
-      carrier.put("X-B3-Flags", "1");
+      request.put("X-B3-Flags", "1");
     } else if (flags.sampled() != null) {
-      carrier.put("X-B3-Sampled", flags.sampled() ? "1" : "0");
+      request.put("X-B3-Sampled", flags.sampled() ? "1" : "0");
     }
   }
 

--- a/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
+++ b/brave-tests/src/test/java/brave/propagation/B3SinglePropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -54,9 +54,9 @@ public class B3SinglePropagationTest extends PropagationTest<String> {
     return 0;
   }
 
-  @Override protected void inject(Map<String, String> carrier, SamplingFlags flags) {
+  @Override protected void inject(Map<String, String> request, SamplingFlags flags) {
     char sampledChar = sampledChar(flags.sampled(), flags.debug());
-    if (sampledChar != 0) carrier.put("b3", String.valueOf(sampledChar));
+    if (sampledChar != 0) request.put("b3", String.valueOf(sampledChar));
   }
 
   @Test public void extractTraceContext_sampledFalse() {

--- a/brave-tests/src/test/java/brave/propagation/URLConnectionSetterTest.java
+++ b/brave-tests/src/test/java/brave/propagation/URLConnectionSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,10 +20,10 @@ import java.net.URLConnection;
 
 /** Example setter test */
 public class URLConnectionSetterTest extends PropagationSetterTest<URLConnection, String> {
-  final URLConnection carrier;
+  final URLConnection request;
 
   public URLConnectionSetterTest() throws IOException {
-    carrier = new URLConnection(URI.create("http://127.0.0.1:9999").toURL()) {
+    request = new URLConnection(URI.create("http://127.0.0.1:9999").toURL()) {
       @Override public void connect() throws IOException {
       }
     };
@@ -33,15 +33,15 @@ public class URLConnectionSetterTest extends PropagationSetterTest<URLConnection
     return Propagation.KeyFactory.STRING;
   }
 
-  @Override protected URLConnection carrier() {
-    return carrier;
+  @Override protected URLConnection request() {
+    return request;
   }
 
   @Override protected Propagation.Setter<URLConnection, String> setter() {
     return URLConnection::setRequestProperty;
   }
 
-  @Override protected Iterable<String> read(URLConnection carrier, String key) {
-    return carrier.getRequestProperties().get(key);
+  @Override protected Iterable<String> read(URLConnection request, String key) {
+    return request.getRequestProperties().get(key);
   }
 }

--- a/brave/README.md
+++ b/brave/README.md
@@ -504,8 +504,8 @@ span = tracer.nextSpan(extractor.extract(request));
 ```
 
 ### Extracting a propagated context
-The `TraceContext.Extractor<C>` reads trace identifiers and sampling status
-from an incoming request or message. The carrier is usually a request object
+The `TraceContext.Extractor<R>` reads trace identifiers and sampling status
+from an incoming request or message. The request is usually a request object
 or headers.
 
 This utility is used in standard instrumentation like [HttpServerHandler](../instrumentation/http/src/main/java/brave/http/HttpServerHandler.java),
@@ -564,7 +564,7 @@ via `Tracing.Builder.supportsJoin(false)`. This will force a new child span on
 
 ### Implementing Propagation
 
-`TraceContext.Extractor<C>` is implemented by a `Propagation.Factory` plugin. Internally, this code
+`TraceContext.Extractor<R>` is implemented by a `Propagation.Factory` plugin. Internally, this code
 will create the union type `TraceContextOrSamplingFlags` with one of the following:
 * `TraceContext` if trace and span IDs were present.
 * `TraceIdContext` if a trace ID was present, but not span IDs.
@@ -1047,9 +1047,9 @@ from [WeakConcurrentMap](https://github.com/raphw/weak-lock-free).
 
 ### Propagation Api
 OpenTracing's Tracer type has methods to inject or extract a trace
-context from a carrier. While naming is similar, Brave optimizes for
-direct integration with carrier types (such as http request) vs routing
-through an intermediate (such as a map). Brave also considers propagation
+context from a request. While naming is similar, Brave optimizes for
+direct integration with request types (such as http request) vs routing
+through a "carrier" (such as a map). Brave also considers propagation
 a separate api from the tracer.
 
 ### Current Tracer Api

--- a/brave/src/main/java/brave/internal/InternalBaggage.java
+++ b/brave/src/main/java/brave/internal/InternalBaggage.java
@@ -27,7 +27,7 @@ public abstract class InternalBaggage {
   public static InternalBaggage instance;
 
   /** Returns all lower-case trace context or baggage key names. */
-  // This is here to support extraction from carriers missing a get field by name function. The only
+  // This is here to support extraction from requests missing a get field by name function. The only
   // known example is OpenTracing TextMap https://github.com/opentracing/opentracing-java/issues/305
   public abstract Set<String> allKeyNames(Propagation.Factory factory);
 }

--- a/brave/src/main/java/brave/internal/WrappingExecutorService.java
+++ b/brave/src/main/java/brave/internal/WrappingExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,7 @@ public abstract class WrappingExecutorService implements ExecutorService {
 
   protected abstract ExecutorService delegate();
 
-  protected abstract <C> Callable<C> wrap(Callable<C> task);
+  protected abstract <R> Callable<R> wrap(Callable<R> task);
 
   protected abstract Runnable wrap(Runnable task);
 

--- a/brave/src/main/java/brave/internal/baggage/BaggageHandler.java
+++ b/brave/src/main/java/brave/internal/baggage/BaggageHandler.java
@@ -70,22 +70,22 @@ public interface BaggageHandler<S> {
   @Nullable S updateState(S state, BaggageField field, @Nullable String value);
 
   /**
-   * Extracts any state from a remote value received by {@link Propagation.Getter#get(Object,
+   * Extracts any state from a request value received by {@link Propagation.Getter#get(Object,
    * Object)}.
    *
-   * <p>Ex. When the state is a simple string, this will just use the remote value directly.
+   * <p>Ex. When the state is a simple string, this will just use the request value directly.
    * {@linkplain #isDynamic() Dynamic values} will need to perform some decoding, such as splitting
    * on comma and equals.
    */
-  @Nullable S fromRemoteValue(String remoteValue);
+  @Nullable S fromRequestValue(Object request, String value);
 
   /**
-   * Converts any state to a remote value used by {@link Propagation.Setter#put(Object, Object,
+   * Converts any state to a request value used by {@link Propagation.Setter#put(Object, Object,
    * String)}.
    *
    * <p>Ex. When the state is a simple string, this will just be returned with no change.
    * {@linkplain #isDynamic() Dynamic values} will need to perform some encoding, such as joining on
    * equals and comma.
    */
-  String toRemoteValue(S state);
+  String toRequestValue(S state);
 }

--- a/brave/src/main/java/brave/internal/baggage/BaggageHandlers.java
+++ b/brave/src/main/java/brave/internal/baggage/BaggageHandlers.java
@@ -57,11 +57,11 @@ public final class BaggageHandlers {
       return value; // overwrite
     }
 
-    @Override public String fromRemoteValue(String encoded) {
-      return encoded;
+    @Override public String fromRequestValue(Object request, String value) {
+      return value;
     }
 
-    @Override public String toRemoteValue(String state) {
+    @Override public String toRequestValue(String state) {
       return state;
     }
   }

--- a/brave/src/main/java/brave/internal/baggage/ExtraBaggageFields.java
+++ b/brave/src/main/java/brave/internal/baggage/ExtraBaggageFields.java
@@ -112,18 +112,19 @@ public final class ExtraBaggageFields {
   }
 
   /**
-   * Returns true if state derived from the remote value was assigned to handler.
+   * Returns true if state derived from the request value was assigned to handler.
    *
    * @see Propagation.Getter
    */
-  public boolean putRemoteValue(BaggageHandler handler, String remoteValue) {
+  public boolean putRequestValue(BaggageHandler handler, Object request, String value) {
     if (handler == null) throw new NullPointerException("handler == null");
-    if (remoteValue == null) throw new NullPointerException("remoteValue == null");
+    if (request == null) throw new NullPointerException("request == null");
+    if (value == null) throw new NullPointerException("value == null");
 
     int index = indexOf(handler);
     if (index == -1) return false;
 
-    Object state = handlers[index].fromRemoteValue(remoteValue);
+    Object state = handlers[index].fromRequestValue(request, value);
     if (state == null) return false;
     // Unsynchronized as only called during extraction when the object is new.
     putState(index, state);
@@ -131,11 +132,11 @@ public final class ExtraBaggageFields {
   }
 
   /**
-   * Returns a remote value to use for the state in this handler.
+   * Returns a request value to use for the state in this handler.
    *
    * @see Propagation.Setter
    */
-  @Nullable public String getRemoteValue(BaggageHandler handler) {
+  @Nullable public String getRequestValue(BaggageHandler handler) {
     if (handler == null) throw new NullPointerException("handler == null");
 
     int index = indexOf(handler);
@@ -143,7 +144,7 @@ public final class ExtraBaggageFields {
 
     Object maybeValue = getState(index);
     if (maybeValue == null) return null;
-    return handlers[index].toRemoteValue(maybeValue);
+    return handlers[index].toRequestValue(maybeValue);
   }
 
   final BaggageHandler[] handlers;

--- a/brave/src/main/java/brave/propagation/B3SingleFormat.java
+++ b/brave/src/main/java/brave/propagation/B3SingleFormat.java
@@ -78,7 +78,7 @@ public final class B3SingleFormat {
   }
 
   /**
-   * Like {@link #writeB3SingleFormatWithoutParentId(TraceContext)}, but for carriers with byte
+   * Like {@link #writeB3SingleFormatWithoutParentId(TraceContext)}, but for requests with byte
    * array or byte buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatWithoutParentIdAsBytes(TraceContext context) {
@@ -102,7 +102,7 @@ public final class B3SingleFormat {
   }
 
   /**
-   * Like {@link #writeB3SingleFormat(TraceContext)}, but for carriers with byte array or byte
+   * Like {@link #writeB3SingleFormat(TraceContext)}, but for requests with byte array or byte
    * buffer values. For example, {@link ByteBuffer#wrap(byte[])} can wrap the result.
    */
   public static byte[] writeB3SingleFormatAsBytes(TraceContext context) {

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -249,11 +249,11 @@ import static java.util.Collections.unmodifiableList;
     return delegate.keys();
   }
 
-  @Override public <C> Injector<C> injector(Setter<C, K> setter) {
+  @Override public <R> Injector<R> injector(Setter<R, K> setter) {
     return delegate.injector(setter);
   }
 
-  @Override public <C> Extractor<C> extractor(Getter<C, K> getter) {
+  @Override public <R> Extractor<R> extractor(Getter<R, K> getter) {
     return delegate.extractor(getter);
   }
 

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -56,14 +56,14 @@ public final class TraceContext extends SamplingFlags {
    * injector.inject(span.context(), connection);
    * }</pre>
    */
-  public interface Injector<C> {
+  public interface Injector<R> {
     /**
      * Usually calls a setter for each propagation field to send downstream.
      *
      * @param traceContext possibly unsampled.
-     * @param carrier holds propagation fields. For example, an outgoing message or http request.
+     * @param request holds propagation fields. For example, an outgoing message or http request.
      */
-    void inject(TraceContext traceContext, C carrier);
+    void inject(TraceContext traceContext, R request);
   }
 
   /**
@@ -71,15 +71,15 @@ public final class TraceContext extends SamplingFlags {
    *
    * @see brave.Tracer#nextSpan(TraceContextOrSamplingFlags)
    */
-  public interface Extractor<C> {
+  public interface Extractor<R> {
 
     /**
-     * Returns either a trace context or sampling flags parsed from the carrier. If nothing was
+     * Returns either a trace context or sampling flags parsed from the request. If nothing was
      * parsable, sampling flags will be set to {@link SamplingFlags#EMPTY}.
      *
-     * @param carrier holds propagation fields. For example, an incoming message or http request.
+     * @param request holds propagation fields. For example, an incoming message or http request.
      */
-    TraceContextOrSamplingFlags extract(C carrier);
+    TraceContextOrSamplingFlags extract(R request);
   }
 
   public static Builder newBuilder() {
@@ -363,7 +363,7 @@ public final class TraceContext extends SamplingFlags {
      * <p>Example use:
      * <pre>{@code
      * // Attempt to parse the trace ID or break out if unsuccessful for any reason
-     * String traceIdString = getter.get(carrier, key);
+     * String traceIdString = getter.get(request, key);
      * if (!builder.parseTraceId(traceIdString, propagation.traceIdKey)) {
      *   return TraceContextOrSamplingFlags.EMPTY;
      * }
@@ -414,8 +414,8 @@ public final class TraceContext extends SamplingFlags {
     }
 
     /** Parses the parent id from the input string. Returns true if the ID was missing or valid. */
-    final <C, K> boolean parseParentId(Propagation.Getter<C, K> getter, C carrier, K key) {
-      String parentIdString = getter.get(carrier, key);
+    final <R, K> boolean parseParentId(Propagation.Getter<R, K> getter, R request, K key) {
+      String parentIdString = getter.get(request, key);
       if (parentIdString == null) return true; // absent parent is ok
       int length = parentIdString.length();
       if (invalidIdLength(key, length, 16)) return false;
@@ -427,8 +427,8 @@ public final class TraceContext extends SamplingFlags {
     }
 
     /** Parses the span id from the input string. Returns true if the ID is valid. */
-    final <C, K> boolean parseSpanId(Propagation.Getter<C, K> getter, C carrier, K key) {
-      String spanIdString = getter.get(carrier, key);
+    final <R, K> boolean parseSpanId(Propagation.Getter<R, K> getter, R request, K key) {
+      String spanIdString = getter.get(request, key);
       if (isNull(key, spanIdString)) return false;
       int length = spanIdString.length();
       if (invalidIdLength(key, length, 16)) return false;

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -101,7 +101,7 @@ public final class TraceContextOrSamplingFlags {
 
   /**
    * Non-empty when {@link #context} is null: A list of additional state extracted from the
-   * carrier.
+   * request.
    *
    * @see TraceContext#extra()
    */

--- a/brave/src/test/java/brave/features/baggage/DynamicBaggageHandler.java
+++ b/brave/src/test/java/brave/features/baggage/DynamicBaggageHandler.java
@@ -77,7 +77,7 @@ final class DynamicBaggageHandler implements BaggageHandler<Map<BaggageField, St
   }
 
   @Override
-  public Map<BaggageField, String> fromRemoteValue(String encoded) {
+  public Map<BaggageField, String> fromRequestValue(Object request, String encoded) {
     Properties decoded = new Properties();
     try {
       decoded.load(new StringReader(encoded));
@@ -92,7 +92,7 @@ final class DynamicBaggageHandler implements BaggageHandler<Map<BaggageField, St
     return result;
   }
 
-  @Override public String toRemoteValue(Map<BaggageField, String> state) {
+  @Override public String toRequestValue(Map<BaggageField, String> state) {
     Properties encoded = new Properties();
     state.forEach((f, v) -> encoded.put(f.name(), v));
     StringBuilder result = new StringBuilder();

--- a/brave/src/test/java/brave/features/baggage/DynamicBaggageTest.java
+++ b/brave/src/test/java/brave/features/baggage/DynamicBaggageTest.java
@@ -64,9 +64,9 @@ public class DynamicBaggageTest extends ExtraBaggageFieldsTest {
     extraBaggageFields.updateValue(field2, "2");
     extraBaggageFields.updateValue(field3, "3");
 
-    assertThat(extraBaggageFields.getRemoteValue(singleValueHandler))
+    assertThat(extraBaggageFields.getRequestValue(singleValueHandler))
       .isEqualTo("1");
-    assertThat(extraBaggageFields.getRemoteValue(dynamicHandler))
+    assertThat(extraBaggageFields.getRequestValue(dynamicHandler))
       .contains(""
         + "two=2\n"
         + "three=3");

--- a/brave/src/test/java/brave/features/opentracing/BraveTracer.java
+++ b/brave/src/test/java/brave/features/opentracing/BraveTracer.java
@@ -70,19 +70,19 @@ final class BraveTracer implements Tracer {
     return new BraveSpanBuilder(tracer, operationName);
   }
 
-  @Override public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+  @Override public <R> void inject(SpanContext spanContext, Format<R> format, R request) {
     if (format != Format.Builtin.HTTP_HEADERS) {
       throw new UnsupportedOperationException(format + " != Format.Builtin.HTTP_HEADERS");
     }
     TraceContext traceContext = ((BraveSpanContext) spanContext).context;
-    injector.inject(traceContext, (TextMap) carrier);
+    injector.inject(traceContext, (TextMap) request);
   }
 
-  @Override public <C> BraveSpanContext extract(Format<C> format, C carrier) {
+  @Override public <R> BraveSpanContext extract(Format<R> format, R request) {
     if (format != Format.Builtin.HTTP_HEADERS) {
       throw new UnsupportedOperationException(format.toString());
     }
-    TraceContextOrSamplingFlags extractionResult = extractor.extract((TextMap) carrier);
+    TraceContextOrSamplingFlags extractionResult = extractor.extract((TextMap) request);
     return BraveSpanContext.create(extractionResult);
   }
 
@@ -91,8 +91,8 @@ final class BraveTracer implements Tracer {
   }
 
   static final Setter<TextMap, String> TEXT_MAP_SETTER = new Setter<TextMap, String>() {
-    @Override public void put(TextMap carrier, String key, String value) {
-      carrier.put(key, value);
+    @Override public void put(TextMap request, String key, String value) {
+      request.put(key, value);
     }
 
     @Override public String toString() {
@@ -102,8 +102,8 @@ final class BraveTracer implements Tracer {
 
   static final Getter<Map<String, String>, String> LC_MAP_GETTER =
     new Getter<Map<String, String>, String>() {
-      @Override public String get(Map<String, String> carrier, String key) {
-        return carrier.get(key.toLowerCase(Locale.ROOT));
+      @Override public String get(Map<String, String> request, String key) {
+        return request.get(key.toLowerCase(Locale.ROOT));
       }
 
       @Override public String toString() {

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -106,8 +106,8 @@ public class OpenTracingAdapterTest {
       .sampled(true).build();
 
     Map<String, String> map = new LinkedHashMap<>();
-    TextMapAdapter carrier = new TextMapAdapter(map);
-    opentracing.inject(new BraveSpanContext(context), Format.Builtin.HTTP_HEADERS, carrier);
+    TextMapAdapter request = new TextMapAdapter(map);
+    opentracing.inject(new BraveSpanContext(context), Format.Builtin.HTTP_HEADERS, request);
 
     assertThat(map).containsExactly(
       entry("X-B3-TraceId", "0000000000000001"),

--- a/brave/src/test/java/brave/features/propagation/package-info.java
+++ b/brave/src/test/java/brave/features/propagation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,6 @@
 /**
  * Before, we had the same algorithm for encoding B3 copy pasted a couple times. We now have a type
  * {@link brave.propagation.Propagation} which supplies an implementation such as B3. This includes
- * common functions such as how to extract and inject based on map-like carriers.
+ * common functions such as how to extract and inject header-based requests.
  */
 package brave.features.propagation;

--- a/instrumentation/benchmarks/src/main/java/brave/baggage/BaggagePropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/baggage/BaggagePropagationBenchmarks.java
@@ -74,8 +74,8 @@ public class BaggagePropagationBenchmarks {
   static final Map<String, String> nothingIncoming = Collections.emptyMap();
 
   @Benchmark public void inject() {
-    Map<String, String> carrier = new LinkedHashMap<>();
-    injector.inject(context, carrier);
+    Map<String, String> request = new LinkedHashMap<>();
+    injector.inject(context, request);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract() {

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/B3PropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/B3PropagationBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -73,8 +73,8 @@ public class B3PropagationBenchmarks {
   static final Map<String, String> nothingIncoming = Collections.emptyMap();
 
   @Benchmark public void inject() {
-    Map<String, String> carrier = new LinkedHashMap<>();
-    b3Injector.inject(context, carrier);
+    Map<String, String> request = new LinkedHashMap<>();
+    b3Injector.inject(context, request);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract() {

--- a/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/propagation/B3SinglePropagationBenchmarks.java
@@ -82,8 +82,8 @@ public class B3SinglePropagationBenchmarks {
   static final Map<String, String> nothingIncoming = Collections.emptyMap();
 
   @Benchmark public void inject() {
-    Map<String, String> carrier = new LinkedHashMap<>();
-    b3Injector.inject(context, carrier);
+    Map<String, String> request = new LinkedHashMap<>();
+    b3Injector.inject(context, request);
   }
 
   @Benchmark public TraceContextOrSamplingFlags extract_128() {

--- a/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestSetterTest.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/GrpcClientRequestSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,7 +29,7 @@ public class GrpcClientRequestSetterTest
     return AsciiMetadataKeyFactory.INSTANCE;
   }
 
-  @Override protected GrpcClientRequest carrier() {
+  @Override protected GrpcClientRequest request() {
     return request;
   }
 

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -182,7 +182,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
    * @deprecated Since 5.7, use {@link #handleSend(HttpClientRequest)}.
    */
   @Deprecated public <C> Span handleSend(Injector<C> injector, C carrier, Req request, Span span) {
-    if (request == null) throw new NullPointerException("request == null");
+    if (request == null) throw new NullPointerException("carrier == null");
     if (span == null) throw new NullPointerException("span == null");
 
     injector.inject(span.context(), carrier);

--- a/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientRequest.java
@@ -26,8 +26,8 @@ import brave.propagation.TraceContext;
  */
 public abstract class HttpClientRequest extends HttpRequest {
   static final Setter<HttpClientRequest, String> SETTER = new Setter<HttpClientRequest, String>() {
-    @Override public void put(HttpClientRequest carrier, String key, String value) {
-      carrier.header(key, value);
+    @Override public void put(HttpClientRequest request, String key, String value) {
+      request.header(key, value);
     }
 
     @Override public String toString() {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -123,7 +123,7 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
    * @deprecated Since 5.7, use {@link #handleReceive(HttpServerRequest)}
    */
   @Deprecated public <C> Span handleReceive(Extractor<C> extractor, C carrier, Req request) {
-    if (request == null) throw new NullPointerException("request == null");
+    if (carrier == null) throw new NullPointerException("request == null");
 
     HttpServerRequest serverRequest;
     if (request instanceof HttpServerRequest) {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerRequest.java
@@ -25,8 +25,8 @@ import brave.propagation.Propagation.Getter;
  */
 public abstract class HttpServerRequest extends HttpRequest {
   static final Getter<HttpServerRequest, String> GETTER = new Getter<HttpServerRequest, String>() {
-    @Override public String get(HttpServerRequest carrier, String key) {
-      return carrier.header(key);
+    @Override public String get(HttpServerRequest request, String key) {
+      return request.header(key);
     }
 
     @Override public String toString() {

--- a/instrumentation/http/src/test/java/brave/http/DeprecatedHttpClientHandlerTest.java
+++ b/instrumentation/http/src/test/java/brave/http/DeprecatedHttpClientHandlerTest.java
@@ -95,11 +95,11 @@ import static org.mockito.Mockito.when;
     verify(injector).inject(context, request);
   }
 
-  @Test public void handleSend_injectsTheTraceContext_onTheCarrier() {
-    HttpClientRequest customCarrier = mock(HttpClientRequest.class);
-    TraceContext context = handler.handleSend(injector, customCarrier, request).context();
+  @Test public void handleSend_injectsTheTraceContext_onTheRequest() {
+    HttpClientRequest customRequest = mock(HttpClientRequest.class);
+    TraceContext context = handler.handleSend(injector, customRequest, request).context();
 
-    verify(injector).inject(context, customCarrier);
+    verify(injector).inject(context, customRequest);
   }
 
   @Test public void handleSend_addsClientAddressWhenOnlyServiceName() {

--- a/instrumentation/http/src/test/java/brave/http/HttpClientRequestSetterTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientRequestSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,7 +28,7 @@ public class HttpClientRequestSetterTest extends PropagationSetterTest<HttpClien
     return Propagation.KeyFactory.STRING;
   }
 
-  @Override protected HttpClientRequest carrier() {
+  @Override protected HttpClientRequest request() {
     return new HttpClientRequest() {
       @Override public Object unwrap() {
         return null;
@@ -61,7 +61,7 @@ public class HttpClientRequestSetterTest extends PropagationSetterTest<HttpClien
     return SETTER;
   }
 
-  @Override protected Iterable<String> read(HttpClientRequest carrier, String key) {
+  @Override protected Iterable<String> read(HttpClientRequest request, String key) {
     String result = headers.get(key);
     return result != null ? Collections.singletonList(result) : Collections.emptyList();
   }

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,13 +21,13 @@ import org.apache.kafka.common.header.Headers;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 final class KafkaPropagation {
-  static final Setter<Headers, String> SETTER = (carrier, key, value) -> {
-    carrier.remove(key);
-    carrier.add(key, value.getBytes(UTF_8));
+  static final Setter<Headers, String> SETTER = (headers, key, value) -> {
+    headers.remove(key);
+    headers.add(key, value.getBytes(UTF_8));
   };
 
-  static final Getter<Headers, String> GETTER = (carrier, key) -> {
-    Header header = carrier.lastHeader(key);
+  static final Getter<Headers, String> GETTER = (headers, key) -> {
+    Header header = headers.lastHeader(key);
     if (header == null || header.value() == null) return null;
     return new String(header.value(), UTF_8);
   };

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -205,13 +205,13 @@ public class ITKafkaTracing extends ITKafka {
       return Collections.singletonList(key);
     }
 
-    @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
-      return (traceContext, carrier) -> setter.put(carrier, key, traceContext.traceIdString());
+    @Override public <R> TraceContext.Injector<R> injector(Setter<R, K> setter) {
+      return (traceContext, request) -> setter.put(request, key, traceContext.traceIdString());
     }
 
-    @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
-      return carrier -> {
-        String result = getter.get(carrier, key);
+    @Override public <R> TraceContext.Extractor<R> extractor(Getter<R, K> getter) {
+      return request -> {
+        String result = getter.get(request, key);
         if (result == null) return TraceContextOrSamplingFlags.create(SamplingFlags.EMPTY);
         return TraceContextOrSamplingFlags.create(TraceIdContext.newBuilder()
           .traceId(HexCodec.lowerHexToUnsignedLong(result))

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaConsumerRequestSetterTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaConsumerRequestSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class KafkaConsumerRequestSetterTest
   extends PropagationSetterTest<KafkaConsumerRequest, String> {
-  KafkaConsumerRequest carrier = new KafkaConsumerRequest(
+  KafkaConsumerRequest request = new KafkaConsumerRequest(
     new ConsumerRecord<>("topic", 0, 1L, "key", "value")
   );
 
@@ -31,16 +31,16 @@ public class KafkaConsumerRequestSetterTest
     return Propagation.KeyFactory.STRING;
   }
 
-  @Override protected KafkaConsumerRequest carrier() {
-    return carrier;
+  @Override protected KafkaConsumerRequest request() {
+    return request;
   }
 
   @Override protected Propagation.Setter<KafkaConsumerRequest, String> setter() {
     return KafkaConsumerRequest::setHeader;
   }
 
-  @Override protected Iterable<String> read(KafkaConsumerRequest carrier, String key) {
-    return StreamSupport.stream(carrier.delegate.headers().headers(key).spliterator(), false)
+  @Override protected Iterable<String> read(KafkaConsumerRequest request, String key) {
+    return StreamSupport.stream(request.delegate.headers().headers(key).spliterator(), false)
       .map(h -> new String(h.value(), UTF_8))
       .collect(Collectors.toList());
   }

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsPropagation.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,15 +21,15 @@ import org.apache.kafka.common.header.Headers;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 final class KafkaStreamsPropagation {
-  static final Getter<Headers, String> GETTER = (carrier, key) -> {
-    Header header = carrier.lastHeader(key);
+  static final Getter<Headers, String> GETTER = (headers, key) -> {
+    Header header = headers.lastHeader(key);
     if (header == null) return null;
     return new String(header.value(), UTF_8);
   };
 
-  static final Setter<Headers, String> SETTER = (carrier, key, value) -> {
-    carrier.remove(key);
-    carrier.add(key, value.getBytes(UTF_8));
+  static final Setter<Headers, String> SETTER = (headers, key, value) -> {
+    headers.remove(key);
+    headers.add(key, value.getBytes(UTF_8));
   };
 
   KafkaStreamsPropagation() {

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitPropagation.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,8 +19,8 @@ import org.springframework.amqp.core.MessageProperties;
 
 final class SpringRabbitPropagation {
   static final Setter<MessageProperties, String> SETTER = new Setter<MessageProperties, String>() {
-    @Override public void put(MessageProperties carrier, String key, String value) {
-      carrier.setHeader(key, value);
+    @Override public void put(MessageProperties properties, String key, String value) {
+      properties.setHeader(key, value);
     }
 
     @Override public String toString() {
@@ -29,8 +29,8 @@ final class SpringRabbitPropagation {
   };
 
   static final Getter<MessageProperties, String> GETTER = new Getter<MessageProperties, String>() {
-    @Override public String get(MessageProperties carrier, String key) {
-      return (String) carrier.getHeaders().get(key);
+    @Override public String get(MessageProperties properties, String key) {
+      return (String) properties.getHeaders().get(key);
     }
 
     @Override public String toString() {

--- a/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/MessagePropertiesSetterTest.java
+++ b/instrumentation/spring-rabbit/src/test/java/brave/spring/rabbit/MessagePropertiesSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,22 +22,22 @@ import static brave.spring.rabbit.SpringRabbitPropagation.GETTER;
 import static brave.spring.rabbit.SpringRabbitPropagation.SETTER;
 
 public class MessagePropertiesSetterTest extends PropagationSetterTest<MessageProperties, String> {
-  MessageProperties carrier = new MessageProperties();
+  MessageProperties properties = new MessageProperties();
 
   @Override public Propagation.KeyFactory<String> keyFactory() {
     return Propagation.KeyFactory.STRING;
   }
 
-  @Override protected MessageProperties carrier() {
-    return carrier;
+  @Override protected MessageProperties request() {
+    return properties;
   }
 
   @Override protected Propagation.Setter<MessageProperties, String> setter() {
     return SETTER;
   }
 
-  @Override protected Iterable<String> read(MessageProperties carrier, String key) {
-    String result = GETTER.get(carrier, key);
+  @Override protected Iterable<String> read(MessageProperties properties, String key) {
+    String result = GETTER.get(properties, key);
     return result == null ? Collections.emptyList() : Collections.singleton(result);
   }
 }


### PR DESCRIPTION
We prematurely adopted the confusing term "carrier" when trying to work
with OpenTracing years ago. This removes that term for request
everywhere. This does not break any api, as the only thing besides
parameter renames are test methods.

This is in preparation of a future Brave 6 world where ideally no one
will ever need to be confused about what "carrier" is, only for us to
say "an awkward word for request".