### PR TITLE
Fixes test order in ITHttpClient and ITHttpServer.spanHandlerSeesError

### DIFF
--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -81,7 +81,7 @@ public abstract class ITRemote {
    * needed even in a an overloaded CI server or extreme garbage collection pause.
    */
   @Rule public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(20)); // max per method
-  @Rule public IntegrationTestSpanHandler spanHandler = new IntegrationTestSpanHandler();
+  @Rule public IntegrationTestSpanHandler testSpanHandler = new IntegrationTestSpanHandler();
   @Rule public TestName testName = new TestName();
 
   /** Returns a trace context for use in propagation tests. */
@@ -135,7 +135,7 @@ public abstract class ITRemote {
     return Tracing.newBuilder()
       .localServiceName(getClass().getSimpleName())
       .localIp("127.0.0.1") // Prevent implicit lookups
-      .addSpanHandler(spanHandler)
+      .addSpanHandler(testSpanHandler)
       .propagationFactory(propagationFactory)
       .currentTraceContext(currentTraceContext)
       .sampler(sampler);

--- a/brave-tests/src/test/java/brave/test/ITRemoteTest.java
+++ b/brave-tests/src/test/java/brave/test/ITRemoteTest.java
@@ -26,7 +26,7 @@ public class ITRemoteTest {
     ITRemoteDummy itRemote = new ITRemoteDummy();
     itRemote.tracing.tracer().newTrace().start(1L).finish(1L);
 
-    MutableSpan span = itRemote.spanHandler.takeLocalSpan();
+    MutableSpan span = itRemote.testSpanHandler.takeLocalSpan();
     assertThat(span.localServiceName())
         .isEqualTo("ITRemoteDummy"); // much better than "unknown"
   }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/FinishSpanTest.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/FinishSpanTest.java
@@ -40,7 +40,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, clientRequest, null, null, span);
 
-    spanHandler.takeRemoteSpan(Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Kind.CLIENT);
   }
 
   @Test public void finish_null_result_and_error_DubboServerRequest() {
@@ -48,7 +48,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, serverRequest, null, null, span);
 
-    spanHandler.takeRemoteSpan(Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Kind.SERVER);
   }
 
   @Test public void finish_result_but_null_error_DubboClientRequest() {
@@ -56,7 +56,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, clientRequest, mock(Result.class), null, span);
 
-    spanHandler.takeRemoteSpan(Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Kind.CLIENT);
   }
 
   @Test public void finish_result_but_null_error_DubboServerRequest() {
@@ -64,7 +64,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, serverRequest, mock(Result.class), null, span);
 
-    spanHandler.takeRemoteSpan(Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Kind.SERVER);
   }
 
   @Test public void finish_error_but_null_result_DubboClientRequest() {
@@ -73,7 +73,7 @@ public class FinishSpanTest extends ITTracingFilter {
     Throwable error = new RuntimeException("melted");
     FinishSpan.finish(filter, clientRequest, null, error, span);
 
-    spanHandler.takeRemoteSpanWithError(Kind.CLIENT, error);
+    testSpanHandler.takeRemoteSpanWithError(Kind.CLIENT, error);
   }
 
   @Test public void finish_error_but_null_result_DubboServerRequest() {
@@ -82,7 +82,7 @@ public class FinishSpanTest extends ITTracingFilter {
     Throwable error = new RuntimeException("melted");
     FinishSpan.finish(filter, serverRequest, null, error, span);
 
-    spanHandler.takeRemoteSpanWithError(Kind.SERVER, error);
+    testSpanHandler.takeRemoteSpanWithError(Kind.SERVER, error);
   }
 
   @Test public void create_null_result_value_and_error_DubboClientRequest() {
@@ -91,7 +91,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, clientRequest, mock(Result.class), span)
         .accept(null, null);
 
-    spanHandler.takeRemoteSpan(Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Kind.CLIENT);
   }
 
   @Test public void create_null_result_value_and_error_DubboServerRequest() {
@@ -100,7 +100,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, serverRequest, mock(Result.class), span)
         .accept(null, null);
 
-    spanHandler.takeRemoteSpan(Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Kind.SERVER);
   }
 
   @Test public void create_result_value_but_null_error_DubboClientRequest() {
@@ -109,7 +109,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, clientRequest, mock(Result.class), span)
         .accept(new Object(), null);
 
-    spanHandler.takeRemoteSpan(Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Kind.CLIENT);
   }
 
   @Test public void create_result_value_but_null_error_DubboServerRequest() {
@@ -118,7 +118,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, serverRequest, mock(Result.class), span)
         .accept(new Object(), null);
 
-    spanHandler.takeRemoteSpan(Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Kind.SERVER);
   }
 
   @Test public void create_error_but_null_result_value_DubboClientRequest() {
@@ -128,7 +128,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, clientRequest, mock(Result.class), span)
         .accept(null, error);
 
-    spanHandler.takeRemoteSpanWithError(Kind.CLIENT, error);
+    testSpanHandler.takeRemoteSpanWithError(Kind.CLIENT, error);
   }
 
   @Test public void create_error_but_null_result_value_DubboServerRequest() {
@@ -138,6 +138,6 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, serverRequest, mock(Result.class), span)
         .accept(null, error);
 
-    spanHandler.takeRemoteSpanWithError(Kind.SERVER, error);
+    testSpanHandler.takeRemoteSpanWithError(Kind.SERVER, error);
   }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Provider.java
@@ -68,7 +68,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     RpcContext.getContext().getAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
     client.get().sayHello("jorge");
 
-    assertSameIds(spanHandler.takeRemoteSpan(SERVER), parent);
+    assertSameIds(testSpanHandler.takeRemoteSpan(SERVER), parent);
   }
 
   @Test public void createsChildWhenJoinDisabled() {
@@ -80,7 +80,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     RpcContext.getContext().getAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
     client.get().sayHello("jorge");
 
-    assertChildOf(spanHandler.takeRemoteSpan(SERVER), parent);
+    assertChildOf(testSpanHandler.takeRemoteSpan(SERVER), parent);
   }
 
   @Test public void samplingDisabled() {
@@ -96,20 +96,20 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     assertThat(client.get().sayHello("jorge"))
         .isNotEmpty();
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void reportsServerKindToZipkin() {
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).kind())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).kind())
         .isEqualTo(SERVER);
   }
 
   @Test public void defaultSpanNameIsMethodName() {
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).name())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).name())
         .isEqualTo("brave.dubbo.rpc.GreeterService/sayHello");
   }
 
@@ -117,7 +117,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     assertThatThrownBy(() -> client.get().sayHello("bad"))
         .isInstanceOf(IllegalArgumentException.class);
 
-    spanHandler.takeRemoteSpanWithErrorMessage(SERVER, "bad");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(SERVER, "bad");
   }
 
   /* RpcTracing-specific feature tests */
@@ -135,7 +135,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     // sampled
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).name()).endsWith("sayHello");
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).name()).endsWith("sayHello");
     // @After will also check that sayGoodbye was not sampled
   }
 
