### PR TITLE
Moves internal collection related stuff into brave.internal.collect

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -40,7 +40,7 @@ import static brave.internal.InternalPropagation.FLAG_SAMPLED;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 import static brave.internal.InternalPropagation.FLAG_SHARED;
-import static brave.internal.Lists.concat;
+import static brave.internal.collect.Lists.concat;
 import static brave.propagation.SamplingFlags.EMPTY;
 import static brave.propagation.SamplingFlags.NOT_SAMPLED;
 import static brave.propagation.SamplingFlags.SAMPLED;

--- a/brave/src/main/java/brave/baggage/BaggagePropagation.java
+++ b/brave/src/main/java/brave/baggage/BaggagePropagation.java
@@ -14,7 +14,7 @@
 package brave.baggage;
 
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
-import brave.internal.Lists;
+import brave.internal.collect.Lists;
 import brave.internal.Nullable;
 import brave.internal.baggage.BaggageCodec;
 import brave.internal.baggage.BaggageFields;

--- a/brave/src/main/java/brave/internal/baggage/BaggageFields.java
+++ b/brave/src/main/java/brave/internal/baggage/BaggageFields.java
@@ -16,7 +16,9 @@ package brave.internal.baggage;
 import brave.baggage.BaggageField;
 import brave.internal.Nullable;
 import brave.internal.Platform;
-import brave.internal.baggage.UnsafeArrayMap.Mapper;
+import brave.internal.collect.LongBitSet;
+import brave.internal.collect.UnsafeArrayMap;
+import brave.internal.collect.UnsafeArrayMap.Mapper;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import java.util.ArrayList;
@@ -26,8 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 import static brave.internal.baggage.BaggageFieldsHandler.MAX_DYNAMIC_FIELDS;
-import static brave.internal.baggage.LongBitSet.isSet;
-import static brave.internal.baggage.LongBitSet.setBit;
+import static brave.internal.collect.LongBitSet.isSet;
+import static brave.internal.collect.LongBitSet.setBit;
 
 /**
  * Holds one or more baggage fields in {@link TraceContext#extra()} or {@link

--- a/brave/src/main/java/brave/internal/collect/Lists.java
+++ b/brave/src/main/java/brave/internal/collect/Lists.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal;
+package brave.internal.collect;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/brave/src/main/java/brave/internal/collect/LongBitSet.java
+++ b/brave/src/main/java/brave/internal/collect/LongBitSet.java
@@ -11,29 +11,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal.baggage;
+package brave.internal.collect;
 
 import java.util.BitSet;
 
 /**
  * This is more efficient than {@link BitSet} as this doesn't implicitly allocate arrays.
  */
