### PR TITLE
Decouples propagatation "extra" from remote key names

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -40,7 +40,7 @@ import static brave.internal.InternalPropagation.FLAG_SAMPLED;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 import static brave.internal.InternalPropagation.FLAG_SHARED;
-import static brave.internal.Lists.concatImmutableLists;
+import static brave.internal.Lists.concat;
 import static brave.propagation.SamplingFlags.EMPTY;
 import static brave.propagation.SamplingFlags.NOT_SAMPLED;
 import static brave.propagation.SamplingFlags.SAMPLED;
@@ -359,7 +359,7 @@ public class Tracer {
       traceId = parent.traceId();
       localRootId = parent.localRootId();
       spanId = parent.spanId();
-      extra = concatImmutableLists(extra, parent.extra());
+      extra = concat(extra, parent.extra());
     } else {
       flags = InternalPropagation.instance.flags(samplingFlags);
     }

--- a/brave/src/main/java/brave/internal/baggage/BaggageHandlers.java
+++ b/brave/src/main/java/brave/internal/baggage/BaggageHandlers.java
@@ -15,7 +15,6 @@ package brave.internal.baggage;
 
 import brave.baggage.BaggageField;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -61,22 +60,17 @@ public final class BaggageHandlers {
   }
 
   /** Only handles a single remote field value. */
