### PR TITLE
Test maintenance

### DIFF
--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -20,6 +20,8 @@ import brave.baggage.BaggagePropagation;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.handler.MutableSpan;
 import brave.internal.InternalPropagation;
+import brave.internal.Platform;
+import brave.internal.handler.OrphanTracker;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
@@ -134,6 +136,8 @@ public abstract class ITRemote {
   protected Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
       .localServiceName(getClass().getSimpleName())
+      // Throw an exception if anything leaked!
+      .addSpanHandler(new OrphanTracker(Platform.get().clock(), true))
       .addSpanHandler(spanHandler)
       .propagationFactory(propagationFactory)
       .currentTraceContext(currentTraceContext)

--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -133,6 +133,7 @@ public abstract class ITRemote {
 
   protected Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
+      .localServiceName(getClass().getSimpleName())
       .addSpanHandler(spanHandler)
       .propagationFactory(propagationFactory)
       .currentTraceContext(currentTraceContext)

--- a/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
@@ -280,7 +280,7 @@ public final class IntegrationTestSpanHandler extends SpanHandler implements Tes
     } else if (errorMessage != null) {
       assertThat(result.error())
           .withFailMessage(
-              "Expected %s to have an error message matching %s, but there was no error", result,
+              "Expected %s to have an error message matching [%s], but there was no error", result,
               errorMessage)
           .isNotNull();
 
@@ -288,8 +288,8 @@ public final class IntegrationTestSpanHandler extends SpanHandler implements Tes
       Pattern regex = Pattern.compile(errorMessage, Pattern.DOTALL);
       String actual = result.error().getMessage();
       assertThat(actual)
-          .withFailMessage("Expected %s to have an error message matching %s, but was %s", result,
-              errorMessage, actual)
+          .withFailMessage("Expected %s to have an error message matching [%s], but was [%s]",
+              result, errorMessage, actual)
           .matches(regex);
       assertNoErrorTag(result);
     } else if (errorTag != null) {

--- a/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
@@ -13,6 +13,7 @@
  */
 package brave.internal.recorder;
 
+import brave.Clock;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.internal.InternalPropagation;
@@ -68,8 +69,12 @@ public class PendingSpansClassLoaderTest {
 
   static class OrphanedContext implements Runnable {
     @Override public void run() {
-      PendingSpans pendingSpans = new PendingSpans(new MutableSpan(),
-        Platform.get().clock(), new OrphanTracker(Platform.get().clock()), new AtomicBoolean());
+      MutableSpan defaultSpan = new MutableSpan();
+      Clock clock = Platform.get().clock();
+      SpanHandler orphanTracker =
+          OrphanTracker.newBuilder().clock(clock).defaultSpan(defaultSpan).build();
+      PendingSpans pendingSpans =
+          new PendingSpans(defaultSpan, clock, orphanTracker, new AtomicBoolean());
 
       TraceContext context = CONTEXT.toBuilder().build(); // intentionally make a copy
       pendingSpans.getOrCreate(null, context, true);

--- a/brave-tests/src/test/java/brave/test/ITRemoteTest.java
+++ b/brave-tests/src/test/java/brave/test/ITRemoteTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test;
+
+import brave.handler.MutableSpan;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITRemoteTest {
+  static final class ITRemoteDummy extends ITRemote {
+  }
+
+  @Test public void tracer_includesClassName() {
+    ITRemoteDummy itRemote = new ITRemoteDummy();
+    itRemote.tracing.tracer().newTrace().start(1L).finish(1L);
+
+    MutableSpan span = itRemote.spanHandler.takeLocalSpan();
+    assertThat(span.localServiceName())
+        .isEqualTo("ITRemoteDummy"); // much better than "unknown"
+  }
+}

--- a/brave-tests/src/test/java/brave/test/IntegrationTestSpanHandlerTest.java
+++ b/brave-tests/src/test/java/brave/test/IntegrationTestSpanHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test;
+
+import brave.Span;
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import org.junit.Test;
+
+import static brave.Span.Kind.CLIENT;
+import static brave.handler.SpanHandler.Cause.FINISHED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class IntegrationTestSpanHandlerTest {
+  IntegrationTestSpanHandler spanHandler = new IntegrationTestSpanHandler();
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
+  MutableSpan span = new MutableSpan(context, null);
+
+  @Test public void toString_includesSpans() {
+    spanHandler.end(context, span, FINISHED);
+
+    assertThat(spanHandler)
+        .hasToString("[{\"traceId\":\"0000000000000001\",\"id\":\"0000000000000002\"}]");
+  }
+
+  /** Shows the argument is a pattern, not equals */
+  @Test public void takeRemoteSpanWithErrorMessage_pattern() {
+    span.kind(CLIENT);
+    span.startTimestamp(1L);
+    span.error(new RuntimeException("ice ice baby"));
+    span.finishTimestamp(2L);
+    spanHandler.end(context, span, FINISHED);
+
+    assertThat(spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".* ice.*")).isSameAs(span);
+  }
+
+  /**
+   * Some exceptions, like Dubbo, are multi-line where the line of interest isn't even always on the
+   * last line.
+   */
+  @Test public void takeRemoteSpanWithErrorMessage_multiline() {
+    span.kind(CLIENT);
+    span.startTimestamp(1L);
+    span.error(new RuntimeException("ice ice baby\nvanilla\nice ice baby"));
+    span.finishTimestamp(2L);
+    spanHandler.end(context, span, FINISHED);
+
+    assertThat(spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*vanilla.*")).isSameAs(span);
+  }
+
+  /**
+   * When we don't know the error message, or the message can be {@code null}, we should use {@link
+   * IntegrationTestSpanHandler#takeRemoteSpanWithError(Span.Kind)}, not {@link
+   * IntegrationTestSpanHandler#takeRemoteSpanWithErrorMessage(Span.Kind, String)} (regex).
+   */
+  @Test public void takeRemoteSpanWithErrorMessage_null_notOk() {
+    span.kind(CLIENT);
+    span.startTimestamp(1L);
+    span.error(new RuntimeException());
+    span.finishTimestamp(2L);
+    spanHandler.end(context, span, FINISHED);
+
+    assertThatThrownBy(() -> spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".+"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageEndingWith("to have an error message matching [.+], but was [null]");
+  }
+
+  @Test public void takeRemoteSpanWithError_nullMessage() {
+    span.kind(CLIENT);
+    span.startTimestamp(1L);
+    span.error(new RuntimeException());
+    span.finishTimestamp(2L);
+    spanHandler.end(context, span, FINISHED);
+
+    assertThat(spanHandler.takeRemoteSpanWithError(CLIENT)).isSameAs(span);
+  }
+}

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -486,7 +486,9 @@ public abstract class Tracing implements Closeable {
                 .build());
       }
       if (spanHandlers.isEmpty()) spanHandlers.add(new LogSpanHandler());
-      if (builder.trackOrphans) spanHandlers.add(new OrphanTracker(clock, false));
+      if (builder.trackOrphans) {
+        spanHandlers.add(OrphanTracker.newBuilder().defaultSpan(defaultSpan).clock(clock).build());
+      }
 
       // Make sure any exceptions caused by span handlers don't crash callers
       SpanHandler spanHandler =

--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -486,7 +486,7 @@ public abstract class Tracing implements Closeable {
                 .build());
       }
       if (spanHandlers.isEmpty()) spanHandlers.add(new LogSpanHandler());
-      if (builder.trackOrphans) spanHandlers.add(new OrphanTracker(clock));
+      if (builder.trackOrphans) spanHandlers.add(new OrphanTracker(clock, false));
 
       // Make sure any exceptions caused by span handlers don't crash callers
       SpanHandler spanHandler =

--- a/brave/src/main/java/brave/internal/handler/OrphanTracker.java
+++ b/brave/src/main/java/brave/internal/handler/OrphanTracker.java
@@ -14,6 +14,8 @@
 package brave.internal.handler;
 
 import brave.Clock;
+import brave.ScopedSpan;
+import brave.Span;
 import brave.Tracing;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
@@ -21,16 +23,77 @@ import brave.internal.Nullable;
 import brave.internal.Platform;
 import brave.internal.collect.WeakConcurrentMap;
 import brave.propagation.TraceContext;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-/** Internal support class for {@link Tracing.Builder#trackOrphans()}. */
-public final class OrphanTracker extends SpanHandler {
-  final Clock clock; // only used when a span is orphaned
+/**
+ * Internal support class for {@link Tracing.Builder#trackOrphans()}.
+ *
+ * <p>It is unlikely this can be made non-internal as there's a chicken-egg concern between what's
+ * needed to initialize this. For example, this is needed inside the {@link Tracing} constructor,
+ * and with the final reference of the internal {@link MutableSpan} it uses as well the final
+ * reference of the {@link Clock}. However, this can be used in our integration tests as we can take
+ * care to initialize those items carefully.
+ */
+// not final for tests and to avoid CI related problems with experimental final class mocks
+public class OrphanTracker extends SpanHandler {
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    MutableSpan defaultSpan;
+    Clock clock;
+    Level logLevel = Level.FINE;
+
+    /**
+     * When initializing a new span, defaults such as service name are copied. We need to be able to
+     * tell if the span at the end hook is default or not. Hence, we need access to the same default
+     * data. No default.
+     */
+    public Builder defaultSpan(MutableSpan defaultSpan) {
+      this.defaultSpan = defaultSpan;
+      return this;
+    }
+
+    /**
+     * Only used when a span is orphaned, used to add "brave.flush" annotation with the timestamp it
+     * was expunged due to garbage collection. Unless overridden by {@link
+     * Tracing.Builder#clock(Clock)}, this will be {@link Platform#clock()}. No default.
+     */
+    public Builder clock(Clock clock) {
+      this.clock = clock;
+      return this;
+    }
+
+    /**
+     * {@link Level#FINE} for production (to not fill logs) or {@link Level#WARNING} for unit tests
+     * (so bugs can be seen). Default {@link Level#FINE}
+     */
+    public Builder logLevel(Level logLevel) {
+      this.logLevel = logLevel;
+      return this;
+    }
+
+    public SpanHandler build() {
+      if (defaultSpan == null) throw new NullPointerException("defaultSpan == null");
+      if (clock == null) throw new NullPointerException("clock == null");
+      return new OrphanTracker(this);
+    }
+
+    Builder() {
+    }
+  }
+
+  final MutableSpan defaultSpan;
+  final Clock clock;
   final WeakConcurrentMap<MutableSpan, Throwable> spanToCaller = new WeakConcurrentMap<>();
-  final boolean shouldThrow;
+  final Level logLevel;
 
-  public OrphanTracker(Clock clock, boolean shouldThrow) {
-    this.clock = clock;
-    this.shouldThrow = shouldThrow;
+  OrphanTracker(Builder builder) {
+    this.defaultSpan = builder.defaultSpan;
+    this.clock = builder.clock;
+    this.logLevel = builder.logLevel;
   }
 
   @Override
@@ -42,26 +105,42 @@ public final class OrphanTracker extends SpanHandler {
     return true;
   }
 
+  /**
+   * In the case of {@link Cause#ORPHANED}, the calling thread will be an arbitrary invocation of
+   * {@link Span} or {@link ScopedSpan} as spans orphaned from GC are expunged inline (not on the GC
+   * thread). While this class is used for troubleshooting, it should do the least work possible to
+   * prevent harm to arbitrary callers.
+   */
   @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
     Throwable caller = spanToCaller.remove(span);
     if (cause != Cause.ORPHANED) return true;
-    if (caller != null) {
-      String message = span.equals(new MutableSpan(context, null))
-          ? "Span " + context + " was allocated but never used"
-          : "Span " + context + " neither finished nor flushed before GC";
-      logOrThrow(message, caller, shouldThrow);
-    }
+    boolean allocatedButNotUsed = span.equals(new MutableSpan(context, defaultSpan));
+    if (caller != null) log(context, allocatedButNotUsed, caller);
+    if (allocatedButNotUsed) return true; // skip adding an annotation
     span.annotate(clock.currentTimeMicroseconds(), "brave.flush");
     return true;
+  }
+
+  void log(TraceContext context, boolean allocatedButNotUsed, Throwable caller) {
+    Logger logger = logger();
+    if (!logger.isLoggable(logLevel)) return;
+    String message = allocatedButNotUsed
+        ? "Span " + context + " was allocated but never used"
+        : "Span " + context + " neither finished nor flushed before GC";
+    logger.log(logLevel, message, caller);
+  }
+
+  Logger logger() {
+    return LoggerHolder.LOG;
   }
 
   @Override public String toString() {
     return "OrphanTracker{}";
   }
 
-  static boolean logOrThrow(String msg, Throwable caller, boolean shouldThrow) {
-    if (shouldThrow) throw Platform.get().assertionError(msg, caller);
-    Platform.get().log(msg, caller);
-    return false;
+  // Use nested class to ensure logger isn't initialized unless it is accessed once.
+  static final class LoggerHolder {
+    /** @see Tracing.Builder#trackOrphans() which mentions this logger */
+    static final Logger LOG = Logger.getLogger(Tracing.class.getName());
   }
 }

--- a/brave/src/main/java/brave/internal/propagation/InjectorFactory.java
+++ b/brave/src/main/java/brave/internal/propagation/InjectorFactory.java
@@ -36,8 +36,8 @@ import java.util.Set;
  *
  * <p>A deferred injector checks if the {@code request} parameter is an instance of {@link
  * Request}, it considers {@link Request#spanKind()}. If so, it uses this for injection formats
- * accordingly. If not, a {@linkplain Builder#injectorFunction(InjectorFunction...) default
- * function} is used.
+ * accordingly. If not, a {@linkplain Builder#injectorFunction(InjectorFunction,
+ * InjectorFunction...) default function} is used.
  *
  * <p><em>Note</em>: Instrumentation that have not been recently updated may be remote, but neither
  * implement {@link RemoteSetter} nor {@link Request}. In other words, lack of these types do not

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -63,7 +63,7 @@ public class TracerTest {
     .add(SingleBaggageField.remote(BAGGAGE_FIELD)).build();
   Tracer tracer = Tracing.newBuilder()
     .addSpanHandler(spans)
-    .addSpanHandler(new OrphanTracker(Platform.get().clock()))
+    .trackOrphans()
     .propagationFactory(new Propagation.Factory() {
       @Deprecated @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
         return propagationFactory.create(keyFactory);

--- a/brave/src/test/java/brave/internal/handler/OrphanTrackerTest.java
+++ b/brave/src/test/java/brave/internal/handler/OrphanTrackerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.handler;
+
+import brave.TracerTest;
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrphanTrackerTest {
+  @Rule public TestName testName = new TestName();
+
+  List<String> messages = new ArrayList<>();
+  List<Throwable> throwables = new ArrayList<>();
+  AtomicInteger clock = new AtomicInteger(1);
+  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+  MutableSpan defaultSpan, span;
+  OrphanTracker tracker;
+
+  @Before public void setup() {
+    defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName(TracerTest.class.getSimpleName());
+    defaultSpan.localIp("127.0.0.1");
+    span = new MutableSpan(context, defaultSpan); // same as how PendingSpans initializes
+
+    tracker = orphanTrackerWithFakeLogger();
+  }
+
+  @Test public void allocatedAndUsed_logsAndAddsFlushAnnotation() {
+    span.startTimestamp(1L);
+    assertThat(tracker.begin(context, span, null)).isTrue();
+    assertThat(tracker.end(context, span, SpanHandler.Cause.ORPHANED)).isTrue();
+
+    assertThat(span.annotationTimestampAt(0)).isOne(); // initial value of clock
+    assertThat(span.annotationValueAt(0)).isEqualTo("brave.flush");
+
+    assertThat(messages).containsExactly(
+        "Span 0000000000000001/0000000000000002 neither finished nor flushed before GC"
+    );
+    assertThrowableIdentifiesCaller();
+  }
+
+  /** This prevents overhead on dropped spans */
+  @Test public void allocatedButNotUsed_logsButDoesntAddFlushAnnotation() {
+    assertThat(tracker.begin(context, span, null)).isTrue();
+    // We return true to let metrics handlers work
+    assertThat(tracker.end(context, span, SpanHandler.Cause.ORPHANED)).isTrue();
+
+    assertThat(span.annotationCount()).isZero();
+
+    assertThat(messages).containsExactly(
+        "Span 0000000000000001/0000000000000002 was allocated but never used"
+    );
+    assertThrowableIdentifiesCaller();
+  }
+
+  void assertThrowableIdentifiesCaller() {
+    assertThat(throwables).hasSize(1);
+    assertThat(throwables.get(0))
+        .hasNoCause()
+        .hasMessage("Thread main allocated span here")
+        .hasStackTraceContaining(testName.getMethodName());
+  }
+
+  OrphanTracker orphanTrackerWithFakeLogger() {
+    Logger logger = new Logger("", null) {
+      {
+        setLevel(Level.ALL);
+      }
+
+      @Override public void log(Level level, String msg, Throwable throwable) {
+        assertThat(level).isEqualTo(Level.FINE);
+        messages.add(msg);
+        throwables.add(throwable);
+      }
+    };
+
+    return new OrphanTracker(OrphanTracker.newBuilder()
+        .clock(clock::getAndIncrement).defaultSpan(defaultSpan)) {
+      @Override Logger logger() {
+        return logger;
+      }
+    };
+  }
+}

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -421,7 +421,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     }
 
     // We don't know the transport exception
-    return spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".+");
+    return spanHandler.takeRemoteSpanWithError(CLIENT);
   }
 
   protected String url(String pathIncludingQuery) {


### PR DESCRIPTION
* Fixes bug where ITHttpClient used a pattern where it shouldn't
* Fixes ITRemote which should use a sensible service name (as spans end up in logs)
* Adds some basic tests of the IT fixtures