### PR TITLE
Bump Kafka versions to 2.5.0

### DIFF
--- a/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -29,6 +31,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -100,6 +103,10 @@ public class TracingProducerBenchmarks {
 
     @Override
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> map, String s) {
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
     }
 
     @Override public void commitTransaction() {

--- a/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
@@ -106,7 +105,8 @@ public class TracingProducerBenchmarks {
     }
 
     @Override
-    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+      ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
     }
 
     @Override public void commitTransaction() {

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -28,13 +28,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+
+import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -305,6 +300,11 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions,
     Duration timeout) {
     return delegate.endOffsets(partitions, timeout);
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 2.5
+  public ConsumerGroupMetadata groupMetadata() {
+    return delegate.groupMetadata();
   }
 
   @Override public void close() {

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -28,8 +28,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -37,6 +38,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
 
 final class TracingProducer<K, V> implements Producer<K, V> {
   final Producer<K, V> delegate;
@@ -165,5 +167,11 @@ final class TracingProducer<K, V> implements Producer<K, V> {
   public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
     String consumerGroupId) {
     delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 2.5
+  public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+    ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
+    delegate.sendOffsetsToTransaction(offsets, groupMetadata);
   }
 }

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -786,7 +786,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
     assertThat(spanProcessor.error()).hasMessage("illegal-argument");
     assertChildOf(spanProcessor, spanInput);
 
-    assertThat(!streams.state().isRunning());
+    assertThat(!streams.state().isRunningOrRebalancing());
 
     streams.close();
     streams.cleanUp();
@@ -838,7 +838,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
     assertThat(spanProcessor.error()).hasMessage("file-not-found");
     assertChildOf(spanProcessor, spanInput);
 
-    assertThat(!streams.state().isRunning());
+    assertThat(!streams.state().isRunningOrRebalancing());
 
     streams.close();
     streams.cleanUp();
@@ -1342,7 +1342,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
         Thread.currentThread().interrupt();
         throw new AssertionError(e);
       }
-    } while (!streams.state().isRunning());
+    } while (!streams.state().isRunningOrRebalancing());
   }
 
   KafkaStreams buildKafkaStreams(Topology topology) {

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
     <resteasy.version>3.11.2.Final</resteasy.version>
 
-    <kafka.version>2.4.1</kafka.version>
+    <kafka.version>2.5.0</kafka.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.1.8</kafka-junit.version>
+    <kafka-junit.version>4.1.9</kafka-junit.version>
     <activemq.version>5.15.12</activemq.version>
     <spring-rabbit.version>2.2.6.RELEASE</spring-rabbit.version>
 


### PR DESCRIPTION
Btw, if https://github.com/openzipkin-contrib/zipkin-storage-kafka/pull/70 is successful, we could evaluate replacing kafka-junit with Testcontainers :)