### PR TITLE
Use JDK 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 language: java
 
-jdk: openjdk13
+jdk: openjdk14
 
 before_install:
   # Disable testcontainers checks

--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11,14)</version>
+                  <version>[11,15)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
This allows and uses JDK 14 when building the project.

It doesn't change the Java level needed for usage of Brave.