-final class LongBitSet {
-  static final int MAX_SIZE = Long.SIZE;
+public final class LongBitSet {
+  public static final int MAX_SIZE = Long.SIZE;
 
-  static int size(long bitset) {
+  public static int size(long bitset) {
     return Long.bitCount(bitset);
   }
 
-  static boolean isSet(long bitset, long i) {
+  public static boolean isSet(long bitset, long i) {
     return (bitset & (1 << i)) != 0;
   }
 
-  static long unsetBit(long bitset, long i) {
+  public static long unsetBit(long bitset, long i) {
     return bitset & ~(1 << i);
   }
 
-  static long setBit(long bitset, long i) {
+  public static long setBit(long bitset, long i) {
     return bitset | (1 << i);
   }
 }

--- a/brave/src/main/java/brave/internal/collect/UnsafeArrayMap.java
+++ b/brave/src/main/java/brave/internal/collect/UnsafeArrayMap.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal.baggage;
+package brave.internal.collect;
 
 import java.lang.reflect.Array;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static brave.internal.baggage.LongBitSet.isSet;
-import static brave.internal.baggage.LongBitSet.setBit;
+import static brave.internal.collect.LongBitSet.isSet;
+import static brave.internal.collect.LongBitSet.setBit;
 
 /**
  * A potentially read-only map which is a view over an array of {@code key, value} pairs. No key can
@@ -38,29 +38,29 @@ import static brave.internal.baggage.LongBitSet.setBit;
  * #entrySet()} might return constants. As expected, stateful objects such as {@link Iterator} will
  * never be shared.
  */
-class UnsafeArrayMap<K, V> implements Map<K, V> {
+public class UnsafeArrayMap<K, V> implements Map<K, V> {
   static final int MAX_FILTERED_KEYS = LongBitSet.MAX_SIZE;
 
-  interface Mapper<V1, V2> {
+  public interface Mapper<V1, V2> {
     V2 map(V1 input);
   }
 
-  static <K, V> Builder<K, V> newBuilder() {
+  public static <K, V> Builder<K, V> newBuilder() {
     return new Builder<>();
   }
 
-  static final class Builder<K, V> {
+  public static final class Builder<K, V> {
     Mapper<Object, K> keyMapper;
     K[] filteredKeys = (K[]) new Object[0];
 
-    Builder<K, V> mapKeys(Mapper<Object, K> keyMapper) {
+    public Builder<K, V> mapKeys(Mapper<Object, K> keyMapper) {
       if (keyMapper == null) throw new NullPointerException("keyMapper == null");
       this.keyMapper = keyMapper;
       return this;
     }
 
     /** @param filteredKeys keys that won't be visible in the resulting map. */
-    Builder<K, V> filterKeys(K... filteredKeys) {
+    public Builder<K, V> filterKeys(K... filteredKeys) {
       if (filteredKeys == null) throw new NullPointerException("filteredKeys == null");
       if (filteredKeys.length > MAX_FILTERED_KEYS) {
         throw new IllegalArgumentException(
@@ -71,7 +71,7 @@ class UnsafeArrayMap<K, V> implements Map<K, V> {
     }
 
     /** @param array pairwise array holding key values */
-    Map<K, V> build(Object[] array) {
+    public Map<K, V> build(Object[] array) {
       if (array == null) throw new NullPointerException("array == null");
       long filteredBitSet = 0;
       int i = 0, numFiltered = 0;

--- a/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
+++ b/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal.weaklockfree;
+package brave.internal.collect;
 
 import brave.internal.Nullable;
 import java.lang.ref.Reference;

--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -19,7 +19,7 @@ import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.internal.Nullable;
 import brave.internal.Platform;
-import brave.internal.weaklockfree.WeakConcurrentMap;
+import brave.internal.collect.WeakConcurrentMap;
 import brave.propagation.TraceContext;
 import java.lang.ref.Reference;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/brave/src/main/java/brave/propagation/TraceContext.java
+++ b/brave/src/main/java/brave/propagation/TraceContext.java
@@ -30,8 +30,8 @@ import static brave.internal.InternalPropagation.FLAG_SAMPLED;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
 import static brave.internal.InternalPropagation.FLAG_SHARED;
-import static brave.internal.Lists.ensureImmutable;
-import static brave.internal.Lists.ensureMutable;
+import static brave.internal.collect.Lists.ensureImmutable;
+import static brave.internal.collect.Lists.ensureMutable;
 import static brave.propagation.TraceIdContext.toTraceIdString;
 
 /**

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -24,7 +24,7 @@ import java.util.List;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_LOCAL;
 import static brave.internal.InternalPropagation.FLAG_SAMPLED_SET;
-import static brave.internal.Lists.ensureImmutable;
+import static brave.internal.collect.Lists.ensureImmutable;
 import static brave.propagation.TraceContext.ensureExtraAdded;
 import static java.util.Collections.emptyList;
 

--- a/brave/src/test/java/brave/internal/collect/ListsTest.java
+++ b/brave/src/test/java/brave/internal/collect/ListsTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal;
+package brave.internal.collect;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;

--- a/brave/src/test/java/brave/internal/collect/UnsafeArrayMapTest.java
+++ b/brave/src/test/java/brave/internal/collect/UnsafeArrayMapTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal.baggage;
+package brave.internal.collect;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/brave/src/test/java/brave/internal/collect/WeakConcurrentMapTest.java
+++ b/brave/src/test/java/brave/internal/collect/WeakConcurrentMapTest.java
@@ -11,10 +11,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.internal.weaklockfree;
+package brave.internal.collect;
 
 import brave.GarbageCollectors;
-import brave.internal.weaklockfree.WeakConcurrentMap.WeakKey;
+import brave.internal.collect.WeakConcurrentMap.WeakKey;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import org.junit.Test;


### PR DESCRIPTION
It is easy to lose track of our goodies. This moves them before
re-introducing a map base type for Extra.