### PR TITLE
Refreshes main README about Request tracing

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -167,21 +167,14 @@ void userCode() {
 }
 ```
 
-### Request tracing
-Check for [instrumentation written here](../instrumentation/) and [Zipkin's list](https://zipkin.io/pages/existing_instrumentations.html)
-before rolling your own Request instrumentation!
+### Remote spans
+Check for [instrumentation and abstractions](../instrumentation/) and [Zipkin's list](https://zipkin.io/pages/existing_instrumentations.html)
+for common patterns like client-server or messaging communication. Please at
+least read [this doc](../instrumentation/README.md) before deciding to write
+your own code to represent remote communication.
 
-Brave includes two fundamental types to support tracing interprocess
-communication `brave.Request` and `brave.Response`. These types represent the
-following communication patterns, defined by the [Zipkin Api][https://zipkin.io/zipkin-api/#/default/post_spans]
-and returned by `spanKind()`:
-
- * CLIENT
- * SERVER
- * PRODUCER
- * CONSUMER
-
-Once you model your request, you generally need to...
+If you really think that the existing abstractions do not match your need, and
+you want to model your request yourself, you generally need to...
 1. Start the span and add trace headers to the request
 2. Put the span in scope so things like log integration works
 3. Invoke the request
@@ -206,20 +199,6 @@ try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
   span.finish(); // 5.
 }
 ```
-
-The above code is example only. Abstractions exist that handle aspects
-including sampling, header processing and data parsing:
- * [HTTP](../instrumentation/http/README.md) is CLIENT/SERVER
- * [Messaging](../instrumentation/rpc/README.md) is PRODUCER/CONSUMER
- * [RPC](../instrumentation/rpc/README.md) is CLIENT/SERVER
-
-You should use these abstractions instead of modeling your own, as there are
-modeling gotchas that might not be intuitive at first. For example, a common
-mistake is using CLIENT kind for long lived connections such as database pools
-or chat sessions. Doing so, however, can result in confusing data, such as
-incorrect service diagrams or server calls being attached to the wrong trace.
-If you have doubts, please chat with a maintainer on [Gitter](https://gitter.im/openzipkin/zipkin]
-as it might save you grief later!
 
 ## Sampling
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -140,7 +140,7 @@ work.
 
 If you end up in a position where you still believe you need a custom model,
 please contact us before committing to it. There may be an alternative not yet
-documented, that might prefer. Moreover, folks usually want support and we
+documented, you might prefer. Moreover, folks usually want support and we
 cannot support every idea. It is better to understand this before you commit to
 something bespoke. In short, please reach out on [gitter](https://gitter.im/openzipkin/zipkin),
 as there are usually others around to help.

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -95,14 +95,52 @@ We worked very hard to make writing new instrumentation easy and efficient.
 Most of our built-in instrumentation are 50-100 lines of code, yet allow
 flexible configuration of tags and sampling policy.
 
-If you need to write new http instrumentation, check [our docs](http/README.md),
-as this shows how to write it in a way that is least effort for you and
-easy for others to configure. For example, we have a standard [test suite](http-tests)
-you can use to make sure things interop, and standard configuration works.
+Brave includes two fundamental types to support tracing interprocess
+communication `brave.Request` and `brave.Response`. These types represent the
+following communication patterns, defined by the [Zipkin Api][https://zipkin.io/zipkin-api/#/default/post_spans]
+and returned by `spanKind()`:
 
-If you need to do something not http, you'll want to use our [tracer library](../brave/README.md).
-If you are in this position, you may find our [feature tests](../brave/src/test/java/brave/features)
-helpful.
+ * CLIENT
+ * SERVER
+ * PRODUCER
+ * CONSUMER
 
-Regardless, you may need support along the way. Please reach out on [gitter](https://gitter.im/openzipkin/zipkin),
-as there's usually others around to help.
+Brave includes abstractions for the above that handle aspects including
+sampling, header processing and data parsing:
+ * [HTTP](http/README.md) is CLIENT/SERVER
+ * [Messaging](messaging/README.md) is PRODUCER/CONSUMER
+ * [RPC](rpc/README.md) is CLIENT/SERVER
+
+You should use these abstractions instead of modeling your own. Not only are
+they well thought through, but they also include tests to prevent common
+mistakes. For example, [HTTP tests](http-tests) makes sure spans are modeled
+consistently and uniform configuration works.
+
+Using abstractions also helps avoid modeling gotchas that might not be
+intuitive at first.
+
+For example, a common mistake is using CLIENT kind for long lived connections
+such as database pools or chat sessions. Doing so, however, can result in
+confusing data, such as incorrect service diagrams or server calls being
+attached to the wrong trace.
+
+It is also a common misconception that a grouping of CLIENT spans should itself
+be a CLIENT span. A logical span that serves only to group others, is a local
+span (Span.kind() is unset). CLIENT spans represent a single remote request. It
+is relatively common to use a local span as the parent of multiple CLIENT
+requests, or to represent a single request that was served from a local cache.
+
+Some features that already exist are subtle, yet proven with tests. It is best
+to look for tests in the "features" package before deciding something doesn't
+work.
+* [Core feature tests](../brave/src/test/java/brave/features)
+* [HTTP feature tests](http-tests/src/test/java/brave/http/features)
+* [Messaging feature tests](messaging/src/test/java/brave/rpc/features)
+* [RPC feature tests](rpc/src/test/java/brave/rpc/features)
+
+If you end up in a position where you still believe you need a custom model,
+please contact us before committing to it. There may be an alternative not yet
+documented, that might prefer. Moreover, folks usually want support and we
+cannot support every idea. It is better to understand this before you commit to
+something bespoke. In short, please reach out on [gitter](https://gitter.im/openzipkin/zipkin),
+as there are usually others around to help.


### PR DESCRIPTION
This attempts to clarify the main README to reduce grief for folks who read it.
Particularly, sometimes we get people modeling different things, such as local
activity or long-lived connections as CLIENT spans.

See https://github.com/openzipkin/zipkin-support/issues/2