### PR TITLE
Makes Dubbo Error code words not numbers

### DIFF
--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -32,7 +32,7 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
     <!-- Use brave-instrumentation-dubbo for Apache Dubbo 2.7+, not this module. -->
-    <dubbo.version>2.6.7</dubbo.version>
+    <dubbo.version>2.6.8</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboParser.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboParser.java
@@ -69,19 +69,28 @@ final class DubboParser {
   }
 
   /**
-   * We decided to not map Dubbo codes to human readable names like {@link
-   * RpcException#BIZ_EXCEPTION} even though we defined "rpc.error_code" as a human readable name.
-   *
-   * <p>The reason was a comparison with HTTP status codes, and the choice was between returning
-   * just numbers or reusing "UNKNOWN_EXCEPTION" which is defined in Dubbo for code "0" for any
-   * unknown code. Returning numbers was the less bad option as it doesn't conflate code words.
-   *
-   * <p>Later, we can revert this back to code words, but once this gets into the RPC mapping for
-   * Dubbo it will be hard to change.
+   * This library is no-longer being released, so it should not have any maintenance on error codes.
+   * The error codes here were defined in 2012.
    */
   @Nullable static String errorCode(Throwable error) {
     if (error instanceof RpcException) {
-      return String.valueOf(((RpcException) error).getCode());
+      int code = ((RpcException) error).getCode();
+      switch (code) {
+        case RpcException.UNKNOWN_EXCEPTION:
+          return "UNKNOWN_EXCEPTION";
+        case RpcException.NETWORK_EXCEPTION:
+          return "NETWORK_EXCEPTION";
+        case RpcException.TIMEOUT_EXCEPTION:
+          return "TIMEOUT_EXCEPTION";
+        case RpcException.BIZ_EXCEPTION:
+          return "BIZ_EXCEPTION";
+        case RpcException.FORBIDDEN_EXCEPTION:
+          return "FORBIDDEN_EXCEPTION";
+        case RpcException.SERIALIZATION_EXCEPTION:
+          return "SERIALIZATION_EXCEPTION";
+        default:
+          return String.valueOf(code);
+      }
     }
     return null;
   }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboParserTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboParserTest.java
