### PR TITLE
Backfills JMS baggage tests and emphasizes in ITRemote header names

### DIFF
--- a/brave-tests/src/main/java/brave/test/propagation/CurrentTraceContextTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/CurrentTraceContextTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public abstract class CurrentTraceContextTest {
   protected static final SingleCorrelationField CORRELATION_FIELD =
-    SingleCorrelationField.create(BaggageField.create("user-id"));
+    SingleCorrelationField.create(BaggageField.create("userId"));
 
   Propagation.Factory baggageFactory = BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY)
     .add(SingleBaggageField.remote(CORRELATION_FIELD.baggageField())).build();

--- a/brave/src/test/java/brave/baggage/CorrelationScopeDecoratorTest.java
+++ b/brave/src/test/java/brave/baggage/CorrelationScopeDecoratorTest.java
@@ -42,7 +42,7 @@ public class CorrelationScopeDecoratorTest {
   static final SingleCorrelationField
     TRACE_ID =
     SingleCorrelationField.newBuilder(BaggageFields.TRACE_ID).name("X-B3-TraceId").build(),
-    FIELD = SingleCorrelationField.create(BaggageField.create("user-id")),
+    FIELD = SingleCorrelationField.create(BaggageField.create("userId")),
     FIELD_2 = SingleCorrelationField.create(BaggageField.create("country-code")),
     DIRTY_FIELD = FIELD.toBuilder().name("dirty").dirty().build(),
     LOCAL_FIELD = SingleCorrelationField.create(BaggageField.create("serviceId")),

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -37,12 +37,13 @@ import static org.assertj.core.data.MapEntry.entry;
  * the core concepts.
  */
 public class OpenTracingAdapterTest {
-  static final BaggageField BAGGAGE_FIELD = BaggageField.create("user-id");
+  static final BaggageField BAGGAGE_FIELD = BaggageField.create("userId");
 
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing brave = Tracing.newBuilder()
     .propagationFactory(BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY)
-      .add(SingleBaggageField.remote(BAGGAGE_FIELD)).build())
+        .add(SingleBaggageField.newBuilder(BAGGAGE_FIELD)
+            .addKeyName("user-id").build()).build())
     .spanReporter(spans::add).build();
 
   BraveTracer opentracing = BraveTracer.wrap(brave);

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -14,6 +14,7 @@
 package brave.test.http;
 
 import brave.SpanCustomizer;
+import brave.baggage.BaggageField;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.http.HttpAdapter;
@@ -25,7 +26,6 @@ import brave.http.HttpServerParser;
 import brave.http.HttpTags;
 import brave.http.HttpTracing;
 import brave.propagation.B3SingleFormat;
-import brave.baggage.BaggageField;
 import brave.propagation.SamplingFlags;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
@@ -125,13 +125,13 @@ public abstract class ITHttpServer extends ITRemote {
   }
 
   /**
-   * The /baggage endpoint should copy the value of {@link #BAGGAGE_FIELD} to the response body using
-   * {@link BaggageField#getValue()}.
+   * The /baggage endpoint should copy the value of {@link #BAGGAGE_FIELD} to the response body
+   * using {@link BaggageField#getValue()}.
    */
   void readsBaggage(Request.Builder builder) throws IOException {
     Request request = builder.url(url("/baggage"))
       // this is the pre-configured key we can pass through
-      .header(BAGGAGE_FIELD.name(), "joey").build();
+      .header(BAGGAGE_FIELD_KEY, "joey").build();
 
     Response response = get(request);
     assertThat(response.isSuccessful()).isTrue();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -115,7 +115,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
-      ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD.name(), BAGGAGE_FIELD.getValue());
+      ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD_KEY, BAGGAGE_FIELD.getValue());
       chain.doFilter(request, response);
     }
 
@@ -129,10 +129,10 @@ public abstract class ITServlet25Container extends ITServletContainer {
     String path = "/foo";
 
     Request request = new Request.Builder().url(url(path))
-      .header(BAGGAGE_FIELD.name(), "abcdefg").build();
+      .header(BAGGAGE_FIELD_KEY, "abcdefg").build();
     try (Response response = client.newCall(request).execute()) {
       assertThat(response.isSuccessful()).isTrue();
-      assertThat(response.header(BAGGAGE_FIELD.name()))
+      assertThat(response.header(BAGGAGE_FIELD_KEY))
         .isEqualTo("abcdefg");
     }
 
@@ -149,7 +149,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
       throws IOException, ServletException {
       TraceContext context = (TraceContext) request.getAttribute("brave.propagation.TraceContext");
       String value = BAGGAGE_FIELD.getValue(context);
-      ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD.name(), value);
+      ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD_KEY, value);
       chain.doFilter(request, response);
     }
 
@@ -163,11 +163,11 @@ public abstract class ITServlet25Container extends ITServletContainer {
     String path = "/foo";
 
     Request request = new Request.Builder().url(url(path))
-      .header(BAGGAGE_FIELD.name(), "abcdefg").build();
+      .header(BAGGAGE_FIELD_KEY, "abcdefg").build();
     try (Response response = client.newCall(request).execute()) {
       assertThat(response.isSuccessful()).isTrue();
-      assertThat(response.header(BAGGAGE_FIELD.name()))
-        .isEqualTo("abcdefg");
+      assertThat(response.header(BAGGAGE_FIELD_KEY))
+          .isEqualTo("abcdefg");
     }
 
     reporter.takeRemoteSpan(Span.Kind.SERVER);

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
@@ -50,7 +50,7 @@ public class KafkaTracingTest extends ITKafka {
 
   @Test public void nextSpan_should_create_span_with_baggage() {
     addB3MultiHeaders(fakeRecord);
-    fakeRecord.headers().add(BAGGAGE_FIELD.name(), "user1".getBytes());
+    fakeRecord.headers().add(BAGGAGE_FIELD_KEY, "user1".getBytes());
 
     Span span = kafkaTracing.nextSpan(fakeRecord);
     assertThat(BAGGAGE_FIELD.getValue(span.context())).contains("user1");

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -322,7 +322,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
     KafkaStreams streams = buildKafkaStreams(topology);
 
     ProducerRecord<String, String> record = new ProducerRecord<>(inputTopic, TEST_KEY, TEST_VALUE);
-    record.headers().add(BAGGAGE_FIELD.name(), "user1".getBytes());
+    record.headers().add(BAGGAGE_FIELD_KEY, "user1".getBytes());
     send(record);
 
     waitForStreamToRun(streams);

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/KafkaStreamsTracingTest.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/KafkaStreamsTracingTest.java
@@ -82,7 +82,7 @@ public class KafkaStreamsTracingTest extends ITKafkaStreams {
               assertThat(BAGGAGE_FIELD.getValue()).isEqualTo("user1");
             }
           });
-    Headers headers = new RecordHeaders().add(BAGGAGE_FIELD.name(), "user1".getBytes());
+    Headers headers = new RecordHeaders().add(BAGGAGE_FIELD_KEY, "user1".getBytes());
     Processor<String, String> processor = processorSupplier.get();
     processor.init(processorContextSupplier.apply(headers));
     processor.process(TEST_KEY, TEST_VALUE);


### PR DESCRIPTION
This backfills missing integration tests for JMS, which show that
baggage propagation works today. It adds to the base integration test
that we should be careful about header name choices for the '-'
reason.