@@ -164,7 +164,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
     String javaResult = client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
         .containsEntry("dubbo.result_value", javaResult);
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/FinishSpanTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/FinishSpanTest.java
@@ -41,7 +41,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, clientRequest, null, null, span);
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void finish_null_result_and_error_DubboServerRequest() {
@@ -49,7 +49,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, serverRequest, null, null, span);
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void finish_result_but_null_error_DubboClientRequest() {
@@ -57,7 +57,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, clientRequest, mock(Result.class), null, span);
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void finish_result_but_null_error_DubboServerRequest() {
@@ -65,7 +65,7 @@ public class FinishSpanTest extends ITTracingFilter {
 
     FinishSpan.finish(filter, serverRequest, mock(Result.class), null, span);
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void finish_error_but_null_result_DubboClientRequest() {
@@ -74,7 +74,7 @@ public class FinishSpanTest extends ITTracingFilter {
     Throwable error = new RuntimeException("melted");
     FinishSpan.finish(filter, clientRequest, null, error, span);
 
-    spanHandler.takeRemoteSpanWithError(CLIENT, error);
+    testSpanHandler.takeRemoteSpanWithError(CLIENT, error);
   }
 
   @Test public void finish_error_but_null_result_DubboServerRequest() {
@@ -83,7 +83,7 @@ public class FinishSpanTest extends ITTracingFilter {
     Throwable error = new RuntimeException("melted");
     FinishSpan.finish(filter, serverRequest, null, error, span);
 
-    spanHandler.takeRemoteSpanWithError(SERVER, error);
+    testSpanHandler.takeRemoteSpanWithError(SERVER, error);
   }
 
   @Test public void create_null_result_value_and_error_DubboClientRequest() {
@@ -92,7 +92,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, clientRequest, mock(Result.class), span)
         .accept(null, null);
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void create_null_result_value_and_error_DubboServerRequest() {
@@ -101,7 +101,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, serverRequest, mock(Result.class), span)
         .accept(null, null);
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void create_result_value_but_null_error_DubboClientRequest() {
@@ -110,7 +110,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, clientRequest, mock(Result.class), span)
         .accept(new Object(), null);
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void create_result_value_but_null_error_DubboServerRequest() {
@@ -119,7 +119,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, serverRequest, mock(Result.class), span)
         .accept(new Object(), null);
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void create_error_but_null_result_value_DubboClientRequest() {
@@ -129,7 +129,7 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, clientRequest, mock(Result.class), span)
         .accept(null, error);
 
-    spanHandler.takeRemoteSpanWithError(CLIENT, error);
+    testSpanHandler.takeRemoteSpanWithError(CLIENT, error);
   }
 
   @Test public void create_error_but_null_result_value_DubboServerRequest() {
@@ -139,6 +139,6 @@ public class FinishSpanTest extends ITTracingFilter {
     FinishSpan.create(filter, serverRequest, mock(Result.class), span)
         .accept(null, error);
 
-    spanHandler.takeRemoteSpanWithError(SERVER, error);
+    testSpanHandler.takeRemoteSpanWithError(SERVER, error);
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -71,7 +71,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     // perform a warmup request to allow CI to fail quicker
     client.get().sayHello("jorge");
     server.takeRequest();
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @After public void stop() {
@@ -85,7 +85,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     TraceContext extracted = server.takeRequest().context();
     assertThat(extracted.sampled()).isTrue();
     assertThat(extracted.parentIdString()).isNull();
-    assertSameIds(spanHandler.takeRemoteSpan(CLIENT), extracted);
+    assertSameIds(testSpanHandler.takeRemoteSpan(CLIENT), extracted);
   }
 
   @Test public void propagatesChildOfCurrentSpan() {
@@ -97,7 +97,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     TraceContext extracted = server.takeRequest().context();
     assertThat(extracted.sampled()).isTrue();
     assertChildOf(extracted, parent);
-    assertSameIds(spanHandler.takeRemoteSpan(CLIENT), extracted);
+    assertSameIds(testSpanHandler.takeRemoteSpan(CLIENT), extracted);
   }
 
   /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
@@ -122,7 +122,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     TraceContext extracted = server.takeRequest().context();
     assertThat(BAGGAGE_FIELD.getValue(extracted)).isEqualTo("joey");
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void propagatesBaggage_unsampled() {
@@ -147,7 +147,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     }
     long finish = clock.currentTimeMicroseconds();
 
-    MutableSpan clientSpan = spanHandler.takeRemoteSpan(CLIENT);
+    MutableSpan clientSpan = testSpanHandler.takeRemoteSpan(CLIENT);
     assertChildOf(clientSpan, parent);
     assertSpanInInterval(clientSpan, start, finish);
   }
@@ -181,20 +181,20 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     // The spans may report in a different order than the requests
     for (int i = 0; i < 2; i++) {
-      assertChildOf(spanHandler.takeRemoteSpan(CLIENT), parent);
+      assertChildOf(testSpanHandler.takeRemoteSpan(CLIENT), parent);
     }
   }
 
   @Test public void reportsClientKindToZipkin() {
     client.get().sayHello("jorge");
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void defaultSpanNameIsMethodName() {
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).name())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).name())
         .isEqualTo("brave.dubbo.GreeterService/sayHello");
   }
 
@@ -204,7 +204,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     assertThatThrownBy(() -> client.get().sayHello("jorge"))
         .isInstanceOf(RpcException.class);
 
-    spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*RemotingException.*");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*RemotingException.*");
   }
 
   @Test public void onTransportException_setError_async() {
@@ -212,7 +212,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     RpcContext.getContext().asyncCall(() -> client.get().sayHello("romeo"));
 
-    spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*RemotingException.*");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*RemotingException.*");
   }
 
   @Test public void finishesOneWaySpan() {
@@ -220,7 +220,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
       client.get().sayHello("romeo");
     });
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void setError_onUnimplemented() {
@@ -228,7 +228,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
         .isInstanceOf(RpcException.class);
 
     MutableSpan span =
-        spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*Not found exported service.*");
+        testSpanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*Not found exported service.*");
     assertThat(span.tags())
         .containsEntry("dubbo.error_code", "1");
   }
@@ -246,7 +246,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
         .isInstanceOf(RpcException.class);
 
     MutableSpan span =
-        spanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*Not found exported service.*");
+        testSpanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*Not found exported service.*");
     assertThat(span.tags())
         .containsEntry("dubbo.error_code", "1");
   }
@@ -266,7 +266,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
     // sampled
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).name()).endsWith("sayHello");
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).name()).endsWith("sayHello");
     // @After will also check that sayGoodbye was not sampled
   }
 
@@ -290,7 +290,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
 
     String javaResult = client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).tags())
         .containsEntry("dubbo.result_value", javaResult);
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -64,7 +64,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
     // perform a warmup request to allow CI to fail quicker
     client.get().sayHello("jorge");
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void reusesPropagatedSpanId() {
@@ -73,7 +73,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     RpcContext.getContext().getAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
     client.get().sayHello("jorge");
 
-    assertSameIds(spanHandler.takeRemoteSpan(SERVER), parent);
+    assertSameIds(testSpanHandler.takeRemoteSpan(SERVER), parent);
   }
 
   @Test public void createsChildWhenJoinDisabled() {
@@ -85,7 +85,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     RpcContext.getContext().getAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
     client.get().sayHello("jorge");
 
-    MutableSpan span = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);
     assertChildOf(span, parent);
     assertThat(span.id()).isNotEqualTo(parent.spanIdString());
   }
@@ -103,19 +103,19 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     assertThat(client.get().sayHello("jorge"))
         .isNotEmpty();
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void reportsServerKindToZipkin() {
     client.get().sayHello("jorge");
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void defaultSpanNameIsMethodName() {
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).name())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).name())
         .isEqualTo("brave.dubbo.GreeterService/sayHello");
   }
 
@@ -123,7 +123,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     assertThatThrownBy(() -> client.get().sayHello("bad"))
         .isInstanceOf(IllegalArgumentException.class);
 
-    spanHandler.takeRemoteSpanWithErrorMessage(SERVER, "bad");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(SERVER, "bad");
   }
 
   /* RpcTracing-specific feature tests */
