### PR TITLE
Allows MutableSpan to be used directly with Zipkin Reporter

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -30,7 +30,7 @@
 
     <!-- use the same values in ../pom.xml -->
     <zipkin.version>2.21.1</zipkin.version>
-    <zipkin-reporter.version>2.13.2</zipkin-reporter.version>
+    <zipkin-reporter.version>2.14.0</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/brave/README.md
+++ b/brave/README.md
@@ -21,14 +21,13 @@ HTTP (as opposed to Kafka).
 // Configure a reporter, which controls how often spans are sent
 //   (this dependency is io.zipkin.reporter2:zipkin-sender-okhttp3)
 sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
-spanReporter = AsyncReporter.create(sender);
 //   (this dependency is io.zipkin.reporter2:zipkin-reporter-brave)
-zipkinHandler = ZipkinSpanHandler.create(reporter)
+zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender);
 
 // Create a tracing component with the service name you want to see in Zipkin.
 tracing = Tracing.newBuilder()
                  .localServiceName("my-service")
-                 .addSpanHandler(ZipkinSpanHandler.create(reporter))
+                 .addSpanHandler(zipkinSpanHandler)
                  .build();
 
 // Tracing exposes objects you might need, most importantly the tracer
@@ -38,7 +37,7 @@ tracer = tracing.tracer();
 // longer needed, close the components you made in reverse order. This might be
 // a shutdown hook for some users.
 tracing.close();
-spanReporter.close();
+zipkinSpanHandler.close();
 sender.close();
 ```
 
@@ -49,8 +48,8 @@ Zipkin v1 format. See [zipkin-reporter](https://github.com/openzipkin/zipkin-rep
 ```java
 sender = URLConnectionSender.create("http://localhost:9411/api/v1/spans");
 reporter = AsyncReporter.builder(sender)
