### PR TITLE
Adds UnsafeArrayMap and deprecated BaggageField.getAll for getAllValues

### DIFF
--- a/brave/RATIONALE.md
+++ b/brave/RATIONALE.md
@@ -300,3 +300,66 @@ instrumentation vs 3rd party code).
 The other reason is that this is only used internally where we control the
 call sites. These call sites are already try/finally in nature, which addresses
 the concern we can control.
+
+## ExtraBaggageFields
+`FixedBaggageState` is copy-on-write context storage of `BaggageField` values.
+It is added only once to a request extraction or trace context regardless of
+the count of fields.
+
+Copy-on-write means a call to `BaggageField.updateValue` will replace its
+internal state with a copy of the prior (usually the parent). Until an update
+occurs (possibly never!), a constant `initialState` is shared by all trace
+contexts. In other words, if baggage is configured, but never used, the only
+overhead is one state wrapper (`FixedBaggageState`) per `TraceContext`. If
+only one context has a change in that local root, then only one copy of the
+state is made.
+
+Put short the copy-on-write aspect limits overhead under the assumption that
+changes to `BaggageField` values are infrequent. We believe this assumption
+holds due to practice. For example, common baggage are immutable after parsing
+a request, such as request ID, country code, device ID, etc.
+
+### Internal state is an `Object[]`
+`BaggageField` values are `String`, so to hold state means an association of
+some kind between `BaggageField` and a single `String` value. Updates to
+baggage are generally infrequent, sometimes never, and many times only when
+extracting headers from a request. As such, we choose pair-wise layout in an
+object array (`Object[]`).
+
+To remind, pair-wise means an association `{k1=v1, k2=v2}` is laid out in an
+array as `[k1, v1, k2, v2]`. The size of the association is `array.length/2`.
+Retrieving a value means finding the key's index and returning `array[i+1]`
+
+In our specific case, we add `null` values for all known fields. For example,
+if `BaggageConfiguration` is initialized with fields countryCode and deviceId,
+the initial state array is `[countryCode, null, deviceId, null]`
+
+Retaining fields even when `null` allows among many things, the following:
+* Queries for all potential field names (remote propagation)
+* Constant time index lookup of predefined fields.
+
+In practice, we use a constant `HashMap` to find the index of a predefined
+fields. This is how we achieve constant time index lookup, while also keeping
+iteration performance of an array!
+
+### `Map` views over `BaggageField` values
+As `Map` is a standard type, it is a safer type to expose to consumers of all
+baggage fields. We decided to use an unmodifiable `Map` instead of an internal
+type for use cases such as coalescing all baggage into a single header. This
+map must also hide local fields from propagation.
+
+#### Why not a standard `Map` type
+We considered copying the internal state array to an existing `Map` type, such
+as `LinkedHashMap`. However, doing so would add overhead regardless of it that
+`Map` was ever used, or if that map had a value for the field the consumer was
+interested in! Concretely, we'd pay to create the map, to copy the values in
+the array into it, and also pay implicit cost of iterator allocation for
+operations such as `entrySet()` even if the entry desired was not present. This
+holds present even extending `AbstractMap`, as most operations, even `get()`
+allocate iterators.
+
+#### `UnsafeArrayMap`
+We created `UnsafeArrayMap` as a view over our pair-wise internal state array.
+The implementation is very simple except that we have a redaction use case to
+address, which implies filtering keys. To address that, we keep a bitmap of all
+filtered keys and consider that when performing any scan operations.

--- a/brave/src/main/java/brave/baggage/BaggageField.java
+++ b/brave/src/main/java/brave/baggage/BaggageField.java
@@ -16,14 +16,15 @@ package brave.baggage;
 import brave.Tracing;
 import brave.internal.InternalBaggage;
 import brave.internal.Nullable;
-import brave.internal.baggage.BaggageContext;
 import brave.internal.baggage.BaggageCodec;
+import brave.internal.baggage.BaggageContext;
 import brave.internal.baggage.ExtraBaggageContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Defines a trace context scoped field, usually but not always analogous to an HTTP header. Fields
@@ -108,36 +109,58 @@ public final class BaggageField {
     return new BaggageField(name, ExtraBaggageContext.get());
   }
 