-  public static RemoteBaggageHandler<String> string(SingleBaggageField field) {
-    List<String> keyNameList = Collections.unmodifiableList(new ArrayList<>(field.keyNames()));
-    return new RemoteStringBaggageHandler(field.field(), keyNameList);
+  public static RemoteBaggageHandler<String> remoteString(SingleBaggageField fieldConfig) {
+    if (fieldConfig == null) throw new NullPointerException("fieldConfig == null");
+    if (fieldConfig.keyNames().isEmpty()) throw new NullPointerException("remote has keyNames");
+    return new RemoteStringBaggageHandler(fieldConfig.field());
   }
 
   static final class RemoteStringBaggageHandler extends StringBaggageHandler
-    implements RemoteBaggageHandler<String> {
-    final List<String> keyNames;
+      implements RemoteBaggageHandler<String> {
 
-    RemoteStringBaggageHandler(BaggageField field, List<String> keyNames) {
+    RemoteStringBaggageHandler(BaggageField field) {
       super(field);
-      this.keyNames = keyNames;
-    }
-
-    @Override public List<String> keyNames() {
-      return keyNames;
     }
 
     @Override public String fromRemoteValue(Object request, String value) {

--- a/brave/src/main/java/brave/internal/baggage/ExtraBaggageContext.java
+++ b/brave/src/main/java/brave/internal/baggage/ExtraBaggageContext.java
@@ -32,15 +32,6 @@ public final class ExtraBaggageContext extends BaggageContext {
     return INSTANCE;
   }
 
-  public static List<String> getAllKeyNames(TraceContextOrSamplingFlags extracted) {
-    if (extracted.context() != null) return getAllKeyNames(extracted.context());
-    return getAllKeyNames(extracted.extra());
-  }
-
-  public static List<String> getAllKeyNames(TraceContext context) {
-    return getAllKeyNames(context.extra());
-  }
-
   public static List<BaggageField> getAllFields(TraceContextOrSamplingFlags extracted) {
     if (extracted.context() != null) return getAllFields(extracted.context());
     return getAllFields(extracted.extra());
@@ -77,12 +68,6 @@ public final class ExtraBaggageContext extends BaggageContext {
 
   @Override public boolean updateValue(BaggageField field, TraceContext context, String value) {
     return updateValue(field, context.extra(), value);
-  }
-
-  static List<String> getAllKeyNames(List<Object> extra) {
-    ExtraBaggageFields fields = findExtra(ExtraBaggageFields.class, extra);
-    if (fields == null) return Collections.emptyList();
-    return fields.getAllKeyNames();
   }
 
   static List<BaggageField> getAllFields(List<Object> extra) {

--- a/brave/src/main/java/brave/internal/baggage/ExtraBaggageFields.java
+++ b/brave/src/main/java/brave/internal/baggage/ExtraBaggageFields.java
@@ -61,16 +61,6 @@ public final class ExtraBaggageFields {
     return Collections.unmodifiableList(result);
   }
 
-  public List<String> getAllKeyNames() {
-    List<String> result = new ArrayList<>();
-    for (BaggageHandler handler : handlers) {
-      if (handler instanceof RemoteBaggageHandler) {
-        result.addAll(((RemoteBaggageHandler) handler).keyNames());
-      }
-    }
-    return Collections.unmodifiableList(result);
-  }
-
   /**
    * Returns the value of the field with the specified name or null if not available.
    *

--- a/brave/src/main/java/brave/internal/baggage/RemoteBaggageHandler.java
+++ b/brave/src/main/java/brave/internal/baggage/RemoteBaggageHandler.java
@@ -18,7 +18,6 @@ import brave.baggage.BaggagePropagationConfig;
 import brave.internal.Nullable;
 import brave.propagation.Propagation.Getter;
 import brave.propagation.Propagation.Setter;
-import java.util.List;
 
 /**
  * Handles context storage of one or more baggage fields using one {@link ExtraBaggageFields}
@@ -27,10 +26,6 @@ import java.util.List;
  * @param <S> the state that represents one or more baggage fields
  */
 public interface RemoteBaggageHandler<S> extends BaggageHandler<S> {
-
-  /** Returns all remote key names used for this field. */
-  List<String> keyNames();
-
   /**
    * Extracts any state from a request value received by {@link Getter#get(Object, Object)}.
    *

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
-import static brave.internal.Lists.concatImmutableLists;
+import static brave.internal.Lists.concat;
 import static brave.internal.Lists.ensureImmutable;
 import static java.util.Collections.emptyList;
 
@@ -222,8 +222,7 @@ public final class TraceContextOrSamplingFlags {
         if (context.extra().isEmpty()) {
           context = InternalPropagation.instance.withExtra(context, ensureImmutable(extra));
         } else {
-          context = InternalPropagation.instance.withExtra(context,
-            concatImmutableLists(context.extra(), extra));
+          context = InternalPropagation.instance.withExtra(context, concat(context.extra(), extra));
         }
         result = new TraceContextOrSamplingFlags(type, context, emptyList());
       } else {

--- a/brave/src/test/java/brave/features/baggage/DynamicBaggageTest.java
+++ b/brave/src/test/java/brave/features/baggage/DynamicBaggageTest.java
@@ -26,10 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** This is an internal feature until we settle on an encoding format. */
 public class DynamicBaggageTest extends ExtraBaggageFieldsTest {
-  RemoteBaggageHandler<String> singleValueHandler = BaggageHandlers.string(
-    SingleBaggageField.remote(field1));
-  RemoteBaggageHandler<Map<BaggageField, String>> dynamicHandler =
-    DynamicBaggageHandler.create("baggage");
+  RemoteBaggageHandler<String> singleValueHandler =
+      BaggageHandlers.remoteString(SingleBaggageField.remote(field1));
+  RemoteBaggageHandler<Map<BaggageField, String>> dynamicHandler = DynamicBaggageHandler.get();
 
   @Override protected boolean isEmpty(Object state) {
     return state == null || (state instanceof Map && ((Map) state).isEmpty());

--- a/brave/src/test/java/brave/internal/ListsTest.java
+++ b/brave/src/test/java/brave/internal/ListsTest.java
@@ -80,19 +80,19 @@ public class ListsTest {
       .isSameAs(list);
   }
 
-  @Test public void concatImmutableLists_choosesNonEmpty() {
+  @Test public void concat_choosesNonEmpty() {
     List<Object> list = ImmutableList.of("foo");
-    assertThat(Lists.concatImmutableLists(list, Collections.emptyList()))
+    assertThat(Lists.concat(list, Collections.emptyList()))
       .isSameAs(list);
-    assertThat(Lists.concatImmutableLists(Collections.emptyList(), list))
+    assertThat(Lists.concat(Collections.emptyList(), list))
       .isSameAs(list);
   }
 
-  @Test public void concatImmutableLists_concatenates() {
+  @Test public void concat_concatenates() {
     List<Object> list1 = ImmutableList.of("foo");
     List<Object> list2 = ImmutableList.of("bar", "baz");
 
-    assertThat(Lists.concatImmutableLists(list1, list2))
+    assertThat(Lists.concat(list1, list2))
       .hasSameClassAs(Collections.unmodifiableList(list1))
       .containsExactly("foo", "bar", "baz");
   }

--- a/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
+++ b/brave/src/test/java/brave/propagation/ExtraFieldPropagationTest.java
@@ -238,7 +238,7 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
       .isEqualTo(context);
     assertThat(extracted.context().extra())
-      .hasSize(1);
+      .hasSize(2);
 
     assertThat(BaggageField.getByName(extracted, "x-amzn-trace-id").getValue(extracted))
       .isEqualTo(awsTraceId);
@@ -253,7 +253,7 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
       .isEqualTo(context);
     assertThat(extracted.context().extra())
-      .hasSize(1);
+      .hasSize(2);
 
     assertThat(BaggageField.getByName(extracted, "x-amzn-trace-id").getValue(extracted))
       .isEqualTo(awsTraceId);
@@ -276,7 +276,7 @@ public class ExtraFieldPropagationTest {
     assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
       .isEqualTo(context);
     assertThat(extracted.context().extra())
-      .hasSize(1);
+      .hasSize(2);
 
     assertThat(BaggageField.getByName(extracted, "country-code").getValue(extracted))
       .isEqualTo("FO");

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 
     <sparkjava.version>2.9.1</sparkjava.version>
     <junit.version>4.13</junit.version>
-    <assertj.version>3.14.0</assertj.version>
+    <assertj.version>3.15.0</assertj.version>
     <powermock.version>2.0.5</powermock.version>
     <mockito.version>2.28.2</mockito.version>
     <jersey.version>2.25.1</jersey.version>


### PR DESCRIPTION
This starts the process of decoupling internals of BaggagePropagation
so that we can allow remote configuration independent of state handling.

I also noticed we can simplify `TraceContext.extra()` structurally by
backing unmodifiable lists with Arrays.asList as opposed to ArrayList.