### PR TITLE
Adds MutableSpan.removeTag for common case conversion of tags to fields

### DIFF
--- a/brave/src/main/java/brave/handler/MutableSpan.java
+++ b/brave/src/main/java/brave/handler/MutableSpan.java
@@ -662,6 +662,32 @@ public final class MutableSpan implements Cloneable {
   }
 
   /**
+   * Removes and returns the last {@linkplain brave.SpanCustomizer#tag(String, String) tag value}
+   * associated with the key or returns {@code null} if it was never set.
+   *
+   * <p>Ex. to remove any tag named "remoteServiceName" and set it as {@link
+   * #remoteServiceName(String)} instead:
+   * <pre>{@code
+   * String remoteServiceName = span.removeTag("peer.service");
+   * if (remoteServiceName != null) span.remoteServiceName(remoteServiceName);
+   * }</pre>
+   *
+   * @since 5.12
+   */
+  @Nullable public String removeTag(String key) {
+    if (key == null) throw new NullPointerException("key == null");
+    if (key.isEmpty()) throw new IllegalArgumentException("key is empty");
+    for (int i = 0, length = tagCount * 2; i < length; i += 2) {
+      if (key.equals(tags[i])) {
+        String value = (String) tags[i + 1];
+        remove(tags, i);
+        return value;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Iterates over all {@linkplain SpanCustomizer#tag(String, String) tags} for purposes such as
    * copying values. Unlike {@link #tags()}, using this is allocation free.
    *

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -100,6 +100,18 @@ public class MutableSpanTest {
   }
 
   /** This is a compile test to show how the signature is intended to be used */
+  @Test public void removeTag_usageExplained() {
+    MutableSpan span = new MutableSpan();
+    span.tag("peer.service", "amazon-s3");
+
+    String remoteServiceName = span.removeTag("peer.service");
+    if (remoteServiceName != null) span.remoteServiceName(remoteServiceName);
+
+    assertThat(span.tags()).isEmpty();
+    assertThat(span.remoteServiceName()).isEqualTo("amazon-s3");
+  }
+
+  /** This is a compile test to show how the signature is intended to be used */
   @Test public void forEachTag_updater_usageExplained() {
     MutableSpan span = new MutableSpan();
     span.tag("a", "1");

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -63,7 +63,10 @@ public class MutableSpanTest {
     assertThat(counter.orphans).isEqualTo(2);
   }
 
-  /** This is a compile test to show how the signature is intended to be used */
+  /**
+   * This shows how the {@link MutableSpan#forEachTag(MutableSpan.TagConsumer, Object)}  is intended
+   * to be used
+   */
   @Test public void forEachTag_consumer_usageExplained() {
     MutableSpan span = new MutableSpan();
     span.tag("a", "1");
@@ -99,7 +102,7 @@ public class MutableSpanTest {
     );
   }
 
-  /** This is a compile test to show how the signature is intended to be used */
+  /** This shows how {@link MutableSpan#removeTag(String)} is intended to be used */
   @Test public void removeTag_usageExplained() {
     MutableSpan span = new MutableSpan();
     span.tag("peer.service", "amazon-s3");
@@ -111,7 +114,7 @@ public class MutableSpanTest {
     assertThat(span.remoteServiceName()).isEqualTo("amazon-s3");
   }
 
-  /** This is a compile test to show how the signature is intended to be used */
+  /** This shows how {@link MutableSpan#forEachTag(MutableSpan.TagUpdater)} is intended to be used */
   @Test public void forEachTag_updater_usageExplained() {
     MutableSpan span = new MutableSpan();
     span.tag("a", "1");

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2020 The OpenZipkin Authors
+# Copyright 2013-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
This allows an easier syntax for re-mapping tags as fields.

Ex.
```java
String remoteServiceName = span.removeTag("peer.service");
if (remoteServiceName != null) span.remoteServiceName(remoteServiceName);
```

See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1620