### PR TITLE
Adds client side of HTTP OPTIONS and empty path tests

### DIFF
--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpClient.java
@@ -64,9 +64,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     client = newClient(server.getPort());
   }
 
-  /**
-   * Make sure the client you return has retries disabled.
-   */
+  /** Make sure the client you return has retries disabled. */
   protected abstract C newClient(int port) throws IOException;
 
   protected abstract void closeClient(C client) throws IOException;
@@ -77,9 +75,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
 
   protected abstract void post(C client, String pathIncludingQuery, String body) throws IOException;
 
-  /**
-   * Closes the client prior to calling {@link ITRemote#close()}
-   */
+  /** Closes the client prior to calling {@link ITRemote#close()} */
   @Override @After public void close() throws Exception {
     closeClient(client);
     super.close();
@@ -109,9 +105,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertSameIds(testSpanHandler.takeRemoteSpan(CLIENT), extracted);
   }
 
-  /**
-   * Unlike Brave 3, Brave 4 propagates trace ids even when unsampled
-   */
+  /** Unlike Brave 3, Brave 4 propagates trace ids even when unsampled */
   @Test public void propagatesUnsampledContext() throws IOException {
     server.enqueue(new MockResponse());
 
@@ -171,9 +165,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     assertThat(extract(takeRequest()).sampled()).isFalse();
   }
 