@@ -141,7 +141,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     // sampled
     client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).name()).endsWith("sayHello");
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).name()).endsWith("sayHello");
     // @After will also check that sayGoodbye was not sampled
   }
 
@@ -165,7 +165,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
     String javaResult = client.get().sayHello("jorge");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
         .containsEntry("dubbo.result_value", javaResult);
   }
 }

--- a/instrumentation/grpc/src/test/java/brave/grpc/BaseITTracingServerInterceptor.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/BaseITTracingServerInterceptor.java
@@ -124,7 +124,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
     Channel channel = clientWithB3SingleHeader(parent);
     GreeterGrpc.newBlockingStub(channel).sayHello(HELLO_REQUEST);
 
-    assertSameIds(spanHandler.takeRemoteSpan(Span.Kind.SERVER), parent);
+    assertSameIds(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER), parent);
   }
 
   @Test public void createsChildWhenJoinDisabled() throws IOException {
@@ -136,7 +136,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
     Channel channel = clientWithB3SingleHeader(parent);
     GreeterGrpc.newBlockingStub(channel).sayHello(HELLO_REQUEST);
 
-    assertChildOf(spanHandler.takeRemoteSpan(Span.Kind.SERVER), parent);
+    assertChildOf(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER), parent);
   }
 
   @Test public void samplingDisabled() throws IOException {
@@ -170,19 +170,19 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
     assertThat(fromUserInterceptor.get())
         .isNotNull();
 
-    spanHandler.takeRemoteSpan(Span.Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Test public void reportsServerKindToZipkin() {
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
 
-    spanHandler.takeRemoteSpan(Span.Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Test public void defaultSpanNameIsMethodName() {
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).name())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).name())
         .isEqualTo("helloworld.Greeter/SayHello");
   }
 
@@ -191,7 +191,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
     assertThatThrownBy(() -> GreeterGrpc.newBlockingStub(client)
         .sayHello(HelloRequest.newBuilder().setName("bad").build()));
 
-    MutableSpan span = spanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "bad");
+    MutableSpan span = testSpanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "bad");
     assertThat(span.tags()).containsEntry("grpc.status_code", "UNKNOWN");
   }
 
@@ -200,7 +200,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
         .sayHello(HelloRequest.newBuilder().setName("testerror").build()))
         .isInstanceOf(StatusRuntimeException.class);
 
-    MutableSpan span = spanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "testerror");
+    MutableSpan span = testSpanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "testerror");
     assertThat(span.tags().get("grpc.status_code")).isNull();
   }
 
@@ -230,7 +230,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
 
-    MutableSpan span = spanHandler.takeRemoteSpan(Span.Kind.SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(Span.Kind.SERVER);
     assertThat(span.name()).isEqualTo("UNARY");
     assertThat(span.tags().keySet()).containsExactlyInAnyOrder(
         "grpc.message_received", "grpc.message_sent",
@@ -252,7 +252,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
         .sayHelloWithManyReplies(HELLO_REQUEST);
     assertThat(replies).toIterable().hasSize(10);
     // all response messages are tagged to the same span
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags()).hasSize(10);
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags()).hasSize(10);
   }
 
   // Make sure we work well with bad user interceptors.
@@ -267,7 +267,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     assertThatThrownBy(() -> GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST))
         .isInstanceOf(StatusRuntimeException.class);
-    spanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
   }
 
   @Test public void userInterceptor_throwsOnSendMessage() throws IOException {
@@ -284,7 +284,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     assertThatThrownBy(() -> GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST))
         .isInstanceOf(StatusRuntimeException.class);
-    spanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
   }
 
   @Test public void userInterceptor_throwsOnClose() throws IOException {
@@ -301,7 +301,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     assertThatThrownBy(() -> GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST))
         .isInstanceOf(StatusRuntimeException.class);
-    spanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
   }
 
   @Test public void userInterceptor_throwsOnOnHalfClose() throws IOException {
@@ -318,7 +318,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     assertThatThrownBy(() -> GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST))
         .isInstanceOf(StatusRuntimeException.class);
-    spanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
+    testSpanHandler.takeRemoteSpanWithErrorMessage(Span.Kind.SERVER, "I'm a bad interceptor.");
   }
 
   /**
@@ -351,7 +351,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags()).containsKeys(
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags()).containsKeys(
         "grpc.message_recv.0", "grpc.message_send.0"
     );
 
@@ -360,7 +360,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
     assertThat(replies).toIterable().hasSize(10);
 
     // Intentionally verbose here to show that only one recv and 10 replies
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags()).containsKeys(
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags()).containsKeys(
         "grpc.message_recv.1",
         "grpc.message_send.1",
         "grpc.message_send.2",
@@ -392,7 +392,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
     // sampled
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).name())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).name())
         .isEqualTo("helloworld.Greeter/SayHello");
 
     // @After will also check that sayHelloWithManyReplies was not sampled
@@ -424,7 +424,7 @@ public abstract class BaseITTracingServerInterceptor extends ITRemote {
 
     GreeterGrpc.newBlockingStub(client).sayHello(HELLO_REQUEST);
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
         .containsEntry("grpc.method_type", "UNARY")
         .containsEntry("grpc.response_encoding", "identity");
   }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpAsyncClient.java
@@ -73,7 +73,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     // The spans may report in a different order than the requests
     for (int i = 0; i < 2; i++) {
-      assertChildOf(spanHandler.takeRemoteSpan(CLIENT), parent);
+      assertChildOf(testSpanHandler.takeRemoteSpan(CLIENT), parent);
     }
   }
 
@@ -99,7 +99,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     callback.join(); // ensures listener ran
     assertThat(invocationContext.get()).isSameAs(parent);
-    assertChildOf(spanHandler.takeRemoteSpan(CLIENT), parent);
+    assertChildOf(testSpanHandler.takeRemoteSpan(CLIENT), parent);
   }
 
   /** This ensures that response callbacks run when there is no invocation trace context. */
@@ -116,7 +116,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
 
     callback.join(); // ensures listener ran
     assertThat(invocationContext.get()).isNull();
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).parentId()).isNull();
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).parentId()).isNull();
   }
 
   @Test public void addsStatusCodeWhenNotOk_async() {
@@ -131,7 +131,7 @@ public abstract class ITHttpAsyncClient<C> extends ITHttpClient<C> {
     // Ensure the getAsync() method is implemented correctly
     callback.join();
 
-    assertThat(spanHandler.takeRemoteSpanWithErrorTag(CLIENT, "400").tags())
+    assertThat(testSpanHandler.takeRemoteSpanWithErrorTag(CLIENT, "400").tags())
       .containsEntry("http.status_code", "400");
   }
 }

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -396,6 +396,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
           return true;
         }
       })
+      // The blocking span handler goes after the error catcher, so we can assert on the errors.
       .addSpanHandler(testSpanHandler)
       .build());
     client = newClient(server.getPort());

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -86,7 +86,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext extracted = extract(takeRequest());
     assertThat(extracted.sampled()).isTrue();
     assertThat(extracted.parentIdString()).isNull();
-    assertSameIds(spanHandler.takeRemoteSpan(CLIENT), extracted);
+    assertSameIds(testSpanHandler.takeRemoteSpan(CLIENT), extracted);
   }
 
   @Test public void propagatesChildOfCurrentSpan() throws IOException {
@@ -100,7 +100,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext extracted = extract(takeRequest());
     assertThat(extracted.sampled()).isTrue();
     assertChildOf(extracted, parent);
-    assertSameIds(spanHandler.takeRemoteSpan(CLIENT), extracted);
+    assertSameIds(testSpanHandler.takeRemoteSpan(CLIENT), extracted);
   }
 
   /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