@@ -112,10 +112,19 @@ public class DubboParserTest {
       .isEqualTo(DubboParser.errorCode(new IOException("timeout")))
       .isNull();
 
-    // Prove that we don't map codes to human readable names defined in RpcException
-    for (int i = 0; i < 6; i++) {
-      assertThat(DubboParser.errorCode(new RpcException(i)))
-        .isEqualTo(String.valueOf(i));
-    }
+    assertThat(DubboParser.errorCode(new RpcException(0)))
+      .isEqualTo("UNKNOWN_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(1)))
+      .isEqualTo("NETWORK_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(2)))
+      .isEqualTo("TIMEOUT_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(3)))
+      .isEqualTo("BIZ_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(4)))
+      .isEqualTo("FORBIDDEN_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(5)))
+      .isEqualTo("SERIALIZATION_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(6)))
+      .isEqualTo("6"); // this will catch drift if Dubbo adds another code
   }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
@@ -188,7 +188,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     Span span =
       reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, ".*Not found exported service.*");
-    assertThat(span.tags().get("dubbo.error_code")).isEqualTo("1");
+    assertThat(span.tags().get("dubbo.error_code")).isEqualTo("NETWORK_EXCEPTION");
   }
 
   /** Ensures the span completes on asynchronous invocation. */

--- a/instrumentation/dubbo/RATIONALE.md
+++ b/instrumentation/dubbo/RATIONALE.md
@@ -1,0 +1,25 @@
+# brave-instrumentation-dubbo rationale
+
+## Error code words not numbers
+Similar to [RPC](../rpc/RATIONALE.md), we use error code names, not numbers in
+Dubbo.
+
+HTTP status codes are grouped by classification, and have existed so long that
+support teams can usually identify meaning by looking at a number like 401.
+Being triple digits, it is relatively easy to search for what an HTTP status
+means.
+
+Dubbo code numbers are more like enum ordinals. There's no grouping and it is
+not easy to identify a problem quickly by seeing a number like 2 vs the code
+name "TIMEOUT_EXCEPTION". There is no generic documentation on Dubbo errors. If
+given only the number 2, a user unfamiliar with how Dubbo works internally will
+have a hard time. For example, searching Dubbo's code base for "2" will return
+less relevant results than searching for "TIMEOUT_EXCEPTION".
+
+It may seem that exception messages can overcome this problem, and they
+certainly can when present. Also, exception messages can be localized. However,
+exception messages are not good for trace search because they are long and
+contain variables.
+
+For all these reasons, we use code names, not numbers, for Dubbo, as defined in
+`RpcException`'s constants (so that they are easy to search).

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboParser.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboParser.java
@@ -43,7 +43,11 @@ final class DubboParser {
   static Map<Integer, String> errorCodeNumberToName() {
     Map<Integer, String> result = new LinkedHashMap<>();
     for (Field field : RpcException.class.getDeclaredFields()) {
-      if (Modifier.isStatic(field.getModifiers()) && field.getType() == int.class) {
+      if (Modifier.isPublic(field.getModifiers())
+        && Modifier.isStatic(field.getModifiers())
+        && Modifier.isFinal(field.getModifiers())
+        && field.getType() == int.class
+      ) {
         try {
           result.put((Integer) field.get(null), field.getName());
         } catch (Exception e) {

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboParser.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboParser.java
@@ -70,19 +70,32 @@ final class DubboParser {
   }
 
   /**
-   * We decided to not map Dubbo codes to human readable names like {@link
-   * RpcException#BIZ_EXCEPTION} even though we defined "rpc.error_code" as a human readable name.
-   *
-   * <p>The reason was a comparison with HTTP status codes, and the choice was between returning
-   * just numbers or reusing "UNKNOWN_EXCEPTION" which is defined in Dubbo for code "0" for any
-   * unknown code. Returning numbers was the less bad option as it doesn't conflate code words.
-   *
-   * <p>Later, we can revert this back to code words, but once this gets into the RPC mapping for
-   * Dubbo it will be hard to change.
+   * On occasion, (roughly once a year) Dubbo adds more error code numbers. When this occurs, do
+   * not use the symbol name, in the switch statement, as it will affect the minimum version.
    */
   @Nullable static String errorCode(Throwable error) {
     if (error instanceof RpcException) {
-      return String.valueOf(((RpcException) error).getCode());
+      int code = ((RpcException) error).getCode();
+      switch (code) { // requires maintenance if constants are updated
+        case RpcException.UNKNOWN_EXCEPTION:
+          return "UNKNOWN_EXCEPTION";
+        case RpcException.NETWORK_EXCEPTION:
+          return "NETWORK_EXCEPTION";
+        case RpcException.TIMEOUT_EXCEPTION:
+          return "TIMEOUT_EXCEPTION";
+        case RpcException.BIZ_EXCEPTION:
+          return "BIZ_EXCEPTION";
+        case RpcException.FORBIDDEN_EXCEPTION:
+          return "FORBIDDEN_EXCEPTION";
+        case RpcException.SERIALIZATION_EXCEPTION:
+          return "SERIALIZATION_EXCEPTION";
+        case RpcException.NO_INVOKER_AVAILABLE_AFTER_FILTER:
+          return "NO_INVOKER_AVAILABLE_AFTER_FILTER";
+        case 7: // RpcException.LIMIT_EXCEEDED_EXCEPTION Added in 2.7.3
+          return "LIMIT_EXCEEDED_EXCEPTION";
+        default:
+          return String.valueOf(code);
+      }
     }
     return null;
   }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
@@ -129,6 +129,6 @@ public class DubboParserTest {
     assertThat(DubboParser.errorCode(new RpcException(7)))
       .isEqualTo("LIMIT_EXCEEDED_EXCEPTION");
     assertThat(DubboParser.errorCode(new RpcException(8)))
-      .isEqualTo("8"); // this will catch drift if Dubbo adds another code
+      .isNull(); // This test will drift with a new error code name if Dubbo adds one.
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
@@ -112,10 +112,23 @@ public class DubboParserTest {
       .isEqualTo(DubboParser.errorCode(new IOException("timeout")))
       .isNull();
 
-    // Prove that we don't map codes to human readable names defined in RpcException
-    for (int i = 0; i < 8; i++) {
-      assertThat(DubboParser.errorCode(new RpcException(i)))
-        .isEqualTo(String.valueOf(i));
-    }
+    assertThat(DubboParser.errorCode(new RpcException(0)))
+      .isEqualTo("UNKNOWN_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(1)))
+      .isEqualTo("NETWORK_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(2)))
+      .isEqualTo("TIMEOUT_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(3)))
+      .isEqualTo("BIZ_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(4)))
+      .isEqualTo("FORBIDDEN_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(5)))
+      .isEqualTo("SERIALIZATION_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(6)))
+      .isEqualTo("NO_INVOKER_AVAILABLE_AFTER_FILTER");
+    assertThat(DubboParser.errorCode(new RpcException(7)))
+      .isEqualTo("LIMIT_EXCEEDED_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(8)))
+      .isEqualTo("8"); // this will catch drift if Dubbo adds another code
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -240,6 +240,6 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     Span span =
       reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, ".*Not found exported service.*");
-    assertThat(span.tags().get("dubbo.error_code")).isEqualTo("1");
+    assertThat(span.tags().get("dubbo.error_code")).isEqualTo("NETWORK_EXCEPTION");
   }
 }


### PR DESCRIPTION
This makes "dubbo.error_code" use the code name, like "TIMEOUT_EXCEPTION", as
opposed to the code number like 2.

This primarily matches conventions being defined in #999, where we prefer error
code names over numbers. The below rationale is a copy/paste from the new
RATIONALE.md for Dubbo, and helps explain the subtle points here vs HTTP status.

---

HTTP status codes are grouped by classification, and have existed so long that
support teams can usually identify meaning by looking at a number like 401.
Being triple digits, it is relatively easy to search for what an HTTP status
means.

Dubbo code numbers are more like enum ordinals. There's no grouping and it is
not easy to identify a problem quickly by seeing a number like 2 vs the code
name "TIMEOUT_EXCEPTION". There is no generic documentation on Dubbo errors. If
given only the number 2, a user unfamiliar with how Dubbo works internally will
have a hard time. For example, searching Dubbo's code base for "2" will return
less relevant results than searching for "TIMEOUT_EXCEPTION".

It may seem that exception messages can overcome this problem, and they
certainly can when present. Also, exception messages can be localized. However,
exception messages are not good for trace search because they are long and
contain variables.

For all these reasons, we use code names, not numbers, for Dubbo, as defined in
`RpcException`'s constants (so that they are easy to search).