-  /**
-   * This prevents confusion as a blocking client should end before, the start of the next span.
-   */
+  /** This prevents confusion as a blocking client should end before, the start of the next span. */
   @Test public void clientTimestampAndDurationEnclosedByParent() throws IOException {
     server.enqueue(new MockResponse());
 
@@ -204,8 +196,8 @@ public abstract class ITHttpClient<C> extends ITRemote {
     get(client, "/foo");
 
     assertThat(testSpanHandler.takeRemoteSpan(CLIENT))
-      .extracting(MutableSpan::remoteIp, MutableSpan::remotePort)
-      .containsExactly("127.0.0.1", server.getPort());
+        .extracting(MutableSpan::remoteIp, MutableSpan::remotePort)
+        .containsExactly("127.0.0.1", server.getPort());
   }
 
   @Test public void defaultSpanNameIsMethodName() throws IOException {
@@ -414,8 +406,8 @@ public abstract class ITHttpClient<C> extends ITRemote {
   }
 
   /**
-   * This ensures custom span handlers can see the actual exception thrown, not just the "error" tag
-   * value.
+   * This ensures custom span handlers can see the actual exception thrown, not just the "error"
+   * tag value.
    */
   void spanHandlerSeesError(Callable<Void> get) throws IOException {
     ConcurrentLinkedDeque<Throwable> caughtThrowables = new ConcurrentLinkedDeque<>();
@@ -442,8 +434,8 @@ public abstract class ITHttpClient<C> extends ITRemote {
     checkReportsSpanOnTransportException(get);
 
     assertThat(caughtThrowables)
-      .withFailMessage("Span finished with error, but caughtThrowables empty")
-      .isNotEmpty();
+        .withFailMessage("Span finished with error, but caughtThrowables empty")
+        .isNotEmpty();
     if (caughtThrowables.size() > 1) {
       for (Throwable throwable : caughtThrowables) {
         Logger.getAnonymousLogger().log(Level.SEVERE, "multiple calls to finish", throwable);
@@ -469,9 +461,7 @@ public abstract class ITHttpClient<C> extends ITRemote {
     return "http://127.0.0.1:" + server.getPort() + pathIncludingQuery;
   }
 
-  /**
-   * Ensures a timeout receiving a request happens before the method timeout
-   */
+  /** Ensures a timeout receiving a request happens before the method timeout */
   protected RecordedRequest takeRequest() {
     try {
       return server.takeRequest(3, TimeUnit.SECONDS);

--- a/instrumentation/http/src/main/java/brave/http/HttpRequest.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpRequest.java
@@ -69,6 +69,20 @@ public abstract class HttpRequest extends Request {
    *
    * <p>{@code null} could mean not applicable to the HTTP method (ex CONNECT).
    *
+   * <h3>Implementation notes</h3>
+   * Some HTTP client abstractions, such as JAX-RS and spring-web, return the input as opposed to
+   * the absolute path. One common problem is a path requested as "", not "/". When that's the case,
+   * normalize "" to "/". This ensures values are consistent with wire-level clients and behaviour
+   * consistent with RFC 7230 Section 2.7.3.
+   *
+   * <p>Ex.
+   * <pre>{@code
+   * @Override public String path() {
+   *   String result = delegate.getURI().getPath();
+   *   return result != null && result.isEmpty() ? "/" : result;
+   * }
+   * }</pre>
+   *
    * @see #url()
    * @see HttpResponse#route()
    * @see HttpTags#PATH

--- a/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
+++ b/instrumentation/httpasyncclient/src/test/java/brave/httpasyncclient/ITTracingHttpAsyncClientBuilder.java
@@ -27,6 +27,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.concurrent.FutureCallback;
@@ -51,10 +52,14 @@ public class ITTracingHttpAsyncClientBuilder extends ITHttpAsyncClient<Closeable
     client.close();
   }
 
-  @Override protected void get(CloseableHttpAsyncClient client, String pathIncludingQuery)
-    throws IOException {
-    HttpGet get = new HttpGet(URI.create(url(pathIncludingQuery)));
-    invoke(client, get);
+  @Override
+  protected void get(CloseableHttpAsyncClient client, String pathIncludingQuery) throws IOException {
+    invoke(client, new HttpGet(URI.create(url(pathIncludingQuery))));
+  }
+
+  @Override
+  protected void options(CloseableHttpAsyncClient client, String path) throws IOException {
+    invoke(client, new HttpOptions(URI.create(url(path))));
   }
 
   @Override

--- a/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
+++ b/instrumentation/httpclient/src/test/java/brave/httpclient/ITTracingHttpClientBuilder.java
@@ -13,6 +13,7 @@
  */
 package brave.httpclient;
 
+import brave.Span;
 import brave.test.http.ITHttpClient;
 import java.io.IOException;
 import java.net.URI;
@@ -20,11 +21,11 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
-import brave.Span;
 
 import static org.apache.http.util.EntityUtils.consume;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +42,11 @@ public class ITTracingHttpClientBuilder extends ITHttpClient<CloseableHttpClient
   @Override protected void get(CloseableHttpClient client, String pathIncludingQuery)
     throws IOException {
     consume(client.execute(new HttpGet(URI.create(url(pathIncludingQuery)))).getEntity());
+  }
+
+  @Override protected void options(CloseableHttpClient client, String path)
+    throws IOException {
+    consume(client.execute(new HttpOptions(URI.create(url(path)))).getEntity());
   }
 
   @Override protected void post(CloseableHttpClient client, String pathIncludingQuery, String body)

--- a/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
+++ b/instrumentation/jaxrs2/src/main/java/brave/jaxrs2/TracingClientFilter.java
@@ -90,7 +90,8 @@ public final class TracingClientFilter implements ClientRequestFilter, ClientRes
     }
 
     @Override public String path() {
-      return delegate.getUri().getPath();
+      String result = delegate.getUri().getPath();
+      return result != null && result.isEmpty() ? "/" : result;
     }
 
     @Override public String url() {

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientRequestContextWrapperTest.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ClientRequestContextWrapperTest.java
@@ -44,6 +44,14 @@ public class ClientRequestContextWrapperTest {
     assertThat(new ClientRequestContextWrapper(request).path()).isEqualTo("/api");
   }
 
+  // NOTE: While technically possible, it is not easy to make URI.getPath() return null!
+  @Test public void path_emptyToSlash() {
+    when(request.getUri()).thenReturn(URI.create("http://localhost"));
+
+    assertThat(new ClientRequestContextWrapper(request).path())
+      .isEqualTo("/");
+  }
+
   @Test public void url() {
     when(request.getUri()).thenReturn(URI.create("http://localhost/api"));
 

--- a/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
+++ b/instrumentation/jaxrs2/src/test/java/brave/jaxrs2/ITTracingJaxRSClientBuilder.java
@@ -14,6 +14,7 @@
 package brave.jaxrs2;
 
 import brave.test.http.ITHttpAsyncClient;
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -70,6 +71,12 @@ public class ITTracingJaxRSClientBuilder extends ITHttpAsyncClient<Client> {
             callback.accept(null, throwable);
           }
         });
+  }
+
+  @Override protected void options(Client client, String path) throws IOException {
+    client.target(url(path))
+      .request(MediaType.TEXT_PLAIN_TYPE)
+      .options();
   }
 
   @Override

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingCallFactory.java
@@ -65,6 +65,11 @@ public class ITTracingCallFactory extends ITHttpAsyncClient<Call.Factory> {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery)).build()).execute();
   }
 
+  @Override protected void options(Call.Factory client, String path) throws IOException {
+    client.newCall(new Request.Builder().method("OPTIONS", null).url(url(path)).build())
+      .execute();
+  }
+
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
     throws IOException {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery))

--- a/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
+++ b/instrumentation/okhttp3/src/test/java/brave/okhttp3/ITTracingInterceptor.java
@@ -58,6 +58,11 @@ public class ITTracingInterceptor extends ITHttpAsyncClient<Call.Factory> {
       .execute();
   }
 
+  @Override protected void options(Call.Factory client, String path) throws IOException {
+    client.newCall(new Request.Builder().method("OPTIONS", null).url(url(path)).build())
+      .execute();
+  }
+
   @Override protected void post(Call.Factory client, String pathIncludingQuery, String body)
     throws IOException {
     client.newCall(new Request.Builder().url(url(pathIncludingQuery))

--- a/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/it/spring3/src/test/java/brave/spring/web3/ITTracingClientHttpRequestInterceptor.java
@@ -54,6 +54,12 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     restTemplate.getForObject(url(pathIncludingQuery), String.class);
   }
 
+  @Override protected void options(ClientHttpRequestFactory client, String path) {
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.optionsForAllow(url(path), String.class);
+  }
+
   @Override protected void post(ClientHttpRequestFactory client, String uri, String content) {
     RestTemplate restTemplate = new RestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TracingClientHttpRequestInterceptor.java
@@ -78,7 +78,8 @@ public final class TracingClientHttpRequestInterceptor implements ClientHttpRequ
     }
 
     @Override public String path() {
-      return delegate.getURI().getPath();
+      String result = delegate.getURI().getPath(); // per JavaDoc, getURI() is never null
+      return result != null && result.isEmpty() ? "/" : result;
     }
 
     @Override public String url() {

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/HttpRequestWrapperTest.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/HttpRequestWrapperTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.spring.web;
+
+import brave.spring.web.TracingClientHttpRequestInterceptor.HttpRequestWrapper;
+import java.net.URI;
+import org.junit.Test;
+import org.springframework.http.HttpRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HttpRequestWrapperTest {
+  HttpRequest request = mock(HttpRequest.class);
+
+  @Test public void path() {
+    when(request.getURI()).thenReturn(URI.create("http://localhost/api"));
+
+    assertThat(new HttpRequestWrapper(request).path())
+      .isEqualTo("/api");
+  }
+
+  // NOTE: While technically possible, it is not easy to make URI.getPath() return null!
+  @Test public void path_emptyToSlash() {
+    when(request.getURI()).thenReturn(URI.create("http://localhost"));
+
+    assertThat(new HttpRequestWrapper(request).path())
+      .isEqualTo("/");
+  }
+}

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingAsyncClientHttpRequestInterceptor.java
@@ -70,6 +70,12 @@ public class ITTracingAsyncClientHttpRequestInterceptor
     restTemplate.getForEntity(url(pathIncludingQuery), String.class).completable().join();
   }
 
+  @Override protected void options(AsyncClientHttpRequestFactory client, String path) {
+    AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.optionsForAllow(url(path)).completable().join();
+  }
+
   @Override protected void post(AsyncClientHttpRequestFactory client, String uri, String content) {
     AsyncRestTemplate restTemplate = new AsyncRestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));

--- a/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
+++ b/instrumentation/spring-web/src/test/java/brave/spring/web/ITTracingClientHttpRequestInterceptor.java
@@ -63,6 +63,12 @@ public class ITTracingClientHttpRequestInterceptor extends ITHttpClient<ClientHt
     restTemplate.getForObject(url(pathIncludingQuery), String.class);
   }
 
+  @Override protected void options(ClientHttpRequestFactory client, String path) {
+    RestTemplate restTemplate = new RestTemplate(client);
+    restTemplate.setInterceptors(Collections.singletonList(interceptor));
+    restTemplate.optionsForAllow(url(path), String.class);
+  }
+
   @Override protected void post(ClientHttpRequestFactory client, String uri, String content) {
     RestTemplate restTemplate = new RestTemplate(client);
     restTemplate.setInterceptors(Collections.singletonList(interceptor));


### PR DESCRIPTION
This makes the client tests have parity with server ones. Notably, this
tests OPTIONS requests work, and that "" coerses to "/".