### PR TITLE
Makes default propagation for non-request spans B3 single

### DIFF
--- a/brave/src/main/java/brave/propagation/B3Propagation.java
+++ b/brave/src/main/java/brave/propagation/B3Propagation.java
@@ -63,10 +63,10 @@ public abstract class B3Propagation<K> implements Propagation<K> {
 
   /**
    * Defaults to {@link Format#MULTI} for client/server spans and {@link Format#SINGLE_NO_PARENT}
-   * for messaging. Non-request spans default to {@link Format#MULTI}.
+   * for messaging. Non-request spans default to {@link Format#SINGLE_NO_PARENT}.
    */
   public static final class FactoryBuilder {
-    Format injectFormat = Format.MULTI;
+    Format injectFormat = Format.SINGLE_NO_PARENT;
     final EnumMap<Span.Kind, Format[]> kindToInjectFormats = new EnumMap<>(Span.Kind.class);
 
     FactoryBuilder() {
@@ -76,7 +76,7 @@ public abstract class B3Propagation<K> implements Propagation<K> {
       kindToInjectFormats.put(Span.Kind.CONSUMER, new Format[] {Format.SINGLE_NO_PARENT});
     }
 
-    /** Overrides the default format of {@link Format#MULTI}. */
+    /** Overrides the default format of {@link Format#SINGLE_NO_PARENT}. */
     public FactoryBuilder injectFormat(Format format) {
       if (format == null) throw new NullPointerException("format == null");
       injectFormat = format;

--- a/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
+++ b/brave/src/test/java/brave/features/opentracing/OpenTracingAdapterTest.java
@@ -109,9 +109,7 @@ public class OpenTracingAdapterTest {
     opentracing.inject(new BraveSpanContext(context), Format.Builtin.HTTP_HEADERS, request);
 
     assertThat(map).containsExactly(
-      entry("X-B3-TraceId", "0000000000000001"),
-      entry("X-B3-SpanId", "0000000000000002"),
-      entry("X-B3-Sampled", "1")
+      entry("b3", "0000000000000001-0000000000000002-1")
     );
   }
 

--- a/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
+++ b/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
@@ -36,8 +36,7 @@ public class NonStringPropagationKeysTest {
     Metadata metadata = new Metadata();
     injector.inject(context, metadata);
 
-    assertThat(metadata.keys())
-      .containsExactly("x-b3-traceid", "x-b3-spanid", "x-b3-sampled");
+    assertThat(metadata.keys()).containsExactly("b3");
 
     assertThat(extractor.extract(metadata).context())
       .isEqualTo(context);

--- a/brave/src/test/java/brave/propagation/B3PropagationTest.java
+++ b/brave/src/test/java/brave/propagation/B3PropagationTest.java
@@ -77,6 +77,7 @@ public class B3PropagationTest {
 
   @Test public void keys_withoutB3Single() {
     propagation = B3Propagation.newFactoryBuilder()
+      .injectFormat(Format.MULTI)
       .injectFormat(Span.Kind.PRODUCER, Format.MULTI)
       .injectFormat(Span.Kind.CONSUMER, Format.MULTI)
       .build().get();
@@ -92,7 +93,6 @@ public class B3PropagationTest {
 
   @Test public void keys_onlyB3Single() {
     propagation = B3Propagation.newFactoryBuilder()
-      .injectFormat(Format.SINGLE)
       .injectFormat(Span.Kind.CLIENT, Format.SINGLE)
       .injectFormat(Span.Kind.SERVER, Format.SINGLE)
       .build().get();

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2013-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
As described in the referenced issue. In-process messaging sometimes
uses propagation, and the default of B3 multi makes the overhead quite
bad. This switches to B3 single which significantly redudes that burden.

https://github.com/spring-cloud/spring-cloud-sleuth/pull/1607
^^ already changed this in sleuth. this is just defaulting here

We should note that B3 single is widely supported at this point, and all
our instrumentation extend Request when injecting.

See #1020 as this was the change that allowed requests to differentiate