### PR TITLE
Consistently only clear trace ID headers in messaging

### DIFF
--- a/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -48,7 +48,7 @@ abstract class TracingConsumer<C> {
     MessageConsumerRequest request = new MessageConsumerRequest(message, destination(message));
 
     TraceContextOrSamplingFlags extracted =
-      jmsTracing.extractAndClearProperties(extractor, request, message);
+      jmsTracing.extractAndClearTraceIdProperties(extractor, request, message);
     Span span = jmsTracing.nextMessagingSpan(sampler, request, extracted);
 
     if (!span.isNoop()) {

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageListener.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageListener.java
@@ -91,7 +91,7 @@ final class TracingMessageListener implements MessageListener {
     MessageConsumerRequest request = new MessageConsumerRequest(message, destination(message));
 
     TraceContextOrSamplingFlags extracted =
-      jmsTracing.extractAndClearProperties(extractor, request, message);
+      jmsTracing.extractAndClearTraceIdProperties(extractor, request, message);
     Span consumerSpan = jmsTracing.nextMessagingSpan(sampler, request, extracted);
 
     // JMS has no visibility of the incoming message, which incidentally could be local!

--- a/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/JmsTracingTest.java
@@ -253,6 +253,14 @@ public class JmsTracingTest extends ITJms {
     assertThat(ITJms.propertiesToMap(message)).isEmpty();
   }
 
+  @Test public void nextSpan_should_retain_baggage_headers() throws JMSException {
+    message.setStringProperty(BAGGAGE_FIELD_KEY, "");
+
+    jmsTracing.nextSpan(message);
+
+    assertThat(message.getStringProperty(BAGGAGE_FIELD_KEY)).isEmpty();
+  }
+
   @Test public void nextSpan_should_not_clear_other_headers() throws JMSException {
     message.setIntProperty("foo", 1);
 

--- a/instrumentation/jms/src/test/java/brave/jms/TracingJMSConsumerTest.java
+++ b/instrumentation/jms/src/test/java/brave/jms/TracingJMSConsumerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jms;
+
+import brave.handler.MutableSpan;
+import brave.propagation.B3Propagation;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.SamplingFlags;
+import brave.propagation.TraceContext;
+import java.io.IOException;
+import javax.jms.JMSConsumer;
+import javax.jms.Message;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.junit.After;
+import org.junit.Test;
+
+import static brave.Span.Kind.CONSUMER;
+import static brave.propagation.B3SingleFormat.parseB3SingleFormat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TracingJMSConsumerTest extends ITJms {
+  TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
+  JMSConsumer delegate = mock(JMSConsumer.class);
+  JMSConsumer tracingJMSConsumer = new TracingJMSConsumer(delegate, null, jmsTracing);
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  @Test public void receive_creates_consumer_span() throws Exception {
+    ActiveMQTextMessage message = new ActiveMQTextMessage();
+    receive(message);
+
+    MutableSpan consumer = testSpanHandler.takeRemoteSpan(CONSUMER);
+    assertThat(consumer.name()).isEqualTo("receive");
+    assertThat(consumer.name()).isEqualTo("receive");
+  }
+
+  @Test public void receive_continues_parent_trace_single_header() throws Exception {
+    ActiveMQTextMessage message = new ActiveMQTextMessage();
+    message.setStringProperty("b3", B3SingleFormat.writeB3SingleFormatWithoutParentId(parent));
+
+    receive(message);
+
+    // Ensure the current span in on the message, not the parent
+    MutableSpan consumer = testSpanHandler.takeRemoteSpan(CONSUMER);
+    assertChildOf(consumer, parent);
+
+    TraceContext messageContext = parseB3SingleFormat(message.getStringProperty("b3")).context();
+    assertThat(messageContext.traceIdString()).isEqualTo(consumer.traceId());
+    assertThat(messageContext.spanIdString()).isEqualTo(consumer.id());
+  }
+
+  @Test public void receive_retains_baggage_properties() throws Exception {
+    ActiveMQTextMessage message = new ActiveMQTextMessage();
+    B3Propagation.B3_STRING.injector(SETTER).inject(parent, message);
+    message.setStringProperty(BAGGAGE_FIELD_KEY, "");
+
+    receive(message);
+
+    assertThat(message.getProperties())
+      .containsEntry(BAGGAGE_FIELD_KEY, "");
+
+    testSpanHandler.takeRemoteSpan(CONSUMER);
+  }
+
+  void receive(Message message) throws Exception {
+    when(delegate.receive()).thenReturn(message);
+    tracingJMSConsumer.receive();
+  }
+
+  void assertNoProperties(ActiveMQTextMessage message) {
+    try {
+      assertThat(message.getProperties()).isEmpty();
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -97,7 +97,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
         ConsumerRecord<K, V> record = recordsInPartition.get(i);
         KafkaConsumerRequest request = new KafkaConsumerRequest(record);
         TraceContextOrSamplingFlags extracted =
-          kafkaTracing.extractAndClearHeaders(extractor, request, record.headers());
+          kafkaTracing.extractAndClearTraceIdHeaders(extractor, request, record.headers());
 
         // If we extracted neither a trace context, nor request-scoped data (extra),
         // and sharing trace is enabled make or reuse a span for this topic

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
@@ -105,7 +105,7 @@ final class TracingProducer<K, V> implements Producer<K, V> {
     Span span;
     if (maybeParent == null) {
       TraceContextOrSamplingFlags extracted =
-        kafkaTracing.extractAndClearHeaders(extractor, request, record.headers());
+        kafkaTracing.extractAndClearTraceIdHeaders(extractor, request, record.headers());
       span = kafkaTracing.nextMessagingSpan(sampler, request, extracted);
     } else { // If we have a span in scope assume headers were cleared before
       span = tracer.newChild(maybeParent);

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTracingTest.java
@@ -38,7 +38,6 @@ public class KafkaTracingTest extends KafkaTest {
     assertChildOf(spans.get(0), incoming);
   }
 
-
   @Test public void nextSpan_uses_current_context() {
     Span child;
     try (Scope ws = tracing.currentTraceContext().newScope(parent)) {
@@ -105,6 +104,13 @@ public class KafkaTracingTest extends KafkaTest {
 
     kafkaTracing.nextSpan(consumerRecord);
     assertThat(consumerRecord.headers().toArray()).isEmpty();
+  }
+
+  @Test public void nextSpan_should_retain_baggage_headers() {
+    consumerRecord.headers().add(BAGGAGE_FIELD_KEY, new byte[0]);
+
+    kafkaTracing.nextSpan(consumerRecord);
+    assertThat(consumerRecord.headers().headers(BAGGAGE_FIELD_KEY)).isNotEmpty();
   }
 
   @Test public void nextSpan_should_not_clear_other_headers() {

--- a/instrumentation/messaging/RATIONALE.md
+++ b/instrumentation/messaging/RATIONALE.md
@@ -1,20 +1,20 @@
 # brave-instrumentation-messaging rationale
 
-## Why clear trace state headers prior to invoking message processors?
+## Why clear trace ID headers prior to invoking message processors?
 
 When instrumentation intercept invocation of a message processor, they clear
-trace state headers (`Propagation.keys()`) before invoking a listener with a
+trace ID headers (`Propagation.keys()`) before invoking a listener with a
 span in scope. This is due to ordering precedence of tools like
 `KafkaTracing.nextSpan(record)`.
 
-Tools that extract incoming state from message requests prioritize headers
+Tools that extract incoming IDs from message requests prioritize headers
 over the current span (`Tracer.currentSpan()`). This is to prevent an
 accidentally leaked span (due to lack of `Scope.close()`) to become the parent
 of all spans, creating a huge trace. This logic is the same in RPC server
 instrumentation. When we are in control of invoking the message listener, we
 can guarantee no mistakes by clearing the headers first.
 
-We don't do this in server processing, eventhough Finagle used to to this.
+We don't do this in server processing, even though Finagle used to to this.
 There is no specific reason that we were never as defensive there, except that
 we provide not tools like `ServletTracing.nextSpan(request)` because users
 don't typically pass server requests through stages as they do with messaging.
@@ -26,6 +26,14 @@ first and replay them without the keys you want to key. An alternate approach
 we have not tried is to set empty instead of the more difficult and fragile
 "clear first" process. This could be used only in JMS, as other products have
 the ability to clear headers, not just set them.
+
+### Why don't we also clear baggage headers?
+We don't clear baggage (ex. BaggagePropagation.allKeyNames) before invoking
+processors as baggage headers don't interfere with trace hierarchy, and they
+are often used by 3rd party code. For example, clearing a message header named
+"user-id" or "request-id" prevents all code except that integrated with our
+`BaggageField` api from seeing the values. We don't want to prevent layered
+code from copying baggage-related properties into new messages.
 
 ## Why not `send-batch` and `receive-batch` operations?
 

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingMessagePostProcessor.java
@@ -68,7 +68,7 @@ final class TracingMessagePostProcessor implements MessagePostProcessor {
     Span span;
     if (maybeParent == null) {
       TraceContextOrSamplingFlags extracted =
-        springRabbitTracing.extractAndClearHeaders(extractor, request, message);
+        springRabbitTracing.extractAndClearTraceIdHeaders(extractor, request, message);
       span = springRabbitTracing.nextMessagingSpan(sampler, request, extracted);
     } else { // If we have a span in scope assume headers were cleared before
       span = tracer.newChild(maybeParent);

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingRabbitListenerAdvice.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/TracingRabbitListenerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -76,7 +76,7 @@ final class TracingRabbitListenerAdvice implements MethodInterceptor {
     MessageConsumerRequest request = new MessageConsumerRequest(message);
 
     TraceContextOrSamplingFlags extracted =
-      springRabbitTracing.extractAndClearHeaders(extractor, request, message);
+      springRabbitTracing.extractAndClearTraceIdHeaders(extractor, request, message);
 
     // named for BlockingQueueConsumer.nextMessage, which we can't currently see
     Span consumerSpan = springRabbitTracing.nextMessagingSpan(sampler, request, extracted);


### PR DESCRIPTION
Before, we cleared only trace ID headers in messaging, but cleared all
headers in Kafka and Rabbit. The problem in the latter was that it would
clear baggage like "user_id" and "country_code". These don't interfere
with the trace tree and worse, can prevent users from seeing correlation
IDs in third party code that doesn't use Brave.

The fix here is to clarify code and docs, moving implementation of Kafka
and RabbitMQ to match JMS.