### PR TITLE
Internally synchronizes TestSpanHandler

### DIFF
--- a/brave-tests/src/main/java/brave/test/TestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/TestSpanHandler.java
@@ -13,12 +13,14 @@
  */
 package brave.test;
 
+import brave.Span;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.junit.rules.TestRule;
 
 /**
  * Simpler variant of {@link IntegrationTestSpanHandler} appropriate for single-threaded
@@ -40,6 +42,24 @@ import java.util.List;
  *     .isEqualTo("foo");
  * }
  * }</pre>
+ *
+ * <h3>Comparison with {@link IntegrationTestSpanHandler}</h3>
+ * It is possible to use this type in multi-threaded tests, but there are usually problems that
+ * arise better solved by {@link IntegrationTestSpanHandler}. Here's a few examples.
+ *
+ * <p>Multi-threaded tests typically end up with timing issues which can lead to broken builds (aka
+ * "flakey tests"). These are sometimes mitigated by polling assertions such as <a
+ * href="https://github.com/awaitility/awaitility">Awaitility</a>.
+ *
+ * <p>Even with polling assertions, multi-threaded tests have more error cases. Historically, we
+ * found tests passing even in error because people only checked the name. {@link
+ * IntegrationTestSpanHandler} prevents silent errors from passing.
+ *
+ * <p>Usually, multi-threaded tests involve remote spans. {@link IntegrationTestSpanHandler} has
+ * utilities made for remote spans, such as {@link IntegrationTestSpanHandler#takeRemoteSpan(Span.Kind)}.
+ *
+ * <p>It is a common instrumentation bug to accidentally create redundant spans. {@link
+ * IntegrationTestSpanHandler} is a {@link TestRule}, which verifies all spans are accounted for.
  *
  * @see IntegrationTestSpanHandler
  * @since 5.12

--- a/brave-tests/src/main/java/brave/test/TestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/TestSpanHandler.java
@@ -17,7 +17,6 @@ import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 

--- a/brave-tests/src/main/java/brave/test/TestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/TestSpanHandler.java
@@ -45,7 +45,7 @@ import org.junit.rules.TestRule;
  *
  * <h3>Comparison with {@link IntegrationTestSpanHandler}</h3>
  * It is possible to use this type in multi-threaded tests, but there are usually problems that
- * arise better solved by {@link IntegrationTestSpanHandler}. Here's a few examples.
+ * arise better solved by {@link IntegrationTestSpanHandler}. Here are a few examples.
  *
  * <p>Multi-threaded tests typically end up with timing issues which can lead to broken builds (aka
  * "flakey tests"). These are sometimes mitigated by polling assertions such as <a

--- a/brave-tests/src/main/java/brave/test/TestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/TestSpanHandler.java
@@ -17,6 +17,7 @@ import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -45,30 +46,40 @@ import java.util.List;
  * @since 5.12
  */
 public final class TestSpanHandler extends SpanHandler implements Iterable<MutableSpan> {
-  final List<MutableSpan> spans = new ArrayList<>();
+  // Synchronized not to discourage IntegrationTestSpanHandler when it should be used.
+  // Rather, this allows iterative conversion of test code from custom Zipkin reporters to Brave.
+  final List<MutableSpan> spans = new ArrayList<>(); // guarded by itself
 
   public MutableSpan get(int i) {
-    return spans.get(i);
+    synchronized (spans) {
+      return spans.get(i);
+    }
   }
 
   public List<MutableSpan> spans() {
-    return spans;
+    synchronized (spans) { // avoid Iterator pitfalls noted in Collections.synchronizedList
+      return new ArrayList<>(spans);
+    }
   }
 
   @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
-    spans.add(span);
+    synchronized (spans) {
+      spans.add(span);
+    }
     return true;
   }
 
   @Override public Iterator<MutableSpan> iterator() {
-    return spans.iterator();
+    return spans().iterator();
   }
 
   public void clear() {
-    spans.clear();
+    synchronized (spans) {
+      spans.clear();
+    }
   }
 
   @Override public String toString() {
-    return "TestSpanHandler{" + spans + "}";
+    return "TestSpanHandler{" + spans() + "}";
   }
 }


### PR DESCRIPTION
This synchronizes `TestSpanHandler` internally to help people migrate
off tools like Sleuth's `ArrayListSpanReporter` which is pinned to
Zipkin types.