-                        .build(SpanBytesEncoder.JSON_V1);
-zipkinHandler = ZipkinSpanHandler.create(reporter)
+                        .build(SpanBytesEncoder.JSON_V1); // don't forget to close!
+zipkinSpanHandler = ZipkinSpanHandler.create(reporter)
 ```
 
 ## Tracing

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -121,6 +121,18 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <version>${zipkin-reporter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-junit</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/brave/src/main/java/brave/Tag.java
+++ b/brave/src/main/java/brave/Tag.java
@@ -13,8 +13,8 @@
  */
 package brave;
 
-import brave.handler.SpanHandler;
 import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
 import brave.internal.Nullable;
 import brave.internal.Platform;
 import brave.propagation.TraceContext;
@@ -49,11 +49,27 @@ public abstract class Tag<I> {
    * Override to change what data from the input are parsed into the span modeling it. Any
    * exceptions will be logged and ignored.
    *
+   * <p><em>Note</em>: Overrides of {@link Tags#ERROR} must return a valid value when
+   * {@param context} is {@code null}, even if that value is "" (empty string). Otherwise, error
+   * spans will not be marked as such.
+   *
    * @return The result to add as a span tag. {@code null} means no tag will be added. Note: empty
    * string is a valid tag value!
    * @since 5.11
    */
   @Nullable protected abstract String parseValue(I input, @Nullable TraceContext context);
+
+  /**
+   * Returns the value that would be tagged to the span or {@code null}.
+   *
+   * @see #key()
+   * @see #parseValue(Object, TraceContext)
+   * @since 5.12
+   */
+  @Nullable public String value(@Nullable I input, @Nullable TraceContext context) {
+    if (input == null) return null;
+    return parseValue(input, context);
+  }
 
   /** Overrides the tag key based on the input */
   protected String key(I input) {

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -245,8 +245,17 @@ public abstract class Tracing implements Closeable {
      *
      * <p>For example, here's how to batch send spans via HTTP to a Zipkin-compatible endpoint:
      * <pre>{@code
-     * spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v2/spans"));
-     * tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(spanReporter));
+     * // Configure a reporter, which controls how often spans are sent
+     * //   (this dependency is io.zipkin.reporter2:zipkin-sender-okhttp3)
+     * sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
+     * //   (this dependency is io.zipkin.reporter2:zipkin-reporter-brave)
+     * zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender); // don't forget to close!
+     *
+     * // Create a tracing component with the service name you want to see in Zipkin.
+     * tracing = Tracing.newBuilder()
+     *                  .localServiceName("my-service")
+     *                  .addSpanHandler(zipkinSpanHandler)
+     *                  .build();
      * }</pre>
      *
      * @see #addSpanHandler(SpanHandler)

--- a/brave/src/main/java/brave/handler/MutableSpanBytesEncoder.java
+++ b/brave/src/main/java/brave/handler/MutableSpanBytesEncoder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.handler;
+
+import brave.Tag;
+import brave.internal.codec.JsonWriter;
+import brave.internal.codec.ZipkinV2JsonWriter;
+import brave.internal.codec.WriteBuffer;
+import java.util.List;
+
+/** Similar to {@code zipkin2.MutableSpan.SpanBytesEncoder} except no Zipkin dependency. */
+public abstract class MutableSpanBytesEncoder {
+
+  public static MutableSpanBytesEncoder zipkinJsonV2(Tag<Throwable> errorTag) {
+    if (errorTag == null) throw new NullPointerException("errorTag == null");
+    return new ZipkinJsonV2(errorTag);
+  }
+
+  public abstract int sizeInBytes(MutableSpan input);
+
+  /** Serializes an object into its binary form. */
+  public abstract byte[] encode(MutableSpan input);
+
+  /** Serializes a list of objects into their binary form. */
+  public abstract byte[] encodeList(List<MutableSpan> input);
+
+  /** Allows you to encode a list of spans onto a specific offset. For example, when nesting */
+  public abstract int encodeList(List<MutableSpan> spans, byte[] out, int pos);
+
+  /** Corresponds to the Zipkin JSON v2 format */
+  static final class ZipkinJsonV2 extends MutableSpanBytesEncoder {
+    final WriteBuffer.Writer<MutableSpan> writer;
+
+    ZipkinJsonV2(Tag<Throwable> errorTag) {
+      writer = new ZipkinV2JsonWriter(errorTag);
+    }
+
+    @Override
+    public int sizeInBytes(MutableSpan input) {
+      return writer.sizeInBytes(input);
+    }
+
+    @Override
+    public byte[] encode(MutableSpan span) {
+      return JsonWriter.write(writer, span);
+    }
+
+    @Override
+    public byte[] encodeList(List<MutableSpan> spans) {
+      return JsonWriter.writeList(writer, spans);
+    }
+
+    @Override
+    public int encodeList(List<MutableSpan> spans, byte[] out, int pos) {
+      return JsonWriter.writeList(writer, spans, out, pos);
+    }
+  }
+}

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -67,6 +67,12 @@ public abstract class Platform {
       log("error reading nics", e);
     }
     return null;
+  }
+
+  public AssertionError assertionError(String message, Throwable cause) {
+    AssertionError error = new AssertionError(message);
+    error.initCause(cause);
+    throw error;
   }
 
   public static Platform get() {
@@ -183,6 +189,11 @@ public abstract class Platform {
 
     @IgnoreJRERequirement @Override public long nextTraceIdHigh() {
       return nextTraceIdHigh(java.util.concurrent.ThreadLocalRandom.current().nextInt());
+    }
+
+    @IgnoreJRERequirement @Override
+    public AssertionError assertionError(String message, Throwable cause) {
+      return new AssertionError(message, cause);
     }
 
     @Override public String toString() {

--- a/brave/src/main/java/brave/internal/codec/JsonWriter.java
+++ b/brave/src/main/java/brave/internal/codec/JsonWriter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import brave.internal.Platform;
+import brave.internal.codec.WriteBuffer.Writer;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static java.lang.String.format;
+
+// Initially, a partial copy of zipkin2.internal.JsonCodec (the write side)
+public final class JsonWriter {
+  public static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  static <T> int sizeInBytes(Writer<T> writer, List<T> value) {
+    int length = value.size();
+    int sizeInBytes = 2; // []
+    if (length > 1) sizeInBytes += length - 1; // comma to join elements
+    for (int i = 0; i < length; i++) {
+      sizeInBytes += writer.sizeInBytes(value.get(i));
+    }
+    return sizeInBytes;
+  }
+
+  /** Inability to encode is a programming bug. */
+  public static <T> byte[] write(Writer<T> writer, T value) {
+    byte[] result = new byte[writer.sizeInBytes(value)];
+    WriteBuffer b = WriteBuffer.wrap(result);
+    try {
+      writer.write(value, b);
+    } catch (RuntimeException e) {
+      int lengthWritten = result.length;
+      for (int i = 0; i < result.length; i++) {
+        if (result[i] == 0) {
+          lengthWritten = i;
+          break;
+        }
+      }
+
+      // Don't use value directly in the message, as its toString might be implemented using this
+      // method. If that's the case, we'd stack overflow. Instead, emit what we've written so far.
+      String message =
+          format(
+              "Bug found using %s to write %s as json. Wrote %s/%s bytes: %s",
+              writer.getClass().getSimpleName(),
+              value.getClass().getSimpleName(),
+              lengthWritten,
+              result.length,
+              new String(result, 0, lengthWritten, UTF_8));
+      throw Platform.get().assertionError(message, e);
+    }
+    return result;
+  }
+
+  public static <T> byte[] writeList(Writer<T> writer, List<T> value) {
+    if (value.isEmpty()) return new byte[] {'[', ']'};
+    byte[] result = new byte[sizeInBytes(writer, value)];
+    writeList(writer, value, WriteBuffer.wrap(result));
+    return result;
+  }
+
+  public static <T> int writeList(Writer<T> writer, List<T> value, byte[] out,
+      int pos) {
+    if (value.isEmpty()) {
+      out[pos++] = '[';
+      out[pos++] = ']';
+      return 2;
+    }
+    int initialPos = pos;
+    WriteBuffer result = WriteBuffer.wrap(out, pos);
+    writeList(writer, value, result);
+    return result.pos() - initialPos;
+  }
+
+  public static <T> void writeList(Writer<T> writer, List<T> value, WriteBuffer b) {
+    b.writeByte('[');
+    for (int i = 0, length = value.size(); i < length; ) {
+      writer.write(value.get(i++), b);
+      if (i < length) b.writeByte(',');
+    }
+    b.writeByte(']');
+  }
+}

--- a/brave/src/main/java/brave/internal/codec/WriteBuffer.java
+++ b/brave/src/main/java/brave/internal/codec/WriteBuffer.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import static brave.internal.codec.HexCodec.HEX_DIGITS;
+import static brave.internal.codec.JsonWriter.UTF_8;
+
+/**
+ * Writes are unsafe as they do no bounds checks. This means you should take care to allocate or
+ * wrap an array at least as big as you need prior to writing. As it is possible to calculate size
+ * prior to writing, overrunning a buffer is a programming error.
+ */
+// Initially, a partial copy of zipkin2.internal.WriteBuffer
+public final class WriteBuffer {
+  public interface Writer<T> {
+    int sizeInBytes(T value);
+
+    void write(T value, WriteBuffer buffer);
+  }
+
+  public static WriteBuffer wrap(byte[] bytes) {
+    return wrap(bytes, 0);
+  }
+
+  public static WriteBuffer wrap(byte[] bytes, int pos) {
+    return new WriteBuffer(bytes, pos);
+  }
+
+  final byte[] buf;
+  int pos;
+
+  WriteBuffer(byte[] buf, int pos) {
+    this.buf = buf;
+    this.pos = pos;
+  }
+
+  public void writeByte(int v) {
+    buf[pos++] = (byte) (v & 0xff);
+  }
+
+  public void write(byte[] v) {
+    System.arraycopy(v, 0, buf, pos, v.length);
+    pos += v.length;
+  }
+
+  void writeBackwards(long v) {
+    int lastPos = pos + asciiSizeInBytes(v); // We write backwards from right to left.
+    pos = lastPos;
+    while (v != 0) {
+      int digit = (int) (v % 10);
+      buf[--lastPos] = (byte) HEX_DIGITS[digit];
+      v /= 10;
+    }
+  }
+
+  final int pos() {
+    return pos;
+  }
+
+  public void writeAscii(String v) {
+    for (int i = 0, length = v.length(); i < length; i++) {
+      writeByte(v.charAt(i) & 0xff);
+    }
+  }
+
+  /**
+   * This transcodes a UTF-16 Java String to UTF-8 bytes.
+   *
+   * <p>This looks most similar to {@code io.netty.buffer.ByteBufUtil.writeUtf8(AbstractByteBuf,
+   * int, CharSequence, int)} v4.1, modified including features to address ASCII runs of text.
+   */
+  public void writeUtf8(CharSequence string) {
+    writeUtf8(string, 0, string.length());
+  }
+
+  public void writeUtf8(CharSequence string, int fromIndex, int toIndex) {
+    for (int i = fromIndex; i < toIndex; i++) {
+      char ch = string.charAt(i);
+      if (ch < 0x80) { // 7-bit ASCII character
+        writeByte(ch);
+        // This could be an ASCII run, or possibly entirely ASCII
+        while (i < toIndex - 1) {
+          ch = string.charAt(i + 1);
+          if (ch >= 0x80) break;
+          i++;
+          writeByte(ch); // another 7-bit ASCII character
+        }
+      } else if (ch < 0x800) { // 11-bit character
+        writeByte(0xc0 | (ch >> 6));
+        writeByte(0x80 | (ch & 0x3f));
+      } else if (ch < 0xd800 || ch > 0xdfff) { // 16-bit character
+        writeByte(0xe0 | (ch >> 12));
+        writeByte(0x80 | ((ch >> 6) & 0x3f));
+        writeByte(0x80 | (ch & 0x3f));
+      } else { // Possibly a 21-bit character
+        if (!Character.isHighSurrogate(ch)) { // Malformed or not UTF-8
+          writeByte('?');
+          continue;
+        }
+        if (i == toIndex - 1) { // Truncated or not UTF-8
+          writeByte('?');
+          break;
+        }
+        char low = string.charAt(++i);
+        if (!Character.isLowSurrogate(low)) { // Malformed or not UTF-8
+          writeByte('?');
+          writeByte(Character.isHighSurrogate(low) ? '?' : low);
+          continue;
+        }
+        // Write the 21-bit character using 4 bytes
+        // See http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G2630
+        int codePoint = Character.toCodePoint(ch, low);
+        writeByte(0xf0 | (codePoint >> 18));
+        writeByte(0x80 | ((codePoint >> 12) & 0x3f));
+        writeByte(0x80 | ((codePoint >> 6) & 0x3f));
+        writeByte(0x80 | (codePoint & 0x3f));
+      }
+    }
+  }
+
+  // Adapted from okio.Buffer.writeDecimalLong
+  public void writeAscii(long v) {
+    if (v == 0) {
+      writeByte('0');
+      return;
+    }
+
+    if (v == Long.MIN_VALUE) {
+      writeAscii("-9223372036854775808");
+      return;
+    }
+
+    if (v < 0) {
+      writeByte('-');
+      v = -v; // needs to be positive so we can use this for an array index
+    }
+
+    writeBackwards(v);
+  }
+
+  @Override public String toString() {
+    return new String(buf, 0, pos, UTF_8);
+  }
+
+  /**
+   * This returns the bytes needed to transcode a UTF-16 Java String to UTF-8 bytes.
+   *
+   * <p>Originally based on
+   * http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
+   *
+   * <p>Later, ASCII run and malformed surrogate logic borrowed from okio.Utf8
+   */
+  // TODO: benchmark vs https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/Utf8.java#L240
+  // there seem to be less branches for for strings without surrogates
+  public static int utf8SizeInBytes(CharSequence string) {
+    int sizeInBytes = 0;
+    for (int i = 0, len = string.length(); i < len; i++) {
+      char ch = string.charAt(i);
+      if (ch < 0x80) {
+        sizeInBytes++; // 7-bit ASCII character
+        // This could be an ASCII run, or possibly entirely ASCII
+        while (i < len - 1) {
+          ch = string.charAt(i + 1);
+          if (ch >= 0x80) break;
+          i++;
+          sizeInBytes++; // another 7-bit ASCII character
+        }
+      } else if (ch < 0x800) {
+        sizeInBytes += 2; // 11-bit character
+      } else if (ch < 0xd800 || ch > 0xdfff) {
+        sizeInBytes += 3; // 16-bit character
+      } else {
+        int low = i + 1 < len ? string.charAt(i + 1) : 0;
+        if (ch > 0xdbff || low < 0xdc00 || low > 0xdfff) {
+          sizeInBytes++; // A malformed surrogate, which yields '?'.
+        } else {
+          // A 21-bit character
+          sizeInBytes += 4;
+          i++;
+        }
+      }
+    }
+    return sizeInBytes;
+  }
+
+  /**
+   * Binary search for character width which favors matching lower numbers.
+   *
+   * <p>Adapted from okio.Buffer
+   */
+  public static int asciiSizeInBytes(long v) {
+    if (v == 0) return 1;
+    if (v == Long.MIN_VALUE) return 20;
+
+    boolean negative = false;
+    if (v < 0) {
+      v = -v; // making this positive allows us to compare using less-than
+      negative = true;
+    }
+    int width =
+        v < 100000000L
+            ? v < 10000L
+            ? v < 100L ? v < 10L ? 1 : 2 : v < 1000L ? 3 : 4
+            : v < 1000000L ? v < 100000L ? 5 : 6 : v < 10000000L ? 7 : 8
+            : v < 1000000000000L
+                ? v < 10000000000L ? v < 1000000000L ? 9 : 10 : v < 100000000000L ? 11 : 12
+                : v < 1000000000000000L
+                    ? v < 10000000000000L ? 13 : v < 100000000000000L ? 14 : 15
+                    : v < 100000000000000000L
+                        ? v < 10000000000000000L ? 16 : 17
+                        : v < 1000000000000000000L ? 18 : 19;
+    return negative ? width + 1 : width; // conditionally add room for negative sign
+  }
+}

--- a/brave/src/main/java/brave/internal/codec/ZipkinV2JsonWriter.java
+++ b/brave/src/main/java/brave/internal/codec/ZipkinV2JsonWriter.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+import brave.internal.Nullable;
+
+import static brave.internal.codec.JsonEscaper.jsonEscape;
+import static brave.internal.codec.JsonEscaper.jsonEscapedSizeInBytes;
+import static brave.internal.codec.WriteBuffer.asciiSizeInBytes;
+
+// @Immutable
+public final class ZipkinV2JsonWriter implements WriteBuffer.Writer<MutableSpan> {
+  final Tag<Throwable> errorTag;
+
+  public ZipkinV2JsonWriter(Tag<Throwable> errorTag) {
+    if (errorTag == null) throw new NullPointerException("errorTag == null");
+    this.errorTag = errorTag;
+  }
+
+  @Override public int sizeInBytes(MutableSpan span) {
+    int sizeInBytes = 1; // {
+    if (span.traceId() != null) {
+      sizeInBytes += 12; // "traceId":""
+      sizeInBytes += span.traceId().length();
+    }
+    if (span.parentId() != null) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 29; // "parentId":"0123456789abcdef"
+    }
+    if (span.id() != null) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 23; // "id":"0123456789abcdef"
+    }
+    if (span.kind() != null) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 9; // "kind":""
+      sizeInBytes += span.kind().name().length();
+    }
+    if (span.name() != null) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 9; // "name":""
+      sizeInBytes += jsonEscapedSizeInBytes(span.name());
+    }
+    if (span.startTimestamp() != 0L) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 12; // "timestamp":
+      sizeInBytes += asciiSizeInBytes(span.startTimestamp());
+      if (span.finishTimestamp() != 0L) {
+        sizeInBytes += 12; // ,"duration":
+        sizeInBytes += asciiSizeInBytes(span.finishTimestamp() - span.startTimestamp());
+      }
+    }
+    int localEndpointSizeInBytes =
+        endpointSizeInBytes(span.localServiceName(), span.localIp(), span.localPort());
+    if (localEndpointSizeInBytes > 0) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += (16 + localEndpointSizeInBytes); // "localEndpoint":
+    }
+    int remoteEndpointSizeInBytes =
+        endpointSizeInBytes(span.remoteServiceName(), span.remoteIp(), span.remotePort());
+    if (remoteEndpointSizeInBytes > 0) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += (17 + remoteEndpointSizeInBytes); // "remoteEndpoint":
+    }
+    int annotationCount = span.annotationCount();
+    if (annotationCount > 0) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 16; // "annotations":[]
+      if (annotationCount > 1) sizeInBytes += annotationCount - 1; // comma to join elements
+      for (int i = 0; i < annotationCount; i++) {
+        long timestamp = span.annotationTimestampAt(i);
+        String value = span.annotationValueAt(i);
+        sizeInBytes += annotationSizeInBytes(timestamp, value);
+      }
+    }
+    int tagCount = span.tagCount();
+    String errorValue = errorTag.value(span.error(), null);
+    if (tagCount > 0 || errorValue != null) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 9; // "tags":{}
+      boolean foundError = false;
+      for (int i = 0; i < tagCount; i++) {
+        String key = span.tagKeyAt(i);
+        if (!foundError && key.equals("error")) foundError = true;
+        String value = span.tagValueAt(i);
+        sizeInBytes += tagSizeInBytes(key, value);
+      }
+      if (errorValue != null && !foundError) {
+        tagCount++;
+        sizeInBytes += tagSizeInBytes(errorTag.key(), errorValue);
+      }
+      if (tagCount > 1) sizeInBytes += tagCount - 1; // comma to join elements
+    }
+    if (Boolean.TRUE.equals(span.debug())) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 12; // "debug":true
+    }
+    if (Boolean.TRUE.equals(span.shared())) {
+      if (sizeInBytes > 1) sizeInBytes++; // ,
+      sizeInBytes += 13; // "shared":true
+    }
+    return sizeInBytes + 1; // }
+  }
+
+  @Override public void write(MutableSpan span, WriteBuffer b) {
+    b.writeByte('{');
+    boolean wroteField = false;
+    if (span.traceId() != null) {
+      wroteField = writeFieldBegin(b, "traceId", wroteField);
+      b.writeByte('"');
+      b.writeAscii(span.traceId());
+      b.writeByte('"');
+    }
+    if (span.parentId() != null) {
+      wroteField = writeFieldBegin(b, "parentId", wroteField);
+      b.writeByte('"');
+      b.writeAscii(span.parentId());
+      b.writeByte('"');
+    }
+    if (span.id() != null) {
+      wroteField = writeFieldBegin(b, "id", wroteField);
+      b.writeByte('"');
+      b.writeAscii(span.id());
+      b.writeByte('"');
+    }
+    if (span.kind() != null) {
+      wroteField = writeFieldBegin(b, "kind", wroteField);
+      b.writeByte('"');
+      b.writeAscii(span.kind().toString());
+      b.writeByte('"');
+    }
+    if (span.name() != null) {
+      wroteField = writeFieldBegin(b, "name", wroteField);
+      b.writeByte('"');
+      jsonEscape(span.name(), b);
+      b.writeByte('"');
+    }
+    long startTimestamp = span.startTimestamp(), finishTimestamp = span.finishTimestamp();
+    if (startTimestamp != 0L) {
+      wroteField = writeFieldBegin(b, "timestamp", wroteField);
+      b.writeAscii(startTimestamp);
+      if (finishTimestamp != 0L) {
+        wroteField = writeFieldBegin(b, "duration", wroteField);
+        b.writeAscii(finishTimestamp - startTimestamp);
+      }
+    }
+    if (span.localServiceName() != null || span.localIp() != null) {
+      wroteField = writeFieldBegin(b, "localEndpoint", wroteField);
+      writeEndpoint(b, span.localServiceName(), span.localIp(), span.localPort());
+    }
+    if (span.remoteServiceName() != null || span.remoteIp() != null) {
+      wroteField = writeFieldBegin(b, "remoteEndpoint", wroteField);
+      writeEndpoint(b, span.remoteServiceName(), span.remoteIp(), span.remotePort());
+    }
+    int annotationLength = span.annotationCount();
+    if (annotationLength > 0) {
+      wroteField = writeFieldBegin(b, "annotations", wroteField);
+      b.writeByte('[');
+      for (int i = 0; i < annotationLength; ) {
+        long timestamp = span.annotationTimestampAt(i);
+        String value = span.annotationValueAt(i);
+        writeAnnotation(timestamp, value, b);
+        if (++i < annotationLength) b.writeByte(',');
+      }
+      b.writeByte(']');
+    }
+    int tagCount = span.tagCount();
+    String errorValue = errorTag.value(span.error(), null);
+    if (tagCount > 0 || errorValue != null) {
+      wroteField = writeFieldBegin(b, "tags", wroteField);
+      b.writeByte('{');
+      boolean foundError = false;
+      for (int i = 0; i < tagCount; ) {
+        String key = span.tagKeyAt(i);
+        if (!foundError && key.equals("error")) foundError = true;
+        String value = span.tagValueAt(i);
+        writeKeyValue(b, key, value);
+        if (++i < tagCount) b.writeByte(',');
+      }
+      if (errorValue != null && !foundError) {
+        if (tagCount > 0) b.writeByte(',');
+        writeKeyValue(b, errorTag.key(), errorValue);
+      }
+      b.writeByte('}');
+    }
+    if (Boolean.TRUE.equals(span.debug())) {
+      wroteField = writeFieldBegin(b, "debug", wroteField);
+      b.writeAscii("true");
+    }
+    if (Boolean.TRUE.equals(span.shared())) {
+      writeFieldBegin(b, "shared", wroteField);
+      b.writeAscii("true");
+    }
+    b.writeByte('}');
+  }
+
+  static int endpointSizeInBytes(@Nullable String serviceName, @Nullable String ip, int port) {
+    int sizeInBytes = 0;
+    if (serviceName != null) {
+      sizeInBytes += 16; // "serviceName":""
+      sizeInBytes += jsonEscapedSizeInBytes(serviceName);
+    }
+    if (ip != null) {
+      if (sizeInBytes > 0) sizeInBytes++; // ,
+      sizeInBytes += 9; // "ipv4":"" or "ipv6":""
+      sizeInBytes += ip.length();
+      if (port != 0) {
+        if (sizeInBytes != 1) sizeInBytes++; // ,
+        sizeInBytes += 7; // "port":
+        sizeInBytes += asciiSizeInBytes(port);
+      }
+    }
+    return sizeInBytes == 0 ? 0 : sizeInBytes + 2; // {}
+  }
+
+  static int annotationSizeInBytes(long timestamp, String value) {
+    int sizeInBytes = 25; // {"timestamp":,"value":""}
+    sizeInBytes += asciiSizeInBytes(timestamp);
+    sizeInBytes += jsonEscapedSizeInBytes(value);
+    return sizeInBytes;
+  }
+
+  static int tagSizeInBytes(String key, String value) {
+    int sizeInBytes = 5; // "":""
+    sizeInBytes += jsonEscapedSizeInBytes(key);
+    sizeInBytes += jsonEscapedSizeInBytes(value);
+    return sizeInBytes;
+  }
+
+  boolean writeFieldBegin(WriteBuffer b, String fieldName, boolean wroteField) {
+    if (wroteField) b.writeByte(',');
+    wroteField = true;
+
+    b.writeByte('"');
+    b.writeAscii(fieldName);
+    b.writeByte('"');
+    b.writeByte(':');
+    return wroteField;
+  }
+
+  static void writeEndpoint(WriteBuffer b,
+      @Nullable String serviceName, @Nullable String ip, int port) {
+    b.writeByte('{');
+    boolean wroteField = false;
+    if (serviceName != null) {
+      b.writeAscii("\"serviceName\":\"");
+      JsonEscaper.jsonEscape(serviceName, b);
+      b.writeByte('"');
+      wroteField = true;
+    }
+    if (ip != null) {
+      if (wroteField) b.writeByte(',');
+      if (IpLiteral.detectFamily(ip) == IpLiteral.IpFamily.IPv4) {
+        b.writeAscii("\"ipv4\":\"");
+      } else {
+        b.writeAscii("\"ipv6\":\"");
+      }
+      b.writeAscii(ip);
+      b.writeByte('"');
+      wroteField = true;
+    }
+    if (port != 0) {
+      if (wroteField) b.writeByte(',');
+      b.writeAscii("\"port\":");
+      b.writeAscii(port);
+    }
+    b.writeByte('}');
+  }
+
+  static void writeAnnotation(long timestamp, String value, WriteBuffer b) {
+    b.writeAscii("{\"timestamp\":");
+    b.writeAscii(timestamp);
+    b.writeAscii(",\"value\":\"");
+    jsonEscape(value, b);
+    b.writeByte('"');
+    b.writeByte('}');
+  }
+
+  static void writeKeyValue(WriteBuffer b, String key, String value) {
+    b.writeByte('"');
+    JsonEscaper.jsonEscape(key, b);
+    b.writeAscii("\":\"");
+    JsonEscaper.jsonEscape(value, b);
+    b.writeByte('"');
+  }
+}

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.when;
 
 public class TracingTest {
   TestSpanHandler spans = new TestSpanHandler();
+  @Test public void test(){
+    System.err.println("\u2029".getBytes().length);
+  }
 
   /**
    * This behavior could be problematic as downstream services may report spans based on propagated

--- a/brave/src/test/java/brave/features/handler/MutableSpanAsyncReporterTest.java
+++ b/brave/src/test/java/brave/features/handler/MutableSpanAsyncReporterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.features.handler;
+
+import brave.Tags;
+import brave.Tracing;
+import brave.handler.MutableSpan;
+import brave.handler.MutableSpanBytesEncoder;
+import brave.handler.SpanHandler;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.TraceContext;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin2.codec.BytesEncoder;
+import zipkin2.codec.Encoding;
+import zipkin2.junit.ZipkinRule;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is an example of why {@link MutableSpanBytesEncoder} was written. Particularly, it allows
+ * direct encoding from {@link MutableSpan} into JSON without converting to Zipkin model first.
+ */
+public class MutableSpanAsyncReporterTest {
+  @Rule public ZipkinRule zipkin = new ZipkinRule();
+
+  MutableSpanBytesEncoder mutableSpanBytesEncoder = MutableSpanBytesEncoder.zipkinJsonV2(Tags.ERROR);
+  BytesEncoder<MutableSpan> zipkinBytesEncoderAdapter = new BytesEncoder<MutableSpan>() {
+
+    @Override public Encoding encoding() {
+      return Encoding.JSON;
+    }
+
+    @Override public int sizeInBytes(MutableSpan span) {
+      return mutableSpanBytesEncoder.sizeInBytes(span);
+    }
+
+    @Override public byte[] encode(MutableSpan span) {
+      return mutableSpanBytesEncoder.encode(span);
+    }
+
+    @Override public byte[] encodeList(List<MutableSpan> spans) {
+      return mutableSpanBytesEncoder.encodeList(spans);
+    }
+  };
+
+  OkHttpSender sender = OkHttpSender.create(zipkin.httpUrl() + "/api/v2/spans");
+
+  AsyncReporter<MutableSpan> reporter = AsyncReporter.builder(sender)
+      .messageTimeout(0, TimeUnit.MILLISECONDS) // don't spawn a thread
+      .build(zipkinBytesEncoderAdapter);
+
+  SpanHandler spanHandlerAdapter = new SpanHandler() {
+    @Override public boolean end(TraceContext context, MutableSpan span, SpanHandler.Cause cause) {
+      if (!Boolean.TRUE.equals(context.sampled())) return true;
+      reporter.report(span);
+      return true;
+    }
+  };
+
+  Tracing tracing = Tracing.newBuilder()
+      .localServiceName("Aa")
+      .localIp("1.2.3.4")
+      .localPort(80)
+      .addSpanHandler(spanHandlerAdapter)
+      .build();
+
+  @After public void close() {
+    tracing.close();
+    reporter.close();
+    sender.close();
+  }
+
+  /** This mainly shows endpoints are taken from Brave, and error is back-filled. */
+  @Test public void basicSpan() {
+    TraceContext context = B3SingleFormat.parseB3SingleFormat(
+        "50d980fffa300f29-86154a4ba6e91385-1"
+    ).context();
+
+    tracing.tracer().toSpan(context).name("test")
+        .start(1L)
+        .error(new RuntimeException("this cake is a lie"))
+        .finish(3L);
+
+    reporter.flush();
+
+    assertThat(zipkin.getTraces()).hasSize(1).first().hasToString(
+        "[{\"traceId\":\"50d980fffa300f29\","
+            + "\"id\":\"86154a4ba6e91385\","
+            + "\"name\":\"test\","
+            + "\"timestamp\":1,"
+            + "\"duration\":2,"
+            + "\"localEndpoint\":{"
+            + "\"serviceName\":\"aa\","
+            + "\"ipv4\":\"1.2.3.4\","
+            + "\"port\":80},"
+            + "\"tags\":{\"error\":\"this cake is a lie\"}}]"
+    );
+  }
+}

--- a/brave/src/test/java/brave/handler/MutableSpanBytesEncoderTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanBytesEncoderTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.handler;
+
+import brave.Span.Kind;
+import brave.Tags;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test is intentionally sensitive to ensure our custom encoders do not break in subtle ways.
+ */
+// Originally, a subset of zipkin2.code.SpanBytesEncoderTest 
+public class MutableSpanBytesEncoderTest {
+  MutableSpan
+      clientSpan = new MutableSpan(),
+      rootServerSpan = new MutableSpan(),
+      localSpan = new MutableSpan(),
+      errorSpan = new MutableSpan(),
+      utf8Span = new MutableSpan();
+
+  MutableSpanBytesEncoder encoder = MutableSpanBytesEncoder.zipkinJsonV2(Tags.ERROR);
+
+  @Before public void testData() {
+    clientSpan.traceId("7180c278b62e8f6a216a2aea45d08fc9");
+    clientSpan.parentId("6b221d5bc9e6496c");
+    clientSpan.id("5b4185666d50f68b");
+    clientSpan.name("get");
+    clientSpan.kind(Kind.CLIENT);
+    clientSpan.localServiceName("frontend");
+    clientSpan.localIp("127.0.0.1");
+    clientSpan.remoteServiceName("backend");
+    clientSpan.remoteIpAndPort("192.168.99.101", 9000);
+    clientSpan.startTimestamp(1472470996199000L);
+    clientSpan.finishTimestamp(1472470996199000L + 207000L);
+    clientSpan.annotate(1472470996238000L, "foo");
+    clientSpan.annotate(1472470996403000L, "bar");
+    clientSpan.tag("clnt/finagle.version", "6.45.0");
+    clientSpan.tag("http.path", "/api");
+
+    rootServerSpan.traceId("dc955a1d4768875d");
+    rootServerSpan.id("dc955a1d4768875d");
+    rootServerSpan.name("get");
+    rootServerSpan.startTimestamp(1510256710021866L);
+    rootServerSpan.finishTimestamp(1510256710021866L + 1117L);
+    rootServerSpan.kind(Kind.SERVER);
+    rootServerSpan.localServiceName("isao01");
+    rootServerSpan.localIp("10.23.14.72");
+    rootServerSpan.tag("http.path", "/rs/A");
+    rootServerSpan.tag("location", "T67792");
+    rootServerSpan.tag("other", "A");
+
+    localSpan.traceId("dc955a1d4768875d");
+    localSpan.id("dc955a1d4768875d");
+    localSpan.name("encode");
+    localSpan.startTimestamp(1510256710021866L);
+    localSpan.finishTimestamp(1510256710021866L + 1117L);
+    localSpan.localServiceName("isao01");
+    localSpan.localIp("10.23.14.72");
+
+    // the following skeletal span is used in dependency linking
+    errorSpan.traceId("dc955a1d4768875d");
+    errorSpan.id("dc955a1d4768875d");
+    errorSpan.localServiceName("isao01");
+    errorSpan.kind(Kind.CLIENT);
+    errorSpan.tag("error", "");
+
+    // service name is surrounded by control characters
+    utf8Span.traceId("1");
+    utf8Span.id("1");
+    utf8Span.name("get");
+    clientSpan.kind(Kind.CLIENT);
+    // name is terrible
+    utf8Span.name(new String(new char[] {'"', '\\', '\t', '\b', '\n', '\r', '\f'}));
+    // annotation value includes some json newline characters
+    utf8Span.annotate(1L, "\u2028 and \u2029");
+    // tag key includes a quote and value newlines
+    utf8Span.tag("\"foo",
+        "Database error: ORA-00942:\u2028 and \u2029 table or view does not exist\n");
+  }
+
+  @Test public void span_JSON_V2() {
+    assertThat(new String(encoder.encode(clientSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"7180c278b62e8f6a216a2aea45d08fc9\",\"parentId\":\"6b221d5bc9e6496c\",\"id\":\"5b4185666d50f68b\",\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1472470996199000,\"duration\":207000,\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},\"annotations\":[{\"timestamp\":1472470996238000,\"value\":\"foo\"},{\"timestamp\":1472470996403000,\"value\":\"bar\"}],\"tags\":{\"clnt/finagle.version\":\"6.45.0\",\"http.path\":\"/api\"}}");
+  }
+
+  @Test public void localSpan_JSON_V2() {
+    assertThat(new String(encoder.encode(localSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"dc955a1d4768875d\",\"id\":\"dc955a1d4768875d\",\"name\":\"encode\",\"timestamp\":1510256710021866,\"duration\":1117,\"localEndpoint\":{\"serviceName\":\"isao01\",\"ipv4\":\"10.23.14.72\"}}");
+  }
+
+  @Test public void errorSpan_JSON_V2() {
+    assertThat(new String(encoder.encode(errorSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"dc955a1d4768875d\",\"id\":\"dc955a1d4768875d\",\"kind\":\"CLIENT\",\"localEndpoint\":{\"serviceName\":\"isao01\"},\"tags\":{\"error\":\"\"}}");
+  }
+
+  @Test public void span_64bitTraceId_JSON_V2() {
+    clientSpan.traceId(clientSpan.traceId().substring(16));
+
+    assertThat(new String(encoder.encode(clientSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"216a2aea45d08fc9\",\"parentId\":\"6b221d5bc9e6496c\",\"id\":\"5b4185666d50f68b\",\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1472470996199000,\"duration\":207000,\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},\"annotations\":[{\"timestamp\":1472470996238000,\"value\":\"foo\"},{\"timestamp\":1472470996403000,\"value\":\"bar\"}],\"tags\":{\"clnt/finagle.version\":\"6.45.0\",\"http.path\":\"/api\"}}");
+  }
+
+  @Test public void span_shared_JSON_V2() {
+    MutableSpan span = clientSpan;
+    span.kind(Kind.SERVER);
+    span.setShared();
+
+    assertThat(new String(encoder.encode(clientSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"7180c278b62e8f6a216a2aea45d08fc9\",\"parentId\":\"6b221d5bc9e6496c\",\"id\":\"5b4185666d50f68b\",\"kind\":\"SERVER\",\"name\":\"get\",\"timestamp\":1472470996199000,\"duration\":207000,\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},\"annotations\":[{\"timestamp\":1472470996238000,\"value\":\"foo\"},{\"timestamp\":1472470996403000,\"value\":\"bar\"}],\"tags\":{\"clnt/finagle.version\":\"6.45.0\",\"http.path\":\"/api\"},\"shared\":true}");
+  }
+
+  @Test public void specialCharsInJson_JSON_V2() {
+    assertThat(new String(encoder.encode(utf8Span), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"0000000000000001\",\"id\":\"0000000000000001\",\"name\":\"\\\"\\\\\\t\\b\\n\\r\\f\",\"annotations\":[{\"timestamp\":1,\"value\":\"\\u2028 and \\u2029\"}],\"tags\":{\"\\\"foo\":\"Database error: ORA-00942:\\u2028 and \\u2029 table or view does not exist\\n\"}}");
+  }
+
+  @Test public void span_minimum_JSON_V2() {
+    MutableSpan span = new MutableSpan();
+    span.traceId("7180c278b62e8f6a216a2aea45d08fc9");
+    span.id("5b4185666d50f68b");
+
+    assertThat(new String(encoder.encode(span), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"7180c278b62e8f6a216a2aea45d08fc9\",\"id\":\"5b4185666d50f68b\"}");
+  }
+
+  @Test public void span_noLocalServiceName_JSON_V2() {
+    clientSpan.localServiceName(null);
+
+    assertThat(new String(encoder.encode(clientSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"7180c278b62e8f6a216a2aea45d08fc9\",\"parentId\":\"6b221d5bc9e6496c\",\"id\":\"5b4185666d50f68b\",\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1472470996199000,\"duration\":207000,\"localEndpoint\":{\"ipv4\":\"127.0.0.1\"},\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},\"annotations\":[{\"timestamp\":1472470996238000,\"value\":\"foo\"},{\"timestamp\":1472470996403000,\"value\":\"bar\"}],\"tags\":{\"clnt/finagle.version\":\"6.45.0\",\"http.path\":\"/api\"}}");
+  }
+
+  @Test public void span_noRemoteServiceName_JSON_V2() {
+    clientSpan.remoteServiceName(null);
+
+    assertThat(new String(encoder.encode(clientSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"7180c278b62e8f6a216a2aea45d08fc9\",\"parentId\":\"6b221d5bc9e6496c\",\"id\":\"5b4185666d50f68b\",\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1472470996199000,\"duration\":207000,\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},\"remoteEndpoint\":{\"ipv4\":\"192.168.99.101\",\"port\":9000},\"annotations\":[{\"timestamp\":1472470996238000,\"value\":\"foo\"},{\"timestamp\":1472470996403000,\"value\":\"bar\"}],\"tags\":{\"clnt/finagle.version\":\"6.45.0\",\"http.path\":\"/api\"}}");
+  }
+
+  @Test public void rootServerSpan_JSON_V2() {
+    assertThat(new String(encoder.encode(rootServerSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"dc955a1d4768875d\",\"id\":\"dc955a1d4768875d\",\"kind\":\"SERVER\",\"name\":\"get\",\"timestamp\":1510256710021866,\"duration\":1117,\"localEndpoint\":{\"serviceName\":\"isao01\",\"ipv4\":\"10.23.14.72\"},\"tags\":{\"http.path\":\"/rs/A\",\"location\":\"T67792\",\"other\":\"A\"}}");
+  }
+
+  @Test public void rootServerSpan_JSON_V2_incomplete() {
+    rootServerSpan.finishTimestamp(0L);
+
+    assertThat(new String(encoder.encode(rootServerSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"dc955a1d4768875d\",\"id\":\"dc955a1d4768875d\",\"kind\":\"SERVER\",\"name\":\"get\",\"timestamp\":1510256710021866,\"localEndpoint\":{\"serviceName\":\"isao01\",\"ipv4\":\"10.23.14.72\"},\"tags\":{\"http.path\":\"/rs/A\",\"location\":\"T67792\",\"other\":\"A\"}}");
+  }
+
+  @Test public void rootServerSpan_JSON_V2_shared() {
+    rootServerSpan.setShared();
+
+    assertThat(new String(encoder.encode(rootServerSpan), UTF_8))
+        .isEqualTo(
+            "{\"traceId\":\"dc955a1d4768875d\",\"id\":\"dc955a1d4768875d\",\"kind\":\"SERVER\",\"name\":\"get\",\"timestamp\":1510256710021866,\"duration\":1117,\"localEndpoint\":{\"serviceName\":\"isao01\",\"ipv4\":\"10.23.14.72\"},\"tags\":{\"http.path\":\"/rs/A\",\"location\":\"T67792\",\"other\":\"A\"},\"shared\":true}");
+  }
+}

--- a/brave/src/test/java/brave/internal/codec/JsonEscaperTest.java
+++ b/brave/src/test/java/brave/internal/codec/JsonEscaperTest.java
@@ -16,29 +16,46 @@ package brave.internal.codec;
 import org.junit.Test;
 
 import static brave.internal.codec.JsonEscaper.jsonEscape;
+import static brave.internal.codec.JsonEscaper.jsonEscapedSizeInBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // initially a copy of zipkin2.internal.JsonEscaperTest
 public class JsonEscaperTest {
+
+  @Test public void testJsonEscapedSizeInBytes() {
+    assertThat(jsonEscapedSizeInBytes(new String(new char[] {0, 'a', 1})))
+        .isEqualTo(13);
+    assertThat(jsonEscapedSizeInBytes(new String(new char[] {'"', '\\', '\t', '\b'})))
+        .isEqualTo(8);
+    assertThat(jsonEscapedSizeInBytes(new String(new char[] {'\n', '\r', '\f'})))
+        .isEqualTo(6);
+    assertThat(jsonEscapedSizeInBytes("\u2028 and \u2029"))
+        .isEqualTo(17);
+    assertThat(jsonEscapedSizeInBytes("\"foo"))
+        .isEqualTo(5);
+  }
+
+  byte[] buf = new byte[20];
+
   @Test public void testJsonEscape() {
-    StringBuilder builder = new StringBuilder();
-    jsonEscape(new String(new char[] {0, 'a', 1}), builder);
-    assertThat(builder).hasToString("\\u0000a\\u0001");
+    WriteBuffer buffer = new WriteBuffer(buf, 0);
+    jsonEscape(new String(new char[] {0, 'a', 1}), buffer);
+    assertThat(buffer).hasToString("\\u0000a\\u0001");
 
-    builder.setLength(0);
-    jsonEscape(new String(new char[] {'"', '\\', '\t', '\b'}), builder);
-    assertThat(builder).hasToString("\\\"\\\\\\t\\b");
+    buffer.pos = 0;
+    jsonEscape(new String(new char[] {'"', '\\', '\t', '\b'}), buffer);
+    assertThat(buffer).hasToString("\\\"\\\\\\t\\b");
 
-    builder.setLength(0);
-    jsonEscape(new String(new char[] {'\n', '\r', '\f'}), builder);
-    assertThat(builder).hasToString("\\n\\r\\f");
+    buffer.pos = 0;
+    jsonEscape(new String(new char[] {'\n', '\r', '\f'}), buffer);
+    assertThat(buffer).hasToString("\\n\\r\\f");
 
-    builder.setLength(0);
-    jsonEscape("\u2028 and \u2029", builder);
-    assertThat(builder).hasToString("\\u2028 and \\u2029");
+    buffer.pos = 0;
+    jsonEscape("\u2028 and \u2029", buffer);
+    assertThat(buffer).hasToString("\\u2028 and \\u2029");
 
-    builder.setLength(0);
-    jsonEscape("\"foo", builder);
-    assertThat(builder).hasToString("\\\"foo");
+    buffer.pos = 0;
+    jsonEscape("\"foo", buffer);
+    assertThat(buffer).hasToString("\\\"foo");
   }
 }

--- a/brave/src/test/java/brave/internal/codec/JsonWriterTest.java
+++ b/brave/src/test/java/brave/internal/codec/JsonWriterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JsonWriterTest {
+  @Test public void doesntStackOverflowOnToBufferWriterBug_lessThanBytes() {
+    class FooWriter implements WriteBuffer.Writer<Object> {
+      @Override public int sizeInBytes(Object value) {
+        return 2;
+      }
+
+      @Override public void write(Object value, WriteBuffer buffer) {
+        buffer.writeByte('a');
+        throw new RuntimeException("buggy");
+      }
+    }
+
+    class Foo {
+      @Override public String toString() {
+        return new String(JsonWriter.write(new FooWriter(), this), UTF_8);
+      }
+    }
+
+    Foo foo = new Foo();
+    assertThatThrownBy(foo::toString)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Bug found using FooWriter to write Foo as json. Wrote 1/2 bytes: a");
+  }
+
+  @Test public void doesntStackOverflowOnToBufferWriterBug_Overflow() {
+    // pretend there was a bug calculating size, ex it calculated incorrectly as to small
+    class FooWriter implements WriteBuffer.Writer {
+      @Override public int sizeInBytes(Object value) {
+        return 2;
+      }
+
+      @Override public void write(Object value, WriteBuffer buffer) {
+        buffer.writeByte('a');
+        buffer.writeByte('b');
+        buffer.writeByte('c'); // wrote larger than size!
+      }
+    }
+
+    class Foo {
+      @Override public String toString() {
+        return new String(JsonWriter.write(new FooWriter(), this), UTF_8);
+      }
+    }
+
+    Foo foo = new Foo();
+    assertThatThrownBy(foo::toString)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Bug found using FooWriter to write Foo as json. Wrote 2/2 bytes: ab");
+  }
+}

--- a/brave/src/test/java/brave/internal/codec/WriteBufferTest.java
+++ b/brave/src/test/java/brave/internal/codec/WriteBufferTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Originally a subset of zipkin2.internal.WriteBuffer
+public class WriteBufferTest {
+  // Adapted from http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
+  @Test public void utf8SizeInBytes() {
+    for (int codepoint = 0; codepoint <= 0x10FFFF; codepoint++) {
+      if (codepoint == 0xD800) codepoint = 0xDFFF + 1; // skip surrogates
+      if (Character.isDefined(codepoint)) {
+        String test = new String(Character.toChars(codepoint));
+        int expected = test.getBytes(UTF_8).length;
+        int actual = WriteBuffer.utf8SizeInBytes(test);
+        if (actual != expected) {
+          throw new AssertionError(actual + " length != " + expected + " for " + codepoint);
+        }
+      }
+    }
+  }
+
+  /** Uses test data and codepoint wrapping trick from okhttp3.FormBodyTest */
+  @Test public void utf8_malformed() {
+    for (int codepoint : Arrays.asList(0xD800, 0xDFFF, 0xD83D)) {
+      String test = new String(new int[] {'a', codepoint, 'c'}, 0, 3);
+      assertThat(WriteBuffer.utf8SizeInBytes(test))
+          .isEqualTo(3);
+
+      byte[] bytes = new byte[3];
+      WriteBuffer.wrap(bytes).writeUtf8(test);
+      assertThat(bytes)
+          .containsExactly('a', '?', 'c');
+    }
+  }
+
+  @Test public void utf8_21Bit_truncated() {
+    // https://en.wikipedia.org/wiki/Mahjong_Tiles_(Unicode_block)
+    char[] array = "\uD83C\uDC00\uD83C\uDC01".toCharArray();
+    array[array.length - 1] = 'c';
+    String test = new String(array, 0, array.length - 1);
+    assertThat(WriteBuffer.utf8SizeInBytes(test))
+        .isEqualTo(5);
+
+    byte[] bytes = new byte[5];
+    WriteBuffer.wrap(bytes).writeUtf8(test);
+    assertThat(new String(bytes, UTF_8))
+        .isEqualTo("\uD83C\uDC00?");
+  }
+
+  @Test public void utf8_21Bit_brokenLowSurrogate() {
+    // https://en.wikipedia.org/wiki/Mahjong_Tiles_(Unicode_block)
+    char[] array = "\uD83C\uDC00\uD83C\uDC01".toCharArray();
+    array[array.length - 1] = 'c';
+    String test = new String(array);
+    assertThat(WriteBuffer.utf8SizeInBytes(test))
+        .isEqualTo(6);
+
+    byte[] bytes = new byte[6];
+    WriteBuffer.wrap(bytes).writeUtf8(test);
+    assertThat(new String(bytes, UTF_8))
+        .isEqualTo("\uD83C\uDC00?c");
+  }
+
+  @Test public void utf8_matchesJRE() {
+    // examples from http://utf8everywhere.org/
+    for (String string : Arrays.asList(
+        "Приве́т नमस्ते שָׁלוֹם",
+        "ю́ cyrillic small letter yu with acute",
+        "∃y ∀x ¬(x ≺ y)"
+    )) {
+      int encodedSize = WriteBuffer.utf8SizeInBytes(string);
+      assertThat(encodedSize)
+          .isEqualTo(string.getBytes(UTF_8).length);
+
+      byte[] bytes = new byte[encodedSize];
+      WriteBuffer.wrap(bytes).writeUtf8(string);
+      assertThat(new String(bytes, UTF_8))
+          .isEqualTo(string);
+    }
+  }
+
+  @Test public void utf8_matchesAscii() {
+    String ascii = "86154a4ba6e913854d1e00c0db9010db";
+    int encodedSize = WriteBuffer.utf8SizeInBytes(ascii);
+    assertThat(encodedSize)
+        .isEqualTo(ascii.length());
+
+    byte[] bytes = new byte[encodedSize];
+    WriteBuffer.wrap(bytes).writeAscii(ascii);
+    assertThat(new String(bytes, UTF_8))
+        .isEqualTo(ascii);
+
+    WriteBuffer.wrap(bytes).writeUtf8(ascii);
+    assertThat(new String(bytes, UTF_8))
+        .isEqualTo(ascii);
+  }
+
+  @Test public void emoji() {
+    byte[] emojiBytes = {(byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x81};
+    String emoji = new String(emojiBytes, UTF_8);
+    assertThat(WriteBuffer.utf8SizeInBytes(emoji))
+        .isEqualTo(emojiBytes.length);
+
+    byte[] bytes = new byte[emojiBytes.length];
+    WriteBuffer.wrap(bytes).writeUtf8(emoji);
+    assertThat(bytes)
+        .isEqualTo(emojiBytes);
+  }
+
+  @Test public void writeAscii_long() {
+    assertThat(writeAscii(-1005656679588439279L))
+        .isEqualTo("-1005656679588439279");
+    assertThat(writeAscii(0L))
+        .isEqualTo("0");
+    assertThat(writeAscii(-9223372036854775808L /* Long.MIN_VALUE */))
+        .isEqualTo("-9223372036854775808");
+    assertThat(writeAscii(123456789L))
+        .isEqualTo("123456789");
+  }
+
+  static String writeAscii(long v) {
+    byte[] bytes = new byte[WriteBuffer.asciiSizeInBytes(v)];
+    WriteBuffer.wrap(bytes).writeAscii(v);
+    return new String(bytes, UTF_8);
+  }
+
+  // Test creating Buffer for a long string
+  @Test public void writeString() {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < 100000; i++) {
+      builder.append("a");
+    }
+    String string = builder.toString();
+    byte[] bytes = new byte[string.length()];
+    WriteBuffer.wrap(bytes).writeAscii(string);
+    assertThat(new String(bytes, UTF_8)).isEqualTo(string);
+  }
+}

--- a/brave/src/test/java/brave/internal/codec/ZipkinJsonV2JsonWriterTest.java
+++ b/brave/src/test/java/brave/internal/codec/ZipkinJsonV2JsonWriterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import brave.Span;
+import brave.Tags;
+import brave.handler.MutableSpan;
+import brave.handler.MutableSpanTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipkinJsonV2JsonWriterTest {
+  ZipkinV2JsonWriter jsonWriter = new ZipkinV2JsonWriter(Tags.ERROR);
+  WriteBuffer buffer = new WriteBuffer(new byte[512], 0);
+
+  MutableSpan clientSpan = new MutableSpan();
+
+  @Before public void createClientSpan() {
+    clientSpan.traceId("1"); // note: we didn't pad here.. it is done implicitly
+    clientSpan.localRootId("2"); // not a zipkin v2 field
+    clientSpan.parentId("2");
+    clientSpan.id("3");
+    clientSpan.name("get");
+    clientSpan.kind(Span.Kind.CLIENT);
+    clientSpan.localServiceName("frontend");
+    clientSpan.localIp("127.0.0.1");
+    clientSpan.remoteServiceName("backend");
+    clientSpan.remoteIpAndPort("192.168.99.101", 9000);
+    clientSpan.startTimestamp(1000L);
+    clientSpan.finishTimestamp(1200L);
+    clientSpan.annotate(1100L, "foo");
+    clientSpan.tag("http.path", "/api");
+    clientSpan.tag("clnt/finagle.version", "6.45.0");
+  }
+
+  @Test public void sizeInBytes_matchesWhatsWritten() {
+    assertThat(jsonWriter.sizeInBytes(MutableSpanTest.PERMUTATIONS.get(0).get()))
+        .isEqualTo(2); // {}
+
+    // check for simple bugs
+    for (int i = 1, length = MutableSpanTest.PERMUTATIONS.size(); i < length; i++) {
+      buffer.pos = 0;
+      MutableSpan span = MutableSpanTest.PERMUTATIONS.get(i).get();
+
+      jsonWriter.write(span, buffer);
+      int size = jsonWriter.sizeInBytes(span);
+      assertThat(jsonWriter.sizeInBytes(span))
+          .withFailMessage("expected to write %s bytes: was %s for %s", size, buffer.pos, span)
+          .isEqualTo(buffer.pos);
+    }
+  }
+
+  @Test public void missingFields_testCases() {
+    jsonWriter.write(MutableSpanTest.PERMUTATIONS.get(0).get(), buffer);
+    assertThat(buffer.toString()).isEqualTo("{}");
+
+    // check for simple bugs
+    for (int i = 1, length = MutableSpanTest.PERMUTATIONS.size(); i < length; i++) {
+      buffer.pos = 0;
+
+      MutableSpan span = MutableSpanTest.PERMUTATIONS.get(i).get();
+      jsonWriter.write(span, buffer);
+
+      assertThat(buffer.toString())
+          .doesNotContain("null")
+          .doesNotContain(":0");
+    }
+  }
+
+  @Test public void writeClientSpan() {
+    jsonWriter.write(clientSpan, buffer);
+
+    assertThat(buffer.toString()).isEqualTo("{"
+        + "\"traceId\":\"0000000000000001\",\"parentId\":\"0000000000000002\",\"id\":\"0000000000000003\","
+        + "\"kind\":\"CLIENT\",\"name\":\"get\",\"timestamp\":1000,\"duration\":200,"
+        + "\"localEndpoint\":{\"serviceName\":\"frontend\",\"ipv4\":\"127.0.0.1\"},"
+        + "\"remoteEndpoint\":{\"serviceName\":\"backend\",\"ipv4\":\"192.168.99.101\",\"port\":9000},"
+        + "\"annotations\":[{\"timestamp\":1100,\"value\":\"foo\"}],"
+        + "\"tags\":{\"http.path\":\"/api\",\"clnt/finagle.version\":\"6.45.0\"}"
+        + "}");
+  }
+}

--- a/instrumentation/dubbo-rpc/README.md
+++ b/instrumentation/dubbo-rpc/README.md
@@ -46,8 +46,8 @@ import brave.Tracing;
 import brave.rpc.RpcTracing;
 import brave.rpc.RpcRuleSampler;
 import com.alibaba.dubbo.common.extension.ExtensionFactory;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
 import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
 import brave.Span;
 
 import static brave.rpc.RpcRequestMatchers.methodEquals;
@@ -72,12 +72,14 @@ public class TracingExtensionFactory implements ExtensionFactory {
   Tracing tracing() {
     return Tracing.newBuilder()
                   .localServiceName("my-service")
-                  .addSpanHandler(new ZipkinSpanHandler(spanReporter()))
+                  .addSpanHandler(spanHandler())
                   .build();
   }
 
-  // NOTE: The reporter should be closed with a shutdown hook
-  AsyncReporter<Span> spanReporter() {
+  // NOTE: When async, the spanHandler should be closed with a shutdown hook
+  ZipkinSpanHandler spanHandler() {
+    //   (this dependency is io.zipkin.reporter2:zipkin-reporter-brave)
+    return ZipkinSpanHandler.create(AsyncReporter.builder(sender()));
 --snip--
 ```
 