@@ -129,7 +129,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     TraceContext extracted = extract(takeRequest());
     assertThat(BAGGAGE_FIELD.getValue(extracted)).isEqualTo("joey");
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void propagatesBaggage_unsampled() throws IOException {
@@ -176,7 +176,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     }
     long finish = clock.currentTimeMicroseconds();
 
-    MutableSpan clientSpan = spanHandler.takeRemoteSpan(CLIENT);
+    MutableSpan clientSpan = testSpanHandler.takeRemoteSpan(CLIENT);
     assertChildOf(clientSpan, parent);
     assertSpanInInterval(clientSpan, start, finish);
   }
@@ -185,7 +185,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, "/foo");
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test
@@ -193,7 +193,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, "/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT))
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT))
         .extracting(MutableSpan::remoteIp, MutableSpan::remotePort)
         .containsExactly("127.0.0.1", server.getPort());
   }
@@ -202,7 +202,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, "/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).name())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).name())
       .isEqualTo("GET");
   }
 
@@ -220,7 +220,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).tags())
       .containsEntry("http.url", url(uri));
   }
 
@@ -244,7 +244,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    MutableSpan span = spanHandler.takeRemoteSpan(CLIENT);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(CLIENT);
     assertThat(span.name())
       .isEqualTo("get /foo/bar");
 
@@ -285,7 +285,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    MutableSpan span = spanHandler.takeRemoteSpan(CLIENT);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(CLIENT);
     assertThat(span.name())
       .isEqualTo("get /foo/bar");
 
@@ -308,7 +308,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
       // some clients raise 400 as an exception such as HttpClientError
     }
 
-    assertThat(spanHandler.takeRemoteSpanWithErrorTag(CLIENT, "400").tags())
+    assertThat(testSpanHandler.takeRemoteSpanWithErrorTag(CLIENT, "400").tags())
       .containsEntry("http.status_code", "400");
   }
 
@@ -324,8 +324,8 @@ public abstract class ITHttpClient<C> extends ITRemote {
       // some clients raise 404 as an exception such as HttpClientError
     }
 
-    MutableSpan initial = spanHandler.takeRemoteSpan(CLIENT);
-    MutableSpan redirected = spanHandler.takeRemoteSpanWithErrorTag(CLIENT, "404");
+    MutableSpan initial = testSpanHandler.takeRemoteSpan(CLIENT);
+    MutableSpan redirected = testSpanHandler.takeRemoteSpanWithErrorTag(CLIENT, "404");
 
     for (MutableSpan child : Arrays.asList(initial, redirected)) {
       assertChildOf(child, parent);
@@ -347,7 +347,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertThat(takeRequest().getBody().readUtf8())
       .isEqualTo(body);
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).name())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).name())
       .isEqualTo("POST");
   }
 
@@ -357,7 +357,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     server.enqueue(new MockResponse());
     get(client, path);
 
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).tags())
       .containsEntry("http.path", "/foo");
   }
 
@@ -384,6 +384,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     ConcurrentLinkedDeque<Throwable> caughtThrowables = new ConcurrentLinkedDeque<>();
     closeClient(client);
     httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE)
+      .clearSpanHandlers()
       .addSpanHandler(new SpanHandler() {
         @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
           Throwable error = span.error();
@@ -395,13 +396,15 @@ public abstract class ITHttpClient<C> extends ITRemote {
           return true;
         }
       })
+      .addSpanHandler(testSpanHandler)
       .build());
     client = newClient(server.getPort());
 
+    // If this passes, a span was reported with an error
     checkReportsSpanOnTransportException(get);
 
     assertThat(caughtThrowables)
-        .withFailMessage("Span didn't finish")
+        .withFailMessage("Span finished with error, but caughtThrowables empty")
         .isNotEmpty();
     if (caughtThrowables.size() > 1) {
       for (Throwable throwable : caughtThrowables) {
@@ -421,7 +424,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     }
 
     // We don't know the transport exception
-    return spanHandler.takeRemoteSpanWithError(CLIENT);
+    return testSpanHandler.takeRemoteSpanWithError(CLIENT);
   }
 
   protected String url(String pathIncludingQuery) {

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -36,8 +36,6 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.UnavailableException;
@@ -82,7 +80,7 @@ public abstract class ITHttpServer extends ITRemote {
       .header("b3", B3SingleFormat.writeB3SingleFormat(parent))
       .build());
 
-    assertSameIds(spanHandler.takeRemoteSpan(SERVER), parent);
+    assertSameIds(testSpanHandler.takeRemoteSpan(SERVER), parent);
   }
 
   @Test public void createsChildWhenJoinDisabled() throws IOException {
@@ -97,7 +95,7 @@ public abstract class ITHttpServer extends ITRemote {
       .header("b3", B3SingleFormat.writeB3SingleFormat(parent))
       .build());
 
-    MutableSpan span = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);
     assertChildOf(span, parent);
     assertThat(span.id()).isNotEqualTo(parent.spanIdString());
   }
