### PR TITLE
Fix comment; s/HttpTracing.serverName/HttpTracing.clientOf

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpTracing.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpTracing.java
@@ -93,7 +93,7 @@ public class HttpTracing implements Closeable {
    *
    * For example:
    * <pre>{@code
-   * github = TracingHttpClientBuilder.create(httpTracing.serverName("github"));
+   * github = TracingHttpClientBuilder.create(httpTracing.clientOf("github"));
    * }</pre>
    *
    * @see HttpClientHandler


### PR DESCRIPTION
Now, `HttpTracing#serverName` is not public method, thus replace it with `clientOf`.