### PR TITLE
Kafka Streams instrumentation Rationale

### DIFF
--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -30,7 +30,7 @@ Kafka Streams materializes its topology _internally_ based on DSL operations.
 Therefore, is not possible to hook into the topology creation process to instrument each operation.
 
 We considered changing Kafka Streams to have hooks to do this, but it would be a hard sell.
-The impact of adding these and rearrange lacking context would have a considerable impact surface.
+Adding these and rearrange lacking context would have a considerable library impact.
 
 Even if available, it would potentially expose excessive details as **all**
 operations would be traced (while not all of them are interesting),

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -1,0 +1,42 @@
+# brave-kafka-streams rationale
+
+## What's happening?
+Typically, there are at least two spans involved in traces produces by a Kafka Stream application:
+* One created by the Consumers that starts a Stream or Table, by `builder.stream(topic)`.
+* One created by the Producer that sends a records to a Stream, by `builder.to(topic)`
+
+By receiving records in a Kafka Streams application with Tracing enabled, the span created, once
+a record is received, will inject the span context on the headers of the Record, and it will get
+propagated downstream onto the Stream topology. As the span context is stored in the Record Headers,
+the Producers at the middle (e.g. `builder.through(topic)`) or at the end of a Stream topology
+will reference the initial span, and mark the end of a Stream Process.
+
+If intermediate steps on the Stream topology require tracing, then `TracingProcessorSupplier` and
+`TracingTransformerSupplier` will allow you to define a Processor/Transformer where execution is recorded as Span,
+referencing the parent context stored on Headers, if available.
+
+### Partitioning
+
+Be aware that operations that require `builder.transformer(...)` will cause re-partitioning when
+grouping or joining downstream ([Kafka docs](https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html#applying-processors-and-transformers-processor-api-integration)).
+
+### Why doesn't this trace all Kafka Streams operations?
+
+When starting to design this instrumentation, “trace everything” was the first idea:
+When a message enters the Kafka Streams topology starts a new `poll` span, and every operation
+(e.g. `map`, `filter`, `join`, etc.) is chained as an additional child span.
+
+Kafka Streams materializes its topology _internally_ based on DSL operations.
+Therefore, is not possible to hook into the topology creation process to instrument each operation.
+
+We considered changing Kafka Streams to have hooks to do this, but it would be a hard sell.
+The impact of adding these and rearrange lacking context would have a considerable impact surface.
+
+Even if available, it would potentially expose excessive details as **all**
+operations would be traced (while not all of them are interesting),
+making traces harder to grok; and would probably create the need to support
+functionality to **do not** trace some operations, requiring anyway changes to your code.
+
+Given the current scenario, `KafkaStreamsTracing` is equipped with a set of common DSL operation wrapped as
+Processors/Transformers APIs that enable tracing when needed;
+apart from `poll` and `send` spans available out-of-the-box.

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -12,7 +12,7 @@ the Producers at the middle (e.g. `builder.through(topic)`) or at the end of a S
 will reference the initial span, and mark the end of a Stream Process.
 
 If intermediate steps on the Stream topology require tracing, `TracingProcessorSupplier` and
-`TracingTransformerSupplier` will allow you to define a Processor/Transformer where execution is recorded as Span,
+`TracingTransformerSupplier` record execution into a new Span,
 referencing the parent context stored on Headers, if available.
 
 ### Partitioning

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -32,10 +32,9 @@ Therefore, is not possible to hook into the topology creation process to instrum
 We considered changing Kafka Streams to have hooks to do this, but it would be a hard sell.
 Adding these and rearrange lacking context would have a considerable library impact.
 
-Even if available, it would potentially expose excessive details as **all**
-operations would be traced (while not all of them are interesting),
-making traces harder to grok; and would probably create the need to support
-functionality to **do not** trace some operations, requiring anyway changes to your code.
+Even if we had hooks, tracing all operations would be excessive. The resulting large
+traces would be harder to understand, leading to requests to disable tracing. The
+code involved to disable tracing may mean more code than visa versa!
 
 Given the current scenario, `KafkaStreamsTracing` is equipped with a set of common DSL operation wrapped as
 Processors/Transformers APIs that enable tracing when needed;

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -7,7 +7,7 @@ Typically, there are at least two spans involved in traces produces by a Kafka S
 
 By receiving records in a Kafka Streams application with Tracing enabled, the span created, once
 a record is received, will inject the span context on the headers of the Record, and it will get
-propagated downstream onto the Stream topology. As the span context is stored in the Record Headers,
+propagated downstream onto the Stream topology. The span context is stored in the Record Headers,
 the Producers at the middle (e.g. `builder.through(topic)`) or at the end of a Stream topology
 will reference the initial span, and mark the end of a Stream Process.
 

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -11,7 +11,7 @@ propagated downstream onto the Stream topology. The span context is stored in th
 the Producers at the middle (e.g. `builder.through(topic)`) or at the end of a Stream topology
 will reference the initial span, and mark the end of a Stream Process.
 
-If intermediate steps on the Stream topology require tracing, then `TracingProcessorSupplier` and
+If intermediate steps on the Stream topology require tracing, `TracingProcessorSupplier` and
 `TracingTransformerSupplier` will allow you to define a Processor/Transformer where execution is recorded as Span,
 referencing the parent context stored on Headers, if available.
 

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -3,7 +3,7 @@
 ## What's happening?
 Typically, there are at least two spans involved in traces produces by a Kafka Stream application:
 * One created by the Consumers that starts a Stream or Table, by `builder.stream(topic)`.
-* One created by the Producer that sends a records to a Stream, by `builder.to(topic)`
+* One created by the Producer that sends a record to a Stream, by `builder.to(topic)`
 
 By receiving records in a Kafka Streams application with Tracing enabled, the span created, once
 a record is received, will inject the span context on the headers of the Record, and it will get
@@ -15,9 +15,15 @@ If intermediate steps on the Stream topology require tracing, `TracingProcessorS
 `TracingTransformerSupplier` record execution into a new Span,
 referencing the parent context stored on Headers, if available.
 
-### Partitioning
+### Transformers and Partitioning
 
-Be aware that operations that require `builder.transformer(...)` will cause re-partitioning when
+The behaviour of some operations wrapped into Kafka Streams Processor API types could change the underlying topology.
+
+For example, `filter` operation on the Kafka Streams DSL is stateless and doesn't impact partitioning;
+but `kafkaStreamsTracing.filter()` returns a `Transformer` that if grouping or joining operations
+follows, it could lead to **unintentional partitioning**.
+
+Be aware operations that any usage of `builder.transformer(...)` will cause re-partitioning when
 grouping or joining downstream ([Kafka docs](https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html#applying-processors-and-transformers-processor-api-integration)).
 
 ### Why doesn't this trace all Kafka Streams operations?

--- a/instrumentation/kafka-streams/RATIONALE.md
+++ b/instrumentation/kafka-streams/RATIONALE.md
@@ -1,4 +1,4 @@
-# brave-kafka-streams rationale
+# brave-instrumentation-kafka-streams rationale
 
 ## What's happening?
 Typically, there are at least two spans involved in traces produces by a Kafka Stream application:

--- a/instrumentation/kafka-streams/README.md
+++ b/instrumentation/kafka-streams/README.md
@@ -95,6 +95,22 @@ referencing the parent context stored on Headers, if available.
 Be aware that operations that require `builder.transformer(...)` will cause re-partitioning when
 grouping or joining downstream ([Kafka docs](https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html#applying-processors-and-transformers-processor-api-integration)).
 
+### Why not to trace _every_ Kafka Streams operation?
+
+When starting to design this instrumentation, “trace everything” was the first idea:
+When a message enters the Kafka Streams topology starts a new `poll` span, and every operation
+(e.g. `map`, `filter`, `join`, etc.) is chained as an additional child span.
+
+Kafka Streams materializes its topology _internally_ based on DSL operation. Therefore, is not possible to hook into
+the topology creation process to instrument each operation. Even though this could be desirable, it would
+require, first, to add new "doors" on the Kafka Streams side to manipulate or intercept data around each operation
+--which will be hard to sale--; and, if available, it would potentially expose excessive details as **all**
+operations would be traced, making traces harder to grok--and would probably create the need to support
+functionality to **not** trace each operation, and changing your code anyhow.
+
+Given the current scenario, `KafkaStreamsTracing` is equipped with a set of common DSL operation wrappers that
+enable tracing. Consider that this will require changes on your code, as the examples above.
+
 ## Notes
 
 * This tracer is only compatible with Kafka Streams versions including headers support ( > 2.0.0).

--- a/instrumentation/kafka-streams/README.md
+++ b/instrumentation/kafka-streams/README.md
@@ -101,17 +101,18 @@ When starting to design this instrumentation, “trace everything” was the fir
 When a message enters the Kafka Streams topology starts a new `poll` span, and every operation
 (e.g. `map`, `filter`, `join`, etc.) is chained as an additional child span.
 
-Kafka Streams materializes its topology _internally_ based on DSL operations. Therefore, is not possible to hook into
+Kafka Streams materializes its topology _internally_ based on DSL operations. 
+Therefore, is not possible to hook into
 the topology creation process to instrument each operation.
 
 Even though this could be desirable it would require, first, to add new "doors" on the Kafka Streams
-side to manipulate or intercept data around each operation--which will be hard to sale--;
+side to manipulate or intercept data around each operation&mdash;which will be hard to sale&mdash;;
 and even if available, it would potentially expose excessive details as **all**
-operations would be traced, making traces harder to grok--and would probably create the need to support
+operations would be traced, making traces harder to grok&mdash;and would probably create the need to support
 functionality to **do not** trace some operations, requiring anyway changes to your code.
 
 Given the current scenario, `KafkaStreamsTracing` is equipped with a set of common DSL operation wrappers that
-enable tracing when needed--apart from `poll` and `send` spans available out-of-the-box.
+enable tracing when needed&mdash;apart from `poll` and `send` spans available out-of-the-box.
 
 ## Notes
 

--- a/instrumentation/kafka-streams/README.md
+++ b/instrumentation/kafka-streams/README.md
@@ -5,6 +5,8 @@ Add decorators for Kafka Streams to enable tracing.
 * `TracingProcessorSupplier` completes a span on `process`
 * `TracingTransformerSupplier` completes a span on `transform`
 
+This does not trace all operations by default. See [RATIONALE.md] for why.
+
 ## Setup
 
 First, setup the generic Kafka Streams component like this:
@@ -74,45 +76,6 @@ To create a Kafka Streams with Tracing Client Supplier enabled, pass your topolo
 ```java
 KafkaStreams kafkaStreams = kafkaStreamsTracing.kafkaStreams(topology, streamsConfig);
 ```
-
-## What's happening?
-Typically, there are at least two spans involved in traces produces by a Kafka Stream application:
-* One created by the Consumers that starts a Stream or Table, by `builder.stream(topic)`.
-* One created by the Producer that sends a records to a Stream, by `builder.to(topic)`
-
-By receiving records in a Kafka Streams application with Tracing enabled, the span created, once
-a record is received, will inject the span context on the headers of the Record, and it will get
-propagated downstream onto the Stream topology. As the span context is stored in the Record Headers,
-the Producers at the middle (e.g. `builder.through(topic)`) or at the end of a Stream topology
-will reference the initial span, and mark the end of a Stream Process.
-
-If intermediate steps on the Stream topology require tracing, then `TracingProcessorSupplier` and
-`TracingTransformerSupplier` will allow you to define a Processor/Transformer where execution is recorded as Span,
-referencing the parent context stored on Headers, if available.
-
-### Partitioning
-
-Be aware that operations that require `builder.transformer(...)` will cause re-partitioning when
-grouping or joining downstream ([Kafka docs](https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html#applying-processors-and-transformers-processor-api-integration)).
-
-### Why not to trace _every_ Kafka Streams operation?
-
-When starting to design this instrumentation, “trace everything” was the first idea:
-When a message enters the Kafka Streams topology starts a new `poll` span, and every operation
-(e.g. `map`, `filter`, `join`, etc.) is chained as an additional child span.
-
-Kafka Streams materializes its topology _internally_ based on DSL operations. 
-Therefore, is not possible to hook into
-the topology creation process to instrument each operation.
-
-Even though this could be desirable it would require, first, to add new "doors" on the Kafka Streams
-side to manipulate or intercept data around each operation&mdash;which will be hard to sale&mdash;;
-and even if available, it would potentially expose excessive details as **all**
-operations would be traced, making traces harder to grok&mdash;and would probably create the need to support
-functionality to **do not** trace some operations, requiring anyway changes to your code.
-
-Given the current scenario, `KafkaStreamsTracing` is equipped with a set of common DSL operation wrappers that
-enable tracing when needed&mdash;apart from `poll` and `send` spans available out-of-the-box.
 
 ## Notes
 

--- a/instrumentation/kafka-streams/README.md
+++ b/instrumentation/kafka-streams/README.md
@@ -101,15 +101,17 @@ When starting to design this instrumentation, “trace everything” was the fir
 When a message enters the Kafka Streams topology starts a new `poll` span, and every operation
 (e.g. `map`, `filter`, `join`, etc.) is chained as an additional child span.
 
-Kafka Streams materializes its topology _internally_ based on DSL operation. Therefore, is not possible to hook into
-the topology creation process to instrument each operation. Even though this could be desirable, it would
-require, first, to add new "doors" on the Kafka Streams side to manipulate or intercept data around each operation
---which will be hard to sale--; and, if available, it would potentially expose excessive details as **all**
+Kafka Streams materializes its topology _internally_ based on DSL operations. Therefore, is not possible to hook into
+the topology creation process to instrument each operation.
+
+Even though this could be desirable it would require, first, to add new "doors" on the Kafka Streams
+side to manipulate or intercept data around each operation--which will be hard to sale--;
+and even if available, it would potentially expose excessive details as **all**
 operations would be traced, making traces harder to grok--and would probably create the need to support
-functionality to **not** trace each operation, and changing your code anyhow.
+functionality to **do not** trace some operations, requiring anyway changes to your code.
 
 Given the current scenario, `KafkaStreamsTracing` is equipped with a set of common DSL operation wrappers that
-enable tracing. Consider that this will require changes on your code, as the examples above.
+enable tracing when needed--apart from `poll` and `send` spans available out-of-the-box.
 
 ## Notes
 


### PR DESCRIPTION
Changes:

- Add more details on transformers and partitioning
- Add note on tracing all Kafka Streams operations.