### PR TITLE
Makes MutableSpan easier with tags() and annotations() method

### DIFF
--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -117,7 +117,7 @@ public final class MutableSpan implements Cloneable {
   /** @since 5.12 */
   public MutableSpan(MutableSpan toCopy) {
     if (toCopy == null) throw new NullPointerException("toCopy == null");
-    if (toCopy == EMPTY) return;
+    if (toCopy.equals(EMPTY)) return;
     traceId = toCopy.traceId;
     localRootId = toCopy.localRootId;
     parentId = toCopy.parentId;
@@ -491,6 +491,11 @@ public final class MutableSpan implements Cloneable {
     flags |= FLAG_SHARED;
   }
 
+  /** @since 5.12 */
+  public int annotationCount() {
+    return annotations.length / 2;
+  }
+
   /**
    * A read-only view of the current annotations as a collection of {@code (epochMicroseconds ->
    * value)}.
@@ -584,6 +589,11 @@ public final class MutableSpan implements Cloneable {
     if (timestamp == 0L) return; // silently ignore data Zipkin would drop
     // Annotations are always add. copy-on-write means we can share initial data until a write
     annotations = add(annotations, timestamp, value);
+  }
+
+  /** @since 5.12 */
+  public int tagCount() {
+    return tags.length / 2;
   }
 
   /**

--- a/brave/src/test/java/brave/TagTest.java
+++ b/brave/src/test/java/brave/TagTest.java
@@ -263,7 +263,7 @@ public class TagTest {
 
     MutableSpan expected = new MutableSpan();
     expected.tag("key", "value");
-    assertThat(mutableSpan).isEqualToComparingFieldByField(expected);
+    assertThat(mutableSpan).isEqualTo(expected);
   }
 
   @Test public void tag_mutableSpan_nullContext() {
@@ -276,7 +276,7 @@ public class TagTest {
 
     MutableSpan expected = new MutableSpan();
     expected.tag("key", "value");
-    assertThat(mutableSpan).isEqualToComparingFieldByField(expected);
+    assertThat(mutableSpan).isEqualTo(expected);
   }
 
   @Test public void tag_mutableSpan_empty() {
@@ -289,7 +289,7 @@ public class TagTest {
 
     MutableSpan expected = new MutableSpan();
     expected.tag("key", "");
-    assertThat(mutableSpan).isEqualToComparingFieldByField(expected);
+    assertThat(mutableSpan).isEqualTo(expected);
   }
 
   @Test public void tag_mutableSpan_ignoredErrorParsing() {

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -130,12 +130,13 @@ public class MutableSpanTest {
     MutableSpan span = new MutableSpan();
     span.annotate(1L, "ws");
 
+    // this shows the copy-constructor copies internal arrays.
     MutableSpan span2 = new MutableSpan(span);
-    assertThat(span2.annotations).isSameAs(span.annotations);
+    assertThat(span2.annotations)
+        .isNotSameAs(span.annotations)
+        .isEqualTo(span.annotations);
 
     span.annotate(2L, "wr");
-    assertThat(span2.annotations).isNotSameAs(span.annotations);
-
     assertThat(span.annotations()).containsExactly(
         entry(1L, "ws"),
         entry(2L, "wr")
@@ -569,16 +570,17 @@ public class MutableSpanTest {
       .isEqualTo(new MutableSpan(context, null));
   }
 
-  @Test public void tags_copyOnWrite() {
+  @Test public void tags_copyConstructor() {
     MutableSpan span = new MutableSpan();
     span.tag("http.method", "GET");
 
+    // this shows the copy-constructor copies internal arrays.
     MutableSpan span2 = new MutableSpan(span);
-    assertThat(span2.tags).isSameAs(span.tags);
+    assertThat(span2.tags)
+        .isNotSameAs(span.tags)
+        .isEqualTo(span.tags);
 
     span.tag("error", "500");
-    assertThat(span2.tags).isNotSameAs(span.tags);
-
     assertThat(span.tags()).containsExactly(
         entry("http.method", "GET"),
         entry("error", "500")
@@ -633,7 +635,7 @@ public class MutableSpanTest {
         .doesNotContain(":0");
     }
 
-    // now, test something more interesting zipkin2.TestObjects.CLIENT_SPAN
+    // now, test something more interesting .TestObjects.CLIENT_SPAN
     MutableSpan span = new MutableSpan();
     span.traceId("1");
     span.localRootId("2"); // not in zipkin format

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -666,13 +666,13 @@ public class MutableSpanTest {
     span.forEachTag((key, value) -> !key.equals("redacted") ? value : null);
 
     assertThat(span).hasToString("{"
-        + "\"traceId\":\"1\",\"parentId\":\"2\",\"id\":\"2\","
-        + "\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1000,\"duration\":200,"
-        + "\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},"
-        + "\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},"
-        + "\"annotations\":[{\"timestamp\":1100,\"value\":\"foo}],"
-        + "\"tags\":{\"http.path\":\"/api\",\"clnt/finagle.version\":\"6.45.0\"}"
-        + "}");
+      + "\"traceId\":\"1\",\"parentId\":\"2\",\"id\":\"2\","
+      + "\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1000,\"duration\":200,"
+      + "\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},"
+      + "\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},"
+      + "\"annotations\":[{\"timestamp\":1100,\"value\":\"foo}],"
+      + "\"tags\":{\"http.path\":\"/api\",\"clnt/finagle.version\":\"6.45.0\"}"
+      + "}");
   }
 
   @Test public void remove() {


### PR DESCRIPTION
This makes `MutableSpan` easier, especially in tests, by adding methods
for tags and annotations similar to `zipkin2.Span`. Unlike
`zipkin2.Span`, this presents annotations as a collection of `Map.Entry`.

Doing so keeps us from having to define a new type mostly used in tests.
The allocation-free consumer functions are left in place.

One unit test was converted in the process. We can convert the rest of
them following this PR.

Under the scenes, this uses the same `UnsafeArrayMap` we use in baggage.
To port to this model, we had to use arrays directly instead of arraylist.
However, we act internally the same as arraylist does.