--- a/instrumentation/dubbo/README.md
+++ b/instrumentation/dubbo/README.md
@@ -46,7 +46,6 @@ import brave.Tracing;
 import brave.rpc.RpcTracing;
 import brave.rpc.RpcRuleSampler;
 import org.apache.dubbo.common.extension.ExtensionFactory;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
 import brave.Span;
@@ -73,12 +72,14 @@ public class TracingExtensionFactory implements ExtensionFactory {
   Tracing tracing() {
     return Tracing.newBuilder()
                   .localServiceName("my-service")
-                  .addSpanHandler(ZipkinSpanHandler.create(spanReporter()))
+                  .addSpanHandler(spanHandler())
                   .build();
   }
 
-  // NOTE: The reporter should be closed with a shutdown hook
-  AsyncReporter<Span> spanReporter() {
+  // NOTE: When async, the spanHandler should be closed with a shutdown hook
+  ZipkinSpanHandler spanHandler() {
+    //   (this dependency is io.zipkin.reporter2:zipkin-reporter-brave)
+    return ZipkinSpanHandler.create(AsyncReporter.builder(sender()));
 --snip--
 ```
 

--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcParser.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcParser.java
@@ -16,6 +16,7 @@ package brave.grpc;
 import brave.ErrorParser;
 import brave.Span;
 import brave.SpanCustomizer;
+import brave.Tag;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext;
 import brave.rpc.RpcResponse;
@@ -49,7 +50,7 @@ public class GrpcParser extends MessageProcessor implements RpcResponseParser {
 
   /**
    * @deprecated This is only used in Zipkin reporting. Since 5.12, use {@link
-   * zipkin2.reporter.brave.ZipkinSpanHandler.Builder#errorParser(ErrorParser)}
+   * zipkin2.reporter.brave.ZipkinSpanHandler.Builder#errorTag(Tag)}
    */
   @Deprecated protected ErrorParser errorParser() {
     return ERROR_PARSER;

--- a/instrumentation/http/src/main/java/brave/http/HttpParser.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpParser.java
@@ -15,6 +15,7 @@ package brave.http;
 
 import brave.ErrorParser;
 import brave.SpanCustomizer;
+import brave.Tag;
 import brave.internal.Nullable;
 
 import static brave.http.HttpResponseParser.Default.catchAllName;
@@ -25,7 +26,7 @@ import static brave.http.HttpResponseParser.Default.catchAllName;
 
   /**
    * @deprecated This is only used in Zipkin reporting. Since 5.12, use {@link
-   * zipkin2.reporter.brave.ZipkinSpanHandler.Builder#errorParser(ErrorParser)}
+   * zipkin2.reporter.brave.ZipkinSpanHandler.Builder#errorTag(Tag)}
    */
   protected ErrorParser errorParser() {
     return ERROR_PARSER;

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
     <!-- use the same values in bom/pom.xml -->
     <zipkin.version>2.21.1</zipkin.version>
-    <zipkin-reporter.version>2.13.2</zipkin-reporter.version>
+    <zipkin-reporter.version>2.14.0</zipkin-reporter.version>
 
     <!-- Ensure older versions of spring still work -->
     <spring5.version>5.2.6.RELEASE</spring5.version>

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -23,10 +23,8 @@ Here are some example beans using the factories in this module:
   </bean>
 
   <!-- Configuration for how to buffer spans into messages for Zipkin -->
-  <bean id="spanReporter" class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
+  <bean id="zipkinSpanHandler" class="zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean">
     <property name="sender" ref="sender"/>
-    <!-- wait up to half a second for any in-flight spans on close -->
-    <property name="closeTimeout" value="500"/>
   </bean>
 
   <!-- Allows log patterns to use %{traceId} and %{spanId} -->
@@ -39,11 +37,7 @@ Here are some example beans using the factories in this module:
   <!-- Controls aspects of tracing such as the service name that shows up in the UI -->
   <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
     <property name="localServiceName" value="brave-webmvc-example"/>
-    <property name="spanHandlers">
-      <bean class="zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean">
-        <property name="spanReporter" ref="spanReporter"/>
-      </bean>
-    </property>
+    <property name="spanHandlers" ref="zipkinSpanHandler"/>
     <property name="currentTraceContext">
       <bean class="brave.spring.beans.CurrentTraceContextFactoryBean">
         <property name="scopeDecorators" ref="correlationScopeDecorator"/>

--- a/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
+++ b/spring-beans/src/test/java/brave/spring/beans/TracingFactoryBeanTest.java
@@ -128,7 +128,7 @@ public class TracingFactoryBeanTest {
     );
 
     assertThat(context.getBean("tracing", Tracing.class))
-      .extracting("tracer.spanHandler.delegate.spanReporter")
+      .extracting("tracer.spanHandler.delegate.spanReporter.delegate")
       .isEqualTo(Reporter.CONSOLE);
   }
 


### PR DESCRIPTION
This shows how a direct (zero conversion) async reporter can exist in
the next version of Zipkin Reporter. This test should be left around so
that people don't accidentally break it!

Incidentally, this can be leveraged in other libraries as well.

See https://github.com/openzipkin/zipkin/issues/3005