### PR TITLE
Improves quality of TraceContextOrSamplingFlags

### DIFF
--- a/brave/src/main/java/brave/internal/Lists.java
+++ b/brave/src/main/java/brave/internal/Lists.java
@@ -36,7 +36,7 @@ public final class Lists {
     if (list.size() == 1) return Collections.singletonList(list.get(0));
     if (isImmutable(list)) return list;
 
-    return concat(list, Collections.emptyList());
+    return Collections.unmodifiableList(new ArrayList<>(list));
   }
 
   static boolean isImmutable(List<?> extra) {

--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -280,8 +280,16 @@ public final class B3Propagation<K> implements Propagation<K> {
       boolean debug = "1".equals(getter.get(request, propagation.debugKey));
 
       String traceIdString = getter.get(request, propagation.traceIdKey);
+
       // It is ok to go without a trace ID, if sampling or debug is set
-      if (traceIdString == null) return TraceContextOrSamplingFlags.create(sampledV, debug);
+      if (traceIdString == null) {
+        if (debug) return TraceContextOrSamplingFlags.DEBUG;
+        if (sampledV != null) {
+          return sampledV
+              ? TraceContextOrSamplingFlags.SAMPLED
+              : TraceContextOrSamplingFlags.NOT_SAMPLED;
+        }
+      }
 
       // Try to parse the trace IDs into the context
       TraceContext.Builder result = TraceContext.newBuilder();

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -119,9 +119,9 @@ public class SamplingFlags {
       result.append("DEBUG");
     } else  if ((flags & FLAG_SAMPLED_SET) == FLAG_SAMPLED_SET) {
       if ((flags & FLAG_SAMPLED) == FLAG_SAMPLED) {
-        result.append("SAMPLED");
+        result.append("SAMPLED_REMOTE");
       } else {
-        result.append("NOT_SAMPLED");
+        result.append("NOT_SAMPLED_REMOTE");
       }
     }
     if ((flags & FLAG_SAMPLED_LOCAL) == FLAG_SAMPLED_LOCAL) {

--- a/brave/src/main/java/brave/propagation/SamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/SamplingFlags.java
@@ -110,13 +110,25 @@ public class SamplingFlags {
   }
 
   @Override public String toString() {
-    return "SamplingFlags(sampled="
-      + sampled()
-      + ", sampledLocal="
-      + sampledLocal()
-      + ", debug="
-      + debug()
-      + ")";
+    return toString(flags);
+  }
+
+  static String toString(int flags) {
+    StringBuilder result = new StringBuilder();
+    if ((flags & FLAG_DEBUG) == FLAG_DEBUG) {
+      result.append("DEBUG");
+    } else  if ((flags & FLAG_SAMPLED_SET) == FLAG_SAMPLED_SET) {
+      if ((flags & FLAG_SAMPLED) == FLAG_SAMPLED) {
+        result.append("SAMPLED");
+      } else {
+        result.append("NOT_SAMPLED");
+      }
+    }
+    if ((flags & FLAG_SAMPLED_LOCAL) == FLAG_SAMPLED_LOCAL) {
+      if (result.length() > 0) result.append('|');
+      result.append("SAMPLED_LOCAL");
+    }
+    return result.toString();
   }
 
   /** @deprecated prefer using constants. This will be removed in Brave v6 */

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -18,6 +18,7 @@ import brave.internal.InternalPropagation;
 import brave.internal.Nullable;
 import brave.internal.Platform;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,6 +31,7 @@ import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 import static brave.internal.InternalPropagation.FLAG_SHARED;
 import static brave.internal.Lists.ensureImmutable;
+import static brave.internal.Lists.ensureMutable;
 import static brave.propagation.TraceIdContext.toTraceIdString;
 
 /**
@@ -176,7 +178,7 @@ public final class TraceContext extends SamplingFlags {
    * when {@link Propagation.Factory#decorate(TraceContext)} is called.
    */
   public List<Object> extra() {
-    return extra;
+    return extraList;
   }
 
   /**
@@ -187,7 +189,7 @@ public final class TraceContext extends SamplingFlags {
    * this can break logic.
    */
   public @Nullable <T> T findExtra(Class<T> type) {
-    return findExtra(type, extra);
+    return findExtra(type, extraList);
   }
 
   public Builder toBuilder() {
@@ -259,7 +261,7 @@ public final class TraceContext extends SamplingFlags {
     long traceIdHigh, traceId, parentId, spanId;
     long localRootId; // intentionally only mutable by the copy constructor to control usage.
     int flags;
-    List<Object> extra = Collections.emptyList();
+    List<Object> extraList = Collections.emptyList();
 
     Builder(TraceContext context) { // no external implementations
       traceIdHigh = context.traceIdHigh;
@@ -268,7 +270,7 @@ public final class TraceContext extends SamplingFlags {
       parentId = context.parentId;
       spanId = context.spanId;
       flags = context.flags;
-      extra = context.extra;
+      extraList = context.extraList;
     }
 
     /** @see TraceContext#traceIdHigh() */
@@ -343,13 +345,18 @@ public final class TraceContext extends SamplingFlags {
       return this;
     }
 
-    /**
-     * Shares the input with the builder, replacing any current data in the builder.
-     *
-     * @see TraceContext#extra()
-     */
-    public final Builder extra(List<Object> extra) {
-      this.extra = extra;
+    /** @deprecated Since 5.12, use {@link #addExtra(Object)} */
+    @Deprecated public final Builder extra(List<Object> extraList) {
+      if (extraList == null) throw new NullPointerException("extraList == null");
+      for (Object extra : extraList) {
+        addExtra(extra);
+      }
+      return this;
+    }
+
+    /** @see #extra() */
+    public final Builder addExtra(Object extra) {
+      extraList = ensureExtraAdded(extraList, extra);
       return this;
     }
 
@@ -365,7 +372,7 @@ public final class TraceContext extends SamplingFlags {
      * // Attempt to parse the trace ID or break out if unsuccessful for any reason
      * String traceIdString = getter.get(request, key);
      * if (!builder.parseTraceId(traceIdString, propagation.traceIdKey)) {
-     *   return TraceContextOrSamplingFlags.EMPTY;
+     *   return EMPTY;
      * }
      * }</pre>
      *
@@ -481,7 +488,7 @@ public final class TraceContext extends SamplingFlags {
       if (spanId == 0L) missing += " spanId";
       if (!"".equals(missing)) throw new IllegalArgumentException("Missing:" + missing);
       return new TraceContext(
-        flags, traceIdHigh, traceId, localRootId, parentId, spanId, ensureImmutable(extra)
+        flags, traceIdHigh, traceId, localRootId, parentId, spanId, ensureImmutable(extraList)
       );
     }
 
@@ -490,7 +497,7 @@ public final class TraceContext extends SamplingFlags {
   }
 
   TraceContext shallowCopy() {
-    return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extra);
+    return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extraList);
   }
 
   TraceContext withExtra(List<Object> extra) {
@@ -498,11 +505,11 @@ public final class TraceContext extends SamplingFlags {
   }
 
   TraceContext withFlags(int flags) {
-    return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extra);
+    return new TraceContext(flags, traceIdHigh, traceId, localRootId, parentId, spanId, extraList);
   }
 
   final long traceIdHigh, traceId, localRootId, parentId, spanId;
-  final List<Object> extra;
+  final List<Object> extraList;
 
   TraceContext(
     int flags,
@@ -511,7 +518,7 @@ public final class TraceContext extends SamplingFlags {
     long localRootId,
     long parentId,
     long spanId,
-    List<Object> extra
+    List<Object> extraList
   ) {
     super(flags);
     this.traceIdHigh = traceIdHigh;
@@ -519,7 +526,7 @@ public final class TraceContext extends SamplingFlags {
     this.localRootId = localRootId;
     this.parentId = parentId;
     this.spanId = spanId;
-    this.extra = extra;
+    this.extraList = extraList;
   }
 
   /**
@@ -564,6 +571,17 @@ public final class TraceContext extends SamplingFlags {
       hashCode = h;
     }
     return h;
+  }
+
+  static List<Object> ensureExtraAdded(List<Object> extraList, Object extra) {
+    if (extra == null) throw new NullPointerException("extra == null");
+    // ignore adding the same instance twice
+    for (int i = 0, length = extraList.size(); i < length; i++) {
+      if (extra == extraList.get(i)) return extraList;
+    }
+    extraList = ensureMutable(extraList);
+    extraList.add(extra);
+    return extraList;
   }
 
   static <T> T findExtra(Class<T> type, List<Object> extra) {

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -372,7 +372,7 @@ public final class TraceContext extends SamplingFlags {
      * // Attempt to parse the trace ID or break out if unsuccessful for any reason
      * String traceIdString = getter.get(request, key);
      * if (!builder.parseTraceId(traceIdString, propagation.traceIdKey)) {
-     *   return EMPTY;
+     *   return TraceContextOrSamplingFlags.EMPTY;
      * }
      * }</pre>
      *

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -16,21 +16,23 @@ package brave.propagation;
 import brave.Tracer;
 import brave.internal.InternalPropagation;
 import brave.internal.Nullable;
+import brave.propagation.TraceContext.Extractor;
+import brave.sampler.SamplerFunction;
 import java.util.ArrayList;
 import java.util.List;
 
 import static brave.internal.InternalPropagation.FLAG_SAMPLED;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
-import static brave.internal.Lists.concat;
 import static brave.internal.Lists.ensureImmutable;
+import static brave.propagation.TraceContext.ensureExtraAdded;
 import static java.util.Collections.emptyList;
 
 /**
  * Union type that contains only one of trace context, trace ID context or sampling flags. This type
  * is designed for use with {@link Tracer#nextSpan(TraceContextOrSamplingFlags)}.
  *
- * <p>Users should not create instances of this, rather use {@link TraceContext.Extractor} provided
+ * <p>Users should not create instances of this, rather use {@link Extractor} provided
  * by a {@link Propagation} implementation such as {@link Propagation#B3_STRING}.
  *
  * <p>Those implementing {@link Propagation} should use the following advice:
@@ -46,18 +48,111 @@ import static java.util.Collections.emptyList;
  * <p>This started as a port of {@code com.github.kristofa.brave.TraceData}, which served the same
  * purpose.
  *
- * @see TraceContext.Extractor
+ * @see Extractor
+ * @since 4.0
  */
 //@Immutable
 public final class TraceContextOrSamplingFlags {
   public static final TraceContextOrSamplingFlags
-    EMPTY = new TraceContextOrSamplingFlags(3, SamplingFlags.EMPTY, emptyList()),
-    NOT_SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.NOT_SAMPLED, emptyList()),
-    SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.SAMPLED, emptyList()),
-    DEBUG = new TraceContextOrSamplingFlags(3, SamplingFlags.DEBUG, emptyList());
+      EMPTY = new TraceContextOrSamplingFlags(3, SamplingFlags.EMPTY, emptyList()),
+      NOT_SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.NOT_SAMPLED, emptyList()),
+      SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.SAMPLED, emptyList()),
+      DEBUG = new TraceContextOrSamplingFlags(3, SamplingFlags.DEBUG, emptyList());
 
-  public static Builder newBuilder() {
-    return new Builder();
+  /**
+   * Used to implement {@link Extractor#extract(Object)} for a format that can extract a complete
+   * {@link TraceContext}, including a {@linkplain TraceContext#traceIdString() trace ID} and
+   * {@linkplain TraceContext#spanIdString() span ID}.
+   *
+   * @see #context()
+   * @see #newBuilder(TraceContext)
+   * @see Extractor#extract(Object)
+   * @since 4.3
+   */
+  public static TraceContextOrSamplingFlags create(TraceContext context) {
+    return new TraceContextOrSamplingFlags(1, context, emptyList());
+  }
+
+  /**
+   * Used to implement {@link Extractor#extract(Object)} when the format allows extracting a
+   * {@linkplain TraceContext#traceIdString() trace ID} without a {@linkplain
+   * TraceContext#spanIdString() span ID}
+   *
+   * @see #traceIdContext()
+   * @see #newBuilder(TraceIdContext)
+   * @see Extractor#extract(Object)
+   * @since 4.9
+   */
+  public static TraceContextOrSamplingFlags create(TraceIdContext traceIdContext) {
+    return new TraceContextOrSamplingFlags(2, traceIdContext, emptyList());
+  }
+
+  /**
+   * Used to implement {@link Extractor#extract(Object)} when the format allows extracting only
+   * {@linkplain SamplingFlags sampling flags}.
+   *
+   * @see #samplingFlags()
+   * @see #newBuilder(TraceIdContext)
+   * @see Extractor#extract(Object)
+   * @since 4.3
+   */
+  public static TraceContextOrSamplingFlags create(SamplingFlags flags) {
+    // reuses constants to avoid excess allocation
+    if (flags == SamplingFlags.SAMPLED) return SAMPLED;
+    if (flags == SamplingFlags.EMPTY) return EMPTY;
+    if (flags == SamplingFlags.NOT_SAMPLED) return NOT_SAMPLED;
+    if (flags == SamplingFlags.DEBUG) return DEBUG;
+    return new TraceContextOrSamplingFlags(3, flags, emptyList());
+  }
+
+  /**
+   * Use when implementing {@link Extractor#extract(Object)} requires {@link Builder#sampledLocal()}
+   * or {@link Builder#addExtra(Object)}. Otherwise, use {@link #create(TraceContext)} as it is more
+   * efficient.
+   *
+   * @see #create(TraceContext)
+   * @see Extractor#extract(Object)
+   * @since 5.12
+   */
+  public static Builder newBuilder(TraceContext context) {
+    if (context == null) throw new NullPointerException("context == null");
+    return new Builder(1, context, context.extra());
+  }
+
+  /**
+   * Use when implementing {@link Extractor#extract(Object)} requires {@link Builder#sampledLocal()}
+   * or {@link Builder#addExtra(Object)}. Otherwise, use {@link #create(TraceIdContext)} as it is
+   * more efficient.
+   *
+   * @see #create(TraceIdContext)
+   * @see Extractor#extract(Object)
+   * @since 5.12
+   */
+  public static Builder newBuilder(TraceIdContext traceIdContext) {
+    if (traceIdContext == null) throw new NullPointerException("traceIdContext == null");
+    return new Builder(2, traceIdContext, emptyList());
+  }
+
+  /**
+   * Use when implementing {@link Extractor#extract(Object)} requires {@link Builder#sampledLocal()}
+   * or {@link Builder#addExtra(Object)}. Otherwise, use {@link #create(SamplingFlags)} as it is
+   * more efficient.
+   *
+   * @see #create(SamplingFlags)
+   * @see Extractor#extract(Object)
+   * @since 5.12
+   */
+  public static Builder newBuilder(SamplingFlags flags) {
+    if (flags == null) throw new NullPointerException("flags == null");
+    return new Builder(3, flags, emptyList());
+  }
+
+  /**
+   * @deprecated Since 5.12, use {@link #newBuilder(TraceContext)}, {@link
+   * #newBuilder(TraceIdContext)} or {@link #newBuilder(SamplingFlags)}.
+   */
+  @Deprecated public static Builder newBuilder() {
+    return new Builder(0, null, emptyList());
   }
 
   /** Returns {@link SamplingFlags#sampled()}, regardless of subtype. */
@@ -65,7 +160,7 @@ public final class TraceContextOrSamplingFlags {
     return value.sampled();
   }
 
-  /** Returns {@link SamplingFlags#sampledLocal()}}, regardless of subtype. */
+  /** Returns {@link SamplingFlags#sampledLocal()}, regardless of subtype. */
   public final boolean sampledLocal() {
     return (value.flags & FLAG_SAMPLED_LOCAL) == FLAG_SAMPLED_LOCAL;
   }
@@ -81,64 +176,128 @@ public final class TraceContextOrSamplingFlags {
     return withFlags(flags);
   }
 
+  /**
+   * This is used to apply a {@link SamplerFunction} decision with least overhead.
+   *
+   * Ex.
+   * <pre>{@code
+   * Boolean sampled = extracted.sampled();
+   * // only recreate the context if the messaging sampler made a decision
+   * if (sampled == null && (sampled = sampler.trySample(request)) != null) {
+   *   extracted = extracted.sampled(sampled.booleanValue());
+   * }
+   * }</pre>
+   *
+   * @param sampled decision to apply
+   * @return {@code this} unless {@link #sampled()} differs from the input.
+   * @since 5.2
+   */
   public TraceContextOrSamplingFlags sampled(boolean sampled) {
+    Boolean thisSampled = sampled();
+    if (thisSampled != null && thisSampled.equals(sampled)) return this;
     int flags = InternalPropagation.sampled(sampled, value.flags);
     if (flags == value.flags) return this; // save effort if no change
     return withFlags(flags);
   }
 
+  /**
+   * Returns non-{@code null} when both a {@linkplain TraceContext#traceIdString() trace ID} and
+   * {@linkplain TraceContext#spanIdString() span ID} were  {@link Extractor#extract(Object)
+   * extracted} from a request.
+   *
+   * <p>For example, given the header "b3: 80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1",
+   * {@link B3Propagation} extracts the following:
+   * <ul>
+   *   <li>{@link TraceContext#traceIdString()}: "80f198ee56343ba864fe8b2a57d3eff7"</li>
+   *   <li>{@link TraceContext#spanIdString()}: "e457b5a2e4d86bd1"</li>
+   *   <li>{@link TraceContext#sampled()}: {@code true}</li>
+   * </ul>
+   *
+   * @return the trace context when {@link #traceIdContext()} ()} and {@link #samplingFlags()} are
+   * not {@code null}
+   * @see #create(TraceContext)
+   * @see #newBuilder(TraceContext)
+   * @since 4.0
+   */
   @Nullable public TraceContext context() {
     return type == 1 ? (TraceContext) value : null;
   }
 
+  /**
+   * Returns non-{@code null} when a {@linkplain TraceIdContext#traceIdString() trace ID} was {@link
+   * Extractor#extract(Object) extracted} from a request, but a {@linkplain
+   * TraceContext#spanIdString() span ID} was not.
+   *
+   * <p>For example, given the header "x-amzn-trace-id: Root=1-5759e988-bd862e3fe1be46a994272793",
+   * <a href="https://github.com/openzipkin/zipkin-aws/tree/master/brave-propagation-aws">AWSPropagation</a>
+   * extracts the following:
+   * <ul>
+   *   <li>{@link TraceIdContext#traceIdString()}: "15759e988bd862e3fe1be46a994272793"</li>
+   *   <li>{@link TraceIdContext#sampled()}: {@code null}</li>
+   * </ul>
+   *
+   * @return the trace ID context when {@link #context()} and {@link #samplingFlags()} are not
+   * {@code null}
+   * @see #create(TraceIdContext)
+   * @see #newBuilder(TraceIdContext)
+   * @since 4.9
+   */
   @Nullable public TraceIdContext traceIdContext() {
     return type == 2 ? (TraceIdContext) value : null;
   }
 
+  /**
+   * Returns non-{@code null} when a {@linkplain TraceContext#traceIdString() trace ID} was not
+   * {@link Extractor#extract(Object) extracted} from a request.
+   *
+   * <p>For example, given the header "b3: 1", {@link B3Propagation} extracts {@link #SAMPLED}.
+   *
+   * @return sampling flags when {@link #context()} and {@link #traceIdContext()} are not {@code
+   * null}
+   * @see #create(SamplingFlags)
+   * @see #newBuilder(SamplingFlags)
+   * @since 4.9
+   */
   @Nullable public SamplingFlags samplingFlags() {
     return type == 3 ? value : null;
   }
 
   /**
-   * Non-empty when {@link #context} is null: A list of additional state extracted from the
-   * request.
+   * Non-empty when {@link #context()} is {@code null}: A list of additional state extracted from
+   * the request.
    *
    * @see TraceContext#extra()
+   * @since 4.9
    */
   public final List<Object> extra() {
-    return extra;
+    return extraList;
   }
 
-  public final Builder toBuilder() {
-    Builder result = new Builder();
-    result.type = type;
-    result.value = value;
-    result.extra = extra;
-    return result;
+  /**
+   * Use to decorate an {@link Extractor#extract extraction result} with {@link #sampledLocal()} or
+   * additional {@link #extra()}.
+   *
+   * @since 4.9
+   */
+  public Builder toBuilder() {
+    return new Builder(type, value, effectiveExtra());
   }
 
-  @Override
-  public String toString() {
-    return "{value=" + value + ", extra=" + extra + "}";
+  @Override public String toString() {
+    List<Object> extra = effectiveExtra();
+    StringBuilder result = new StringBuilder();
+    result.append(value.getClass().getSimpleName()).append('=').append(value);
+    result.setCharAt(0, Character.toLowerCase(result.charAt(0))); // lowercase the first char
+    if (type != 3) {
+      String flagsString = SamplingFlags.toString(value.flags);
+      if (!flagsString.isEmpty()) result.append(", samplingFlags=").append(flagsString);
+    }
+    if (!extra.isEmpty()) result.append(", extra=").append(extra);
+    return result.insert(0, "Extracted{").append('}').toString();
   }
 
-  public static TraceContextOrSamplingFlags create(TraceContext context) {
-    return new TraceContextOrSamplingFlags(1, context, emptyList());
-  }
-
-  public static TraceContextOrSamplingFlags create(TraceIdContext traceIdContext) {
-    return new TraceContextOrSamplingFlags(2, traceIdContext, emptyList());
-  }
-
-  public static TraceContextOrSamplingFlags create(SamplingFlags flags) {
-    // reuses constants to avoid excess allocation
-    if (flags == SamplingFlags.SAMPLED) return SAMPLED;
-    if (flags == SamplingFlags.EMPTY) return EMPTY;
-    if (flags == SamplingFlags.NOT_SAMPLED) return NOT_SAMPLED;
-    if (flags == SamplingFlags.DEBUG) return DEBUG;
-    return new TraceContextOrSamplingFlags(3, flags, emptyList());
-  }
-
+  /** @deprecated Since 5.12, use constants defined on this type as needed. */
+  @Deprecated
   public static TraceContextOrSamplingFlags create(@Nullable Boolean sampled, boolean debug) {
     if (debug) return DEBUG;
     if (sampled == null) return EMPTY;
@@ -147,36 +306,47 @@ public final class TraceContextOrSamplingFlags {
 
   final int type;
   final SamplingFlags value;
-  final List<Object> extra;
+  final List<Object> extraList;
 
-  TraceContextOrSamplingFlags(int type, SamplingFlags value, List<Object> extra) {
+  TraceContextOrSamplingFlags(int type, SamplingFlags value, List<Object> extraList) {
     if (value == null) throw new NullPointerException("value == null");
-    if (extra == null) throw new NullPointerException("extra == null");
+    if (extraList == null) throw new NullPointerException("extra == null");
     this.type = type;
     this.value = value;
-    this.extra = extra;
+    this.extraList = extraList;
   }
 
   public static final class Builder {
     int type;
     SamplingFlags value;
-    List<Object> extra = emptyList();
+    List<Object> extraList;
     boolean sampledLocal = false;
 
-    /** @see TraceContextOrSamplingFlags#context() */
-    public final Builder context(TraceContext context) {
-      if (context == null) throw new NullPointerException("context == null");
-      type = 1;
-      value = context;
-      return this;
+    Builder(int type, SamplingFlags value, List<Object> extraList) {
+      this.type = type;
+      this.value = value;
+      this.extraList = extraList;
     }
 
-    /** @see TraceContextOrSamplingFlags#traceIdContext() */
-    public final Builder traceIdContext(TraceIdContext traceIdContext) {
-      if (traceIdContext == null) throw new NullPointerException("traceIdContext == null");
-      type = 2;
-      value = traceIdContext;
-      return this;
+    /** @deprecated Since 5.12, use {@link #newBuilder(TraceIdContext)} */
+    @Deprecated public Builder context(TraceContext context) {
+      return copyStateTo(newBuilder(context));
+    }
+
+    /** @deprecated Since 5.12, use {@link #newBuilder(TraceIdContext)} */
+    @Deprecated public Builder traceIdContext(TraceIdContext traceIdContext) {
+      return copyStateTo(newBuilder(traceIdContext));
+    }
+
+    /** @deprecated Since 5.12, use {@link #newBuilder(SamplingFlags)} */
+    @Deprecated public Builder samplingFlags(SamplingFlags samplingFlags) {
+      return copyStateTo(newBuilder(samplingFlags));
+    }
+
+    Builder copyStateTo(Builder builder) {
+      if (sampledLocal) builder.sampledLocal();
+      for (Object extra : extraList) builder.addExtra(extra);
+      return builder;
     }
 
     /** @see TraceContext#sampledLocal() */
@@ -185,56 +355,38 @@ public final class TraceContextOrSamplingFlags {
       return this;
     }
 
-    /** @see TraceContextOrSamplingFlags#samplingFlags() */
-    public final Builder samplingFlags(SamplingFlags samplingFlags) {
-      if (samplingFlags == null) throw new NullPointerException("samplingFlags == null");
-      type = 3;
-      value = samplingFlags;
-      return this;
-    }
-
-    /**
-     * Shares the input with the builder, replacing any current data in the builder.
-     *
-     * @see TraceContextOrSamplingFlags#extra()
-     */
-    public final Builder extra(List<Object> extra) {
-      if (extra == null) throw new NullPointerException("extra == null");
-      this.extra = extra; // sharing a copy in case it is immutable
+    /** @deprecated Since 5.12, use {@link #addExtra(Object)} */
+    @Deprecated public Builder extra(List<Object> extraList) {
+      if (extraList == null) throw new NullPointerException("extraList == null");
+      this.extraList = new ArrayList<>();
+      for (Object extra : extraList) addExtra(extra);
       return this;
     }
 
     /** @see TraceContextOrSamplingFlags#extra() */
-    public final Builder addExtra(Object extra) {
-      if (extra == null) throw new NullPointerException("extra == null");
-      if (!(this.extra instanceof ArrayList)) {
-        this.extra = new ArrayList<>(this.extra); // make it mutable
-      }
-      this.extra.add(extra);
+    public Builder addExtra(Object extra) {
+      extraList = ensureExtraAdded(extraList, extra);
       return this;
     }
 
     /** Returns an immutable result from the values currently in the builder */
     public final TraceContextOrSamplingFlags build() {
+      if (value == null) {
+        throw new IllegalArgumentException(
+            "Value unset. Use a non-deprecated newBuilder method instead.");
+      }
       final TraceContextOrSamplingFlags result;
-      if (!extra.isEmpty() && type == 1) { // move extra to the trace context
+      if (!extraList.isEmpty() && type == 1) { // move extra to the trace context
         TraceContext context = (TraceContext) value;
-        if (context.extra().isEmpty()) {
-          context = InternalPropagation.instance.withExtra(context, ensureImmutable(extra));
-        } else {
-          context = InternalPropagation.instance.withExtra(context, concat(context.extra(), extra));
-        }
+        context = InternalPropagation.instance.withExtra(context, ensureImmutable(extraList));
         result = new TraceContextOrSamplingFlags(type, context, emptyList());
       } else {
         // make sure the extra state is immutable and unmodifiable
-        result = new TraceContextOrSamplingFlags(type, value, ensureImmutable(extra));
+        result = new TraceContextOrSamplingFlags(type, value, ensureImmutable(extraList));
       }
 
       if (!sampledLocal) return result; // save effort if no change
       return result.withFlags(value.flags | FLAG_SAMPLED_LOCAL);
-    }
-
-    Builder() { // no external implementations
     }
   }
 
@@ -242,17 +394,22 @@ public final class TraceContextOrSamplingFlags {
     if (o == this) return true;
     if (!(o instanceof TraceContextOrSamplingFlags)) return false;
     TraceContextOrSamplingFlags that = (TraceContextOrSamplingFlags) o;
-    return type == that.type && value.equals(that.value) && extra.equals(that.extra);
+    return type == that.type && value.equals(that.value)
+        && effectiveExtra().equals(that.effectiveExtra());
+  }
+
+  List<Object> effectiveExtra() {
+    return type == 1 ? ((TraceContext) value).extra() : extraList;
   }
 
   @Override public int hashCode() {
     int h = 1;
     h *= 1000003;
-    h ^= this.type;
+    h ^= type;
     h *= 1000003;
-    h ^= this.value.hashCode();
+    h ^= value.hashCode();
     h *= 1000003;
-    h ^= this.extra.hashCode();
+    h ^= effectiveExtra().hashCode();
     return h;
   }
 
@@ -260,14 +417,14 @@ public final class TraceContextOrSamplingFlags {
     switch (type) {
       case 1:
         TraceContext context = InternalPropagation.instance.withFlags((TraceContext) value, flags);
-        return new TraceContextOrSamplingFlags(type, context, extra);
+        return new TraceContextOrSamplingFlags(type, context, extraList);
       case 2:
         TraceIdContext traceIdContext = idContextWithFlags(flags);
-        return new TraceContextOrSamplingFlags(type, traceIdContext, extra);
+        return new TraceContextOrSamplingFlags(type, traceIdContext, extraList);
       case 3:
         SamplingFlags samplingFlags = SamplingFlags.toSamplingFlags(flags);
-        if (extra.isEmpty()) return create(samplingFlags);
-        return new TraceContextOrSamplingFlags(type, samplingFlags, extra);
+        if (extraList.isEmpty()) return create(samplingFlags);
+        return new TraceContextOrSamplingFlags(type, samplingFlags, extraList);
     }
     throw new AssertionError("programming error");
   }

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -263,8 +263,8 @@ public final class TraceContextOrSamplingFlags {
   }
 
   /**
-   * Non-empty when {@link #context()} is {@code null}: A list of additional state extracted from
-   * the request.
+   * Returns a list of additional state extracted from the request. Will be non-empty when {@link
+   * #context()} is {@code null}.
    *
    * @see TraceContext#extra()
    * @since 4.9
@@ -285,9 +285,11 @@ public final class TraceContextOrSamplingFlags {
 
   @Override public String toString() {
     List<Object> extra = effectiveExtra();
-    StringBuilder result = new StringBuilder();
-    result.append(value.getClass().getSimpleName()).append('=').append(value);
-    result.setCharAt(0, Character.toLowerCase(result.charAt(0))); // lowercase the first char
+    StringBuilder result = new StringBuilder("Extracted{");
+    String valueClass = value.getClass().getSimpleName();
+    // Lowercase first char of class name
+    result.append(Character.toLowerCase(valueClass.charAt(0)));
+    result.append(valueClass, 1, valueClass.length()).append('=').append(value);
     if (type != 3) {
       String flagsString = SamplingFlags.toString(value.flags);
       if (!flagsString.isEmpty()) result.append(", samplingFlags=").append(flagsString);
@@ -295,7 +297,7 @@ public final class TraceContextOrSamplingFlags {
     if (!extra.isEmpty()) result.append(", extra=").append(extra);
     // NOTE: it would be nice to rename this type, but it would cause a major Api break:
     // This is the result of Extractor::extract which is used in a lot of 3rd party code.
-    return result.insert(0, "Extracted{").append('}').toString();
+    return result.append('}').toString();
   }
 
   /** @deprecated Since 5.12, use constants defined on this type as needed. */

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -54,10 +54,10 @@ import static java.util.Collections.emptyList;
 //@Immutable
 public final class TraceContextOrSamplingFlags {
   public static final TraceContextOrSamplingFlags
-      EMPTY = new TraceContextOrSamplingFlags(3, SamplingFlags.EMPTY, emptyList()),
-      NOT_SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.NOT_SAMPLED, emptyList()),
-      SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.SAMPLED, emptyList()),
-      DEBUG = new TraceContextOrSamplingFlags(3, SamplingFlags.DEBUG, emptyList());
+    EMPTY = new TraceContextOrSamplingFlags(3, SamplingFlags.EMPTY, emptyList()),
+    NOT_SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.NOT_SAMPLED, emptyList()),
+    SAMPLED = new TraceContextOrSamplingFlags(3, SamplingFlags.SAMPLED, emptyList()),
+    DEBUG = new TraceContextOrSamplingFlags(3, SamplingFlags.DEBUG, emptyList());
 
   /**
    * Used to implement {@link Extractor#extract(Object)} for a format that can extract a complete

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -293,6 +293,8 @@ public final class TraceContextOrSamplingFlags {
       if (!flagsString.isEmpty()) result.append(", samplingFlags=").append(flagsString);
     }
     if (!extra.isEmpty()) result.append(", extra=").append(extra);
+    // NOTE: it would be nice to rename this type, but it would cause a major Api break:
+    // This is the result of Extractor::extract which is used in a lot of 3rd party code.
     return result.insert(0, "Extracted{").append('}').toString();
   }
 

--- a/brave/src/test/java/brave/baggage/BaggageFieldTest.java
+++ b/brave/src/test/java/brave/baggage/BaggageFieldTest.java
@@ -51,7 +51,7 @@ public class BaggageFieldTest {
   TraceContext emptyContext = factory.decorate(context);
   TraceContextOrSamplingFlags extraction = TraceContextOrSamplingFlags.create(emptyContext);
   TraceContext requestIdContext =
-    context.toBuilder().extra(requestIdExtraction.extra()).build();
+    context.toBuilder().addExtra(requestIdExtraction.extra().get(0)).build();
 
   @Test public void internalStorage() {
     assertThat(BaggageField.create("foo").context)

--- a/brave/src/test/java/brave/baggage/BaggageFieldsTest.java
+++ b/brave/src/test/java/brave/baggage/BaggageFieldsTest.java
@@ -34,9 +34,8 @@ public class BaggageFieldsTest {
     .sampled(true)
     .build();
   TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(context);
-  TraceContextOrSamplingFlags extractedTraceId = TraceContextOrSamplingFlags.newBuilder()
-    .traceIdContext(TraceIdContext.newBuilder().traceIdHigh(1L).traceId(2L).sampled(true).build())
-    .build();
+  TraceContextOrSamplingFlags extractedTraceId = TraceContextOrSamplingFlags.create(
+    TraceIdContext.newBuilder().traceIdHigh(1L).traceId(2L).sampled(true).build());
 
   @Test public void traceId() {
     assertThat(BaggageFields.TRACE_ID.getValue(context))

--- a/brave/src/test/java/brave/baggage/BaggagePropagationTest.java
+++ b/brave/src/test/java/brave/baggage/BaggagePropagationTest.java
@@ -25,7 +25,6 @@ import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -162,10 +161,8 @@ public class BaggagePropagationTest {
     request.put(amznTraceId.name(), awsTraceId);
 
     TraceContextOrSamplingFlags extracted = extractor.extract(request);
-    assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
-      .isEqualTo(context);
-    assertThat(extracted.context().extra())
-      .hasSize(2);
+    assertThat(extracted.context()).isEqualTo(context);
+    assertThat(extracted.context().extra()).hasSize(2);
 
     assertThat(amznTraceId.getValue(extracted))
       .isEqualTo(awsTraceId);
@@ -177,10 +174,8 @@ public class BaggagePropagationTest {
     request.put(vcapRequestId.name(), uuid);
 
     TraceContextOrSamplingFlags extracted = extractor.extract(request);
-    assertThat(extracted.context().toBuilder().extra(Collections.emptyList()).build())
-      .isEqualTo(context);
-    assertThat(extracted.context().extra())
-      .hasSize(2);
+    assertThat(extracted.context()).isEqualTo(context);
+    assertThat(extracted.context().extra()).hasSize(2);
 
     assertThat(amznTraceId.getValue(extracted))
       .isEqualTo(awsTraceId);

--- a/brave/src/test/java/brave/internal/ListsTest.java
+++ b/brave/src/test/java/brave/internal/ListsTest.java
@@ -51,6 +51,15 @@ public class ListsTest {
       .isEqualTo("SingletonList");
   }
 
+  @Test public void ensureImmutable_convertsToUnmodifiableList() {
+    List<Long> list = new ArrayList<>();
+    list.add(1L);
+    list.add(2L);
+
+    assertThat(Lists.ensureImmutable(list).getClass().getSimpleName())
+      .startsWith("Unmodifiable");
+  }
+
   @Test public void ensureImmutable_returnsEmptyList() {
     List<Object> list = Collections.emptyList();
     assertThat(Lists.ensureImmutable(list))

--- a/brave/src/test/java/brave/internal/baggage/ExtraBaggageFieldsFactoryTest.java
+++ b/brave/src/test/java/brave/internal/baggage/ExtraBaggageFieldsFactoryTest.java
@@ -20,7 +20,6 @@ import brave.internal.InternalPropagation;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
-import brave.propagation.SamplingFlags;
 import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -31,6 +30,7 @@ import java.util.Map.Entry;
 import org.junit.Test;
 import zipkin2.reporter.Reporter;
 
+import static brave.propagation.SamplingFlags.EMPTY;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -128,8 +128,7 @@ public class ExtraBaggageFieldsFactoryTest {
     try (Tracing tracing = withNoopSpanReporter()) {
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
-          .samplingFlags(SamplingFlags.EMPTY)
+        TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder(EMPTY)
           .addExtra(factory.create())
           .build();
 
@@ -156,8 +155,7 @@ public class ExtraBaggageFieldsFactoryTest {
 
       ScopedSpan parent = tracing.tracer().startScopedSpan("parent");
       try {
-        TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
-          .samplingFlags(SamplingFlags.EMPTY)
+        TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder(EMPTY)
           .addExtra(factory.create())
           .build();
 
@@ -183,9 +181,7 @@ public class ExtraBaggageFieldsFactoryTest {
       try {
         field1.updateValue(parent.context(), value1);
 
-        TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.newBuilder()
-          .samplingFlags(SamplingFlags.EMPTY)
-          .build();
+        TraceContextOrSamplingFlags extracted = TraceContextOrSamplingFlags.create(EMPTY);
 
         // TODO didn't pass the reference from parent
         TraceContext context1 = tracing.tracer().nextSpan(extracted).context();

--- a/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
@@ -83,10 +83,10 @@ public class SamplingFlagsTest {
       .hasToString("");
     assertThat(toSamplingFlags(SamplingFlags.NOT_SAMPLED.flags))
       .isSameAs(SamplingFlags.NOT_SAMPLED)
-      .hasToString("NOT_SAMPLED");
+      .hasToString("NOT_SAMPLED_REMOTE");
     assertThat(toSamplingFlags(SamplingFlags.SAMPLED.flags))
       .isSameAs(SamplingFlags.SAMPLED)
-      .hasToString("SAMPLED");
+      .hasToString("SAMPLED_REMOTE");
     assertThat(toSamplingFlags(SamplingFlags.DEBUG.flags))
       .isSameAs(SamplingFlags.DEBUG)
       .hasToString("DEBUG");
@@ -95,10 +95,10 @@ public class SamplingFlagsTest {
       .hasToString("SAMPLED_LOCAL");
     assertThat(toSamplingFlags(SamplingFlags.NOT_SAMPLED.flags | FLAG_SAMPLED_LOCAL))
       .isSameAs(SamplingFlags.NOT_SAMPLED_SAMPLED_LOCAL)
-      .hasToString("NOT_SAMPLED|SAMPLED_LOCAL");
+      .hasToString("NOT_SAMPLED_REMOTE|SAMPLED_LOCAL");
     assertThat(toSamplingFlags(SamplingFlags.SAMPLED.flags | FLAG_SAMPLED_LOCAL))
       .isSameAs(SamplingFlags.SAMPLED_SAMPLED_LOCAL)
-      .hasToString("SAMPLED|SAMPLED_LOCAL");
+      .hasToString("SAMPLED_REMOTE|SAMPLED_LOCAL");
     assertThat(toSamplingFlags(SamplingFlags.DEBUG.flags | FLAG_SAMPLED_LOCAL))
       .isSameAs(SamplingFlags.DEBUG_SAMPLED_LOCAL)
       .hasToString("DEBUG|SAMPLED_LOCAL");

--- a/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/SamplingFlagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -77,23 +77,31 @@ public class SamplingFlagsTest {
   }
 
   /** Ensures constants are used */
-  @Test public void toSamplingFlags_returnsConstants() {
+  @Test public void toSamplingFlags_returnsConstantsAndHasNiceToString() {
     assertThat(toSamplingFlags(SamplingFlags.EMPTY.flags))
-      .isSameAs(SamplingFlags.EMPTY);
+      .isSameAs(SamplingFlags.EMPTY)
+      .hasToString("");
     assertThat(toSamplingFlags(SamplingFlags.NOT_SAMPLED.flags))
-      .isSameAs(SamplingFlags.NOT_SAMPLED);
+      .isSameAs(SamplingFlags.NOT_SAMPLED)
+      .hasToString("NOT_SAMPLED");
     assertThat(toSamplingFlags(SamplingFlags.SAMPLED.flags))
-      .isSameAs(SamplingFlags.SAMPLED);
+      .isSameAs(SamplingFlags.SAMPLED)
+      .hasToString("SAMPLED");
     assertThat(toSamplingFlags(SamplingFlags.DEBUG.flags))
-      .isSameAs(SamplingFlags.DEBUG);
+      .isSameAs(SamplingFlags.DEBUG)
+      .hasToString("DEBUG");
     assertThat(toSamplingFlags(SamplingFlags.EMPTY.flags | FLAG_SAMPLED_LOCAL))
-      .isSameAs(SamplingFlags.EMPTY_SAMPLED_LOCAL);
+      .isSameAs(SamplingFlags.EMPTY_SAMPLED_LOCAL)
+      .hasToString("SAMPLED_LOCAL");
     assertThat(toSamplingFlags(SamplingFlags.NOT_SAMPLED.flags | FLAG_SAMPLED_LOCAL))
-      .isSameAs(SamplingFlags.NOT_SAMPLED_SAMPLED_LOCAL);
+      .isSameAs(SamplingFlags.NOT_SAMPLED_SAMPLED_LOCAL)
+      .hasToString("NOT_SAMPLED|SAMPLED_LOCAL");
     assertThat(toSamplingFlags(SamplingFlags.SAMPLED.flags | FLAG_SAMPLED_LOCAL))
-      .isSameAs(SamplingFlags.SAMPLED_SAMPLED_LOCAL);
+      .isSameAs(SamplingFlags.SAMPLED_SAMPLED_LOCAL)
+      .hasToString("SAMPLED|SAMPLED_LOCAL");
     assertThat(toSamplingFlags(SamplingFlags.DEBUG.flags | FLAG_SAMPLED_LOCAL))
-      .isSameAs(SamplingFlags.DEBUG_SAMPLED_LOCAL);
+      .isSameAs(SamplingFlags.DEBUG_SAMPLED_LOCAL)
+      .hasToString("DEBUG|SAMPLED_LOCAL");
   }
 
   @Test public void sampledLocal() {

--- a/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
@@ -319,24 +319,24 @@ public class TraceContextOrSamplingFlagsTest {
   @Test public void toString_context() {
     toString(
         () -> TraceContextOrSamplingFlags.create(context),
-        "Extracted{traceContext=000000000000014d/0000000000000001, samplingFlags=SAMPLED}",
-        "Extracted{traceContext=000000000000014d/0000000000000001, samplingFlags=SAMPLED, extra=[1, 2]}"
+        "Extracted{traceContext=000000000000014d/0000000000000001, samplingFlags=SAMPLED_REMOTE}",
+        "Extracted{traceContext=000000000000014d/0000000000000001, samplingFlags=SAMPLED_REMOTE, extra=[1, 2]}"
     );
   }
 
   @Test public void toString_samplingFlags() {
     toString(
         () -> TraceContextOrSamplingFlags.create(SAMPLED),
-        "Extracted{samplingFlags=SAMPLED}",
-        "Extracted{samplingFlags=SAMPLED, extra=[1, 2]}"
+        "Extracted{samplingFlags=SAMPLED_REMOTE}",
+        "Extracted{samplingFlags=SAMPLED_REMOTE, extra=[1, 2]}"
     );
   }
 
   @Test public void toString_traceIdContext() {
     toString(
         () -> TraceContextOrSamplingFlags.create(idContext),
-        "Extracted{traceIdContext=000000000000014d, samplingFlags=SAMPLED}",
-        "Extracted{traceIdContext=000000000000014d, samplingFlags=SAMPLED, extra=[1, 2]}"
+        "Extracted{traceIdContext=000000000000014d, samplingFlags=SAMPLED_REMOTE}",
+        "Extracted{traceIdContext=000000000000014d, samplingFlags=SAMPLED_REMOTE, extra=[1, 2]}"
     );
   }
 

--- a/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,204 +13,513 @@
  */
 package brave.propagation;
 
-import java.util.Collections;
+import java.util.function.Supplier;
 import org.junit.Test;
 
-import static brave.internal.InternalPropagation.FLAG_SAMPLED;
-import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
+import static brave.propagation.SamplingFlags.EMPTY;
+import static brave.propagation.SamplingFlags.NOT_SAMPLED;
+import static brave.propagation.SamplingFlags.SAMPLED;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TraceContextOrSamplingFlagsTest {
-  TraceContext base = TraceContext.newBuilder().traceId(333L).spanId(1L).build();
+  TraceContext context = TraceContext.newBuilder().traceId(333L).spanId(1L).sampled(true).build();
+  TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).sampled(true).build();
 
-  @Test public void create_sampledNullDebugFalse() {
-    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(null, false);
+  TraceContextOrSamplingFlags extracted;
 
-    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.EMPTY);
-    assertThat(flags.sampled()).isNull();
-    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.EMPTY);
+  @Test public void create_context() {
+    extracted = TraceContextOrSamplingFlags.create(context);
+    assertThat(extracted.context()).isSameAs(context);
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.samplingFlags()).isNull();
   }
 
-  @Test public void create_sampledNullDebugTrue() {
-    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(null, true);
-
-    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.DEBUG);
-    assertThat(flags.sampled()).isTrue();
-    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.DEBUG);
+  @Test public void create_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.create(SAMPLED);
+    assertThat(extracted.context()).isNull();
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.samplingFlags()).isSameAs(SAMPLED);
   }
 
-  @Test public void create_sampledTrueDebugFalse() {
-    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(true, false);
-
-    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.SAMPLED);
-    assertThat(flags.sampled()).isTrue();
-    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.SAMPLED);
+  @Test public void create_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.create(idContext);
+    assertThat(extracted.context()).isNull();
+    assertThat(extracted.traceIdContext()).isSameAs(idContext);
+    assertThat(extracted.samplingFlags()).isNull();
   }
 
-  @Test public void create_sampledFalseDebugFalse() {
-    TraceContextOrSamplingFlags flags = TraceContextOrSamplingFlags.create(false, false);
+  @Test public void sampled_get_context() {
+    assertThat(TraceContextOrSamplingFlags.create(context).sampled()).isTrue();
 
-    assertThat(flags).isSameAs(TraceContextOrSamplingFlags.NOT_SAMPLED);
-    assertThat(flags.sampled()).isFalse();
-    assertThat(flags.samplingFlags()).isSameAs(SamplingFlags.NOT_SAMPLED);
+    extracted = TraceContextOrSamplingFlags.create(context.toBuilder().sampled(null).build());
+    assertThat(extracted.sampled()).isNull();
   }
 
-  @Test public void contextWhenIdsAreSet() {
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.create(base);
+  @Test public void sampled_get_samplingFlags() {
+    assertThat(TraceContextOrSamplingFlags.create(SAMPLED).sampled()).isTrue();
 
-    assertThat(toTest.context())
-      .isEqualTo(base);
-    assertThat(toTest.traceIdContext())
-      .isNull();
-    assertThat(toTest.samplingFlags())
-      .isNull();
+    extracted = TraceContextOrSamplingFlags.create(EMPTY);
+    assertThat(extracted.sampled()).isNull();
   }
 
-  @Test public void contextWhenIdsAndSamplingAreSet() {
-    TraceContext.Builder builder = base.toBuilder().sampled(true);
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.create(builder.build());
+  @Test public void sampled_get_traceIdContext() {
+    assertThat(TraceContextOrSamplingFlags.create(idContext).sampled()).isTrue();
 
-    assertThat(toTest.context())
-      .isEqualTo(builder.build());
-    assertThat(toTest.traceIdContext())
-      .isNull();
-    assertThat(toTest.samplingFlags())
-      .isNull();
+    extracted = TraceContextOrSamplingFlags.create(idContext.toBuilder().sampled(null).build());
+    assertThat(extracted.sampled()).isNull();
   }
 
-  @Test public void build_extra() {
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(base)
-      .addExtra(1L).build();
-    assertThat(toTest.extra()).isEmpty();
-    assertThat(toTest.context().extra()).containsExactly(1L);
+  @Test public void sampled_set_context() {
+    extracted = TraceContextOrSamplingFlags.create(context);
+    assertThat(extracted.sampled(true)).isSameAs(extracted);
+    assertThat(extracted.sampled(false).sampled()).isFalse();
+    assertThat(extracted.sampled(false).context().sampled()).isFalse();
 
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
-    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
-      .addExtra(1L).build();
-    assertThat(toTest.extra()).containsExactly(1L);
-
-    toTest = TraceContextOrSamplingFlags.newBuilder()
-      .samplingFlags(SamplingFlags.SAMPLED).addExtra(1L).build();
-    assertThat(toTest.extra()).containsExactly(1L);
+    extracted = TraceContextOrSamplingFlags.create(context.toBuilder().sampled(null).build());
+    assertThat(extracted.sampled(true).sampled()).isTrue();
+    assertThat(extracted.sampled(false).sampled()).isFalse();
+    assertThat(extracted.sampled(true).context().sampled()).isTrue();
+    assertThat(extracted.sampled(false).context().sampled()).isFalse();
   }
 
-  @Test public void build_threeExtra() {
-    TraceContext context = base.toBuilder()
-      .extra(Collections.singletonList(1L)).build();
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(context)
-      .addExtra(2L).addExtra(3L).build();
-    assertThat(toTest.extra()).isEmpty();
-    assertThat(toTest.context().extra())
-      .containsExactly(1L, 2L, 3L);
+  @Test public void sampled_set_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.create(SAMPLED);
+    assertThat(extracted.sampled(true)).isSameAs(extracted);
+    assertThat(extracted.sampled(false).sampled()).isFalse();
 
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
-    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
-      .addExtra(1L).addExtra(2L).addExtra(3L).build();
-    assertThat(toTest.extra())
-      .containsExactly(1L, 2L, 3L);
-
-    toTest = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.SAMPLED)
-      .addExtra(1L).addExtra(2L).addExtra(3L).build();
-    assertThat(toTest.extra())
-      .containsExactly(1L, 2L, 3L);
+    extracted = TraceContextOrSamplingFlags.create(EMPTY);
+    assertThat(extracted.sampled(true).sampled()).isTrue();
+    assertThat(extracted.sampled(false).sampled()).isFalse();
   }
 
-  @Test public void flags() {
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.create(SamplingFlags.SAMPLED);
+  @Test public void sampled_set_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.create(idContext);
+    assertThat(extracted.sampled(true)).isSameAs(extracted);
+    assertThat(extracted.sampled(false).sampled()).isFalse();
+    assertThat(extracted.sampled(false).traceIdContext().sampled()).isFalse();
 
-    assertThat(toTest.context())
-      .isNull();
-    assertThat(toTest.traceIdContext())
-      .isNull();
-    assertThat(toTest.samplingFlags())
-      .isSameAs(SamplingFlags.SAMPLED);
+    extracted = TraceContextOrSamplingFlags.create(idContext.toBuilder().sampled(null).build());
+    assertThat(extracted.sampled(true).sampled()).isTrue();
+    assertThat(extracted.sampled(false).sampled()).isFalse();
+    assertThat(extracted.sampled(true).traceIdContext().sampled()).isTrue();
+    assertThat(extracted.sampled(false).traceIdContext().sampled()).isFalse();
   }
 
-  @Test public void sampled_true() {
-    assertThat(TraceContextOrSamplingFlags.create(base).sampled(true).value.flags)
-      .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
-
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
-    assertThat(TraceContextOrSamplingFlags.create(idContext).sampled(true).value.flags)
-      .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
-
-    assertThat(TraceContextOrSamplingFlags.EMPTY.sampled(true).value.flags)
-      .isEqualTo(FLAG_SAMPLED_SET | FLAG_SAMPLED);
+  @Test public void sampled_set_keepsExtra_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).addExtra(1L).build();
+    assertThat(extracted.sampled(false).context().extra()).contains(1L);
   }
 
-  @Test public void sampled_false() {
-    assertThat(TraceContextOrSamplingFlags.create(base).sampled(false).value.flags)
-      .isEqualTo(FLAG_SAMPLED_SET);
-
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
-    assertThat(TraceContextOrSamplingFlags.create(idContext).sampled(false).value.flags)
-      .isEqualTo(FLAG_SAMPLED_SET);
-
-    assertThat(TraceContextOrSamplingFlags.EMPTY.sampled(false).value.flags)
-      .isEqualTo(FLAG_SAMPLED_SET);
+  @Test public void sampled_set_keepsExtra_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).addExtra(1L).build();
+    assertThat(extracted.sampled(false).extra()).contains(1L);
   }
 
-  @Test public void sampledLocal() {
-    assertThat(TraceContextOrSamplingFlags.create(base).sampledLocal())
-      .isFalse();
-    assertThat(
-      new TraceContextOrSamplingFlags.Builder().context(base).sampledLocal().build().sampledLocal())
-      .isTrue();
+  @Test public void sampled_set_keepsExtra_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).addExtra(1L).build();
+    assertThat(extracted.sampled(false).extra()).contains(1L);
+  }
 
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).build();
-    assertThat(TraceContextOrSamplingFlags.create(idContext).sampledLocal())
-      .isFalse();
-    assertThat(new TraceContextOrSamplingFlags.Builder().traceIdContext(idContext)
-      .sampledLocal()
-      .build()
-      .sampledLocal())
-      .isTrue();
+  @Test public void sampled_set_keepsSampledLocal_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).sampledLocal().build();
 
-    assertThat(new TraceContextOrSamplingFlags.Builder().samplingFlags(SamplingFlags.SAMPLED)
-      .sampledLocal()
-      .build()
-      .sampledLocal())
-      .isTrue();
+    extracted = extracted.sampled(false);
+    assertThat(extracted.sampled()).isFalse();
+    assertThat(extracted.sampledLocal()).isTrue();
+  }
+
+  @Test public void sampled_set_keepsSampledLocal_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).sampledLocal().build();
+
+    extracted = extracted.sampled(false);
+    assertThat(extracted.sampled()).isFalse();
+    assertThat(extracted.sampledLocal()).isTrue();
+  }
+
+  @Test public void sampled_set_keepsSampledLocal_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).sampledLocal().build();
+
+    extracted = extracted.sampled(false);
+    assertThat(extracted.sampled()).isFalse();
+    assertThat(extracted.sampledLocal()).isTrue();
+  }
+
+  @Test public void newBuilder_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).build();
+    assertThat(extracted.context()).isSameAs(context);
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.samplingFlags()).isNull();
+  }
+
+  @Test public void newBuilder_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).build();
+    assertThat(extracted.context()).isNull();
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.samplingFlags()).isSameAs(SAMPLED);
+  }
+
+  @Test public void newBuilder_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).build();
+    assertThat(extracted.context()).isNull();
+    assertThat(extracted.traceIdContext()).isSameAs(idContext);
+    assertThat(extracted.samplingFlags()).isNull();
+  }
+
+  @Test public void builder_addExtra_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).addExtra(1L).build();
+    assertThat(extracted.context().extra()).containsExactly(1L);
+    assertThat(extracted.extra()).isEmpty();
+  }
+
+  @Test public void builder_addExtra_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).addExtra(1L).build();
+    assertThat(extracted.extra()).containsExactly(1L);
+  }
+
+  @Test public void builder_addExtra_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).addExtra(1L).build();
+    assertThat(extracted.extra()).containsExactly(1L);
+  }
+
+  @Test public void builder_addExtra_toExisting_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).addExtra(1L).build();
+
+    extracted = extracted.toBuilder().addExtra(2L).build();
+    assertThat(extracted.context().extra()).containsExactly(1L, 2L);
+    assertThat(extracted.extra()).isEmpty();
+  }
+
+  @Test public void builder_addExtra_toExisting_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).addExtra(1L).build();
+
+    extracted = extracted.toBuilder().addExtra(2L).build();
+    assertThat(extracted.extra()).containsExactly(1L, 2L);
+  }
+
+  @Test public void builder_addExtra_toExisting_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).addExtra(1L).build();
+
+    extracted = extracted.toBuilder().addExtra(2L).build();
+    assertThat(extracted.extra()).containsExactly(1L, 2L);
+  }
+
+  @Test public void builder_addExtra_redundantIgnored_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).addExtra(1L).build();
+
+    extracted = extracted.toBuilder().addExtra(1L).build();
+    assertThat(extracted.context().extra()).containsExactly(1L);
+    assertThat(extracted.extra()).isEmpty();
+  }
+
+  @Test public void builder_addExtra_redundantIgnored_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).addExtra(1L).build();
+
+    extracted = extracted.toBuilder().addExtra(1L).build();
+    assertThat(extracted.extra()).containsExactly(1L);
+  }
+
+  @Test public void builder_addExtra_redundantIgnored_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).addExtra(1L).build();
+    extracted = extracted.toBuilder().addExtra(1L).build();
+
+    assertThat(extracted.extra()).containsExactly(1L);
+  }
+
+  @Test public void builder_sampledLocal_context() {
+    assertThat(TraceContextOrSamplingFlags.create(context).sampledLocal())
+        .isFalse();
+    assertThat(TraceContextOrSamplingFlags.newBuilder(context)
+        .sampledLocal().build().sampledLocal())
+        .isTrue();
+  }
+
+  @Test public void builder_sampledLocal_samplingFlags() {
+    assertThat(TraceContextOrSamplingFlags.newBuilder(SAMPLED)
+        .sampledLocal().build().sampledLocal())
+        .isTrue();
 
     assertThat(TraceContextOrSamplingFlags.EMPTY.sampledLocal())
-      .isFalse();
+        .isFalse();
     assertThat(TraceContextOrSamplingFlags.SAMPLED.sampledLocal())
-      .isFalse();
+        .isFalse();
     assertThat(TraceContextOrSamplingFlags.NOT_SAMPLED.sampledLocal())
-      .isFalse();
+        .isFalse();
     assertThat(TraceContextOrSamplingFlags.DEBUG.sampledLocal())
-      .isFalse();
+        .isFalse();
   }
 
