### PR TITLE
Adds Tracing.Builder.spanHandlers() and clearSpanHandlers()

### DIFF
--- a/brave/src/test/java/brave/RealSpanCustomizerTest.java
+++ b/brave/src/test/java/brave/RealSpanCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -24,6 +24,7 @@ import brave.sampler.Sampler;
 import brave.test.TestSpanHandler;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Test;
@@ -265,5 +266,29 @@ public class TracingTest {
 
       assertThat(tracing.tracer().alwaysSampleLocal).isTrue();
     }
+  }
+
+  @Test public void spanHandlers_clearAndAdd() {
+    SpanHandler one = mock(SpanHandler.class);
+    SpanHandler two = mock(SpanHandler.class);
+    SpanHandler three = mock(SpanHandler.class);
+
+    Tracing.Builder builder = Tracing.newBuilder()
+        .addSpanHandler(one)
+        .addSpanHandler(two)
+        .addSpanHandler(three);
+
+    Set<SpanHandler> spanHandlers = builder.spanHandlers();
+
+    builder.clearSpanHandlers();
+
+    spanHandlers.forEach(builder::addSpanHandler);
+
+    assertThat(builder)
+        .usingRecursiveComparison()
+        .isEqualTo(Tracing.newBuilder()
+            .addSpanHandler(one)
+            .addSpanHandler(two)
+            .addSpanHandler(three));
   }
 }

--- a/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
+++ b/brave/src/test/java/brave/features/advanced/CustomScopedClockTracingTest.java
@@ -32,13 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class CustomScopedClockTracingTest {
   TestSpanHandler spans = new TestSpanHandler();
+  StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(StrictCurrentTraceContext.create())
-    .addSpanHandler(spans)
-    .build();
+    .addSpanHandler(spans).currentTraceContext(currentTraceContext).build();
 
   @After public void close() {
-    Tracing.current().close();
+    tracing.close();
+    currentTraceContext.close();
   }
 
   class Connection {

--- a/brave/src/test/java/brave/features/handler/DefaultTagsTest.java
+++ b/brave/src/test/java/brave/features/handler/DefaultTagsTest.java
@@ -17,7 +17,6 @@ import brave.ScopedSpan;
 import brave.Tracing;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
-import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.TestSpanHandler;
 import org.junit.After;
@@ -33,7 +32,6 @@ import static org.assertj.core.api.Assertions.entry;
 public class DefaultTagsTest {
   TestSpanHandler spans = new TestSpanHandler();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(StrictCurrentTraceContext.create())
     .addSpanHandler(new SpanHandler() {
       @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
         if (context.isLocalRoot()) {

--- a/brave/src/test/java/brave/features/handler/RedactingSpanHandlerTest.java
+++ b/brave/src/test/java/brave/features/handler/RedactingSpanHandlerTest.java
@@ -20,7 +20,6 @@ import brave.handler.MutableSpan;
 import brave.handler.MutableSpan.AnnotationUpdater;
 import brave.handler.MutableSpan.TagUpdater;
 import brave.handler.SpanHandler;
-import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -74,7 +73,6 @@ public class RedactingSpanHandlerTest {
   };
 
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(StrictCurrentTraceContext.create())
     .addSpanHandler(redacter)
     .addSpanHandler(new SpanHandler() {
       @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {

--- a/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
+++ b/brave/src/test/java/brave/features/sampler/AspectJSamplerTest.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AspectJSamplerTest {
 
   // Don't use static configuration in real life. This is only to satisfy the unit test runner
+  static StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   static TestSpanHandler spans = new TestSpanHandler();
   static AtomicReference<Tracing> tracing = new AtomicReference<>();
 
@@ -53,7 +54,7 @@ public class AspectJSamplerTest {
 
   @Before public void clear() {
     tracing.set(Tracing.newBuilder()
-      .currentTraceContext(StrictCurrentTraceContext.create())
+      .currentTraceContext(currentTraceContext)
       .addSpanHandler(spans)
       .sampler(new Sampler() {
         @Override public boolean isSampled(long traceId) {
@@ -66,6 +67,7 @@ public class AspectJSamplerTest {
   @After public void close() {
     Tracing currentTracing = tracing.get();
     if (currentTracing != null) currentTracing.close();
+    currentTraceContext.close();
   }
 
   @Test public void traced() {

--- a/brave/src/test/java/brave/propagation/ThreadLocalSpanTest.java
+++ b/brave/src/test/java/brave/propagation/ThreadLocalSpanTest.java
@@ -21,9 +21,10 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadLocalSpanTest {
+  StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   TestSpanHandler spans = new TestSpanHandler();
   Tracing tracing = Tracing.newBuilder()
-    .currentTraceContext(StrictCurrentTraceContext.create())
+    .currentTraceContext(currentTraceContext)
     .addSpanHandler(spans)
     .build();
 
@@ -31,6 +32,7 @@ public class ThreadLocalSpanTest {
 
   @After public void close() {
     tracing.close();
+    currentTraceContext.close();
   }
 
   @Test public void next() {

--- a/brave/src/test/java/brave/test/TestSpanHandler.java
+++ b/brave/src/test/java/brave/test/TestSpanHandler.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package brave.test;
 
 import brave.handler.MutableSpan;


### PR DESCRIPTION
Unlike span reporter, span handlers are additive. Unless there's a way
to readback the current state, you cannot replace a handler of a
specific type or configuration. By adding the same methods as we did on
`BaggagePropagation` for `configs()`, span handlers can be re-orderered
or pruned.