@@ -106,7 +104,7 @@ public abstract class ITHttpServer extends ITRemote {
   public void readsBaggage_newTrace() throws IOException {
     readsBaggage(new Request.Builder());
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void readsBaggage_unsampled() throws IOException {
@@ -123,7 +121,7 @@ public abstract class ITHttpServer extends ITRemote {
       .header("X-B3-TraceId", traceId)
       .header("X-B3-SpanId", traceId));
 
-    MutableSpan span = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);
     assertThat(span.traceId()).isEqualTo(traceId);
     assertThat(span.id()).isEqualTo(traceId);
   }
@@ -179,7 +177,7 @@ public abstract class ITHttpServer extends ITRemote {
     Response response = get("/async");
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   /**
@@ -191,8 +189,8 @@ public abstract class ITHttpServer extends ITRemote {
   @Test public void createsChildSpan() throws IOException {
     get("/child");
 
-    MutableSpan child = spanHandler.takeLocalSpan();
-    MutableSpan server = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan child = testSpanHandler.takeLocalSpan();
+    MutableSpan server = testSpanHandler.takeRemoteSpan(SERVER);
     assertChildOf(child, server);
     assertThat(child.name()).isEqualTo("child"); // sanity check
   }
@@ -204,8 +202,8 @@ public abstract class ITHttpServer extends ITRemote {
   @Test public void childCompletesBeforeServer() throws IOException {
     get("/child");
 
-    MutableSpan child = spanHandler.takeLocalSpan();
-    MutableSpan server = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan child = testSpanHandler.takeLocalSpan();
+    MutableSpan server = testSpanHandler.takeRemoteSpan(SERVER);
     assertChildOf(child, server);
     assertThat(child.name()).isEqualTo("child"); // sanity check
 
@@ -215,7 +213,7 @@ public abstract class ITHttpServer extends ITRemote {
   @Test public void reportsClientAddress() throws IOException {
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).remoteIp())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).remoteIp())
       .isNotNull();
   }
 
@@ -224,20 +222,20 @@ public abstract class ITHttpServer extends ITRemote {
       .header("X-Forwarded-For", "1.2.3.4")
       .build());
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).remoteIp())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).remoteIp())
       .isEqualTo("1.2.3.4");
   }
 
   @Test public void reportsServerKindToZipkin() throws IOException {
     get("/foo");
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void defaultSpanNameIsMethodNameOrRoute() throws IOException {
     get("/foo");
 
-    MutableSpan span = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);
     if (!span.name().equals("GET")) {
       assertThat(span.name())
         .isEqualTo("GET /foo");
@@ -255,7 +253,7 @@ public abstract class ITHttpServer extends ITRemote {
     String uri = "/foo?z=2&yAA=1";
     get(uri);
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
       .containsEntry("http.url", url(uri));
   }
 
@@ -276,7 +274,7 @@ public abstract class ITHttpServer extends ITRemote {
     String uri = "/foo?z=2&yAA=1";
     get(uri);
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
       .containsEntry("http.url", url(uri))
       .containsEntry("request_customizer.is_span", "false")
       .containsEntry("response_customizer.is_span", "false");
@@ -303,7 +301,7 @@ public abstract class ITHttpServer extends ITRemote {
     String uri = "/foo?z=2&yAA=1";
     get(uri);
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
       .containsEntry("http.url", url(uri))
       .containsEntry("context.visible", "true")
       .containsEntry("request_customizer.is_span", "false")
@@ -358,8 +356,8 @@ public abstract class ITHttpServer extends ITRemote {
     assertThat(request2.body().string())
       .isEqualTo("2");
 
-    MutableSpan span1 = spanHandler.takeRemoteSpan(SERVER);
-    MutableSpan span2 = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span1 = testSpanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span2 = testSpanHandler.takeRemoteSpan(SERVER);
 
     // verify that the path and url reflect the initial request (not a route expression)
     assertThat(span1.tags())
@@ -392,7 +390,7 @@ public abstract class ITHttpServer extends ITRemote {
     assertThat(call("GET", "/foo/bark").code())
       .isEqualTo(404);
 
-    MutableSpan span = spanHandler.takeRemoteSpanWithErrorTag(SERVER, "404");
+    MutableSpan span = testSpanHandler.takeRemoteSpanWithErrorTag(SERVER, "404");
 
     // verify normal tags
     assertThat(span.tags())
@@ -416,7 +414,7 @@ public abstract class ITHttpServer extends ITRemote {
     assertThat(call("OPTIONS", "/").isSuccessful())
       .isTrue();
 
-    MutableSpan span = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);
 
     // verify normal tags
     assertThat(span.tags())
@@ -437,14 +435,14 @@ public abstract class ITHttpServer extends ITRemote {
       // some servers think 400 is an error
     }
 
-    assertThat(spanHandler.takeRemoteSpanWithErrorTag(SERVER, "400").tags())
+    assertThat(testSpanHandler.takeRemoteSpanWithErrorTag(SERVER, "400").tags())
       .containsEntry("error", "400");
   }
 
   @Test public void httpPathTagExcludesQueryParams() throws IOException {
     get("/foo?z=2&yAA=1");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
       .containsEntry("http.path", "/foo");
   }
 
@@ -488,14 +486,14 @@ public abstract class ITHttpServer extends ITRemote {
     Response response = get(path);
 
     String responseCode = String.valueOf(response.code());
-    MutableSpan span = spanHandler.takeRemoteSpanWithErrorMessage(SERVER, errorMessage);
+    MutableSpan span = testSpanHandler.takeRemoteSpanWithErrorMessage(SERVER, errorMessage);
     assertThat(span.tags()).containsEntry("http.status_code", responseCode);
     return response;
   }
 
   Response httpStatusCodeTagMatchesResponse_onUncaughtException(String path) throws IOException {
     Response response = get(path);
-    MutableSpan span = spanHandler.takeRemoteSpanWithError(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpanWithError(SERVER);
     assertThat(span.tags()).containsEntry("http.status_code", String.valueOf(response.code()));
     return response;
   }
@@ -512,13 +510,14 @@ public abstract class ITHttpServer extends ITRemote {
     spanHandlerSeesError("/exception");
   }
 
-  @Test public void spanHandlerSeesException_async() throws IOException {
+  @Test public void spanHandlerSeesError_async() throws IOException {
     spanHandlerSeesError("/exceptionAsync");
   }
 
   void spanHandlerSeesError(String path) throws IOException {
     ConcurrentLinkedDeque<Throwable> caughtThrowables = new ConcurrentLinkedDeque<>();
     httpTracing = HttpTracing.create(tracingBuilder(Sampler.ALWAYS_SAMPLE)
+        .clearSpanHandlers()
         .addSpanHandler(new SpanHandler() {
           @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
             Throwable error = span.error();
@@ -530,13 +529,15 @@ public abstract class ITHttpServer extends ITRemote {
             return true;
           }
         })
+        .addSpanHandler(testSpanHandler)
         .build());
     init();
 
+    // If this passes, a span was reported with an error
     httpStatusCodeTagMatchesResponse_onUncaughtException(path, ".*not ready");
 
     assertThat(caughtThrowables)
-        .withFailMessage("Span didn't finish")
+        .withFailMessage("Span finished with error, but caughtThrowables empty")
         .isNotEmpty();
     if (caughtThrowables.size() > 1) {
       for (Throwable throwable : caughtThrowables) {
@@ -555,7 +556,7 @@ public abstract class ITHttpServer extends ITRemote {
     if (response.code() == 404) {
       // 404 path may or may not be instrumented. Ensure the AssumptionViolatedException isn't
       // masked by a failure to take a server span.
-      spanHandler.ignoreAnySpans();
+      testSpanHandler.ignoreAnySpans();
       throw new AssumptionViolatedException(
         response.request().url().encodedPath() + " not supported"
       );

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -529,6 +529,7 @@ public abstract class ITHttpServer extends ITRemote {
             return true;
           }
         })
+        // The blocking span handler goes after the error catcher, so we can assert on the errors.
         .addSpanHandler(testSpanHandler)
         .build());
     init();

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet25Container.java
@@ -132,7 +132,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
         .isEqualTo("abcdefg");
     }
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   // copies the header to the response
@@ -166,7 +166,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
           .isEqualTo("abcdefg");
     }
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   // Shows how a framework can layer on "http.route" logic
@@ -194,7 +194,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).name())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).name())
       .isEqualTo("GET /foo");
   }
 
@@ -222,7 +222,7 @@ public abstract class ITServlet25Container extends ITServletContainer {
 
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
       .containsEntry("foo", "bar");
   }
 

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServlet3Container.java
@@ -49,13 +49,13 @@ public abstract class ITServlet3Container extends ITServlet25Container {
   @Test public void forward() throws Exception {
     get("/forward");
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   @Test public void forwardAsync() throws Exception {
     get("/forwardAsync");
 
-    spanHandler.takeRemoteSpan(SERVER);
+    testSpanHandler.takeRemoteSpan(SERVER);
   }
 
   static class ForwardServlet extends HttpServlet {

--- a/instrumentation/http-tests/src/test/java/brave/http/features/RequestSamplingTest.java
+++ b/instrumentation/http-tests/src/test/java/brave/http/features/RequestSamplingTest.java
@@ -39,13 +39,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** This is an example of http request sampling */
 public class RequestSamplingTest {
   @Rule public MockWebServer server = new MockWebServer();
-  @Rule public IntegrationTestSpanHandler spanHandler = new IntegrationTestSpanHandler();
+  @Rule public IntegrationTestSpanHandler testSpanHandler = new IntegrationTestSpanHandler();
 
   StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
   Tracing tracing = Tracing.newBuilder()
     .localServiceName("server")
     .currentTraceContext(currentTraceContext)
-    .addSpanHandler(spanHandler)
+    .addSpanHandler(testSpanHandler)
     .build();
   HttpTracing httpTracing = HttpTracing.newBuilder(tracing)
     // server starts traces under the path /api
@@ -85,11 +85,11 @@ public class RequestSamplingTest {
   @Test public void clientTracedWhenServerIs() throws Exception {
     callServer("/api");
 
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
         .containsEntry("http.path", "/next");
-    assertThat(spanHandler.takeRemoteSpan(CLIENT).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(CLIENT).tags())
         .containsEntry("http.path", "/next");
-    assertThat(spanHandler.takeRemoteSpan(SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
         .containsEntry("http.path", "/api");
   }
 

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -87,7 +87,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    spanHandler.takeRemoteSpan(CLIENT);
+    testSpanHandler.takeRemoteSpan(CLIENT);
   }
 
   @Test public void failedInterceptorRemovesScope() {
@@ -104,7 +104,7 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
 
     assertThat(currentTraceContext.get()).isNull();
 
-    spanHandler.takeRemoteSpanWithError(CLIENT, error);
+    testSpanHandler.takeRemoteSpanWithError(CLIENT, error);
   }
 
   @Override

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingCachingHttpClientBuilder.java
@@ -50,8 +50,8 @@ public class ITTracingCachingHttpClientBuilder extends ITTracingHttpClientBuilde
 
     assertThat(server.getRequestCount()).isEqualTo(1);
 
-    MutableSpan real = spanHandler.takeRemoteSpan(CLIENT);
-    MutableSpan cached = spanHandler.takeLocalSpan();
+    MutableSpan real = testSpanHandler.takeRemoteSpan(CLIENT);
+    MutableSpan cached = testSpanHandler.takeLocalSpan();
     assertThat(cached.tags()).containsKey("http.cache_hit");
 
     for (MutableSpan child : Arrays.asList(real, cached)) {

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -65,6 +65,6 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    spanHandler.takeRemoteSpan(Span.Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -67,7 +67,7 @@ public class ITSpanCustomizingContainerFilter extends ITServletContainer {
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITSpanCustomizingContainerFilter.java
@@ -61,7 +61,7 @@ public class ITSpanCustomizingContainerFilter extends ITServletContainer {
   }
 
   @Override @Ignore("resteasy swallows the exception")
-  public void spanHandlerSeesException_async() {
+  public void spanHandlerSeesError_async() {
   }
 
   @Test public void tagsResource() throws Exception {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITSpanCustomizingApplicationEventListener.java
@@ -42,7 +42,7 @@ public class ITSpanCustomizingApplicationEventListener extends ITServletContaine
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }
@@ -52,7 +52,7 @@ public class ITSpanCustomizingApplicationEventListener extends ITServletContaine
   @Test public void managedAsync() throws Exception {
     get("/managedAsync");
 
-    spanHandler.takeRemoteSpan(Span.Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
+++ b/instrumentation/jersey-server/src/test/java/brave/jersey/server/ITTracingApplicationEventListener.java
@@ -38,7 +38,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
   @Test public void tagsResource() throws Exception {
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("jaxrs.resource.class", "TestResource")
       .containsEntry("jaxrs.resource.method", "foo");
   }
@@ -48,7 +48,7 @@ public class ITTracingApplicationEventListener extends ITServletContainer {
     Response response = get("/managedAsync");
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    spanHandler.takeRemoteSpan(Span.Kind.SERVER);
+    testSpanHandler.takeRemoteSpan(Span.Kind.SERVER);
   }
 
   @Override public void init(ServletContextHandler handler) {

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageConsumer.java
@@ -137,7 +137,8 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     });
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
     assertChildOf(listenerSpan, consumerSpan);
     assertSequential(consumerSpan, listenerSpan);
   }
@@ -187,7 +188,8 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     );
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
 
     assertThat(consumerSpan.name()).isEqualTo("receive");
     assertThat(consumerSpan.parentId()).isNull(); // root span
@@ -228,7 +230,9 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     TraceContext parent = resetB3PropertyWithNewSampledContext(jms);
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
+
     assertChildOf(consumerSpan, parent);
     assertChildOf(listenerSpan, consumerSpan);
     assertThat(listenerSpan.tags())
@@ -266,7 +270,9 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     lockMessages();
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
+
     assertThat(consumerSpan.parentId()).isNull();
     assertChildOf(listenerSpan, consumerSpan);
     assertThat(listenerSpan.tags())
@@ -303,7 +309,7 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
 
     messageConsumer.receive();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(consumerSpan.name()).isEqualTo("receive");
     assertThat(consumerSpan.parentId()).isNull(); // root span
     assertThat(consumerSpan.tags()).containsAllEntriesOf(consumerTags);
@@ -331,7 +337,7 @@ public class ITJms_1_1_TracingMessageConsumer extends ITJms {
     send.run();
 
     Message received = messageConsumer.receive();
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertChildOf(consumerSpan, parent);
 
     assertThat(received.getStringProperty("b3"))

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageProducer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_1_1_TracingMessageProducer.java
@@ -127,7 +127,7 @@ public class ITJms_1_1_TracingMessageProducer extends ITJms {
   }
 
   void assertHasB3SingleProperty(Message received) throws JMSException {
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
 
     assertThat(propertiesToMap(received))
       .containsAllEntriesOf(existingProperties)
@@ -142,7 +142,7 @@ public class ITJms_1_1_TracingMessageProducer extends ITJms {
 
     Message received = messageConsumer.receive();
 
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertChildOf(producerSpan, parent);
 
     assertThat(propertiesToMap(received))
@@ -161,7 +161,7 @@ public class ITJms_1_1_TracingMessageProducer extends ITJms {
 
     Message received = messageConsumer.receive();
 
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertChildOf(producerSpan, parent);
 
     assertThat(propertiesToMap(received))
@@ -185,7 +185,7 @@ public class ITJms_1_1_TracingMessageProducer extends ITJms {
   }
 
   void should_record_properties(Map<String, String> producerTags) {
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(producerSpan.name()).isEqualTo("send");
     assertThat(producerSpan.tags()).containsAllEntriesOf(producerTags);
   }
@@ -214,7 +214,7 @@ public class ITJms_1_1_TracingMessageProducer extends ITJms {
       message = e.getMessage();
     }
 
-    spanHandler.takeRemoteSpanWithErrorMessage(PRODUCER, message);
+    testSpanHandler.takeRemoteSpanWithErrorMessage(PRODUCER, message);
   }
 
   @Test public void customSampler() throws JMSException {

--- a/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageProducer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITJms_2_0_TracingMessageProducer.java
@@ -63,7 +63,7 @@ public class ITJms_2_0_TracingMessageProducer extends ITJms_1_1_TracingMessagePr
       }
     });
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.PRODUCER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.PRODUCER).tags())
       .containsKey("onCompletion");
   }
 
@@ -104,7 +104,7 @@ public class ITJms_2_0_TracingMessageProducer extends ITJms_1_1_TracingMessagePr
     jms.after();
     latch.countDown();
 
-    spanHandler.takeRemoteSpanWithErrorTag(Span.Kind.PRODUCER, "onException");
+    testSpanHandler.takeRemoteSpanWithErrorTag(Span.Kind.PRODUCER, "onException");
   }
 
   @Test public void customSampler() throws JMSException {

--- a/instrumentation/jms/src/test/java/brave/jms/ITTracingJMSConsumer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITTracingJMSConsumer.java
@@ -72,7 +72,9 @@ public class ITTracingJMSConsumer extends ITJms {
     });
     producer.send(jms.queue, "foo");
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
+
     assertChildOf(listenerSpan, consumerSpan);
     assertSequential(consumerSpan, listenerSpan);
   }
@@ -96,7 +98,8 @@ public class ITTracingJMSConsumer extends ITJms {
 
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
 
     assertThat(consumerSpan.name()).isEqualTo("receive");
     assertThat(consumerSpan.tags())
@@ -129,7 +132,9 @@ public class ITTracingJMSConsumer extends ITJms {
     producer.setProperty("b3", parent.traceIdString() + "-" + parent.spanIdString() + "-1");
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
+
     assertChildOf(consumerSpan, parent);
     assertChildOf(listenerSpan, consumerSpan);
 
@@ -155,7 +160,9 @@ public class ITTracingJMSConsumer extends ITJms {
     producer.setProperty(BAGGAGE_FIELD_KEY, baggage);
     send.run();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER), listenerSpan = spanHandler.takeLocalSpan();
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan listenerSpan = testSpanHandler.takeLocalSpan();
+
     assertThat(consumerSpan.parentId()).isNull();
     assertChildOf(listenerSpan, consumerSpan);
     assertThat(listenerSpan.tags())
@@ -173,7 +180,7 @@ public class ITTracingJMSConsumer extends ITJms {
   void receive_startsNewTrace(Runnable send) {
     send.run();
     consumer.receive();
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(consumerSpan.name()).isEqualTo("receive");
     assertThat(consumerSpan.tags()).containsEntry("jms.queue", jms.queueName);
   }
@@ -193,7 +200,7 @@ public class ITTracingJMSConsumer extends ITJms {
 
     Message received = consumer.receive();
 
-    MutableSpan consumerSpan = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan consumerSpan = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertChildOf(consumerSpan, parent);
 
     assertThat(getPropertyIfString(received, "b3"))

--- a/instrumentation/jms/src/test/java/brave/jms/ITTracingJMSProducer.java
+++ b/instrumentation/jms/src/test/java/brave/jms/ITTracingJMSProducer.java
@@ -74,7 +74,7 @@ public class ITTracingJMSProducer extends ITJms {
     producer.send(jms.queue, "foo");
 
     Message received = consumer.receive();
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
 
     assertThat(propertiesToMap(received))
       .containsAllEntriesOf(existingProperties)
@@ -89,7 +89,7 @@ public class ITTracingJMSProducer extends ITJms {
 
     Message received = consumer.receive();
 
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertChildOf(producerSpan, parent);
 
     assertThat(propertiesToMap(received))
@@ -107,7 +107,7 @@ public class ITTracingJMSProducer extends ITJms {
 
     Message received = consumer.receive();
 
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertChildOf(producerSpan, parent);
 
     assertThat(propertiesToMap(received))
@@ -120,7 +120,7 @@ public class ITTracingJMSProducer extends ITJms {
 
     consumer.receive();
 
-    MutableSpan producerSpan = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan producerSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(producerSpan.name()).isEqualTo("send");
     assertThat(producerSpan.tags()).containsEntry("jms.queue", jms.queueName);
   }
@@ -136,7 +136,7 @@ public class ITTracingJMSProducer extends ITJms {
       message = e.getMessage();
     }
 
-    spanHandler.takeRemoteSpanWithErrorMessage(PRODUCER, message);
+    testSpanHandler.takeRemoteSpanWithErrorMessage(PRODUCER, message);
   }
 
   @Test public void should_complete_on_callback() {
@@ -151,7 +151,7 @@ public class ITTracingJMSProducer extends ITJms {
     });
     producer.send(jms.queue, "foo");
 
-    assertThat(spanHandler.takeRemoteSpan(PRODUCER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(PRODUCER).tags())
       .containsKeys("onCompletion");
   }
 

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
@@ -169,14 +169,14 @@ public class JmsTracingTest extends ITJms {
     jmsTracing.messageListener(mock(MessageListener.class), false)
       .onMessage(message);
 
-    assertThat(spanHandler.takeLocalSpan().name()).isEqualTo("on-message");
+    assertThat(testSpanHandler.takeLocalSpan().name()).isEqualTo("on-message");
   }
 
   @Test public void messageListener_traces_addsConsumerSpan() {
     jmsTracing.messageListener(mock(MessageListener.class), true)
       .onMessage(message);
 
-    assertThat(asList(spanHandler.takeRemoteSpan(Kind.CONSUMER), spanHandler.takeLocalSpan()))
+    assertThat(asList(testSpanHandler.takeRemoteSpan(Kind.CONSUMER), testSpanHandler.takeLocalSpan()))
       .extracting(brave.handler.MutableSpan::name)
       .containsExactly("receive", "on-message");
   }
@@ -229,7 +229,7 @@ public class JmsTracingTest extends ITJms {
     message.setDestination(createDestination("foo", QUEUE_TYPE));
     jmsTracing.nextSpan(message).start().finish();
 
-    assertThat(spanHandler.takeLocalSpan().tags())
+    assertThat(testSpanHandler.takeLocalSpan().tags())
       .containsOnly(entry("jms.queue", "foo"));
   }
 
@@ -242,7 +242,7 @@ public class JmsTracingTest extends ITJms {
     message.setDestination(createDestination("foo", QUEUE_TYPE));
     jmsTracing.nextSpan(message).start().finish();
 
-    assertThat(spanHandler.takeLocalSpan().tags()).isEmpty();
+    assertThat(testSpanHandler.takeLocalSpan().tags()).isEmpty();
   }
 
   @Test public void nextSpan_should_clear_propagation_headers() {

--- a/instrumentation/jms/src/test/java/brave/jms/TracingCompletionListenerTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/TracingCompletionListenerTest.java
@@ -51,7 +51,7 @@ public class TracingCompletionListenerTest extends ITJms {
       TracingCompletionListener.create(mock(CompletionListener.class), span, currentTraceContext);
     tracingCompletionListener.onCompletion(message);
 
-    spanHandler.takeLocalSpan();
+    testSpanHandler.takeLocalSpan();
   }
 
   @Test public void on_exception_should_set_error_if_exception() {
@@ -63,7 +63,7 @@ public class TracingCompletionListenerTest extends ITJms {
       TracingCompletionListener.create(mock(CompletionListener.class), span, currentTraceContext);
     tracingCompletionListener.onException(message, error);
 
-    assertThat(spanHandler.takeLocalSpan().error()).isEqualTo(error);
+    assertThat(testSpanHandler.takeLocalSpan().error()).isEqualTo(error);
   }
 
   @Test public void on_completion_should_forward_then_finish_span() {
@@ -77,7 +77,7 @@ public class TracingCompletionListenerTest extends ITJms {
 
     verify(delegate).onCompletion(message);
 
-    spanHandler.takeLocalSpan();
+    testSpanHandler.takeLocalSpan();
   }
 
   @Test public void on_completion_should_have_span_in_scope() {
@@ -96,7 +96,7 @@ public class TracingCompletionListenerTest extends ITJms {
 
     TracingCompletionListener.create(delegate, span, currentTraceContext).onCompletion(message);
 
-    spanHandler.takeLocalSpan();
+    testSpanHandler.takeLocalSpan();
   }
 
   @Test public void on_exception_should_forward_then_set_error() {
@@ -111,6 +111,6 @@ public class TracingCompletionListenerTest extends ITJms {
 
     verify(delegate).onException(message, error);
 
-    assertThat(spanHandler.takeLocalSpan().error()).isEqualTo(error);
+    assertThat(testSpanHandler.takeLocalSpan().error()).isEqualTo(error);
   }
 }

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -186,7 +186,7 @@ public class ITKafkaTracing extends ITKafka {
       processor.start().name("processor").finish();
 
       // The processor doesn't taint the consumer span which has already finished
-      MutableSpan processorSpan = spanHandler.takeLocalSpan();
+      MutableSpan processorSpan = testSpanHandler.takeLocalSpan();
       assertThat(processorSpan.id())
         .isNotEqualTo(consumerSpan.id());
     }

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/ITKafkaStreamsTracing.java
@@ -85,7 +85,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
     streams.close();
@@ -113,7 +113,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
     waitForStreamToRun(streams);
 
     for (int i = 0; i < 3; i++) {
-      MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+      MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
       assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
     }
 
@@ -142,7 +142,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
     streams.close();
@@ -165,7 +165,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
     streams.close();
@@ -189,10 +189,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanInput);
 
@@ -230,10 +230,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
     streams.close();
@@ -257,16 +257,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "false");
 
     // the filter transformer returns true so record is not dropped
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -291,10 +291,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "true");
 
@@ -331,16 +331,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanTransform1 = spanHandler.takeLocalSpan();
+    MutableSpan spanTransform1 = testSpanHandler.takeLocalSpan();
     assertChildOf(spanTransform1, spanInput);
 
-    MutableSpan spanTransform2 = spanHandler.takeLocalSpan();
+    MutableSpan spanTransform2 = testSpanHandler.takeLocalSpan();
     assertChildOf(spanTransform2, spanTransform1);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanTransform2);
 
@@ -365,10 +365,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "true");
 
@@ -395,16 +395,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "false");
 
     // the filter transformer returns true so record is not dropped
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -430,16 +430,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "false");
 
     // the filter transformer returns true so record is not dropped
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -465,10 +465,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "true");
 
@@ -496,10 +496,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "true");
 
@@ -528,16 +528,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags()).containsEntry(KAFKA_STREAMS_FILTERED_TAG, "false");
 
     // the filter transformer returns true so record is not dropped
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -571,14 +571,14 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.annotations()).contains(entry(now, "test"));
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -603,13 +603,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -638,10 +638,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
     streams.close();
@@ -677,7 +677,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    assertThat(spanHandler.takeLocalSpan().tags())
+    assertThat(testSpanHandler.takeLocalSpan().tags())
       .containsOnlyKeys("kafka.streams.application.id", "kafka.streams.task.id");
 
     streams.close();
@@ -727,13 +727,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -779,10 +779,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertThat(spanProcessor.error()).hasMessage("illegal-argument");
     assertChildOf(spanProcessor, spanInput);
 
@@ -831,10 +831,10 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertThat(spanProcessor.error()).hasMessage("file-not-found");
     assertChildOf(spanProcessor, spanInput);
 
@@ -894,16 +894,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags())
       .containsOnlyKeys("kafka.streams.application.id", "kafka.streams.task.id");
 
     for (int i = 0; i < 2; i++) {
-      MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+      MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
       assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
       assertChildOf(spanOutput, spanProcessor);
     }
@@ -955,7 +955,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    assertThat(spanHandler.takeLocalSpan().tags())
+    assertThat(testSpanHandler.takeLocalSpan().tags())
       .containsOnlyKeys("kafka.streams.application.id", "kafka.streams.task.id");
 
     streams.close();
@@ -1005,13 +1005,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -1043,13 +1043,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -1081,16 +1081,16 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
     assertThat(spanProcessor.tags())
       .containsOnlyKeys("kafka.streams.application.id", "kafka.streams.task.id");
 
     for (int i = 0; i < 2; i++) {
-      MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+      MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
       assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
       assertChildOf(spanOutput, spanProcessor);
     }
@@ -1123,13 +1123,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -1161,13 +1161,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -1218,7 +1218,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    assertThat(spanHandler.takeLocalSpan().tags())
+    assertThat(testSpanHandler.takeLocalSpan().tags())
       .containsOnlyKeys("kafka.streams.application.id", "kafka.streams.task.id");
 
     streams.close();
@@ -1268,13 +1268,13 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    MutableSpan spanInput = spanHandler.takeRemoteSpan(CONSUMER);
+    MutableSpan spanInput = testSpanHandler.takeRemoteSpan(CONSUMER);
     assertThat(spanInput.tags()).containsEntry("kafka.topic", inputTopic);
 
-    MutableSpan spanProcessor = spanHandler.takeLocalSpan();
+    MutableSpan spanProcessor = testSpanHandler.takeLocalSpan();
     assertChildOf(spanProcessor, spanInput);
 
-    MutableSpan spanOutput = spanHandler.takeRemoteSpan(PRODUCER);
+    MutableSpan spanOutput = testSpanHandler.takeRemoteSpan(PRODUCER);
     assertThat(spanOutput.tags()).containsEntry("kafka.topic", outputTopic);
     assertChildOf(spanOutput, spanProcessor);
 
@@ -1325,7 +1325,7 @@ public class ITKafkaStreamsTracing extends ITKafkaStreams {
 
     waitForStreamToRun(streams);
 
-    assertThat(spanHandler.takeLocalSpan().tags())
+    assertThat(testSpanHandler.takeLocalSpan().tags())
       .containsOnlyKeys("kafka.streams.application.id", "kafka.streams.task.id");
 
     streams.close();

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -107,6 +107,6 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    spanHandler.takeRemoteSpan(Span.Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Span.Kind.CLIENT);
   }
 }

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -75,7 +75,7 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    spanHandler.takeRemoteSpan(Span.Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Span.Kind.CLIENT);
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -112,7 +112,7 @@ public class ITTracingAsyncClientHttpRequestInterceptor
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    spanHandler.takeRemoteSpan(Span.Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Span.Kind.CLIENT);
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -84,7 +84,7 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     assertThat(request.getHeader("x-b3-traceId"))
       .isEqualTo(request.getHeader("my-id"));
 
-    spanHandler.takeRemoteSpan(Span.Kind.CLIENT);
+    testSpanHandler.takeRemoteSpan(Span.Kind.CLIENT);
   }
 
   @Override @Ignore("blind to the implementation of redirects")

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/BaseITSpanCustomizingHandlerInterceptor.java
@@ -41,7 +41,7 @@ public abstract class BaseITSpanCustomizingHandlerInterceptor extends ITServletC
   @Test public void addsControllerTags() throws Exception {
     get("/foo");
 
-    MutableSpan span = spanHandler.takeRemoteSpan(SERVER);
+    MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);
     assertThat(span.tags())
       .containsKeys("mvc.controller.class", "mvc.controller.method");
     assertThat(span.tags().get("mvc.controller.class"))

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/ITSpanCustomizingAsyncHandlerInterceptor.java
@@ -42,7 +42,7 @@ public class ITSpanCustomizingAsyncHandlerInterceptor extends ITServletContainer
   @Test public void addsControllerTags() throws Exception {
     get("/foo");
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("mvc.controller.class", "Servlet3TestController")
       .containsEntry("mvc.controller.method", "foo");
   }

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -146,7 +146,7 @@ public class ITVertxWebTracing extends ITHttpServer {
     Response response = get(path);
     assertThat(response.isSuccessful()).withFailMessage("not successful: " + response).isTrue();
 
-    assertThat(spanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
+    assertThat(testSpanHandler.takeRemoteSpan(Span.Kind.SERVER).tags())
       .containsEntry("http.path", path)
       .containsEntry("http.url", url(path));
   }


### PR DESCRIPTION
This fixes order where a callback that checked for duplicate errors
happened after span reporting. Depending on how fast the verification
of the span went, the error checker could fail.

This also renames the base test handler so it is more clear which is
which.

https://github.com/line/armeria/pull/2695#issuecomment-630102560