-  @Test public void sampled_true_noop() {
-    TraceContext context = base.toBuilder().sampled(true).build();
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(context)
-      .addExtra(1L).build();
-    assertThat(toTest.sampled(true)).isSameAs(toTest);
-
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).sampled(true).build();
-    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
-      .addExtra(1L).build();
-    assertThat(toTest.sampled(true)).isSameAs(toTest);
-
-    toTest = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.SAMPLED)
-      .addExtra(1L).build();
-    assertThat(toTest.sampled(true)).isSameAs(toTest);
+  @Test public void builder_sampledLocal_traceIdContext() {
+    assertThat(TraceContextOrSamplingFlags.create(idContext).sampledLocal())
+        .isFalse();
+    assertThat(TraceContextOrSamplingFlags.newBuilder(idContext)
+        .sampledLocal().build().sampledLocal())
+        .isTrue();
   }
 
-  @Test public void sampled_false_noop() {
-    TraceContext context = base.toBuilder().sampled(false).build();
-    TraceContextOrSamplingFlags toTest = TraceContextOrSamplingFlags.newBuilder().context(context)
-      .addExtra(1L).build();
-    assertThat(toTest.sampled(false)).isSameAs(toTest);
+  @Test public void equalsAndHashCode_context() {
+    equalsAndHashCode(
+        () -> TraceContextOrSamplingFlags.create(context),
+        () -> TraceContextOrSamplingFlags.create(context.toBuilder().traceId(111L).build()),
+        () -> TraceContextOrSamplingFlags.create(SAMPLED)
+    );
+  }
 
-    TraceIdContext idContext = TraceIdContext.newBuilder().traceId(333L).sampled(false).build();
-    toTest = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext)
-      .addExtra(1L).build();
-    assertThat(toTest.sampled(false)).isSameAs(toTest);
+  @Test public void equalsAndHashCode_samplingFlags() {
+    equalsAndHashCode(
+        () -> TraceContextOrSamplingFlags.create(SAMPLED),
+        () -> TraceContextOrSamplingFlags.create(NOT_SAMPLED),
+        () -> TraceContextOrSamplingFlags.create(context)
+    );
+  }
 
