### PR TITLE
Adds rationale for client response callback context

### DIFF
--- a/instrumentation/RATIONALE.md
+++ b/instrumentation/RATIONALE.md
@@ -87,6 +87,9 @@ rate, if a data dependency is important, you can consider mapping it as a tag.
 This rationale was first mentioned in the below javascript issue.
 https://github.com/openzipkin/zipkin-js/issues/176#issuecomment-355636603
 
+It was later built upon during an [Armeria](https://github.com/line/armeria) pow-wow:
+https://github.com/openzipkin/openzipkin.github.io/wiki/2018-08-06-Zipkin-and-Armeria-at-LINE-Fukuoka#teaching-brave-to-use-armerias-requestcontext
+
 ## Calling `Span.finish()` while the context is in scope
 Instrumentation should call `Span.finish()` with the same context in scope as
 opposed to clearing or using a different span context.

--- a/instrumentation/RATIONALE.md
+++ b/instrumentation/RATIONALE.md
@@ -2,6 +2,91 @@
 Rationale here applies to common decisions made in this directory. See
 [Brave's RATIONALE](../brave/RATIONALE.md) for internal rationale.
 
+## Why does the client response callback run in the invocation context?
+This rationale applies equally to CLIENT and PRODUCER spans.
+
+Asynchronous code is often modeled in terms of callbacks. For example, the
+following pseudo code represents a chain of 3 client calls.
+```java
+ScopedSpan parent = tracer.startScopedSpan("parent");
+try {
+  client.call("1")
+        .flatMap((r) -> client.call("2"))
+        .flatMap((r) -> client.call("3"));
+} finally {
+  parent.finish();
+}
+```
+
+It might be surprising that calls "2" and "3" execute in the "parent" trace
+context, as opposed to the preceding client call. Put another way, response
+callbacks run in the invocation context, which cause new spans to appear as
+as a siblings, as opposed to children of the previous callback (in this case
+a client).
+
+This may sound intuitive to those thinking in terms of callback nesting depth,
+but having a consistent structure allows traces to appear similar regardless of
+imperative vs async invocation. It also is more easy to reason with, but we'll
+touch on that later.
+
+Let's consider the above async pseudo code with the logical equivalent in
+synchronous code. In each case, there are 3 client calls made in sequence. In
+each case, there's a potential data dependency, but it isn't actually used!
+```java
+// synchronous
+ScopedSpan parent = tracer.startScopedSpan("parent");
+try {
+  client.call("1");
+  client.call("2");
+  client.call("3");
+} finally {
+  parent.finish();
+}
+
+// asynchronous
+ScopedSpan parent = tracer.startScopedSpan("parent");
+try {
+  client.call("1")
+        .flatMap((r) -> client.call("2"))
+        .flatMap((r) -> client.call("3"));
+} finally {
+  parent.finish();
+}
+```
+
+We mention that data is ignored to highlight one deduction one can make, which
+is that the hierarchy should represent data dependency, as opposed to logical
+or time wise. While this is interesting, it is difficult to execute in
+practice. Instrumentation are usually at a lower level than the application
+code that they run. Hierarchy is already chosen before it would know if data
+would be read or not. In most cases, it would be unknowable if data were read
+or used at that level of abstraction. In other words, such a relationship is
+more fitting for span tags at a higher level, and decoupled from span
+hierarchy.
+
+Even throwing out the data dependency argument, some may think why not model
+callback depth anyway? We should model spans how the code looks, right?
+
+Only three calls may not seem that bad. Perhaps it is easy to reason with
+what's going on. However, what if there were 100 or 1000? It would be very
+difficult to reason with the actual parent which may be 999 levels up the tree.
+Some backend code perform operations like counting children, in order to
+determine fan out counts. This code would become useless as there would only
+ever be one child! Put visually, imagine clicking '-' 999 times to find the
+real parent in a typical trace UI!
+
+We acknowledge that using the invocation context as the parent of follow-up
+requests (response callback) is imperfect. It means any data dependency between
+one response and the next request is not represented in the hierarchy. It also
+means callback depth with not manifest in the trace hierarchy. That said,
+follow-up requests still share not just the same trace, but also the same local
+root, and also direct parent. As the clocks are the same (and in fact locked
+against skew), the happens after relationship manifests in span timing. At any
+rate, if a data dependency is important, you can consider mapping it as a tag.
+
+This rationale was first mentioned in the below javascript issue.
+https://github.com/openzipkin/zipkin-js/issues/176#issuecomment-355636603
+
 ## Calling `Span.finish()` while the context is in scope
 Instrumentation should call `Span.finish()` with the same context in scope as
 opposed to clearing or using a different span context.

--- a/instrumentation/RATIONALE.md
+++ b/instrumentation/RATIONALE.md
@@ -24,7 +24,7 @@ callbacks run in the invocation context, which cause new spans to appear as
 as a siblings, as opposed to children of the previous callback (in this case
 a client).
 
-This may sound intuitive to those thinking in terms of callback nesting depth,
+This may sound unintuitive to those thinking in terms of callback nesting depth,
 but having a consistent structure allows traces to appear similar regardless of
 imperative vs async invocation. It also is more easy to reason with, but we'll
 touch on that later.

--- a/instrumentation/RATIONALE.md
+++ b/instrumentation/RATIONALE.md
@@ -8,11 +8,15 @@ This rationale applies equally to CLIENT and PRODUCER spans.
 Asynchronous code is often modeled in terms of callbacks. For example, the
 following pseudo code represents a chain of 3 client calls.
 ```java
+// Assume you are reactive: assembling a call doesn't invoke it.
+call = client.call("1")
+             .flatMap((r) -> client.call("2"))
+             .flatMap((r) -> client.call("3"));
+
 ScopedSpan parent = tracer.startScopedSpan("parent");
 try {
-  client.call("1")
-        .flatMap((r) -> client.call("2"))
-        .flatMap((r) -> client.call("3"));
+  // In reactive style, subscribe attaches the trace context
+  call.subscribe(subscriber);
 } finally {
   parent.finish();
 }
@@ -43,12 +47,14 @@ try {
   parent.finish();
 }
 
-// asynchronous
+// reactive
+call = client.call("1")
+             .flatMap((r) -> client.call("2"))
+             .flatMap((r) -> client.call("3"));
+
 ScopedSpan parent = tracer.startScopedSpan("parent");
 try {
-  client.call("1")
-        .flatMap((r) -> client.call("2"))
-        .flatMap((r) -> client.call("3"));
+  call.subscribe(subscriber);
 } finally {
   parent.finish();
 }


### PR DESCRIPTION
I'm raising this as we've had many PRs to fix this over time, but no centralized rationale to discuss it. My motivation is to link gRPC rationale to this, but that can be decoupled.

This is a very long explanation derived from ideas sparked by @eirslett's initial rationale over 2 years ago https://github.com/openzipkin/zipkin-js/issues/176#issuecomment-355636603

It was later expanded upon during an [Armeria](https://github.com/line/armeria) pow-wow with @anuraag @kojilin and @trustin.
https://github.com/openzipkin/openzipkin.github.io/wiki/2018-08-06-Zipkin-and-Armeria-at-LINE-Fukuoka#teaching-brave-to-use-armerias-requestcontext

cc @openzipkin/core 

#1014
#1095
#1067
https://github.com/openzipkin/brave/commit/cf3b13836b81895500d8a8cf0ee2484aae304c6a
