### PR TITLE
Deprecates gRPC message processing via GrpcParser

### DIFF
--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientParser.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcClientParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package brave.grpc;
 
 import brave.SpanCustomizer;
 import io.grpc.CallOptions;
+import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
@@ -23,5 +24,21 @@ public class GrpcClientParser extends GrpcParser {
   protected <ReqT, RespT> void onStart(MethodDescriptor<ReqT, RespT> method, CallOptions options,
     Metadata headers, SpanCustomizer span) {
     span.name(spanName(method));
+  }
+
+  /**
+   * @since 4.8
+   * @deprecated Since 5.12 use {@link ClientCall#sendMessage(Object)}.
+   */
+  @Deprecated @Override protected <M> void onMessageSent(M message, SpanCustomizer span) {
+    super.onMessageSent(message, span);
+  }
+
+  /**
+   * @since 4.8
+   * @deprecated Since 5.12 use {@link ClientCall.Listener#onMessage(Object)}.
+   */
+  @Deprecated @Override protected <M> void onMessageReceived(M message, SpanCustomizer span) {
+    super.onMessageReceived(message, span);
   }
 }

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcParser.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcParser.java
@@ -17,8 +17,10 @@ import brave.ErrorParser;
 import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.internal.Nullable;
+import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
 import io.grpc.Status;
 
 public class GrpcParser {
@@ -48,12 +50,20 @@ public class GrpcParser {
     return methodDescriptor.getFullMethodName();
   }
 
-  /** Override to customize the span based on a message sent to the peer. */
-  protected <M> void onMessageSent(M message, SpanCustomizer span) {
+  /**
+   * @since 4.8
+   * @deprecated Since 5.12 use {@link ClientCall#sendMessage(Object)} or {@link
+   * ServerCall.Listener#onMessage(Object)}.
+   */
+  @Deprecated protected <M> void onMessageSent(M message, SpanCustomizer span) {
   }
 
-  /** Override to customize the span based on the message received from the peer. */
-  protected <M> void onMessageReceived(M message, SpanCustomizer span) {
+  /**
+   * @since 4.8
+   * @deprecated Since 5.12 use {@link ClientCall.Listener#onMessage(Object)} or {@link
+   * ServerCall#sendMessage(Object)}.
+   */
+  @Deprecated protected <M> void onMessageReceived(M message, SpanCustomizer span) {
   }
 
   /**

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerParser.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcServerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,5 +22,21 @@ public class GrpcServerParser extends GrpcParser {
   protected <ReqT, RespT> void onStart(ServerCall<ReqT, RespT> call, Metadata headers,
     SpanCustomizer span) {
     span.name(spanName(call.getMethodDescriptor()));
+  }
+
+  /**
+   * @since 4.8
+   * @deprecated Since 5.12 use {@link ServerCall.Listener#onMessage(Object)}.
+   */
+  @Deprecated @Override protected <M> void onMessageSent(M message, SpanCustomizer span) {
+    super.onMessageSent(message, span);
+  }
+
+  /**
+   * @since 4.8
+   * @deprecated Since 5.12 use {@link ServerCall#sendMessage(Object)}.
+   */
+  @Deprecated @Override protected <M> void onMessageReceived(M message, SpanCustomizer span) {
+    super.onMessageReceived(message, span);
   }
 }


### PR DESCRIPTION
Currently, there is no evidence of usage on GitHub, and also the author,
@jorgheymans confirmed they aren't using these hooks internally at the
moment.

After discussion with Jorg and @anuraaga, we decided that message
processing is better left to normal gRPC interceptors. This allows the
RPC project to finish (#999) without adding complexity for a possibly
unused feature. Meanwhile, this gives us a chance to mention the
alternative (in the README).

See also #1173 about the callback context (though same as before)