### PR TITLE
Makes Http adapters finishable with only (response, span)

### DIFF
--- a/instrumentation/http-tests/src/test/java/brave/http/features/TracingDispatcher.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/TracingDispatcher.java
@@ -47,7 +47,7 @@ final class TracingDispatcher extends Dispatcher {
       error = e;
       throw e;
     } finally {
-      handler.handleSend(new MockResponseWrapper(request, response, error), error, span);
+      handler.handleSend(new MockResponseWrapper(request, response, error), span);
     }
   }
 
@@ -81,10 +81,10 @@ final class TracingDispatcher extends Dispatcher {
 
   static final class MockResponseWrapper extends HttpServerResponse {
     final RecordedRequestWrapper request;
-    final MockResponse response;
+    final @Nullable MockResponse response;
     final @Nullable Throwable error;
 
-    MockResponseWrapper(RecordedRequestWrapper request, MockResponse response,
+    MockResponseWrapper(RecordedRequestWrapper request, @Nullable MockResponse response,
       @Nullable Throwable error) {
       this.request = request;
       this.response = response;
@@ -104,6 +104,7 @@ final class TracingDispatcher extends Dispatcher {
     }
 
     @Override public int statusCode() {
+      if (response == null) return 0;
       return Integer.parseInt(response.getStatus().split(" ")[1]);
     }
   }

--- a/instrumentation/http/RATIONALE.md
+++ b/instrumentation/http/RATIONALE.md
@@ -96,3 +96,16 @@ The `TraceContext` parameter of the parsers provides advanced data handling,
 such as `BaggagePropagation.get(context, "field-name")`. This is explicitly
 passed to avoid reliance on expensive span scoping which no longer occurs
 around parse events.
+
+## Why does `HttpHandler.handleFinish` have no error parameter?
+
+HttpHandler finish hooks once had two parameters: one for the response and one
+for an error. In practice, "http.status_code" sometimes ends up in an
+exception, and parsers usually don't look at exception subtypes. For example,
+the following exceptions include a code and optionally a cause of it:
+* `org.springframework.web.client.HttpStatusCodeException`
+* `javax.ws.rs.WebApplicationException`
+
+Since `Response.error()` exists anyway, it is better to be consistent than have
+those writing parsers have to pin to framework specific code in order to know
+the status code.

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -172,20 +172,19 @@ You generally need to...
 5. Complete the span
 
 ```java
-HttpClientRequestWrapper wrapper = new HttpClientRequestWrapper(request);
-Span span = handler.handleSend(wrapper); // 1.
-Result result = null;
+HttpClientRequestWrapper requestWrapper = new HttpClientRequestWrapper(request);
+Span span = handler.handleSend(requestWrapper); // 1.
+HttpClientResponse response = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
-  return result = invoke(request); // 3.
+  return response = invoke(request); // 3.
 } catch (Throwable e) {
   error = e; // 4.
   throw e;
 } finally {
-  HttpClientResponseWrapper response = result != null
-    ? new HttpClientResponseWrapper(wrapper, result, error)
-    : null;
-  handler.handleReceive(response, error, span); // 5.
+  HttpClientResponseWrapper responseWrapper =
+    new HttpClientResponseWrapper(requestWrapper, response, error);
+  handler.handleReceive(responseWrapper, span); // 5.
 }
 ```
 
@@ -243,20 +242,19 @@ You generally need to...
 5. Complete the span
 
 ```java
-HttpServerRequestWrapper wrapper = new HttpServerRequestWrapper(request);
-Span span = handler.handleReceive(wrapper); // 1.
-Result result = null;
+HttpServerRequestWrapper requestWrapper = new HttpServerRequestWrapper(request);
+Span span = handler.handleReceive(requestWrapper); // 1.
+HttpServerResponse response = null;
 Throwable error = null;
 try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
-  return result = process(request); // 3.
-} catch (RuntimeException | Error e) {
+  return response = process(request); // 3.
+} catch (Throwable e) {
   error = e; // 4.
   throw e;
 } finally {
-  HttpServerResponseWrapper response = result != null
-    ? new HttpServerResponseWrapper(wrapper, result, error)
-    : null;
-  handler.handleSend(response, error, span); // 5.
+  HttpServerResponseWrapper responseWrapper =
+    ? new HttpServerResponseWrapper(requestWrapper, response, error);
+  handler.handleSend(responseWrapper, span); // 5.
 }
 ```
 

--- a/instrumentation/http/src/main/java/brave/http/HttpClientAdapters.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientAdapters.java
@@ -193,12 +193,19 @@ import brave.internal.Nullable;
   @Deprecated static final class FromResponseAdapter<Res> extends HttpClientResponse {
     final HttpClientAdapter<?, Res> adapter;
     final Res response;
+    @Nullable final Throwable error;
 
-    FromResponseAdapter(HttpClientAdapter<?, Res> adapter, Res response) {
+    FromResponseAdapter(
+      HttpClientAdapter<?, Res> adapter, Res response, @Nullable Throwable error) {
       if (adapter == null) throw new NullPointerException("adapter == null");
-      this.adapter = adapter;
       if (response == null) throw new NullPointerException("response == null");
+      this.adapter = adapter;
       this.response = response;
+      this.error = error;
+    }
+
+    @Override public Throwable error() {
+      return error;
     }
 
     @Override public Object unwrap() {

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -97,7 +97,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
     this.tracer = httpTracing.tracing().tracer();
     this.sampler = httpTracing.tracing().sampler();
     this.httpSampler = httpTracing.clientRequestSampler();
-    this.serverName = !"" .equals(httpTracing.serverName()) ? httpTracing.serverName() : null;
+    this.serverName = !"".equals(httpTracing.serverName()) ? httpTracing.serverName() : null;
     // The following allows us to add the method: handleSend(HttpClientRequest request) without
     // duplicating logic from the superclass or deprecated handleReceive methods.
     this.defaultInjector = httpTracing.tracing().propagation().injector(HttpClientRequest.SETTER);

--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -14,6 +14,7 @@
 package brave.http;
 
 import brave.Span;
+import brave.SpanCustomizer;
 import brave.Tracer;
 import brave.http.HttpClientAdapters.FromRequestAdapter;
 import brave.internal.Nullable;
@@ -40,20 +41,19 @@ import static brave.http.HttpClientAdapters.FromResponseAdapter;
  * </ol>
  *
  * <pre>{@code
- * HttpClientRequestWrapper wrapper = new HttpClientRequestWrapper(request);
- * Span span = handler.handleSend(wrapper); // 1.
- * Result result = null;
+ * HttpClientRequestWrapper requestWrapper = new HttpClientRequestWrapper(request);
+ * Span span = handler.handleSend(requestWrapper); // 1.
+ * HttpClientResponse response = null;
  * Throwable error = null;
  * try (Scope ws = currentTraceContext.newScope(span.context())) { // 2.
- *   return result = invoke(request); // 3.
+ *   return response = invoke(request); // 3.
  * } catch (Throwable e) {
  *   error = e; // 4.
  *   throw e;
  * } finally {
- *   HttpClientResponseWrapper response = result != null
- *     ? new HttpClientResponseWrapper(wrapper, result, error)
- *     : null;
- *   handler.handleReceive(response, error, span); // 5.
+ *   HttpClientResponseWrapper responseWrapper =
+ *     new HttpClientResponseWrapper(requestWrapper, response, error);
+ *   handler.handleReceive(responseWrapper, span); // 5.
  * }
  * }</pre>
  *
@@ -97,7 +97,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
     this.tracer = httpTracing.tracing().tracer();
     this.sampler = httpTracing.tracing().sampler();
     this.httpSampler = httpTracing.clientRequestSampler();
-    this.serverName = !"".equals(httpTracing.serverName()) ? httpTracing.serverName() : null;
+    this.serverName = !"" .equals(httpTracing.serverName()) ? httpTracing.serverName() : null;
     // The following allows us to add the method: handleSend(HttpClientRequest request) without
     // duplicating logic from the superclass or deprecated handleReceive methods.
     this.defaultInjector = httpTracing.tracing().propagation().injector(HttpClientRequest.SETTER);
@@ -149,7 +149,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
 
   @Override void parseRequest(HttpRequest request, Span span) {
     if (serverName != null) span.remoteServiceName(serverName);
-    requestParser.parse(request, span.context(), span.customizer());
+    super.parseRequest(request, span);
   }
 
   /**
@@ -213,23 +213,48 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
   }
 
   /**
+   * @since 4.3
+   * @deprecated since 5.12 use {@link #handleReceive(HttpClientResponse, Span)}
+   */
+  @Deprecated
+  public void handleReceive(@Nullable Resp response, @Nullable Throwable error, Span span) {
+    if (span == null) throw new NullPointerException("span == null");
+    if (response == null && error == null) {
+      throw new IllegalArgumentException(
+        "Either the response or error parameters may be null, but not both");
+    }
+
+    if (response == null) {
+      span.error(error).finish();
+      return;
+    }
+
+    HttpClientResponse clientResponse;
+    if (response instanceof HttpClientResponse) {
+      clientResponse = (HttpClientResponse) response;
+      if (clientResponse.error() == null && error != null) {
+        span.error(error);
+      }
+    } else {
+      clientResponse = new FromResponseAdapter<>(adapter, response, error);
+    }
+    handleFinish(clientResponse, span);
+  }
+
+  /**
    * Finishes the client span after assigning it tags according to the response or error.
    *
    * <p>This is typically called once the response headers are received, and after the span is
-   * {@link brave.Tracer.SpanInScope#close() no longer in scope}.
+   * {@link Tracer.SpanInScope#close() no longer in scope}.
    *
-   * <p>Note: Either the response or error parameters may be null, but not both.
+   * <p><em>Note</em>: It is valid to have a {@link HttpClientResponse} that only includes an
+   * {@linkplain HttpClientResponse#error() error}. However, it is better to also include the
+   * {@linkplain HttpClientResponse#request() request}.
    *
-   * @see HttpTracing#clientResponseParser()
-   * @since 4.3
+   * @see HttpResponseParser#parse(HttpResponse, TraceContext, SpanCustomizer)
+   * @since 5.12
    */
-  public void handleReceive(@Nullable Resp response, @Nullable Throwable error, Span span) {
-    HttpClientResponse clientResponse;
-    if (response == null || response instanceof HttpClientResponse) {
-      clientResponse = (HttpClientResponse) response;
-    } else {
-      clientResponse = new FromResponseAdapter(adapter, response);
-    }
-    handleFinish(clientResponse, error, span);
+  public void handleReceive(HttpClientResponse response, Span span) {
+    handleFinish(response, span);
   }
 }

--- a/instrumentation/http/src/main/java/brave/http/HttpClientParserAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientParserAdapter.java
@@ -57,7 +57,8 @@ import brave.propagation.CurrentTraceContext;
     SpanCustomizer customizer) {
     HttpResponse response;
     if (res instanceof HttpClientResponse) {
-      response = new HttpClientAdapters.FromResponseAdapter<>((HttpClientAdapter) adapter, res);
+      response =
+        new HttpClientAdapters.FromResponseAdapter<>((HttpClientAdapter) adapter, res, error);
     } else if (adapter instanceof HttpClientAdapters.ToResponseAdapter) {
       response = ((HttpClientAdapters.ToResponseAdapter) adapter).delegate;
     } else {

--- a/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientResponse.java
@@ -17,7 +17,7 @@ import brave.Span;
 import brave.internal.Nullable;
 
 /**
- * Marks an interface for use in {@link HttpClientHandler#handleReceive(Object, Throwable, Span)}.
+ * Marks an interface for use in {@link HttpClientHandler#handleReceive(HttpClientResponse, Span)}.
  * This gives a standard type to consider when parsing an incoming context.
  *
  * @see HttpClientRequest

--- a/instrumentation/http/src/main/java/brave/http/HttpHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpHandler.java
@@ -15,6 +15,9 @@ package brave.http;
 
 import brave.Span;
 import brave.internal.Nullable;
+import brave.internal.Platform;
+
+import static brave.internal.Throwables.propagateIfFatal;
 
 abstract class HttpHandler {
   /**
@@ -34,9 +37,11 @@ abstract class HttpHandler {
   Span handleStart(HttpRequest request, Span span) {
     if (span.isNoop()) return span;
 
-    span.kind(request.spanKind());
     try {
       parseRequest(request, span);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      Platform.get().log("error parsing request {0}", request, t);
     } finally {
       // all of the above parsing happened before a timestamp on the span
       long timestamp = request.startTimestamp();
@@ -49,27 +54,29 @@ abstract class HttpHandler {
     return span;
   }
 
-  abstract void parseRequest(HttpRequest request, Span span);
+  void parseRequest(HttpRequest request, Span span) {
+    span.kind(request.spanKind());
+    requestParser.parse(request, span.context(), span.customizer());
+  }
 
-  void handleFinish(@Nullable HttpResponse response, @Nullable Throwable error, Span span) {
-    if (response == null && error == null) {
-      throw new IllegalArgumentException(
-        "Either the response or error parameters may be null, but not both");
-    }
+  void parseResponse(HttpResponse response, Span span) {
+    responseParser.parse(response, span.context(), span.customizer());
+  }
 
+  void handleFinish(HttpResponse response, Span span) {
+    if (response == null) throw new NullPointerException("response == null");
+    if (span == null) throw new NullPointerException("span == null");
     if (span.isNoop()) return;
 
-    if (error != null) {
-      span.error(error); // Ensures MutableSpan.error() for FinishedSpanHandler
-
-      if (response == null) { // There's nothing to parse: finish and return;
-        span.finish();
-        return;
-      }
+    if (response.error() != null) {
+      span.error(response.error()); // Ensures MutableSpan.error() for FinishedSpanHandler
     }
 
     try {
-      responseParser.parse(response, span.context(), span.customizer());
+      parseResponse(response, span);
+    } catch (Throwable t) {
+      propagateIfFatal(t);
+      Platform.get().log("error parsing response {0}", response, t);
     } finally {
       long finishTimestamp = response.finishTimestamp();
       if (finishTimestamp == 0L) {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerAdapters.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerAdapters.java
@@ -203,16 +203,23 @@ import brave.internal.Nullable;
   @Deprecated static final class FromResponseAdapter<Res> extends HttpServerResponse {
     final HttpServerAdapter<?, Res> adapter;
     final Res response;
+    @Nullable final Throwable error;
 
-    FromResponseAdapter(HttpServerAdapter<?, Res> adapter, Res response) {
+    FromResponseAdapter(HttpServerAdapter<?, Res> adapter, Res response,
+      @Nullable Throwable error) {
       if (adapter == null) throw new NullPointerException("adapter == null");
-      this.adapter = adapter;
       if (response == null) throw new NullPointerException("response == null");
+      this.adapter = adapter;
       this.response = response;
+      this.error = error;
     }
 
     @Override public Object unwrap() {
       return response;
+    }
+
+    @Override public Throwable error() {
+      return error;
     }
 
     @Override public String method() {

--- a/instrumentation/http/src/main/java/brave/http/HttpServerParserAdapter.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerParserAdapter.java
@@ -57,7 +57,8 @@ import brave.propagation.CurrentTraceContext;
     SpanCustomizer customizer) {
     HttpResponse response;
     if (res instanceof HttpServerResponse) {
-      response = new HttpServerAdapters.FromResponseAdapter<>((HttpServerAdapter) adapter, res);
+      response =
+        new HttpServerAdapters.FromResponseAdapter<>((HttpServerAdapter) adapter, res, error);
     } else if (adapter instanceof HttpServerAdapters.ToResponseAdapter) {
       response = ((HttpServerAdapters.ToResponseAdapter) adapter).delegate;
     } else {

--- a/instrumentation/http/src/main/java/brave/http/HttpTracing.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpTracing.java
@@ -56,7 +56,7 @@ public class HttpTracing implements Closeable {
   }
 
   /**
-   * Used by {@link HttpClientHandler#handleReceive(Object, Throwable, Span)} to add tags about the
+   * Used by {@link HttpClientHandler#handleReceive(HttpClientResponse, Span)} to add tags about the
    * response received from the server.
    *
    * @since 5.10

--- a/instrumentation/http/src/test/java/brave/http/HttpClientAdaptersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpClientAdaptersTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
     toRequestAdapter = new HttpClientAdapters.ToRequestAdapter(request, request);
     fromRequestAdapter = new HttpClientAdapters.FromRequestAdapter<>(requestAdapter, request);
     toResponseAdapter = new HttpClientAdapters.ToResponseAdapter(response, response);
-    fromResponseAdapter = new HttpClientAdapters.FromResponseAdapter<>(responseAdapter, response);
+    fromResponseAdapter =
+      new HttpClientAdapters.FromResponseAdapter<>(responseAdapter, response, null);
   }
 }

--- a/instrumentation/http/src/test/java/brave/http/HttpResponseParserAdaptersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpResponseParserAdaptersTest.java
@@ -62,7 +62,8 @@ public class HttpResponseParserAdaptersTest {
     HttpClientAdapter adapter = mock(HttpClientAdapter.class);
     Object res = new Object();
 
-    parserAdapter.parse(new HttpClientAdapters.FromResponseAdapter(adapter, res), context, span);
+    parserAdapter.parse(new HttpClientAdapters.FromResponseAdapter(adapter, res, null), context,
+      span);
 
     verify(parser).response(adapter, res, null, span);
   }
@@ -116,7 +117,8 @@ public class HttpResponseParserAdaptersTest {
     HttpServerAdapter adapter = mock(HttpServerAdapter.class);
     Object res = new Object();
 
-    parserAdapter.parse(new HttpServerAdapters.FromResponseAdapter(adapter, res), context, span);
+    parserAdapter.parse(new HttpServerAdapters.FromResponseAdapter(adapter, res, null), context,
+      span);
 
     verify(parser).response(adapter, res, null, span);
   }

--- a/instrumentation/http/src/test/java/brave/http/HttpServerAdaptersTest.java
+++ b/instrumentation/http/src/test/java/brave/http/HttpServerAdaptersTest.java
@@ -41,7 +41,8 @@ import static org.mockito.Mockito.when;
     toRequestAdapter = new HttpServerAdapters.ToRequestAdapter(request, request);
     fromRequestAdapter = new HttpServerAdapters.FromRequestAdapter<>(requestAdapter, request);
     toResponseAdapter = new HttpServerAdapters.ToResponseAdapter(response, response);
-    fromResponseAdapter = new HttpServerAdapters.FromResponseAdapter<>(responseAdapter, response);
+    fromResponseAdapter =
+      new HttpServerAdapters.FromResponseAdapter<>(responseAdapter, response, null);
   }
 
   @Test public void toRequestAdapter_parseClientIpAndPort_falseOnNoMatch() {

--- a/instrumentation/http/src/test/java/brave/http/ITHttpTracingClassLoader.java
+++ b/instrumentation/http/src/test/java/brave/http/ITHttpTracingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,14 @@ import zipkin2.reporter.Reporter;
 import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HttpTracingClassLoaderTest {
+// Mockito tests eagerly log which triggers the log4j log manager, which then makes this run fail if
+// run in the same JVM. The easy workaround is to move this to IT, which forces another JVM.
+//
+// Other workarounds:
+// * Stop using log4j2 as we don't need it anyway
+// * Stop using the log4j2 log manager, at least in this project
+// * Do some engineering like this: https://stackoverflow.com/a/28657203/2232476
+public class ITHttpTracingClassLoader {
   @Test public void unloadable_afterClose() {
     assertRunIsUnloadable(ClosesHttpTracing.class, getClass().getClassLoader());
   }

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/HttpResponseWrapperTest.java
@@ -36,7 +36,7 @@ public class HttpResponseWrapperTest {
   @Test public void request() {
     when(context.getRequest()).thenReturn(request);
 
-    assertThat(new HttpResponseWrapper(response, context).request().unwrap())
+    assertThat(new HttpResponseWrapper(response, context, null).request().unwrap())
       .isSameAs(request);
   }
 
@@ -44,10 +44,15 @@ public class HttpResponseWrapperTest {
     when(response.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    assertThat(new HttpResponseWrapper(response, context).statusCode()).isEqualTo(200);
+    assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zeroWhenNoStatusLine() {
-    assertThat(new HttpResponseWrapper(response, context).statusCode()).isZero();
+    assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isZero();
+  }
+
+  @Test public void statusCode_zeroWhenNoResponse() {
+    assertThat(new HttpResponseWrapper(null, context, new IllegalArgumentException()).statusCode())
+      .isZero();
   }
 }

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/HttpResponseWrapperTest.java
@@ -50,4 +50,9 @@ public class HttpResponseWrapperTest {
   @Test public void statusCode_zeroWhenNoStatusLine() {
     assertThat(new HttpResponseWrapper(response, context, null).statusCode()).isZero();
   }
+
+  @Test public void statusCode_zeroWhenNoResponse() {
+    assertThat(new HttpResponseWrapper(null, context, new IllegalArgumentException()).statusCode())
+      .isZero();
+  }
 }

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -71,7 +71,7 @@ public final class TracingClientFilter implements ClientRequestFilter, ClientRes
     Span span = tracer.currentSpan();
     if (span == null) return;
     ((SpanInScope) request.getProperty(SpanInScope.class.getName())).close();
-    handler.handleReceive(new ClientResponseContextWrapper(request, response), null, span);
+    handler.handleReceive(new ClientResponseContextWrapper(request, response), span);
   }
 
   static final class ClientRequestContextWrapper extends HttpClientRequest {

--- a/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/main/java/brave/jersey/server/TracingApplicationEventListener.java
@@ -14,17 +14,22 @@
 package brave.jersey.server;
 
 import brave.Span;
-import brave.Tracer;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.ManagedAsync;
+import org.glassfish.jersey.server.internal.process.MappableException;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
@@ -36,12 +41,12 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     return new TracingApplicationEventListener(httpTracing, new EventParser());
   }
 
-  final Tracer tracer;
+  final CurrentTraceContext currentTraceContext;
   final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
   final EventParser parser;
 
   @Inject TracingApplicationEventListener(HttpTracing httpTracing, EventParser parser) {
-    tracer = httpTracing.tracing().tracer();
+    currentTraceContext = httpTracing.tracing().currentTraceContext();
     handler = HttpServerHandler.create(httpTracing);
     this.parser = parser;
   }
@@ -53,18 +58,17 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
   @Override public RequestEventListener onRequest(RequestEvent event) {
     if (event.getType() != RequestEvent.Type.START) return null;
     Span span = handler.handleReceive(new ContainerRequestWrapper(event.getContainerRequest()));
-    return new TracingRequestEventListener(span, tracer.withSpanInScope(span));
+    return new TracingRequestEventListener(span, currentTraceContext.newScope(span.context()));
   }
 
-  class TracingRequestEventListener implements RequestEventListener {
+  // Scope reference invalidated when an asynchronous method is in use
+  class TracingRequestEventListener extends AtomicReference<Scope> implements RequestEventListener {
     final Span span;
-    // Invalidated when an asynchronous method is in use
-    volatile Tracer.SpanInScope spanInScope;
     volatile boolean async;
 
-    TracingRequestEventListener(Span span, Tracer.SpanInScope spanInScope) {
+    TracingRequestEventListener(Span span, Scope scope) {
+      super(scope);
       this.span = span;
-      this.spanInScope = spanInScope;
     }
 
     /**
@@ -75,7 +79,7 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
      */
     @Override
     public void onEvent(RequestEvent event) {
-      Tracer.SpanInScope maybeSpanInScope;
+      Scope maybeScope;
       switch (event.getType()) {
         // Note: until REQUEST_MATCHED, we don't know metadata such as if the request is async or not
         case REQUEST_MATCHED:
@@ -89,23 +93,21 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
           // Normal async methods sometimes stay on a thread until RESOURCE_METHOD_FINISHED, but
           // this is not reliable. So, we eagerly close the scope from request filters, and re-apply
           // it later when the resource method starts.
-          if (!async || (maybeSpanInScope = spanInScope) == null) break;
-          maybeSpanInScope.close();
-          spanInScope = null;
+          if (!async || (maybeScope = getAndSet(null)) == null) break;
+          maybeScope.close();
           break;
         case RESOURCE_METHOD_START:
           // If we are async, we have to re-scope the span as the resource method invocation is
           // is likely on a different thread than the request filtering.
-          if (!async || spanInScope != null) break;
-          spanInScope = tracer.withSpanInScope(span);
+          if (!async || get() != null) break;
+          set(currentTraceContext.newScope(span.context()));
           break;
         case FINISHED:
-          RequestEventWrapper response = new RequestEventWrapper(event);
-          handler.handleSend(response, response.error(), span);
+          handler.handleSend(new RequestEventWrapper(event), span);
           // In async FINISHED can happen before RESOURCE_METHOD_FINISHED, and on different threads!
           // Don't close the scope unless it is a synchronous method.
-          if (!async && (maybeSpanInScope = spanInScope) != null) {
-            maybeSpanInScope.close();
+          if (!async && (maybeScope = getAndSet(null)) != null) {
+            maybeScope.close();
           }
           break;
         default:
@@ -157,10 +159,12 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
 
   static final class RequestEventWrapper extends HttpServerResponse {
     final RequestEvent event;
+    @Nullable final Throwable error;
     ContainerRequestWrapper request;
 
     RequestEventWrapper(RequestEvent event) {
       this.event = event;
+      this.error = SpanCustomizingApplicationEventListener.unwrapError(event);
     }
 
     @Override public Object unwrap() {
@@ -173,13 +177,22 @@ public final class TracingApplicationEventListener implements ApplicationEventLi
     }
 
     @Override public Throwable error() {
-      return SpanCustomizingApplicationEventListener.unwrapError(event);
+      return error;
     }
 
     @Override public int statusCode() {
       ContainerResponse response = event.getContainerResponse();
-      if (response == null) return 0;
-      return response.getStatus();
+      if (response != null) return response.getStatus();
+
+      Throwable error = event.getException();
+      // For example, if thrown in an async controller
+      if (error instanceof MappableException && error.getCause() != null) {
+        error = error.getCause();
+      }
+      if (error instanceof WebApplicationException) {
+        return ((WebApplicationException) error).getResponse().getStatus();
+      }
+      return 0;
     }
   }
 }

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/RequestEventWrapperTest.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/RequestEventWrapperTest.java
@@ -14,8 +14,10 @@
 package brave.jersey.server;
 
 import brave.jersey.server.TracingApplicationEventListener.RequestEventWrapper;
+import javax.ws.rs.ClientErrorException;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.internal.process.MappableException;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +53,18 @@ public class RequestEventWrapperTest {
     when(response.getStatus()).thenReturn(200);
 
     assertThat(new RequestEventWrapper(event).statusCode()).isEqualTo(200);
+  }
+
+  @Test public void statusCode_exception() {
+    when(event.getException()).thenReturn(new ClientErrorException(400));
+
+    assertThat(new RequestEventWrapper(event).statusCode()).isEqualTo(400);
+  }
+
+  @Test public void statusCode_mappableException() {
+    when(event.getException()).thenReturn(new MappableException(new ClientErrorException(400)));
+
+    assertThat(new RequestEventWrapper(event).statusCode()).isEqualTo(400);
   }
 
   @Test public void statusCode_zeroNoResponse() {

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/NettyHttpTracing.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/NettyHttpTracing.java
@@ -14,10 +14,10 @@
 package brave.netty.http;
 
 import brave.Span;
-import brave.Tracer.SpanInScope;
 import brave.Tracing;
 import brave.http.HttpServerRequest;
 import brave.http.HttpTracing;
+import brave.propagation.CurrentTraceContext.Scope;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.util.AttributeKey;
 
@@ -25,8 +25,6 @@ public final class NettyHttpTracing {
   static final AttributeKey<HttpServerRequest> REQUEST_ATTRIBUTE =
     AttributeKey.valueOf(HttpServerRequest.class.getName());
   static final AttributeKey<Span> SPAN_ATTRIBUTE = AttributeKey.valueOf(Span.class.getName());
-  static final AttributeKey<SpanInScope> SPAN_IN_SCOPE_ATTRIBUTE =
-    AttributeKey.valueOf(SpanInScope.class.getName());
 
   public static NettyHttpTracing create(Tracing tracing) {
     return new NettyHttpTracing(HttpTracing.create(tracing));

--- a/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
+++ b/instrumentation/netty-codec-http/src/main/java/brave/netty/http/TracingHttpServerHandler.java
@@ -14,29 +14,30 @@
 package brave.netty.http;
 
 import brave.Span;
-import brave.Tracer;
-import brave.Tracer.SpanInScope;
 import brave.http.HttpServerHandler;
 import brave.http.HttpServerRequest;
 import brave.http.HttpServerResponse;
 import brave.http.HttpTracing;
 import brave.internal.Nullable;
 import brave.internal.Platform;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.Attribute;
 import java.net.InetSocketAddress;
 import java.net.URI;
 
 final class TracingHttpServerHandler extends ChannelDuplexHandler {
+  final CurrentTraceContext currentTraceContext;
   final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
-  final Tracer tracer;
 
   TracingHttpServerHandler(HttpTracing httpTracing) {
-    tracer = httpTracing.tracing().tracer();
+    currentTraceContext = httpTracing.tracing().currentTraceContext();
     handler = HttpServerHandler.create(httpTracing);
   }
 
@@ -52,8 +53,7 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
     ctx.channel().attr(NettyHttpTracing.REQUEST_ATTRIBUTE).set(request);
     Span span = handler.handleReceive(request);
     ctx.channel().attr(NettyHttpTracing.SPAN_ATTRIBUTE).set(span);
-    SpanInScope spanInScope = tracer.withSpanInScope(span);
-    ctx.channel().attr(NettyHttpTracing.SPAN_IN_SCOPE_ATTRIBUTE).set(spanInScope);
+    Scope scope = currentTraceContext.newScope(span.context());
 
     // Place the span in scope so that downstream code can read trace IDs
     Throwable error = null;
@@ -64,12 +64,14 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
       throw e;
     } finally {
       if (error != null) span.error(error).finish();
-      spanInScope.close();
+      scope.close();
     }
   }
 
   @Override public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise prm) {
-    Span span = ctx.channel().attr(NettyHttpTracing.SPAN_ATTRIBUTE).get();
+    Attribute<Span> spanAttr = ctx.channel().attr(NettyHttpTracing.SPAN_ATTRIBUTE);
+    Span span = spanAttr.get();
+    spanAttr.compareAndSet(span, null);
     if (span == null || !(msg instanceof HttpResponse)) {
       ctx.write(msg, prm);
       return;
@@ -77,9 +79,7 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
 
     HttpResponse response = (HttpResponse) msg;
 
-    // Guard re-scoping the same span
-    SpanInScope spanInScope = ctx.channel().attr(NettyHttpTracing.SPAN_IN_SCOPE_ATTRIBUTE).get();
-    if (spanInScope == null) spanInScope = tracer.withSpanInScope(span);
+    Scope scope = currentTraceContext.maybeScope(span.context());
     Throwable error = null;
     try {
       ctx.write(msg, prm);
@@ -88,8 +88,8 @@ final class TracingHttpServerHandler extends ChannelDuplexHandler {
       throw t;
     } finally {
       HttpServerRequest request = ctx.channel().attr(NettyHttpTracing.REQUEST_ATTRIBUTE).get();
-      handler.handleSend(new HttpResponseWrapper(request, response, error), error, span);
-      spanInScope.close();
+      handler.handleSend(new HttpResponseWrapper(request, response, error), span);
+      scope.close();
     }
   }
 

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ResponseWrapperTest.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ResponseWrapperTest.java
@@ -13,6 +13,7 @@
  */
 package brave.okhttp3;
 
+import brave.okhttp3.TracingInterceptor.RequestWrapper;
 import brave.okhttp3.TracingInterceptor.ResponseWrapper;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -22,26 +23,29 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResponseWrapperTest {
+  RequestWrapper request =
+    new RequestWrapper(new Request.Builder().url("http://localhost/foo").build());
   Response.Builder responseBuilder = new Response.Builder()
-    .request(new Request.Builder().url("http://localhost/foo").build())
+    .request(request.delegate)
     .protocol(Protocol.HTTP_1_1);
 
   @Test public void request() {
     Response response = responseBuilder.code(200).message("ok").build();
 
-    assertThat(new ResponseWrapper(response, null).request().unwrap())
-      .isSameAs(response.request());
+    assertThat(new ResponseWrapper(request, response, null).request())
+      .isSameAs(request);
   }
 
   @Test public void statusCode() {
     Response response = responseBuilder.code(200).message("ok").build();
 
-    assertThat(new ResponseWrapper(response, null).statusCode()).isEqualTo(200);
+    assertThat(new ResponseWrapper(request, response, null).statusCode()).isEqualTo(200);
   }
 
   @Test public void statusCode_zero() {
     Response response = responseBuilder.code(0).message("ice cream!").build();
 
-    assertThat(new ResponseWrapper(response, null).statusCode()).isZero();
+    assertThat(new ResponseWrapper(request, response, null).statusCode()).isZero();
+    assertThat(new ResponseWrapper(request, null, null).statusCode()).isZero();
   }
 }

--- a/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/TracingFilter.java
@@ -91,7 +91,7 @@ public final class TracingFilter implements Filter {
         servlet.handleAsync(handler, req, res, span);
       } else { // we have a synchronous response: finish the span
         HttpServerResponse responseWrapper = HttpServletResponseWrapper.create(req, res, error);
-        handler.handleSend(responseWrapper, responseWrapper.error(), span);
+        handler.handleSend(responseWrapper, span);
       }
       scope.close();
     }

--- a/instrumentation/servlet/src/main/java/brave/servlet/internal/ServletRuntime.java
+++ b/instrumentation/servlet/src/main/java/brave/servlet/internal/ServletRuntime.java
@@ -119,7 +119,7 @@ public abstract class ServletRuntime {
         HttpServletResponse res = (HttpServletResponse) e.getSuppliedResponse();
         HttpServerResponse response =
           brave.servlet.HttpServletResponseWrapper.create(req, res, e.getThrowable());
-        handler.handleSend(response, response.error(), span);
+        handler.handleSend(response, span);
       }
 
       // Per Servlet 3 section 2.3.3.3, we can't see the final HTTP status, yet. defer to onComplete

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingAsyncClientHttpRequestInterceptor.java
@@ -69,7 +69,7 @@ public final class TracingAsyncClientHttpRequestInterceptor
         ? new TraceContextListenableFuture<>(result, currentTraceContext, invocationContext)
         : result;
     } catch (Throwable e) {
-      handler.handleReceive(null, e, span);
+      handler.handleReceive(new ClientHttpResponseWrapper(request, null, e), span);
       throw e;
     }
   }
@@ -89,11 +89,11 @@ public final class TracingAsyncClientHttpRequestInterceptor
     }
 
     @Override public void onFailure(Throwable ex) {
-      handler.handleReceive(null, ex, span);
+      handler.handleReceive(new ClientHttpResponseWrapper(request, null, ex), span);
     }
 
-    @Override public void onSuccess(ClientHttpResponse result) {
-      handler.handleReceive(new ClientHttpResponseWrapper(request, result, null), null, span);
+    @Override public void onSuccess(ClientHttpResponse response) {
+      handler.handleReceive(new ClientHttpResponseWrapper(request, response, null), span);
     }
   }
 }

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ClientHttpResponseWrapperTest.java
@@ -21,7 +21,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -47,6 +49,12 @@ public class ClientHttpResponseWrapperTest {
     when(response.getRawStatusCode()).thenThrow(new IOException());
 
     assertThat(new ClientHttpResponseWrapper(request, response, null).statusCode()).isZero();
+  }
+
+  @Test public void statusCode_fromHttpStatusCodeException() {
+    HttpClientErrorException ex = new HttpClientErrorException(HttpStatus.BAD_REQUEST);
+
+    assertThat(new ClientHttpResponseWrapper(request, null, ex).statusCode()).isEqualTo(400);
   }
 
   @Test public void statusCode_zeroOnIAE() throws IOException {

--- a/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
+++ b/instrumentation/vertx-web/src/main/java/brave/vertx/web/TracingRoutingContextHandler.java
@@ -76,7 +76,7 @@ final class TracingRoutingContextHandler implements Handler<RoutingContext> {
 
     @Override public void handle(Void aVoid) {
       if (!finished.compareAndSet(false, true)) return;
-      handler.handleSend(new HttpServerResponseWrapper(context), context.failure(), span);
+      handler.handleSend(new HttpServerResponseWrapper(context), span);
     }
   }
 


### PR DESCRIPTION
Similar to #999, HTTP should also be able to derive the error directly
from `HttpResponse` vs a second argument. This also allows exceptions
that nest status codes to become parsable into span tags.

This also updates places where we still used Tracer.withSpanInScope
in HTTP. This api has a problem that it cannot detect if a span is already
in scope.