-    toTest = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SamplingFlags.NOT_SAMPLED)
-      .addExtra(1L).build();
-    assertThat(toTest.sampled(false)).isSameAs(toTest);
+  @Test public void equalsAndHashCode_traceIdContext() {
+    equalsAndHashCode(
+        () -> TraceContextOrSamplingFlags.create(idContext),
+        () -> TraceContextOrSamplingFlags.create(idContext.toBuilder().traceId(111L).build()),
+        () -> TraceContextOrSamplingFlags.create(SAMPLED)
+    );
+  }
+
+  void equalsAndHashCode(
+      Supplier<TraceContextOrSamplingFlags> factory,
+      Supplier<TraceContextOrSamplingFlags> differentValueFactory,
+      Supplier<TraceContextOrSamplingFlags> differentTypeFactory
+  ) {
+    // same extracted are equivalent
+    extracted = factory.get();
+    assertThat(extracted).isEqualTo(extracted);
+    assertThat(extracted).hasSameHashCodeAs(extracted);
+
+    // different extracted is equivalent
+    TraceContextOrSamplingFlags sameState = factory.get();
+    assertThat(extracted).isEqualTo(sameState);
+    assertThat(extracted).hasSameHashCodeAs(sameState);
+
+    // different values are not equivalent
+    TraceContextOrSamplingFlags differentValue = differentValueFactory.get();
+    assertThat(extracted).isNotEqualTo(differentValue);
+    assertThat(differentValue).isNotEqualTo(extracted);
+    assertThat(extracted.hashCode()).isNotEqualTo(differentValue);
+
+    // different extra are not equivalent
+    TraceContextOrSamplingFlags withExtra = extracted.toBuilder().addExtra(1L).build();
+    assertThat(extracted).isNotEqualTo(withExtra);
+    assertThat(withExtra).isNotEqualTo(extracted);
+    assertThat(extracted.hashCode()).isNotEqualTo(withExtra);
+
+    // different type are not equivalent
+    TraceContextOrSamplingFlags differentType = differentTypeFactory.get();
+    assertThat(extracted).isNotEqualTo(differentType);
+    assertThat(differentType).isNotEqualTo(extracted);
+    assertThat(extracted.hashCode()).isNotEqualTo(differentType);
+  }
+
+  @Test public void toString_context() {
+    toString(
+        () -> TraceContextOrSamplingFlags.create(context),
+        "Extracted{traceContext=000000000000014d/0000000000000001, samplingFlags=SAMPLED}",
+        "Extracted{traceContext=000000000000014d/0000000000000001, samplingFlags=SAMPLED, extra=[1, 2]}"
+    );
+  }
+
+  @Test public void toString_samplingFlags() {
+    toString(
+        () -> TraceContextOrSamplingFlags.create(SAMPLED),
+        "Extracted{samplingFlags=SAMPLED}",
+        "Extracted{samplingFlags=SAMPLED, extra=[1, 2]}"
+    );
+  }
+
+  @Test public void toString_traceIdContext() {
+    toString(
+        () -> TraceContextOrSamplingFlags.create(idContext),
+        "Extracted{traceIdContext=000000000000014d, samplingFlags=SAMPLED}",
+        "Extracted{traceIdContext=000000000000014d, samplingFlags=SAMPLED, extra=[1, 2]}"
+    );
+  }
+
+  void toString(
+      Supplier<TraceContextOrSamplingFlags> factory, String toString, String toStringWithExtra) {
+    extracted = factory.get();
+    assertThat(extracted).hasToString(toString);
+
+    extracted = factory.get().toBuilder().addExtra(1L).addExtra(2L).build();
+    assertThat(extracted).hasToString(toStringWithExtra);
+  }
+
+  @Deprecated @Test public void deprecated_create_sampledNullDebugFalse() {
+    extracted = TraceContextOrSamplingFlags.create(null, false);
+    assertThat(extracted).isSameAs(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(extracted.sampled()).isNull();
+    assertThat(extracted.samplingFlags()).isSameAs(SamplingFlags.EMPTY);
+  }
+
+  @Deprecated @Test public void deprecated_create_sampledNullDebugTrue() {
+    extracted = TraceContextOrSamplingFlags.create(null, true);
+    assertThat(extracted).isSameAs(TraceContextOrSamplingFlags.DEBUG);
+    assertThat(extracted.sampled()).isTrue();
+    assertThat(extracted.samplingFlags()).isSameAs(SamplingFlags.DEBUG);
+  }
+
+  @Deprecated @Test public void deprecated_create_sampledTrueDebugFalse() {
+    extracted = TraceContextOrSamplingFlags.create(true, false);
+    assertThat(extracted).isSameAs(TraceContextOrSamplingFlags.SAMPLED);
+    assertThat(extracted.sampled()).isTrue();
+    assertThat(extracted.samplingFlags()).isSameAs(SAMPLED);
+  }
+
+  @Deprecated @Test public void deprecated_create_sampledFalseDebugFalse() {
+    extracted = TraceContextOrSamplingFlags.create(false, false);
+    assertThat(extracted).isSameAs(TraceContextOrSamplingFlags.NOT_SAMPLED);
+    assertThat(extracted.sampled()).isFalse();
+    assertThat(extracted.samplingFlags()).isSameAs(SamplingFlags.NOT_SAMPLED);
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_context() {
+    extracted = TraceContextOrSamplingFlags.create(context.toBuilder().sampled(null).build());
+    assertThat(extracted.sampled(null)).isSameAs(extracted);
+
+    extracted = TraceContextOrSamplingFlags.create(context);
+    assertThat(extracted.sampled(null).sampled()).isNull();
+    assertThat(extracted.sampled(null).context().sampled()).isNull();
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.create(EMPTY);
+    assertThat(extracted.sampled(null)).isSameAs(extracted);
+
+    extracted = TraceContextOrSamplingFlags.create(SAMPLED);
+    assertThat(extracted.sampled(null).sampled()).isNull();
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.create(idContext.toBuilder().sampled(null).build());
+    assertThat(extracted.sampled(null)).isSameAs(extracted);
+
+    extracted = TraceContextOrSamplingFlags.create(idContext);
+    assertThat(extracted.sampled(null).sampled()).isNull();
+    assertThat(extracted.sampled(null).traceIdContext().sampled()).isNull();
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_keepsExtra_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).addExtra(1L).build();
+    assertThat(extracted.sampled(null).context().extra()).contains(1L);
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_keepsExtra_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).addExtra(1L).build();
+    assertThat(extracted.sampled(null).extra()).contains(1L);
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_keepsExtra_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).addExtra(1L).build();
+    assertThat(extracted.sampled(null).extra()).contains(1L);
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_keepsSampledLocal_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).sampledLocal().build();
+
+    extracted = extracted.sampled(null);
+    assertThat(extracted.sampled()).isNull();
+    assertThat(extracted.sampledLocal()).isTrue();
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_keepsSampledLocal_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).sampledLocal().build();
+
+    extracted = extracted.sampled(null);
+    assertThat(extracted.sampled()).isNull();
+    assertThat(extracted.sampledLocal()).isTrue();
+  }
+
+  @Deprecated @Test public void deprecated_sampled_set_null_keepsSampledLocal_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).sampledLocal().build();
+
+    extracted = extracted.sampled(null);
+    assertThat(extracted.sampled()).isNull();
+    assertThat(extracted.sampledLocal()).isTrue();
+  }
+
+  @Deprecated @Test public void deprecated_builder_invalid() {
+    TraceContextOrSamplingFlags.Builder builder = TraceContextOrSamplingFlags.newBuilder();
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Value unset. Use a non-deprecated newBuilder method instead.");
+  }
+
+  @Deprecated @Test public void deprecated_builder_extraList_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(context).addExtra(3L).build();
+
+    extracted = extracted.toBuilder().extra(asList(1L, 2L)).build();
+    assertThat(extracted.context().extra()).containsExactly(1L, 2L);
+    assertThat(extracted.extra()).isEmpty();
+  }
+
+  @Deprecated @Test public void deprecated_builder_extraList_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(SAMPLED).addExtra(3L).build();
+
+    extracted = extracted.toBuilder().extra(asList(1L, 2L)).build();
+    assertThat(extracted.extra()).containsExactly(1L, 2L);
+  }
+
+  @Deprecated @Test public void deprecated_builder_extraList_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder(idContext).addExtra(3L).build();
+
+    extracted = extracted.toBuilder().extra(asList(1L, 2L)).build();
+    assertThat(extracted.extra()).containsExactly(1L, 2L);
+  }
+
+  @Deprecated @Test public void deprecated_builder_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder().context(context).build();
+    assertThat(extracted.context()).isSameAs(context);
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.samplingFlags()).isNull();
+  }
+
+  @Deprecated @Test public void deprecated_builder_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder().samplingFlags(SAMPLED).build();
+    assertThat(extracted.context()).isNull();
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.samplingFlags()).isSameAs(SAMPLED);
+  }
+
+  @Deprecated @Test public void deprecated_builder_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder().traceIdContext(idContext).build();
+    assertThat(extracted.context()).isNull();
+    assertThat(extracted.traceIdContext()).isSameAs(idContext);
+    assertThat(extracted.samplingFlags()).isNull();
+  }
+
+  @Deprecated @Test public void deprecated_builder_late_context() {
+    extracted = TraceContextOrSamplingFlags.newBuilder()
+        .sampledLocal()
+        .addExtra(1L)
+        .context(context).build();
+
+    assertThat(extracted.sampledLocal()).isTrue();
+    assertThat(extracted.context().extra()).containsExactly(1L);
+    assertThat(extracted.extra()).isEmpty();
+  }
+
+  @Deprecated @Test public void deprecated_builder_late_samplingFlags() {
+    extracted = TraceContextOrSamplingFlags.newBuilder()
+        .sampledLocal()
+        .addExtra(1L)
+        .samplingFlags(EMPTY).build();
+
+    assertThat(extracted.sampledLocal()).isTrue();
+    assertThat(extracted.extra()).containsExactly(1L);
+  }
+
+  @Deprecated @Test public void deprecated_builder_late_traceIdContext() {
+    extracted = TraceContextOrSamplingFlags.newBuilder()
+        .sampledLocal()
+        .addExtra(1L)
+        .traceIdContext(idContext).build();
+
+    assertThat(extracted.sampledLocal()).isTrue();
+    assertThat(extracted.extra()).containsExactly(1L);
   }
 }

