### PR TITLE
Renovates Dubbo instrumentation in preparation of standard parsing

### DIFF
--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboClientRequest.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,47 +13,73 @@
  */
 package brave.dubbo.rpc;
 
+import brave.Span;
 import brave.propagation.Propagation.Setter;
 import brave.rpc.RpcClientRequest;
+import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
 import java.util.Map;
 
 // intentionally not yet public until we add tag parsing functionality
-final class DubboClientRequest extends RpcClientRequest {
+final class DubboClientRequest extends RpcClientRequest implements DubboRequest {
   static final Setter<DubboClientRequest, String> SETTER =
     new Setter<DubboClientRequest, String>() {
       @Override public void put(DubboClientRequest request, String key, String value) {
-        request.putAttachment(key, value);
+        request.propagationField(key, value);
       }
 
       @Override public String toString() {
-        return "DubboClientRequest::putAttachment";
+        return "DubboClientRequest::propagationField";
       }
     };
 
+  final Invoker<?> invoker;
   final Invocation invocation;
   final Map<String, String> attachments;
 
-  DubboClientRequest(Invocation invocation, Map<String, String> attachments) {
+  DubboClientRequest(Invoker<?> invoker, Invocation invocation, Map<String, String> attachments) {
+    if (invoker == null) throw new NullPointerException("invoker == null");
     if (invocation == null) throw new NullPointerException("invocation == null");
-    this.invocation = invocation;
     if (attachments == null) throw new NullPointerException("attachments == null");
+    this.invoker = invoker;
+    this.invocation = invocation;
     this.attachments = attachments;
   }
 
-  @Override public Object unwrap() {
-    return this;
+  @Override public Invoker<?> invoker() {
+    return invoker;
   }
 
+  @Override public Invocation invocation() {
+    return invocation;
+  }
+
+  /** Returns the {@link Invocation}. */
+  @Override public Invocation unwrap() {
+    return invocation;
+  }
+
+  /**
+   * Returns the method name of the invocation or the first string arg of an "$invoke" or
+   * "$invokeAsync" method.
+   */
   @Override public String method() {
     return DubboParser.method(invocation);
   }
 
+  /**
+   * Returns the {@link URL#getServiceInterface() service interface} of the invocation.
+   */
   @Override public String service() {
     return DubboParser.service(invocation);
   }
 
-  String putAttachment(String key, String value) {
-    return attachments.put(key, value);
+  boolean parseRemoteIpAndPort(Span span) {
+    return DubboParser.parseRemoteIpAndPort(span);
+  }
+
+  void propagationField(String keyName, String value) {
+    attachments.put(keyName, value);
   }
 }

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboClientResponse.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboClientResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.Response;
+import brave.Span;
+import brave.internal.Nullable;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcException;
+
+final class DubboClientResponse extends Response implements DubboResponse {
+  final DubboClientRequest request;
+  @Nullable final Result result;
+  @Nullable final Throwable error;
+
+  DubboClientResponse(
+    DubboClientRequest request, @Nullable Result result, @Nullable Throwable error) {
+    if (request == null) throw new NullPointerException("request == null");
+    this.request = request;
+    this.result = result;
+    this.error = error;
+  }
+
+  @Override public Result result() {
+    return result;
+  }
+
+  @Override public Result unwrap() {
+    return result;
+  }
+
+  @Override public Span.Kind spanKind() {
+    return Span.Kind.CLIENT;
+  }
+
+  @Override public DubboClientRequest request() {
+    return request;
+  }
+
+  @Override public Throwable error() {
+    return error;
+  }
+
+  /** Returns the string form of the {@link RpcException#getCode()} */
+  String errorCode() {
+    return DubboParser.errorCode(error);
+  }
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboRequest.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.rpc.RpcClientRequest;
+import brave.rpc.RpcServerRequest;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+
+/**
+ * Used to access Dubbo specific aspects of a client or server request.
+ *
+ * <p>Here's an example that adds default tags, and if Dubbo, Java arguments:
+ * <pre>{@code
+ * rpcTracing = rpcTracingBuilder
+ *   .clientRequestParser((req, context, span) -> {
+ *      RpcRequestParser.DEFAULT.parse(req, context, span);
+ *      if (req instanceof DubboRequest) {
+ *        tagArguments(((DubboRequest) req).invocation().getArguments());
+ *      }
+ *   }).build();
+ * }</pre>
+ *
+ * <p>Note: Do not implement this type directly. An implementation will be
+ * either as {@link RpcClientRequest} or an {@link RpcServerRequest}.
+ *
+ * @since 5.12
+ */
+// Note: Unlike Apache Dubbo, Alibaba Dubbo is Java 1.6+.
+// This means we cannot add default methods later. However, Alibaba Dubbo is
+// deprecated, so there should not be cause to add methods later.
+interface DubboRequest { // TODO: make public after #999
+  Invoker<?> invoker();
+
+  Invocation invocation();
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboResponse.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.internal.Nullable;
+import com.alibaba.dubbo.rpc.Result;
+
+/**
+ * Used to access Dubbo specific aspects of a client or server response.
+ *
+ * <p>Here's an example that adds default tags, and if Dubbo, the Java result:
+ * <pre>{@code
+ * rpcTracing = rpcTracingBuilder
+ *   .clientResponseParser((res, context, span) -> {
+ *      RpcResponseParser.DEFAULT.parse(res, context, span);
+ *      if (res instanceof DubboResponse) {
+ *        DubboResponse dubboResponse = (DubboResponse) res;
+ *        if (res.result() != null) {
+ *          tagJavaResult(res.result().value());
+ *        }
+ *      }
+ *   }).build();
+ * }</pre>
+ *
+ * @since 5.12
+ */
+interface DubboResponse { // TODO: make public after #999
+  DubboRequest request();
+
+  @Nullable Result result();
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboServerRequest.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,48 +13,68 @@
  */
 package brave.dubbo.rpc;
 
-import brave.internal.Nullable;
+import brave.Span;
 import brave.propagation.Propagation.Getter;
 import brave.rpc.RpcServerRequest;
+import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.rpc.Invocation;
-import java.util.Map;
+import com.alibaba.dubbo.rpc.Invoker;
 
 // intentionally not yet public until we add tag parsing functionality
-final class DubboServerRequest extends RpcServerRequest {
+final class DubboServerRequest extends RpcServerRequest implements DubboRequest {
   static final Getter<DubboServerRequest, String> GETTER =
     new Getter<DubboServerRequest, String>() {
       @Override public String get(DubboServerRequest request, String key) {
-        return request.getAttachment(key);
+        return request.propagationField(key);
       }
 
       @Override public String toString() {
-        return "DubboServerRequest::getAttachment";
+        return "DubboServerRequest::propagationField";
       }
     };
 
+  final Invoker<?> invoker;
   final Invocation invocation;
-  final Map<String, String> attachments;
 
-  DubboServerRequest(Invocation invocation, Map<String, String> attachments) {
+  DubboServerRequest(Invoker<?> invoker, Invocation invocation) {
+    if (invoker == null) throw new NullPointerException("invoker == null");
     if (invocation == null) throw new NullPointerException("invocation == null");
+    this.invoker = invoker;
     this.invocation = invocation;
-    if (attachments == null) throw new NullPointerException("attachments == null");
-    this.attachments = attachments;
   }
 
-  @Override public Object unwrap() {
-    return this;
+  @Override public Invoker<?> invoker() {
+    return invoker;
   }
 
+  @Override public Invocation invocation() {
+    return invocation;
+  }
+
+  /** Returns the {@link Invocation}. */
+  @Override public Invocation unwrap() {
+    return invocation;
+  }
+
+  /**
+   * Returns the method name of the invocation or the first string arg of an "$invoke" method.
+   */
   @Override public String method() {
     return DubboParser.method(invocation);
   }
 
+  /**
+   * Returns the {@link URL#getServiceInterface() service interface} of the invocation.
+   */
   @Override public String service() {
     return DubboParser.service(invocation);
   }
 
-  @Nullable String getAttachment(String key) {
-    return attachments.get(key);
+  boolean parseRemoteIpAndPort(Span span) {
+    return DubboParser.parseRemoteIpAndPort(span);
+  }
+
+  String propagationField(String keyName) {
+    return invocation.getAttachment(keyName);
   }
 }

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboServerResponse.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/DubboServerResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.Response;
+import brave.Span;
+import brave.internal.Nullable;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcException;
+
+final class DubboServerResponse extends Response implements DubboResponse {
+  final DubboServerRequest request;
+  @Nullable final Result result;
+  @Nullable final Throwable error;
+
+  DubboServerResponse(
+    DubboServerRequest request, @Nullable Result result, @Nullable Throwable error) {
+    if (request == null) throw new NullPointerException("request == null");
+    this.request = request;
+    this.result = result;
+    this.error = error;
+  }
+
+  @Override public Span.Kind spanKind() {
+    return Span.Kind.SERVER;
+  }
+
+  @Override public Result result() {
+    return result;
+  }
+
+  @Override public Result unwrap() {
+    return result;
+  }
+
+  @Override public DubboServerRequest request() {
+    return request;
+  }
+
+  @Override public Throwable error() {
+    return error;
+  }
+
+  /** Returns the string form of the {@link RpcException#getCode()} */
+  String errorCode() {
+    return DubboParser.errorCode(error);
+  }
+}

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/FinishSpanResponseFuture.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/FinishSpanResponseFuture.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import brave.Span;
+import brave.internal.Nullable;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+import com.alibaba.dubbo.remoting.exchange.ResponseFuture;
+
+/** Ensures any callbacks finish the span. */
+final class FinishSpanResponseFuture implements ResponseFuture {
+  final ResponseFuture delegate;
+  final Span span;
+  final CurrentTraceContext currentTraceContext;
+  final @Nullable TraceContext callbackContext;
+
+  FinishSpanResponseFuture(ResponseFuture delegate, TracingFilter filter, Span span,
+    @Nullable TraceContext callbackContext) {
+    this.delegate = delegate;
+    this.span = span;
+    this.currentTraceContext = filter.currentTraceContext;
+    this.callbackContext = callbackContext;
+    // Ensures even if no callback added later, for example when a consumer, we finish the span
+    setCallback(null);
+  }
+
+  @Override public Object get() throws RemotingException {
+    return delegate.get();
+  }
+
+  @Override public Object get(int timeoutInMillis) throws RemotingException {
+    return delegate.get(timeoutInMillis);
+  }
+
+  @Override public void setCallback(ResponseCallback callback) {
+    delegate.setCallback(
+      TracingResponseCallback.create(callback, span, currentTraceContext, callbackContext)
+    );
+  }
+
+  @Override public boolean isDone() {
+    return delegate.isDone();
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboClientRequestTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboClientRequestTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DubboClientRequestTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  URL url = URL.valueOf("dubbo://localhost:6666?scope=remote&interface=brave.dubbo.GreeterService");
+  Map<String, String> attachments = new LinkedHashMap<>();
+  DubboClientRequest request = new DubboClientRequest(invoker, invocation, attachments);
+
+  @Test public void service() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+
+    assertThat(request.service())
+      .isEqualTo("brave.dubbo.GreeterService");
+  }
+
+  @Test public void method() {
+    when(invocation.getMethodName()).thenReturn("sayHello");
+
+    assertThat(request.method()).isEqualTo("sayHello");
+  }
+
+  @Test public void unwrap() {
+    assertThat(request.unwrap()).isSameAs(invocation);
+  }
+
+  @Test public void invoker() {
+    assertThat(request.invoker()).isSameAs(invoker);
+  }
+
+  @Test public void invocation() {
+    assertThat(request.invocation()).isSameAs(invocation);
+  }
+
+  @Test public void propagationField() {
+    request.propagationField("b3", "d");
+
+    assertThat(attachments).containsEntry("b3", "d");
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboClientResponseTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboClientResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static com.alibaba.dubbo.rpc.RpcException.TIMEOUT_EXCEPTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DubboClientResponseTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  Result result = mock(Result.class);
+  RpcException error = new RpcException(TIMEOUT_EXCEPTION);
+  Map<String, String> attachments = new LinkedHashMap<>();
+  DubboClientRequest request = new DubboClientRequest(invoker, invocation, attachments);
+  DubboClientResponse response = new DubboClientResponse(request, result, error);
+
+  @Test public void request() {
+    assertThat(response.request()).isSameAs(request);
+  }
+
+  @Test public void result() {
+    assertThat(response.result()).isSameAs(result);
+  }
+
+  @Test public void unwrap() {
+    assertThat(response.unwrap()).isSameAs(result);
+  }
+
+  @Test public void error() {
+    assertThat(response.error()).isSameAs(error);
+  }
+
+  @Test public void errorCode() {
+    assertThat(response.errorCode()).isEqualTo("TIMEOUT_EXCEPTION");
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboServerRequestTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboServerRequestTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DubboServerRequestTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  URL url = URL.valueOf("dubbo://localhost:6666?scope=remote&interface=brave.dubbo.GreeterService");
+  DubboServerRequest request = new DubboServerRequest(invoker, invocation);
+
+  @Test public void service() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+
+    assertThat(request.service())
+      .isEqualTo("brave.dubbo.GreeterService");
+  }
+
+  @Test public void method() {
+    when(invocation.getMethodName()).thenReturn("sayHello");
+
+    assertThat(request.method()).isEqualTo("sayHello");
+  }
+
+  @Test public void unwrap() {
+    assertThat(request.unwrap()).isSameAs(invocation);
+  }
+
+  @Test public void invoker() {
+    assertThat(request.invoker()).isSameAs(invoker);
+  }
+
+  @Test public void invocation() {
+    assertThat(request.invocation()).isSameAs(invocation);
+  }
+
+  @Test public void propagationField() {
+    when(invocation.getAttachment("b3")).thenReturn("d");
+
+    assertThat(request.propagationField("b3")).isEqualTo("d");
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboServerResponseTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/DubboServerResponseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo.rpc;
+
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcException;
+import org.junit.Test;
+
+import static com.alibaba.dubbo.rpc.RpcException.TIMEOUT_EXCEPTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DubboServerResponseTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  Result result = mock(Result.class);
+  RpcException error = new RpcException(TIMEOUT_EXCEPTION);
+  DubboServerRequest request = new DubboServerRequest(invoker, invocation);
+  DubboServerResponse response = new DubboServerResponse(request, result, error);
+
+  @Test public void request() {
+    assertThat(response.request()).isSameAs(request);
+  }
+
+  @Test public void result() {
+    assertThat(response.result()).isSameAs(result);
+  }
+
+  @Test public void unwrap() {
+    assertThat(response.unwrap()).isSameAs(result);
+  }
+
+  @Test public void error() {
+    assertThat(response.error()).isSameAs(error);
+  }
+
+  @Test public void errorCode() {
+    assertThat(response.errorCode()).isEqualTo("TIMEOUT_EXCEPTION");
+  }
+}

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -13,7 +13,6 @@
  */
 package brave.dubbo.rpc;
 
-import brave.rpc.RpcTracing;
 import brave.test.ITRemote;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
 import com.alibaba.dubbo.config.ReferenceConfig;
@@ -21,7 +20,6 @@ import com.alibaba.dubbo.rpc.Filter;
 import org.junit.After;
 
 public abstract class ITTracingFilter extends ITRemote {
-  RpcTracing rpcTracing = RpcTracing.create(tracing);
   TestServer server = new TestServer(propagationFactory);
   ReferenceConfig<GreeterService> client;
 
@@ -30,10 +28,11 @@ public abstract class ITTracingFilter extends ITRemote {
     server.stop();
   }
 
-  /** Call this after updating {@link #tracing} or {@link #rpcTracing} */
-  void init() {
-    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
-      .getExtension("tracing"))
-      .setRpcTracing(rpcTracing);
+  /** Call this after updating {@link #tracing} */
+  TracingFilter init() {
+    TracingFilter filter = (TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+      .getExtension("tracing");
+    filter.setTracing(tracing);
+    return filter;
   }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ITTracingFilter_Provider extends ITTracingFilter {
-
   @Before public void setup() {
     server.service.setFilter("tracing");
     server.service.setInterface(GreeterService.class);
@@ -71,7 +70,6 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
   @Test public void createsChildWhenJoinDisabled() {
     tracing = tracingBuilder(NEVER_SAMPLE).supportsJoin(false).build();
-    rpcTracing = RpcTracing.create(tracing);
     init();
 
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
@@ -84,7 +82,6 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
   @Test public void samplingDisabled() {
     tracing = tracingBuilder(NEVER_SAMPLE).build();
-    rpcTracing = RpcTracing.create(tracing);
     init();
 
     client.get().sayHello("jorge");
@@ -121,11 +118,11 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
   }
 
   @Test public void customSampler() {
-    rpcTracing = RpcTracing.newBuilder(tracing).serverSampler(RpcRuleSampler.newBuilder()
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing).serverSampler(RpcRuleSampler.newBuilder()
       .putRule(methodEquals("sayGoodbye"), NEVER_SAMPLE)
       .putRule(serviceEquals("brave.dubbo"), ALWAYS_SAMPLE)
       .build()).build();
-    init();
+    init().setRpcTracing(rpcTracing);
 
     // unsampled
     client.get().sayGoodbye("jorge");

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/TestServer.java
@@ -15,7 +15,7 @@ package brave.dubbo.rpc;
 
 import brave.internal.Platform;
 import brave.propagation.Propagation;
-import brave.propagation.TraceContext;
+import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContextOrSamplingFlags;
 import com.alibaba.dubbo.common.Constants;
 import com.alibaba.dubbo.config.ApplicationConfig;
@@ -24,19 +24,19 @@ import com.alibaba.dubbo.config.RegistryConfig;
 import com.alibaba.dubbo.config.ServiceConfig;
 import com.alibaba.dubbo.rpc.RpcContext;
 import com.alibaba.dubbo.rpc.service.GenericService;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 class TestServer {
   final BlockingQueue<TraceContextOrSamplingFlags> requestQueue = new LinkedBlockingQueue<>();
-  final TraceContext.Extractor<DubboServerRequest> extractor;
+  final Extractor<Map<String, String>> extractor;
   final ServiceConfig<GenericService> service;
   final String linkLocalIp;
 
   TestServer(Propagation.Factory propagationFactory) {
-    extractor =
-      propagationFactory.get().extractor(DubboServerRequest.GETTER);
+    extractor = propagationFactory.get().extractor(Map::get);
     linkLocalIp = Platform.get().linkLocalIp();
     if (linkLocalIp != null) {
       // avoid dubbo's logic which might pick docker ip
@@ -49,11 +49,7 @@ class TestServer {
     service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
     service.setInterface(GreeterService.class);
     service.setRef((method, parameterTypes, args) -> {
-      RpcContext context = RpcContext.getContext();
-      DubboServerRequest request =
-        new DubboServerRequest(context.getInvocation(), context.getAttachments());
-      requestQueue.add(extractor.extract(request));
-
+      requestQueue.add(extractor.extract(RpcContext.getContext().getAttachments()));
       return args[0];
     });
   }

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboClientResponse.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboClientResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.Response;
+import brave.Span;
+import brave.internal.Nullable;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+
+final class DubboClientResponse extends Response implements DubboResponse {
+  final DubboClientRequest request;
+  @Nullable final Result result;
+  @Nullable final Throwable error;
+
+  DubboClientResponse(
+    DubboClientRequest request, @Nullable Result result, @Nullable Throwable error) {
+    if (request == null) throw new NullPointerException("request == null");
+    this.request = request;
+    this.result = result;
+    this.error = error;
+  }
+
+  @Override public Span.Kind spanKind() {
+    return Span.Kind.CLIENT;
+  }
+
+  @Override public Result result() {
+    return result;
+  }
+
+  @Override public Result unwrap() {
+    return result;
+  }
+
+  @Override public DubboClientRequest request() {
+    return request;
+  }
+
+  @Override public Throwable error() {
+    return error;
+  }
+
+  /** Returns the string form of the {@link RpcException#getCode()} */
+  String errorCode() {
+    return DubboParser.errorCode(error);
+  }
+}

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboRequest.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.rpc.RpcClientRequest;
+import brave.rpc.RpcServerRequest;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+
+/**
+ * Used to access Dubbo specific aspects of a client or server request.
+ *
+ * <p>Here's an example that adds default tags, and if Dubbo, Java arguments:
+ * <pre>{@code
+ * rpcTracing = rpcTracingBuilder
+ *   .clientRequestParser((req, context, span) -> {
+ *      RpcRequestParser.DEFAULT.parse(req, context, span);
+ *      if (req instanceof DubboRequest) {
+ *        tagArguments(((DubboRequest) req).invocation().getArguments());
+ *      }
+ *   }).build();
+ * }</pre>
+ *
+ * <p>Note: Do not implement this type directly. An implementation will be
+ * either as {@link RpcClientRequest} or an {@link RpcServerRequest}.
+ *
+ * @since 5.12
+ */
+// Note: Unlike Alibaba Dubbo, Apache Dubbo is Java 8+.
+// This means we can add default methods later should needs arise.
+interface DubboRequest { // TODO: make public after #999
+  Invoker<?> invoker();
+
+  Invocation invocation();
+}

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboResponse.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.internal.Nullable;
+import org.apache.dubbo.rpc.Result;
+
+/**
+ * Used to access Dubbo specific aspects of a client or server response.
+ *
+ * <p>Here's an example that adds default tags, and if Dubbo, the Java result:
+ * <pre>{@code
+ * rpcTracing = rpcTracingBuilder
+ *   .clientResponseParser((res, context, span) -> {
+ *      RpcResponseParser.DEFAULT.parse(res, context, span);
+ *      if (res instanceof DubboResponse) {
+ *        DubboResponse dubboResponse = (DubboResponse) res;
+ *        if (res.result() != null) {
+ *          tagJavaResult(res.result().value());
+ *        }
+ *      }
+ *   }).build();
+ * }</pre>
+ *
+ * @since 5.12
+ */
+interface DubboResponse { // TODO: make public after #999
+  DubboRequest request();
+
+  @Nullable Result result();
+}

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboServerRequest.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,48 +13,63 @@
  */
 package brave.dubbo;
 
-import brave.internal.Nullable;
-import brave.propagation.Propagation.Getter;
+import brave.propagation.Propagation;
 import brave.rpc.RpcServerRequest;
-import java.util.Map;
+import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
 
-// intentionally not yet public until we add tag parsing functionality
-final class DubboServerRequest extends RpcServerRequest {
-  static final Getter<DubboServerRequest, String> GETTER =
-    new Getter<DubboServerRequest, String>() {
+final class DubboServerRequest extends RpcServerRequest implements DubboRequest {
+  static final Propagation.Getter<DubboServerRequest, String> GETTER =
+    new Propagation.Getter<DubboServerRequest, String>() {
       @Override public String get(DubboServerRequest request, String key) {
-        return request.getAttachment(key);
+        return request.propagationField(key);
       }
 
       @Override public String toString() {
-        return "DubboServerRequest::getAttachment";
+        return "DubboServerRequest::propagationField";
       }
     };
 
+  final Invoker<?> invoker;
   final Invocation invocation;
-  final Map<String, String> attachments;
 
-  DubboServerRequest(Invocation invocation, Map<String, String> attachments) {
+  DubboServerRequest(Invoker<?> invoker, Invocation invocation) {
+    if (invoker == null) throw new NullPointerException("invoker == null");
     if (invocation == null) throw new NullPointerException("invocation == null");
+    this.invoker = invoker;
     this.invocation = invocation;
-    if (attachments == null) throw new NullPointerException("attachments == null");
-    this.attachments = attachments;
   }
 
-  @Override public Object unwrap() {
-    return this;
+  @Override public Invoker<?> invoker() {
+    return invoker;
   }
 
+  @Override public Invocation invocation() {
+    return invocation;
+  }
+
+  /** Returns the {@link Invocation}. */
+  @Override public Invocation unwrap() {
+    return invocation;
+  }
+
+  /**
+   * Returns the method name of the invocation or the first string arg of an "$invoke" or
+   * "$invokeAsync" method.
+   */
   @Override public String method() {
     return DubboParser.method(invocation);
   }
 
+  /**
+   * Returns the {@link URL#getServiceInterface() service interface} of the invocation.
+   */
   @Override public String service() {
     return DubboParser.service(invocation);
   }
 
-  @Nullable String getAttachment(String key) {
-    return attachments.get(key);
+  String propagationField(String keyName) {
+    return invocation.getAttachment(keyName);
   }
 }

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboServerResponse.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboServerResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import brave.Response;
+import brave.Span;
+import brave.internal.Nullable;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+
+final class DubboServerResponse extends Response implements DubboResponse {
+  final DubboServerRequest request;
+  @Nullable final Result result;
+  @Nullable final Throwable error;
+
+  DubboServerResponse(
+    DubboServerRequest request, @Nullable Result result, @Nullable Throwable error) {
+    if (request == null) throw new NullPointerException("request == null");
+    this.request = request;
+    this.result = result;
+    this.error = error;
+  }
+
+  @Override public Span.Kind spanKind() {
+    return Span.Kind.SERVER;
+  }
+
+  @Override public Result result() {
+    return result;
+  }
+
+  @Override public Result unwrap() {
+    return result;
+  }
+
+  @Override public DubboServerRequest request() {
+    return request;
+  }
+
+  @Override public Throwable error() {
+    return error;
+  }
+
+  /** Returns the string form of the {@link RpcException#getCode()} */
+  String errorCode() {
+    return DubboParser.errorCode(error);
+  }
+}

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientRequestTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientRequestTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DubboClientRequestTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  URL url = mock(URL.class);
+  Map<String, String> attachments = new LinkedHashMap<>();
+  DubboClientRequest request = new DubboClientRequest(invoker, invocation, attachments);
+
+  @Test public void service() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+    when(url.getServiceInterface()).thenReturn("brave.dubbo.GreeterService");
+
+    assertThat(request.service())
+      .isEqualTo("brave.dubbo.GreeterService");
+  }
+
+  @Test public void method() {
+    when(invocation.getMethodName()).thenReturn("sayHello");
+
+    assertThat(request.method()).isEqualTo("sayHello");
+  }
+
+  @Test public void unwrap() {
+    assertThat(request.unwrap()).isSameAs(invocation);
+  }
+
+  @Test public void invoker() {
+    assertThat(request.invoker()).isSameAs(invoker);
+  }
+
+  @Test public void invocation() {
+    assertThat(request.invocation()).isSameAs(invocation);
+  }
+
+  @Test public void propagationField() {
+    request.propagationField("b3", "d");
+
+    assertThat(attachments).containsEntry("b3", "d");
+  }
+}

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientResponseTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+import org.junit.Test;
+
+import static org.apache.dubbo.rpc.RpcException.TIMEOUT_EXCEPTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DubboClientResponseTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  Result result = mock(Result.class);
+  RpcException error = new RpcException(TIMEOUT_EXCEPTION);
+  Map<String, String> attachments = new LinkedHashMap<>();
+  DubboClientRequest request = new DubboClientRequest(invoker, invocation, attachments);
+  DubboClientResponse response = new DubboClientResponse(request, result, error);
+
+  @Test public void request() {
+    assertThat(response.request()).isSameAs(request);
+  }
+
+  @Test public void result() {
+    assertThat(response.result()).isSameAs(result);
+  }
+
+  @Test public void unwrap() {
+    assertThat(response.unwrap()).isSameAs(result);
+  }
+
+  @Test public void error() {
+    assertThat(response.error()).isSameAs(error);
+  }
+
+  @Test public void errorCode() {
+    assertThat(response.errorCode()).isEqualTo("TIMEOUT_EXCEPTION");
+  }
+}

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboServerRequestTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboServerRequestTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DubboServerRequestTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  URL url = mock(URL.class);
+  DubboServerRequest request = new DubboServerRequest(invoker, invocation);
+
+  @Test public void service() {
+    when(invocation.getInvoker()).thenReturn(invoker);
+    when(invoker.getUrl()).thenReturn(url);
+    when(url.getServiceInterface()).thenReturn("brave.dubbo.GreeterService");
+
+    assertThat(request.service())
+      .isEqualTo("brave.dubbo.GreeterService");
+  }
+
+  @Test public void method() {
+    when(invocation.getMethodName()).thenReturn("sayHello");
+
+    assertThat(request.method()).isEqualTo("sayHello");
+  }
+
+  @Test public void unwrap() {
+    assertThat(request.unwrap()).isSameAs(invocation);
+  }
+
+  @Test public void invoker() {
+    assertThat(request.invoker()).isSameAs(invoker);
+  }
+
+  @Test public void invocation() {
+    assertThat(request.invocation()).isSameAs(invocation);
+  }
+
+  @Test public void propagationField() {
+    when(invocation.getAttachment("b3")).thenReturn("d");
+
+    assertThat(request.propagationField("b3")).isEqualTo("d");
+  }
+}

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboServerResponseTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboServerResponseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.dubbo;
+
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+import org.junit.Test;
+
+import static org.apache.dubbo.rpc.RpcException.TIMEOUT_EXCEPTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class DubboServerResponseTest {
+  Invoker invoker = mock(Invoker.class);
+  Invocation invocation = mock(Invocation.class);
+  Result result = mock(Result.class);
+  RpcException error = new RpcException(TIMEOUT_EXCEPTION);
+  DubboServerRequest request = new DubboServerRequest(invoker, invocation);
+  DubboServerResponse response = new DubboServerResponse(request, result, error);
+
+  @Test public void request() {
+    assertThat(response.request()).isSameAs(request);
+  }
+
+  @Test public void result() {
+    assertThat(response.result()).isSameAs(result);
+  }
+
+  @Test public void unwrap() {
+    assertThat(response.unwrap()).isSameAs(result);
+  }
+
+  @Test public void error() {
+    assertThat(response.error()).isSameAs(error);
+  }
+
+  @Test public void errorCode() {
+    assertThat(response.errorCode()).isEqualTo("TIMEOUT_EXCEPTION");
+  }
+}

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -13,7 +13,6 @@
  */
 package brave.dubbo;
 
-import brave.rpc.RpcTracing;
 import brave.test.ITRemote;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.ApplicationConfig;
@@ -22,7 +21,6 @@ import org.apache.dubbo.rpc.Filter;
 import org.junit.After;
 
 public abstract class ITTracingFilter extends ITRemote {
-  RpcTracing rpcTracing = RpcTracing.create(tracing);
   ApplicationConfig application = new ApplicationConfig("brave");
   TestServer server = new TestServer(propagationFactory, application);
   ReferenceConfig<GreeterService> client;
@@ -32,10 +30,11 @@ public abstract class ITTracingFilter extends ITRemote {
     server.stop();
   }
 
-  /** Call this after updating {@link #tracing} or {@link #rpcTracing} */
-  void init() {
-    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
-      .getExtension("tracing"))
-      .setRpcTracing(rpcTracing);
+  /** Call this after updating {@link #tracing} */
+  TracingFilter init() {
+    TracingFilter filter = (TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+      .getExtension("tracing");
+    filter.setTracing(tracing);
+    return filter;
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -20,8 +20,10 @@ import brave.propagation.TraceContext;
 import brave.rpc.RpcRuleSampler;
 import brave.rpc.RpcTracing;
 import brave.test.util.AssertableCallback;
+import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.bootstrap.DubboBootstrap;
+import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
 import org.junit.After;
@@ -180,11 +182,11 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
   }
 
   @Test public void customSampler() {
-    rpcTracing = RpcTracing.newBuilder(tracing).clientSampler(RpcRuleSampler.newBuilder()
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing).clientSampler(RpcRuleSampler.newBuilder()
       .putRule(methodEquals("sayGoodbye"), NEVER_SAMPLE)
       .putRule(serviceEquals("brave.dubbo"), ALWAYS_SAMPLE)
       .build()).build();
-    init();
+    init().setRpcTracing(rpcTracing);
 
     // unsampled
     client.get().sayGoodbye("jorge");
@@ -240,6 +242,25 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     Span span =
       reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, ".*Not found exported service.*");
-    assertThat(span.tags().get("dubbo.error_code")).isEqualTo("NETWORK_EXCEPTION");
+    assertThat(span.tags())
+      .containsEntry("dubbo.error_code", "1");
+  }
+
+  /** Shows if you aren't using RpcTracing, the old "dubbo.error_code" works */
+  @Test public void addsErrorTag_onUnimplemented_legacy() {
+    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+      .getExtension("tracing")).isInit = false;
+
+    ((TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
+      .getExtension("tracing"))
+      .setTracing(tracing);
+
+    assertThatThrownBy(() -> wrongClient.get().sayHello("jorge"))
+      .isInstanceOf(RpcException.class);
+
+    Span span =
+      reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, ".*Not found exported service.*");
+    assertThat(span.tags())
+      .containsEntry("dubbo.error_code", "1");
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -74,7 +74,6 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
   @Test public void createsChildWhenJoinDisabled() {
     tracing = tracingBuilder(NEVER_SAMPLE).supportsJoin(false).build();
-    rpcTracing = RpcTracing.create(tracing);
     init();
 
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
@@ -89,7 +88,6 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
   @Test public void samplingDisabled() {
     tracing = tracingBuilder(NEVER_SAMPLE).build();
-    rpcTracing = RpcTracing.create(tracing);
     init();
 
     client.get().sayHello("jorge");
@@ -125,11 +123,11 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
   }
 
   @Test public void customSampler() {
-    rpcTracing = RpcTracing.newBuilder(tracing).serverSampler(RpcRuleSampler.newBuilder()
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing).serverSampler(RpcRuleSampler.newBuilder()
       .putRule(methodEquals("sayGoodbye"), NEVER_SAMPLE)
       .putRule(serviceEquals("brave.dubbo"), ALWAYS_SAMPLE)
       .build()).build();
-    init();
+    init().setRpcTracing(rpcTracing);
 
     // unsampled
     client.get().sayGoodbye("jorge");


### PR DESCRIPTION
This fixes some glitches in preparation of #999. These changes were
already reviewed, just being raised separately to reduce the diff.

* Restores old dubbo.error_code numeric value
  * 999 will use this unless initialized with RpcTracing
* Sets callback context of alibaba dubbo client to invocation context.
* Makes integration tests consistently use setTracing unless sampling
  * This helps classify legacy behavior vs new
* General cleanups on alibaba dubbo Future code
* Addition of types used for 999