-  /**
-   * Gets any fields in the in given trace context.
-   *
-   * @since 5.11
-   */
-  public static List<BaggageField> getAll(@Nullable TraceContext context) {
+  /** @deprecated Since 5.12 use {@link #getAllValues(TraceContext)} */
+  @Deprecated public static List<BaggageField> getAll(@Nullable TraceContext context) {
     if (context == null) return Collections.emptyList();
     return ExtraBaggageContext.getAllFields(context);
   }
 
-  /**
-   * Gets any fields in the in the {@linkplain TraceContext.Extractor#extract(Object) extracted
-   * result}.
-   *
-   * @since 5.11
-   */
-  public static List<BaggageField> getAll(TraceContextOrSamplingFlags extracted) {
+  /** @deprecated Since 5.12 use {@link #getAllValues(TraceContext)} */
+  @Deprecated public static List<BaggageField> getAll(TraceContextOrSamplingFlags extracted) {
     if (extracted == null) throw new NullPointerException("extracted == null");
     return ExtraBaggageContext.getAllFields(extracted);
   }
 
-  /**
-   * Like {@link #getAll(TraceContext)} except against the current trace context.
-   *
-   * <p>Prefer {@link #getAll(TraceContext)} if you have a reference to the trace context.
-   *
-   * @since 5.11
-   */
-  @Nullable public static List<BaggageField> getAll() {
+  /** @deprecated Since 5.12 use {@link #getAllValues(TraceContext)} */
+  @Deprecated @Nullable public static List<BaggageField> getAll() {
     return getAll(currentTraceContext());
+  }
+
+  /**
+   * Returns a map of all {@linkplain BaggageField#name() name} to {@linkplain
+   * BaggageField#getValue(TraceContext) non-{@code null} value} pairs in the {@linkplain
+   * TraceContext.Extractor#extract(Object) extracted result}.
+   *
+   * @see #getAllValues(TraceContextOrSamplingFlags)
+   * @since 5.12
+   */
+  public static Map<String, String> getAllValues(@Nullable TraceContext context) {
+    if (context == null) return Collections.emptyMap();
+    return ExtraBaggageContext.getAllValues(context);
+  }
+
+  /**
+   * Returns a map of all {@linkplain BaggageField#name() name} to {@linkplain
+   * BaggageField#getValue(TraceContextOrSamplingFlags) non-{@code null} value} pairs in the
+   * {@linkplain TraceContext.Extractor#extract(Object) extracted result}.
+   *
+   * @see #getAllValues(TraceContext)
+   * @since 5.12
+   */
+  public static Map<String, String> getAllValues(TraceContextOrSamplingFlags extracted) {
+    if (extracted == null) throw new NullPointerException("extracted == null");
+    return ExtraBaggageContext.getAllValues(extracted);
+  }
+
+  /**
+   * Like {@link #getAllValues(TraceContext)} except against the current trace context.
+   *
+   * <p>Prefer {@link #getAllValues(TraceContext)} if you have a reference to the trace context.
+   *
+   * @since 5.12
+   */
+  @Nullable public static Map<String, String> getAllValues() {
+    return getAllValues(currentTraceContext());
   }
 
   /**

--- a/brave/src/main/java/brave/internal/baggage/BaggageCodec.java
+++ b/brave/src/main/java/brave/internal/baggage/BaggageCodec.java
@@ -22,6 +22,7 @@ import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public interface BaggageCodec {
   /**
@@ -40,7 +41,8 @@ public interface BaggageCodec {
       return false;
     }
 
-    @Override public String encode(ExtraBaggageFields extra, TraceContext context, Object request) {
+    @Override
+    public String encode(Map<String, String> values, TraceContext context, Object request) {
       return null;
     }
 
@@ -87,13 +89,12 @@ public interface BaggageCodec {
    * Encodes any state to a request value used by {@link Setter#put(Object, Object, String)}. When
    * not {@code null}, the value will be used for all {@link #injectKeyNames()}.
    *
-   * <p>Ex. When the {@code state} is a simple string, this will just be returned with no change.
-   * {@linkplain ExtraBaggageFields#isDynamic() Dynamic values} will need to perform some encoding,
-   * such as joining on equals and comma.
+   * <p>The {@code values} parameter is not thread safe. Only use this reference inside the encode
+   * method and do not store it as a field.
    *
-   * @param extra holds {@link BaggageField} state.
+   * @param values a mapping of all remote {@link BaggageField#name()} to non-{@code null} values
    * @return an input to {@link Setter#put(Object, Object, String)}
    * @see #injectKeyNames()
    */
-  @Nullable String encode(ExtraBaggageFields extra, TraceContext context, Object request);
+  @Nullable String encode(Map<String, String> values, TraceContext context, Object request);
 }

--- a/brave/src/main/java/brave/internal/baggage/DynamicBaggageState.java
+++ b/brave/src/main/java/brave/internal/baggage/DynamicBaggageState.java
@@ -37,6 +37,15 @@ final class DynamicBaggageState extends ExtraBaggageFields.State<Map<BaggageFiel
     return Collections.unmodifiableList(new ArrayList<>(state.keySet()));
   }
 
+  @Override Map<String, String> getAllValues() {
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Map.Entry<BaggageField, String> entry: state.entrySet()) {
+      if (entry.getValue() == null) continue;
+      result.put(entry.getKey().name(), entry.getValue());
+    }
+    return result;
+  }
+
   @Override public String getValue(BaggageField field) {
     return state.get(field);
   }