--- a/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
+++ b/brave/src/test/java/brave/propagation/TraceContextOrSamplingFlagsTest.java
@@ -189,6 +189,12 @@ public class TraceContextOrSamplingFlagsTest {
     extracted = extracted.toBuilder().addExtra(2L).build();
     assertThat(extracted.context().extra()).containsExactly(1L, 2L);
     assertThat(extracted.extra()).isEmpty();
+
+
+    assertThatThrownBy(() -> extracted.context().extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> extracted.extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test public void builder_addExtra_toExisting_samplingFlags() {
@@ -196,6 +202,9 @@ public class TraceContextOrSamplingFlagsTest {
 
     extracted = extracted.toBuilder().addExtra(2L).build();
     assertThat(extracted.extra()).containsExactly(1L, 2L);
+
+    assertThatThrownBy(() -> extracted.extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test public void builder_addExtra_toExisting_traceIdContext() {
@@ -203,6 +212,9 @@ public class TraceContextOrSamplingFlagsTest {
 
     extracted = extracted.toBuilder().addExtra(2L).build();
     assertThat(extracted.extra()).containsExactly(1L, 2L);
+
+    assertThatThrownBy(() -> extracted.extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test public void builder_addExtra_redundantIgnored_context() {
@@ -455,6 +467,11 @@ public class TraceContextOrSamplingFlagsTest {
     extracted = extracted.toBuilder().extra(asList(1L, 2L)).build();
     assertThat(extracted.context().extra()).containsExactly(1L, 2L);
     assertThat(extracted.extra()).isEmpty();
+
+    assertThatThrownBy(() -> extracted.context().extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> extracted.extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Deprecated @Test public void deprecated_builder_extraList_samplingFlags() {
@@ -462,6 +479,9 @@ public class TraceContextOrSamplingFlagsTest {
 
     extracted = extracted.toBuilder().extra(asList(1L, 2L)).build();
     assertThat(extracted.extra()).containsExactly(1L, 2L);
+
+    assertThatThrownBy(() -> extracted.extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Deprecated @Test public void deprecated_builder_extraList_traceIdContext() {
@@ -469,6 +489,9 @@ public class TraceContextOrSamplingFlagsTest {
 
     extracted = extracted.toBuilder().extra(asList(1L, 2L)).build();
     assertThat(extracted.extra()).containsExactly(1L, 2L);
+
+    assertThatThrownBy(() -> extracted.extra().add(3L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Deprecated @Test public void deprecated_builder_context() {

--- a/instrumentation/benchmarks/src/main/java/brave/TracerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/TracerBenchmarks.java
@@ -67,8 +67,7 @@ public class TracerBenchmarks {
   TraceContextOrSamplingFlags extractedBaggage = TraceContextOrSamplingFlags.create(contextBaggage);
   TraceContextOrSamplingFlags unsampledExtracted = TraceContextOrSamplingFlags.create(NOT_SAMPLED);
   TraceContextOrSamplingFlags unsampledExtractedBaggage =
-    TraceContextOrSamplingFlags.newBuilder()
-      .samplingFlags(NOT_SAMPLED)
+    TraceContextOrSamplingFlags.newBuilder(NOT_SAMPLED)
       .addExtra(contextBaggage.extra())
       .build();
 


### PR DESCRIPTION
This deprecates methods only used in tests, or those that can lead to
null pointers. It backfills JavaDoc and complete test coverage.

Since `TraceContextOrSamplingFlags` primarily called "extracted", this
improves the `toString` based on experience of what's important to know.

Ex. we want to know what we extracted, if any sampling status exists,
and if any extra propagated state exists.