### PR TITLE
Lets those using IntegrationTestSpanHandler know the difference between orphans and spans never started

### DIFF
--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -231,4 +231,12 @@ public abstract class ITRemote {
       .withFailMessage("Expected to have parent ID(%s): %s", parent.id(), child)
       .isEqualTo(parent.id());
   }
+
+  protected void assertNoError(MutableSpan result) {
+    IntegrationTestSpanHandler.assertNoError(result);
+  }
+
+  protected void assertNoErrorTag(MutableSpan result) {
+    IntegrationTestSpanHandler.assertNoErrorTag(result);
+  }
 }

--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -20,8 +20,6 @@ import brave.baggage.BaggagePropagation;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.handler.MutableSpan;
 import brave.internal.InternalPropagation;
-import brave.internal.Platform;
-import brave.internal.handler.OrphanTracker;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.Propagation;
@@ -33,7 +31,6 @@ import brave.sampler.Sampler;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.logging.Level;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
@@ -109,7 +106,6 @@ public abstract class ITRemote {
   protected final Propagation.Factory propagationFactory;
   protected Tracing tracing; // mutable for test-specific configuration!
 
-  final MutableSpan defaultSpan;
   final Closeable checkForLeakedScopes; // internal to this type
 
   /** Subclass to override the builder. The result will have {@link StrictScopeDecorator} added */
@@ -132,21 +128,13 @@ public abstract class ITRemote {
       .add(SingleBaggageField.newBuilder(BAGGAGE_FIELD)
         .addKeyName(BAGGAGE_FIELD_KEY)
         .build()).build();
-    defaultSpan = new MutableSpan();
-    defaultSpan.localServiceName(getClass().getSimpleName());
-    defaultSpan.localIp("127.0.0.1"); // Prevent implicit lookups
     tracing = tracingBuilder(Sampler.ALWAYS_SAMPLE).build();
   }
 
   protected Tracing.Builder tracingBuilder(Sampler sampler) {
     return Tracing.newBuilder()
-      .localServiceName(defaultSpan.localServiceName())
-      .localIp(defaultSpan.localIp())
-      .addSpanHandler(OrphanTracker.newBuilder()
-        .defaultSpan(defaultSpan)
-        .clock(Platform.get().clock())
-        .logLevel(Level.WARNING) // Default is FINE: invisible in CI.
-        .build())
+      .localServiceName(getClass().getSimpleName())
+      .localIp("127.0.0.1") // Prevent implicit lookups
       .addSpanHandler(spanHandler)
       .propagationFactory(propagationFactory)
       .currentTraceContext(currentTraceContext)
@@ -242,13 +230,5 @@ public abstract class ITRemote {
     assertThat(child.parentId())
       .withFailMessage("Expected to have parent ID(%s): %s", parent.id(), child)
       .isEqualTo(parent.id());
-  }
-
-  protected void assertNoError(MutableSpan result) {
-    IntegrationTestSpanHandler.assertNoError(result);
-  }
-
-  protected void assertNoErrorTag(MutableSpan result) {
-    IntegrationTestSpanHandler.assertNoErrorTag(result);
   }
 }

--- a/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
@@ -134,7 +134,7 @@ public final class IntegrationTestSpanHandler extends SpanHandler implements Tes
     intentionallyWrongDefaultSpan.tag("not", "me");
     orphanTracker = OrphanTracker.newBuilder()
         .defaultSpan(intentionallyWrongDefaultSpan)
-        // This will not be exactly the right timestamp Tracing.Builder.clock is overridden.
+        // This will not be exactly the right timestamp when Tracing.Builder.clock is overridden.
         // However, it is rare to override this in an integration test and complex to pass it.
         .clock(Platform.get().clock())
         // Make sure CI can see when things leak: Intentional leak tests shouldn't use this handler.

--- a/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * This is a special span reporter for remote integration tests.
  *
- * <p>Ex.
+ * <p>Ex. The following is similar to our base test class {@link ITRemote}:
  * <pre>{@code
  * @Rule public IntegrationTestSpanHandler testSpanHandler = new IntegrationTestSpanHandler();
  *
@@ -46,11 +46,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   tracing.close();
  * }
  *
- * @Test public void test() {
- *   tracing.tracer().startScopedSpan("foo").finish();
+ * @Test public void onTransportException_setError() {
+ *   server.stop();
  *
- *   assertThat(takeLocalSpan().name())
- *     .isEqualTo("foo");
+ *   assertThatThrownBy(() -> client.get().sayHello("jorge"))
+ *       .isInstanceOf(RpcException.class);
+ *
+ *   spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*RemotingException.*");
  * }
  * }</pre>
  *

--- a/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
+++ b/brave-tests/src/main/java/brave/test/IntegrationTestSpanHandler.java
@@ -17,10 +17,13 @@ import brave.Span.Kind;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.internal.Nullable;
+import brave.internal.Platform;
+import brave.internal.handler.OrphanTracker;
 import brave.propagation.TraceContext;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
@@ -31,12 +34,33 @@ import org.junit.runners.model.Statement;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * This is a special span reporter for remote integration tests. It has a few features to ensure
- * tests cover common instrumentation bugs. Most of this optimizes for instrumentation occurring on
- * a different thread than main (which does the assertions).
+ * This is a special span reporter for remote integration tests.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * @Rule public IntegrationTestSpanHandler testSpanHandler = new IntegrationTestSpanHandler();
+ *
+ * Tracing tracing = Tracing.newBuilder().addSpanHandler(testSpanHandler).build();
+ *
+ * @After public void close() {
+ *   tracing.close();
+ * }
+ *
+ * @Test public void test() {
+ *   tracing.tracer().startScopedSpan("foo").finish();
+ *
+ *   assertThat(takeLocalSpan().name())
+ *     .isEqualTo("foo");
+ * }
+ * }</pre>
+ *
+ * <p>This type has a few features not in {@link TestSpanHandler}, that cover common
+ * instrumentation bugs. Most of this optimizes for instrumentation occurring on a different thread
+ * than main (which does the assertions).
  *
  * <p><pre><ul>
  *   <li>Spans report into a concurrent blocking queue to prevent assertions race conditions</li>