--- a/brave/src/main/java/brave/internal/baggage/ExtraBaggageContext.java
+++ b/brave/src/main/java/brave/internal/baggage/ExtraBaggageContext.java
@@ -19,6 +19,7 @@ import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Most commonly, field storage is inside {@link TraceContext#extra()}.
@@ -39,6 +40,15 @@ public final class ExtraBaggageContext extends BaggageContext {
 
   public static List<BaggageField> getAllFields(TraceContext context) {
     return getAllFields(context.extra());
+  }
+
+  public static Map<String, String> getAllValues(TraceContextOrSamplingFlags extracted) {
+    if (extracted.context() != null) return getAllValues(extracted.context());
+    return getAllValues(extracted.extra());
+  }
+
+  public static Map<String, String> getAllValues(TraceContext context) {
+    return getAllValues(context.extra());
   }
 
   @Nullable
@@ -70,10 +80,16 @@ public final class ExtraBaggageContext extends BaggageContext {
     return updateValue(field, context.extra(), value);
   }
 
-  static List<BaggageField> getAllFields(List<Object> extra) {
-    ExtraBaggageFields fields = findExtra(ExtraBaggageFields.class, extra);
-    if (fields == null) return Collections.emptyList();
-    return fields.getAllFields();
+  static List<BaggageField> getAllFields(List<Object> extraList) {
+    ExtraBaggageFields extra = findExtra(ExtraBaggageFields.class, extraList);
+    if (extra == null) return Collections.emptyList();
+    return extra.getAllFields();
+  }
+
+  static Map<String, String> getAllValues(List<Object> extraList) {
+    ExtraBaggageFields extra = findExtra(ExtraBaggageFields.class, extraList);
+    if (extra == null) return Collections.emptyMap();
+    return extra.getAllValues();
   }
 
   @Nullable static BaggageField getFieldByName(List<BaggageField> fields, String name) {
@@ -88,15 +104,15 @@ public final class ExtraBaggageContext extends BaggageContext {
     return null;
   }
 
-  @Nullable static String getValue(BaggageField field, List<Object> extra) {
-    ExtraBaggageFields fields = findExtra(ExtraBaggageFields.class, extra);
-    if (fields == null) return null;
-    return fields.getValue(field);
+  @Nullable static String getValue(BaggageField field, List<Object> extraList) {
+    ExtraBaggageFields extra = findExtra(ExtraBaggageFields.class, extraList);
+    if (extra == null) return null;
+    return extra.getValue(field);
   }
 
-  static boolean updateValue(BaggageField field, List<Object> extra, @Nullable String value) {
-    ExtraBaggageFields fields = findExtra(ExtraBaggageFields.class, extra);
-    return fields != null && fields.updateValue(field, value);
+  static boolean updateValue(BaggageField field, List<Object> extraList, @Nullable String value) {
+    ExtraBaggageFields extra = findExtra(ExtraBaggageFields.class, extraList);
+    return extra != null && extra.updateValue(field, value);
   }
 
   public static <T> T findExtra(Class<T> type, List<Object> extra) {

--- a/brave/src/main/java/brave/internal/baggage/ExtraBaggageFields.java
+++ b/brave/src/main/java/brave/internal/baggage/ExtraBaggageFields.java
@@ -18,6 +18,7 @@ import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Holds one or more baggage fields in {@link TraceContext#extra()} or {@link
@@ -51,6 +52,11 @@ public final class ExtraBaggageFields {
   /** The list of fields present, regardless of value. */
   public List<BaggageField> getAllFields() {
     return internal.getAllFields();
+  }
+
+  /** Returns a possibly empty map of all name to non-{@code null} values. */
+  public Map<String, String> getAllValues() {
+    return internal.getAllValues();
   }
 
   /**
@@ -93,8 +99,11 @@ public final class ExtraBaggageFields {
     /** @see ExtraBaggageFields#getAllFields() */
     abstract List<BaggageField> getAllFields();
 
+    /** @see ExtraBaggageFields#getAllValues() */
+    abstract Map<String, String> getAllValues();
+
     /** @see ExtraBaggageFields#getValue(BaggageField) */
-    abstract @Nullable String getValue(BaggageField field);
+    @Nullable  abstract String getValue(BaggageField field);
 
     /** @see ExtraBaggageFields#updateValue(BaggageField, String) */
     abstract boolean updateValue(BaggageField field, @Nullable String value);

--- a/brave/src/main/java/brave/internal/baggage/LongBitSet.java
+++ b/brave/src/main/java/brave/internal/baggage/LongBitSet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.baggage;
+
+import java.util.BitSet;
+
+/**
+ * This is more efficient than {@link BitSet} as this doesn't implicitly allocate arrays.
+ */
+final class LongBitSet {
+  static final int MAX_SIZE = Long.SIZE;
+
+  static int size(long bitset) {
+    return Long.bitCount(bitset);
+  }
+
+  static boolean isSet(long bitset, long i) {
+    return (bitset & (1 << i)) != 0;
+  }
+
+  static long setBit(long bitset, long i) {
+    return bitset | (1 << i);
+  }
+}

--- a/brave/src/main/java/brave/internal/baggage/SingleFieldBaggageCodec.java
+++ b/brave/src/main/java/brave/internal/baggage/SingleFieldBaggageCodec.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public final class SingleFieldBaggageCodec implements BaggageCodec {
   /** Only handles a single remote field. */
@@ -47,7 +48,7 @@ public final class SingleFieldBaggageCodec implements BaggageCodec {
     return extra.updateValue(field, value);
   }
 
-  @Override public String encode(ExtraBaggageFields extra, TraceContext context, Object request) {
-    return extra.getValue(field);
+  @Override public String encode(Map<String, String> values, TraceContext context, Object request) {
+    return field.getValue(context);
   }
 }

--- a/brave/src/main/java/brave/internal/baggage/UnsafeArrayMap.java
+++ b/brave/src/main/java/brave/internal/baggage/UnsafeArrayMap.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.baggage;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static brave.internal.baggage.LongBitSet.isSet;
+import static brave.internal.baggage.LongBitSet.setBit;
+
+/**
+ * A potentially read-only map which is a view over an array of {@code key, value} pairs. No key can
+ * be {@code null}. Keys with {@code null} are filtered out.
+ *
+ * <p>The array is shared with the caller to {@link Builder#build(Object[])}, hence being called
+ * "unsafe". This type supports cheap views over data using thread-local or copy-on-write arrays.
+ *
+ * <p>An input with no keys coerces to {@link Collections#emptyMap()}.
+ *
+ * <p>As this is an immutable view, operations like {@link #keySet()}, {@link #values()} and {@link
+ * #entrySet()} might return constants. As expected, stateful objects such as {@link Iterator} will
+ * never be shared.
+ */
+class UnsafeArrayMap<K, V> implements Map<K, V> {
+  static final int MAX_FILTERED_KEYS = LongBitSet.MAX_SIZE;
+
+  interface Mapper<V1, V2> {
+    V2 map(V1 input);
+  }
+
+  static <K, V> Builder<K, V> newBuilder() {
+    return new Builder<>();
+  }
+
+  static final class Builder<K, V> {
+    Mapper<Object, K> keyMapper;
+    K[] filteredKeys = (K[]) new Object[0];
+
+    Builder<K, V> mapKeys(Mapper<Object, K> keyMapper) {
+      if (keyMapper == null) throw new NullPointerException("keyMapper == null");
+      this.keyMapper = keyMapper;
+      return this;
+    }
+
+    /** @param filteredKeys keys that won't be visible in the resulting map. */
+    Builder<K, V> filterKeys(K... filteredKeys) {
+      if (filteredKeys == null) throw new NullPointerException("filteredKeys == null");
+      if (filteredKeys.length > MAX_FILTERED_KEYS) {
+        throw new IllegalArgumentException(
+            "cannot filter more than " + MAX_FILTERED_KEYS + " keys");
+      }
+      this.filteredKeys = filteredKeys;
+      return this;
+    }
+
+    /** @param array pairwise array holding key values */
+    Map<K, V> build(Object[] array) {
+      if (array == null) throw new NullPointerException("array == null");
+      long filteredBitSet = 0;
+      int i = 0, numFiltered = 0;
+      for (; i < array.length; i += 2) {
+        if (array[i] == null) break; // we ignore anything starting at first null key
+
+        if (array[i + 1] == null) { // filter null values
+          filteredBitSet = setFilteredKey(filteredBitSet, i);
+          numFiltered++;
+          continue;
+        }
+
+        K key = keyMapper != null ? keyMapper.map(array[i]) : (K) array[i];
+        for (K filteredKey : filteredKeys) {
+          if (filteredKey.equals(key)) {
+            filteredBitSet = setFilteredKey(filteredBitSet, i);
+            numFiltered++;
+            break;
+          }
+        }
+      }
+      if (numFiltered == i / 2) return Collections.emptyMap();
+      if (keyMapper == null) return new UnsafeArrayMap<>(array, i, filteredBitSet);
+      return new KeyMapping<>(this, array, i, filteredBitSet);
+    }
+  }
+
+  static final class KeyMapping<K, V> extends UnsafeArrayMap<K, V> {
+    final Mapper<Object, K> keyMapper;
+
+    KeyMapping(Builder builder, Object[] array, int toIndex, long filteredBitSet) {
+      super(array, toIndex, filteredBitSet);
+      this.keyMapper = builder.keyMapper;
+    }
+
+    @Override K key(int i) {
+      return keyMapper.map(array[i]);
+    }
+  }
+
+  final Object[] array;
+  final int toIndex, size;
+  final long filteredBitSet;
+
+  UnsafeArrayMap(Object[] array, int toIndex, long filteredBitSet) {
+    this.array = array;
+    this.toIndex = toIndex;
+    this.filteredBitSet = filteredBitSet;
+    this.size = toIndex / 2 - LongBitSet.size(filteredBitSet);
+  }
+
+  @Override public int size() {
+    return size;
+  }
+
+  @Override public boolean containsKey(Object o) {
+    if (o == null) return false; // null keys are not allowed
+    return arrayIndexOfKey(o) != -1;
+  }
+
+  @Override public boolean containsValue(Object o) {
+    for (int i = 0; i < toIndex; i += 2) {
+      if (!isFilteredKey(filteredBitSet, i) && value(i + 1).equals(o)) return true;
+    }
+    return false;
+  }
+
+  @Override public V get(Object o) {
+    if (o == null) return null; // null keys are not allowed
+    int i = arrayIndexOfKey(o);
+    return i != -1 ? value(i + 1) : null;
+  }
+
+  int arrayIndexOfKey(Object o) {
+    int result = -1;
+    for (int i = 0; i < toIndex; i += 2) {
+      if (!isFilteredKey(filteredBitSet, i) && o.equals(key(i))) {
+        return i;
+      }
+    }
+    return result;
+  }
+
+  K key(int i) {
+    return (K) array[i];
+  }
+
+  V value(int i) {
+    return (V) array[i];
+  }
+
+  @Override public Set<K> keySet() {
+    return new KeySetView();
+  }
+
+  @Override public Collection<V> values() {
+    return new ValuesView();
+  }
+
+  @Override public Set<Map.Entry<K, V>> entrySet() {
+    return new EntrySetView();
+  }
+
+  @Override public boolean isEmpty() {
+    return false;
+  }
+
+  @Override public V put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public V remove(Object key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public void putAll(Map<? extends K, ? extends V> m) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  final class KeySetView extends SetView<K> {
+    @Override K elementAtArrayIndex(int i) {
+      return key(i);
+    }
+
+    @Override public boolean contains(Object o) {
+      return containsKey(o);
+    }
+  }
+
+  final class ValuesView extends SetView<V> {
+    @Override V elementAtArrayIndex(int i) {
+      return value(i + 1);
+    }
+
+    @Override public boolean contains(Object o) {
+      return containsValue(o);
+    }
+  }
+
+  final class EntrySetView extends SetView<Map.Entry<K, V>> {
+    @Override Map.Entry<K, V> elementAtArrayIndex(int i) {
+      return new Entry<>(key(i), value(i + 1));
+    }
+
+    @Override public boolean contains(Object o) {
+      if (!(o instanceof Map.Entry) || ((Map.Entry) o).getKey() == null) return false;
+      Map.Entry that = (Map.Entry) o;
+      int i = arrayIndexOfKey(that.getKey());
+      if (i == -1) return false;
+      return value(i + 1).equals(that.getValue());
+    }
+  }
+
+  abstract class SetView<E> implements Set<E> {
+    int advancePastFiltered(int i) {
+      while (i < toIndex && isFilteredKey(filteredBitSet, i)) i += 2;
+      return i;
+    }
+
+    @Override public int size() {
+      return size;
+    }
+
+    /**
+     * By abstracting this, {@link #keySet()} {@link #values()} and {@link #entrySet()} only
+     * implement need implement two methods based on {@link #<E>}: this method and and {@link
+     * #contains(Object)}.
+     */
+    abstract E elementAtArrayIndex(int i);
+
+    @Override public Iterator<E> iterator() {
+      return new ReadOnlyIterator();
+    }
+
+    @Override public Object[] toArray() {
+      return copyTo(new Object[size]);
+    }
+
+    @Override public <T> T[] toArray(T[] a) {
+      T[] result = a.length >= size ? a
+          : (T[]) Array.newInstance(a.getClass().getComponentType(), size());
+      return copyTo(result);
+    }
+
+    <T> T[] copyTo(T[] dest) {
+      for (int i = 0, d = 0; i < toIndex; i += 2) {
+        if (isFilteredKey(filteredBitSet, i)) continue;
+        dest[d++] = (T) elementAtArrayIndex(i);
+      }
+      return dest;
+    }
+
+    final class ReadOnlyIterator implements Iterator<E> {
+      int i = advancePastFiltered(0);
+
+      @Override public boolean hasNext() {
+        i = advancePastFiltered(i);
+        return i < toIndex;
+      }
+
+      @Override public E next() {
+        if (!hasNext()) throw new NoSuchElementException();
+        E result = elementAtArrayIndex(i);
+        i += 2;
+        return result;
+      }
+
+      @Override public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    }
+
+    @Override public boolean containsAll(Collection<?> c) {
+      if (c == null) return false;
+      if (c.isEmpty()) return true;
+
+      for (Object element : c) {
+        if (!contains(element)) return false;
+      }
+      return true;
+    }
+
+    @Override public boolean isEmpty() {
+      return false;
+    }
+
+    @Override public boolean add(E e) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean remove(Object o) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean addAll(Collection<? extends E> c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean retainAll(Collection<?> c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean removeAll(Collection<?> c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public void clear() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static final class Entry<K, V> implements Map.Entry<K, V> {
+    final K key;
+    final V value;
+
+    Entry(K key, V value) {
+      if (key == null) throw new NullPointerException("key == null");
+      if (value == null) throw new NullPointerException("value == null");
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override public K getKey() {
+      return key;
+    }
+
+    @Override public V getValue() {
+      return value;
+    }
+
+    @Override public V setValue(V value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public int hashCode() {
+      int h = 1000003;
+      h ^= key.hashCode();
+      h *= 1000003;
+      h ^= value == null ? 0 : value.hashCode();
+      return h;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (!(o instanceof Map.Entry)) return false;
+      Map.Entry that = (Map.Entry) o;
+      return key.equals(that.getKey()) && value.equals(that.getValue());
+    }
+
+    @Override public String toString() {
+      return "Entry{" + key + "=" + value + "}";
+    }
+  }
+
+  @Override public String toString() {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < toIndex; i += 2) {
+      if (isFilteredKey(filteredBitSet, i)) continue;
+      if (result.length() > 0) result.append(',');
+      result.append(key(i)).append('=').append(value(i + 1));
+    }
+    return result.insert(0, "UnsafeArrayMap{").append("}").toString();
+  }
+
+  static long setFilteredKey(long filteredKeys, int i) {
+    return setBit(filteredKeys, i / 2);
+  }
+
+  static boolean isFilteredKey(long filteredKeys, int i) {
+    return isSet(filteredKeys, i / 2);
+  }
+}

--- a/brave/src/main/java/brave/internal/baggage/UnsafeArrayMap.java
+++ b/brave/src/main/java/brave/internal/baggage/UnsafeArrayMap.java
@@ -14,6 +14,7 @@
 package brave.internal.baggage;
 
 import java.lang.reflect.Array;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -216,7 +217,7 @@ class UnsafeArrayMap<K, V> implements Map<K, V> {
 
   final class EntrySetView extends SetView<Map.Entry<K, V>> {
     @Override Map.Entry<K, V> elementAtArrayIndex(int i) {
-      return new Entry<>(key(i), value(i + 1));
+      return new SimpleImmutableEntry<>(key(i), value(i + 1));
     }
 
     @Override public boolean contains(Object o) {
@@ -323,48 +324,6 @@ class UnsafeArrayMap<K, V> implements Map<K, V> {
 
     @Override public void clear() {
       throw new UnsupportedOperationException();
-    }
-  }
-
-  static final class Entry<K, V> implements Map.Entry<K, V> {
-    final K key;
-    final V value;
-
-    Entry(K key, V value) {
-      if (key == null) throw new NullPointerException("key == null");
-      if (value == null) throw new NullPointerException("value == null");
-      this.key = key;
-      this.value = value;
-    }
-
-    @Override public K getKey() {
-      return key;
-    }
-
-    @Override public V getValue() {
-      return value;
-    }
-
-    @Override public V setValue(V value) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override public int hashCode() {
-      int h = 1000003;
-      h ^= key.hashCode();
-      h *= 1000003;
-      h ^= value == null ? 0 : value.hashCode();
-      return h;
-    }
-
-    @Override public boolean equals(Object o) {
-      if (!(o instanceof Map.Entry)) return false;
-      Map.Entry that = (Map.Entry) o;
-      return key.equals(that.getKey()) && value.equals(that.getValue());
-    }
-
-    @Override public String toString() {
-      return "Entry{" + key + "=" + value + "}";
     }
   }
 

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -153,23 +153,18 @@ import static java.util.Collections.unmodifiableList;
 
   /** @deprecated Since 5.11 use {@link BaggageField#getAll()} */
   @Deprecated public static Map<String, String> getAll() {
-    return getAll(BaggageField.getAll(), null);
+    return BaggageField.getAllValues();
   }
 
   /** @deprecated Since 5.11 use {@link BaggageField#getAll(TraceContextOrSamplingFlags)} */
   @Deprecated public static Map<String, String> getAll(TraceContextOrSamplingFlags extracted) {
     if (extracted.context() != null) return getAll(extracted.context());
-    Map<String, String> result = new LinkedHashMap<>();
-    for (BaggageField field : BaggageField.getAll(extracted)) {
-      String value = field.getValue(extracted);
-      if (value != null) result.put(field.name(), value);
-    }
-    return result;
+    return BaggageField.getAllValues(extracted);
   }
 
   /** @deprecated Since 5.11 use {@link BaggageField#getAll(TraceContext)} */
   @Deprecated public static Map<String, String> getAll(TraceContext context) {
-    return getAll(BaggageField.getAll(context), context);
+    return BaggageField.getAllValues(context);
   }
 
   /**
@@ -263,14 +258,5 @@ import static java.util.Collections.unmodifiableList;
     fieldName = fieldName.toLowerCase(Locale.ROOT).trim();
     if (fieldName.isEmpty()) throw new IllegalArgumentException("fieldName is empty");
     return fieldName;
-  }
-
-  static Map<String, String> getAll(List<BaggageField> fields, @Nullable TraceContext context) {
-    Map<String, String> result = new LinkedHashMap<>();
-    for (BaggageField field : fields) {
-      String value = context != null ? field.getValue(context) : field.getValue();
-      if (value != null) result.put(field.name(), value);
-    }
-    return result;
   }
 }

--- a/brave/src/test/java/brave/baggage/BaggagePropagationTest.java
+++ b/brave/src/test/java/brave/baggage/BaggagePropagationTest.java
@@ -13,7 +13,7 @@
  */
 package brave.baggage;
 
-import brave.baggage.BaggagePropagation.ExtractKeyNames;
+import brave.baggage.BaggagePropagation.Extra;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.internal.baggage.ExtraBaggageFields;
 import brave.propagation.B3Propagation;
@@ -144,15 +144,15 @@ public class BaggagePropagationTest {
     TraceContextOrSamplingFlags extracted = extractor.extract(request);
     assertThat(extracted.extra())
         .hasSize(1)
-        .noneMatch(ExtractKeyNames.class::isInstance);
+        .noneMatch(Extra.class::isInstance);
   }
 
   @Test public void extract_baggage_addsAllKeyNames_evenWhenEmpty() {
     TraceContextOrSamplingFlags extracted = extractor.extract(request);
     assertThat(extracted.extra()).hasSize(2);
     assertThat(extracted.extra().get(1))
-        .asInstanceOf(InstanceOfAssertFactories.type(ExtractKeyNames.class))
-        .extracting(a -> a.list)
+        .asInstanceOf(InstanceOfAssertFactories.type(Extra.class))
+        .extracting(a -> a.extractKeyNames)
         .asInstanceOf(InstanceOfAssertFactories.list(String.class))
         .containsExactly("x-vcap-request-id", "x-amzn-trace-id");
   }

--- a/brave/src/test/java/brave/features/opentracing/BraveSpanContext.java
+++ b/brave/src/test/java/brave/features/opentracing/BraveSpanContext.java
@@ -18,8 +18,6 @@ import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.opentracing.SpanContext;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 class BraveSpanContext implements SpanContext {
@@ -45,14 +43,7 @@ class BraveSpanContext implements SpanContext {
 
   @Override public Iterable<Map.Entry<String, String>> baggageItems() {
     if (context == null) return Collections.emptyList();
-    List<BaggageField> fields = BaggageField.getAll(context);
-    if (fields.isEmpty()) return Collections.emptyList();
-    Map<String, String> baggage = new LinkedHashMap<>();
-    for (BaggageField field : fields) {
-      String value = field.getValue(context);
-      if (value != null) baggage.put(field.name(), value);
-    }
-    return baggage.entrySet();
+    return BaggageField.getAllValues(context).entrySet();
   }
 
   static final class Incomplete extends BraveSpanContext {

--- a/brave/src/test/java/brave/internal/baggage/ExtraBaggageFieldsFactoryTest.java
+++ b/brave/src/test/java/brave/internal/baggage/ExtraBaggageFieldsFactoryTest.java
@@ -39,7 +39,7 @@ public class ExtraBaggageFieldsFactoryTest {
   BaggageField field2 = BaggageField.create("two");
   String value1 = "1", value2 = "2", value3 = "3";
 
-  ExtraBaggageFieldsFactory factory = FixedBaggageFieldsFactory.create(asList(field1, field2));
+  ExtraBaggageFieldsFactory factory = FixedBaggageFieldsFactory.newFactory(asList(field1, field2));
 
   Propagation.Factory propagationFactory = new Propagation.Factory() {
     @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {

--- a/brave/src/test/java/brave/internal/baggage/FixedBaggageFieldsTest.java
+++ b/brave/src/test/java/brave/internal/baggage/FixedBaggageFieldsTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FixedBaggageFieldsTest extends ExtraBaggageFieldsTest {
   @Override ExtraBaggageFieldsFactory newFactory() {
-    return FixedBaggageFieldsFactory.create(asList(field1, field2));
+    return FixedBaggageFieldsFactory.newFactory(asList(field1, field2));
   }
 
   @Test public void getAllFields_areConstant() {
@@ -41,10 +41,10 @@ public class FixedBaggageFieldsTest extends ExtraBaggageFieldsTest {
   }
 
   @Override boolean isStateEmpty(Object state) {
-    String[] valueArray = (String[]) state;
-    assertThat(valueArray).isNotNull();
-    for (String value : valueArray) {
-      if (value != null) return false;
+    Object[] stateArray = (Object[]) state;
+    assertThat(stateArray).isNotNull();
+    for (int i = 1; i < stateArray.length; i += 2) {
+      if (stateArray[i] != null) return false;
     }
     return true;
   }

--- a/brave/src/test/java/brave/internal/baggage/UnsafeArrayMapTest.java
+++ b/brave/src/test/java/brave/internal/baggage/UnsafeArrayMapTest.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import org.assertj.core.api.AbstractMapAssert;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
@@ -277,43 +276,6 @@ public class UnsafeArrayMapTest {
     assertThat(map.keySet().iterator().hasNext()).isEqualTo(true);
     assertThat(map.values().iterator().hasNext()).isEqualTo(true);
     assertThat(map.entrySet().iterator().hasNext()).isEqualTo(true);
-  }
-
-  /**
-   * This is here just so we can use {@link AbstractMapAssert#containsEntry(Object, Object)} etc.
-   */
-  @Test public void entryTests() {
-    // same entry are equivalent
-    Entry<String, String> entry = new UnsafeArrayMap.Entry<>("1", "one");
-    assertThat(entry).isEqualTo(entry);
-    assertThat(entry).hasSameHashCodeAs(entry);
-
-    // different entry is equivalent
-    Entry<String, String> sameState = new UnsafeArrayMap.Entry<>("1", "one");
-    assertThat(entry).isEqualTo(sameState);
-    assertThat(entry).hasSameHashCodeAs(sameState);
-    assertThat(entry).hasToString("Entry{1=one}");
-
-    // different impl is equivalent
-    Entry<String, String> differentImpl = entry(entry.getKey(), entry.getValue());
-    assertThat(entry).isEqualTo(differentImpl);
-    assertThat(entry).isEqualTo(entry);
-
-    // different keys are not equivalent
-    Entry<String, String> differentKey = new UnsafeArrayMap.Entry<>("2", "one");
-    assertThat(entry).isNotEqualTo(differentKey);
-    assertThat(differentKey).isNotEqualTo(entry);
-    assertThat(entry.hashCode()).isNotEqualTo(differentKey);
-
-    // different values are not equivalent
-    Entry<String, String> differentValue = new UnsafeArrayMap.Entry<>("1", "2");
-    assertThat(entry).isNotEqualTo(differentValue);
-    assertThat(differentValue).isNotEqualTo(entry);
-    assertThat(entry.hashCode()).isNotEqualTo(differentValue);
-
-    assertThatThrownBy(()-> new UnsafeArrayMap.Entry<>("1", null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("value == null");
   }
 
   void assertBaseCase(Map<String, String> map) {

--- a/brave/src/test/java/brave/internal/baggage/UnsafeArrayMapTest.java
+++ b/brave/src/test/java/brave/internal/baggage/UnsafeArrayMapTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.baggage;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.assertj.core.api.AbstractMapAssert;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+public class UnsafeArrayMapTest {
+  Object[] array = new Object[6];
+  UnsafeArrayMap.Builder<String, String> builder = UnsafeArrayMap.newBuilder();
+
+  @Test public void empty() {
+    Map<String, String> map = builder.build(array);
+    assertThat(map).isSameAs(Collections.emptyMap());
+  }
+
+  @Test public void noNullValues() {
+    array[0] = "1";
+    array[1] = "one";
+    array[2] = "2";
+    array[3] = "two";
+    array[4] = "3";
+    array[5] = "three";
+
+    Map<String, String> map = builder.build(array);
+    assertSize(map, 3);
+    assertBaseCase(map);
+
+    assertThat(map).containsOnly(
+        entry("1", "one"),
+        entry("2", "two"),
+        entry("3", "three")
+    );
+    assertThat(map).hasToString(
+        "UnsafeArrayMap{1=one,2=two,3=three}"
+    );
+
+    assertThat(map.get("1")).isEqualTo("one");
+    assertThat(map.get("2")).isEqualTo("two");
+    assertThat(map.get("3")).isEqualTo("three");
+  }
+
+  @Test public void equalValues() {
+    array[0] = "1";
+    array[1] = "1";
+    array[2] = "2";
+    array[3] = "2";
+    array[4] = "3";
+    array[5] = "3";
+
+    Map<String, String> map = builder.build(array);
+    assertSize(map, 3);
+    assertBaseCase(map);
+
+    assertThat(map).containsOnly(
+        entry("1", "1"),
+        entry("2", "2"),
+        entry("3", "3")
+    );
+    assertThat(map).hasToString(
+        "UnsafeArrayMap{1=1,2=2,3=3}"
+    );
+
+    assertThat(map.get("1")).isEqualTo("1");
+    assertThat(map.get("2")).isEqualTo("2");
+    assertThat(map.get("3")).isEqualTo("3");
+  }
+
+  @Test public void mapKeys() {
+    array[0] = " 1";
+    array[1] = "one";
+    array[2] = "2 ";
+    array[3] = "two";
+    array[4] = " 3";
+    array[5] = "three";
+
+    Map<String, String> map = builder.mapKeys(o -> ((String) o).trim()).build(array);
+    assertSize(map, 3);
+    assertBaseCase(map);
+
+    assertThat(map).containsOnly(
+        entry("1", "one"),
+        entry("2", "two"),
+        entry("3", "three")
+    );
+    assertThat(map).hasToString(
+        "UnsafeArrayMap{1=one,2=two,3=three}"
+    );
+
+    assertThat(map.get("1")).isEqualTo("one");
+    assertThat(map.get("2")).isEqualTo("two");
+    assertThat(map.get("3")).isEqualTo("three");
+  }
+
+  @Test public void someNullValues() {
+    array[0] = "1";
+    array[1] = "one";
+    array[2] = "2";
+    array[3] = "two";
+    array[4] = "3";
+
+    Map<String, String> map = builder.build(array);
+    assertSize(map, 2);
+    assertBaseCase(map);
+
+    assertThat(map).containsOnly(
+        entry("1", "one"),
+        entry("2", "two")
+    );
+    assertThat(map).hasToString(
+        "UnsafeArrayMap{1=one,2=two}"
+    );
+
+    assertThat(map.get("1")).isEqualTo("one");
+    assertThat(map.get("2")).isEqualTo("two");
+    assertThat(map.get("3")).isNull();
+  }
+
+  @Test public void onlyNullValues() {
+    array[0] = "1";
+    array[2] = "2";
+    array[4] = "3";
+
+    Map<String, String> map = builder.build(array);
+    assertThat(map).isSameAs(Collections.emptyMap());
+  }
+
+  @Test public void allFiltered() {
+    array[0] = "1";
+    array[1] = "one";
+    array[2] = "2";
+    array[3] = "two";
+    array[4] = "3";
+    array[5] = "three";
+
+    Map<String, String> map = builder.filterKeys("1", "2", "3").build(array);
+    assertThat(map).isSameAs(Collections.emptyMap());
+  }
+
+  @Test public void filter_tooMany() {
+    String[] tooManyKeys = new String[65];
+
+    assertThatThrownBy(() -> builder.filterKeys(tooManyKeys))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("cannot filter more than 64 keys");
+  }
+
+  @Test public void someFiltered() {
+    array[0] = "1";
+    array[1] = "one";
+    array[2] = "2";
+    array[3] = "two";
+    array[4] = "3";
+    array[5] = "three";
+
+    Map<String, String> map = builder.filterKeys("1", "3").build(array);
+    assertSize(map, 1);
+    assertBaseCase(map);
+
+    assertThat(map).containsOnly(
+        entry("2", "two")
+    );
+    assertThat(map).hasToString(
+        "UnsafeArrayMap{2=two}"
+    );
+
+    assertThat(map.get("1")).isNull();
+    assertThat(map.get("2")).isEqualTo("two");
+    assertThat(map.get("3")).isNull();
+  }
+
+  @Test public void toArray() {
+    array[0] = "1";
+    array[1] = "one";
+    array[2] = "2";
+    array[3] = "two";
+    array[4] = "3";
+    Map<String, String> map = builder.build(array);
+
+    testToArray(map.keySet(), "1", "2");
+    testToArray(map.values(), "one", "two");
+    testToArray(map.entrySet(),
+        entry("1", "one"),
+        entry("2", "two")
+    );
+  }
+
+  <E> void testToArray(Collection<E> input, E... expected) {
+    Object[] tooShort = new Object[0], exact = new Object[input.size()], tooLong = new Object[5];
+
+    assertThat(input.toArray())
+        .isNotSameAs(array)
+        .containsExactly(expected);
+
+    assertThat(input.toArray(tooShort))
+        .isNotSameAs(tooShort)
+        .containsExactly(expected);
+
+    assertThat(input.toArray(exact))
+        .isSameAs(exact)
+        .containsExactly(expected);
+
+    assertThat(input.toArray(tooLong))
+        .isSameAs(tooLong)
+        .startsWith(expected);
+  }
+
+  /**
+   * Since there's only one collection impl in {@link UnsafeArrayMap}, this is less work than it
+   * seems.
+   */
+  @Test public void unsupported() {
+    array[0] = "1";
+    array[1] = "1";
+
+    Map<String, String> map = builder.build(array);
+
+    assertThatThrownBy(() -> map.put("1", "1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.putAll(map))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.remove("1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(map::clear)
+        .isInstanceOf(UnsupportedOperationException.class);
+
+    Set<String> set = map.keySet();
+    assertThatThrownBy(() -> set.add("2"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> set.addAll(set))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> set.retainAll(set))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> set.remove("1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> set.removeAll(set))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(set::clear)
+        .isInstanceOf(UnsupportedOperationException.class);
+
+    assertThatThrownBy(() -> set.iterator().remove())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> map.entrySet().iterator().next().setValue("1"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  void assertSize(Map<String, String> map, int size) {
+    assertThat(map).hasSize(size);
+    assertThat(map.keySet()).hasSize(size);
+    assertThat(map.values()).hasSize(size);
+    assertThat(map.entrySet()).hasSize(size);
+    assertThat(map.isEmpty()).isEqualTo(false);
+    assertThat(map.keySet().isEmpty()).isEqualTo(false);
+    assertThat(map.values().isEmpty()).isEqualTo(false);
+    assertThat(map.entrySet().isEmpty()).isEqualTo(false);
+    assertThat(map.keySet().iterator().hasNext()).isEqualTo(true);
+    assertThat(map.values().iterator().hasNext()).isEqualTo(true);
+    assertThat(map.entrySet().iterator().hasNext()).isEqualTo(true);
+  }
+
+  /**
+   * This is here just so we can use {@link AbstractMapAssert#containsEntry(Object, Object)} etc.
+   */
+  @Test public void entryTests() {
+    // same entry are equivalent
+    Entry<String, String> entry = new UnsafeArrayMap.Entry<>("1", "one");
+    assertThat(entry).isEqualTo(entry);
+    assertThat(entry).hasSameHashCodeAs(entry);
+
+    // different entry is equivalent
+    Entry<String, String> sameState = new UnsafeArrayMap.Entry<>("1", "one");
+    assertThat(entry).isEqualTo(sameState);
+    assertThat(entry).hasSameHashCodeAs(sameState);
+    assertThat(entry).hasToString("Entry{1=one}");
+
+    // different impl is equivalent
+    Entry<String, String> differentImpl = entry(entry.getKey(), entry.getValue());
+    assertThat(entry).isEqualTo(differentImpl);
+    assertThat(entry).isEqualTo(entry);
+
+    // different keys are not equivalent
+    Entry<String, String> differentKey = new UnsafeArrayMap.Entry<>("2", "one");
+    assertThat(entry).isNotEqualTo(differentKey);
+    assertThat(differentKey).isNotEqualTo(entry);
+    assertThat(entry.hashCode()).isNotEqualTo(differentKey);
+
+    // different values are not equivalent
+    Entry<String, String> differentValue = new UnsafeArrayMap.Entry<>("1", "2");
+    assertThat(entry).isNotEqualTo(differentValue);
+    assertThat(differentValue).isNotEqualTo(entry);
+    assertThat(entry.hashCode()).isNotEqualTo(differentValue);
+
+    assertThatThrownBy(()-> new UnsafeArrayMap.Entry<>("1", null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("value == null");
+  }
+
+  void assertBaseCase(Map<String, String> map) {
+    assertThat(map)
+        .doesNotContainKey(null)
+        .doesNotContainEntry(null, null)
+        .doesNotContainKey("4")
+        .doesNotContainEntry("4", null);
+
+    assertThat(map.keySet())
+        .doesNotContainNull();
+
+    for (String key : map.keySet()) {
+      assertThat(map.containsKey(key)).isTrue();
+      String value = map.get(key);
+      assertThat(map.values().contains(value)).isTrue();
+      assertThat(map.entrySet().contains(entry(key, value))).isTrue();
+    }
+
+    assertThat(map.entrySet())
+        .extracting(Entry::getKey)
+        .doesNotContainNull();
+
+    assertThat(map.containsKey(null)).isFalse();
+    assertThat(map.containsKey("4")).isFalse();
+
+    assertThat(map.get(null)).isNull();
+    assertThat(map.get("4")).isNull();
+
+    assertThat(map.keySet().contains(null)).isFalse();
+
+    for (Collection collection : asList(map.keySet(), map.values(), map.entrySet())) {
+      assertThat(collection.containsAll(asList())).isTrue();
+      assertThat(collection.containsAll(collection)).isTrue();
+
+      assertThat(collection.contains("4")).isFalse();
+      assertThat(collection.containsAll(asList("4"))).isFalse();
+    }
+
+    // only entrySet() special-cases non-object on contains
+    assertThat(map.entrySet().contains(entry("4", null))).isFalse();
+  }
+}


### PR DESCRIPTION
In analyzing the usage of the (recently added BaggageField.getAll), I
noticed in every case the keys are coersed to strings and all non-null
values are read.

This provides a more efficient alternative, via `UnsafeArrayMap`, pulled
in from #1183