+ *   <li>Spans orphaned by garbage collected result in log warnings and assertion failures</li>
  *   <li>After tests complete, the queue is strictly checked to catch redundant span reporting</li>
  * </ul></pre>
  *
@@ -90,13 +114,30 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public final class IntegrationTestSpanHandler extends SpanHandler implements TestRule {
   static final String ANY_STRING = ".+";
+
   /**
    * When testing servers or asynchronous clients, spans are finished on a worker thread. In order
    * to read them on the main thread, we use a concurrent queue. As some implementations report
    * after a response is sent, we use a blocking queue to prevent race conditions in tests.
    */
-  BlockingQueue<MutableSpan> spans = new LinkedBlockingQueue<>();
+  final BlockingQueue<MutableSpan> spans = new LinkedBlockingQueue<>();
+  final SpanHandler orphanTracker;
   boolean ignoreAnySpans;
+
+  public IntegrationTestSpanHandler() {
+    // OrphanTracker detects to see if it should add "brave.flushed" or not, as it is used in
+    // production some times and avoiding this could be helpful. This forces a failed match,
+    // so that we can detect orphans even when no data was added.
+    MutableSpan intentionallyWrongDefaultSpan = new MutableSpan();
+    intentionallyWrongDefaultSpan.tag("not", "me");
+    orphanTracker = OrphanTracker.newBuilder()
+        .defaultSpan(intentionallyWrongDefaultSpan)
+        // This will not be exactly the right timestamp Tracing.Builder.clock is overridden.
+        // However, it is rare to override this in an integration test and complex to pass it.
+        .clock(Platform.get().clock())
+        // Make sure CI can see when things leak: Intentional leak tests shouldn't use this handler.
+        .logLevel(Level.WARNING).build();
+  }
 
   /**
    * Call this before throwing an {@link AssumptionViolatedException}, when there's a chance a span
@@ -158,8 +199,14 @@ public final class IntegrationTestSpanHandler extends SpanHandler implements Tes
         .withFailMessage("Timeout waiting for span")
         .isNotNull();
 
+    assertThat(result.containsAnnotation("brave.flush"))
+        .withFailMessage("Orphaned span found: %s\n"
+            + "Look for code missing span.flush() or span.finish().", result)
+        .isFalse();
+
     assertThat(result.startTimestamp())
-        .withFailMessage("Expected a startTimestamp: %s", result)
+        .withFailMessage("Expected a startTimestamp: %s\n"
+            + "Look for code missing span.start().", result)
         .isNotZero();
 
     if (flushed) {
@@ -322,7 +369,17 @@ public final class IntegrationTestSpanHandler extends SpanHandler implements Tes
         .isNull();
   }
 
+  @Override
+  public boolean begin(TraceContext context, MutableSpan span, @Nullable TraceContext parent) {
+    return orphanTracker.begin(context, span, parent);
+  }
+
+  @Override public boolean handlesAbandoned() {
+    return orphanTracker.handlesAbandoned();
+  }
+
   @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
+    orphanTracker.end(context, span, cause);
     spans.add(span);
     return true;
   }

--- a/brave-tests/src/test/java/brave/test/IntegrationTestSpanHandlerTest.java
+++ b/brave-tests/src/test/java/brave/test/IntegrationTestSpanHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import static brave.Span.Kind.CLIENT;
 import static brave.handler.SpanHandler.Cause.FINISHED;
+import static brave.handler.SpanHandler.Cause.ORPHANED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -27,6 +28,25 @@ public class IntegrationTestSpanHandlerTest {
   IntegrationTestSpanHandler spanHandler = new IntegrationTestSpanHandler();
   TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(2L).build();
   MutableSpan span = new MutableSpan(context, null);
+
+  @Test public void goodMessageForUnstartedSpan() {
+    spanHandler.end(context, span, FINISHED); // NOT ABANDONED!
+
+    assertThatThrownBy(spanHandler::takeLocalSpan)
+        .hasMessage(
+            "Expected a startTimestamp: {\"traceId\":\"0000000000000001\",\"id\":\"0000000000000002\"}\n"
+                + "Look for code missing span.start().");
+  }
+
+  @Test public void goodMessageForOrphanedSpan() {
+    spanHandler.begin(context, span, null);
+    spanHandler.end(context, span, ORPHANED);
+
+    assertThatThrownBy(spanHandler::takeLocalSpan)
+        .hasMessageStartingWith("Orphaned span found")
+        .hasMessageContaining("brave.flush")
+        .hasMessageEndingWith("Look for code missing span.flush() or span.finish().");
+  }
 
   @Test public void toString_includesSpans() {
     spanHandler.end(context, span, FINISHED);

--- a/brave-tests/src/test/java/brave/test/IntegrationTestSpanHandlerTest.java
+++ b/brave-tests/src/test/java/brave/test/IntegrationTestSpanHandlerTest.java
@@ -30,7 +30,7 @@ public class IntegrationTestSpanHandlerTest {
   MutableSpan span = new MutableSpan(context, null);
 
   @Test public void goodMessageForUnstartedSpan() {
-    spanHandler.end(context, span, FINISHED); // NOT ABANDONED!
+    spanHandler.end(context, span, FINISHED); // NOT ORPHANED!
 
     assertThatThrownBy(spanHandler::takeLocalSpan)
         .hasMessage(


### PR DESCRIPTION
This integrates orphan handling so it is easier to tell if a span was
orphaned, or simply never started. This came up in Sleuth where some
integration tests never started a span and I didn't know which bug it
was.