### PR TITLE
Fixing OSGi resolution issues caused by jdk.internal.vm.annotation

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -35,7 +35,7 @@
 
     <!-- use the same values in ../pom.xml -->
     <zipkin.version>2.21.7</zipkin.version>
-    <zipkin-reporter.version>2.15.1-SNAPSHOT</zipkin-reporter.version>
+    <zipkin-reporter.version>2.15.1</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -34,8 +34,8 @@
     <main.basedir>${project.basedir}/..</main.basedir>
 
     <!-- use the same values in ../pom.xml -->
-    <zipkin.version>2.21.1</zipkin.version>
-    <zipkin-reporter.version>2.15.0</zipkin-reporter.version>
+    <zipkin.version>2.21.7</zipkin.version>
+    <zipkin-reporter.version>2.15.1-SNAPSHOT</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/brave/bnd.bnd
+++ b/brave/bnd.bnd
@@ -1,4 +1,5 @@
 Import-Package: \
+  jdk.internal.vm.annotation;resolution:=optional,\
   *
 Export-Package: \
   brave,\

--- a/brave/src/main/java/brave/baggage/BaggagePropagation.java
+++ b/brave/src/main/java/brave/baggage/BaggagePropagation.java
@@ -276,7 +276,7 @@ public final class BaggagePropagation<K> implements Propagation<K> {
     if (propagation == null) throw new NullPointerException("propagation == null");
     // When baggage or similar is in use, the result != TraceContextOrSamplingFlags.EMPTY
     TraceContextOrSamplingFlags emptyExtraction =
-        propagation.extractor((c, k) -> null).extract(Boolean.TRUE);
+      propagation.extractor(NoopGetter.INSTANCE).extract(Boolean.TRUE);
     List<String> baggageKeyNames = getAllKeyNames(emptyExtraction);
     if (baggageKeyNames.isEmpty()) return propagation.keys();
 
@@ -284,6 +284,16 @@ public final class BaggagePropagation<K> implements Propagation<K> {
     result.addAll(propagation.keys());
     result.addAll(baggageKeyNames);
     return Collections.unmodifiableList(result);
+  }
+
+  // Not lambda as Retrolambda creates an OSGi dependency on jdk.internal.vm.annotation with JDK 14
+  // See https://github.com/luontola/retrolambda/issues/160
+  enum NoopGetter implements Getter<Boolean, String> {
+    INSTANCE;
+
+    @Override public String get(Boolean request, String key) {
+      return null;
+    }
   }
 
   static List<String> getAllKeyNames(TraceContextOrSamplingFlags extracted) {

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
     <!-- use the same values in bom/pom.xml -->
     <zipkin.version>2.21.7</zipkin.version>
-    <zipkin-reporter.version>2.15.1-SNAPSHOT</zipkin-reporter.version>
+    <zipkin-reporter.version>2.15.1</zipkin-reporter.version>
 
     <!-- Ensure older versions of spring still work -->
     <spring5.version>5.2.7.RELEASE</spring5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
     <errorprone.version>2.4.0</errorprone.version>
 
     <!-- use the same values in bom/pom.xml -->
-    <zipkin.version>2.21.1</zipkin.version>
-    <zipkin-reporter.version>2.15.0</zipkin-reporter.version>
+    <zipkin.version>2.21.7</zipkin.version>
+    <zipkin-reporter.version>2.15.1-SNAPSHOT</zipkin-reporter.version>
 
     <!-- Ensure older versions of spring still work -->
     <spring5.version>5.2.7.RELEASE</spring5.version>
@@ -129,7 +129,7 @@
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
     <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-    <maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
Addressed https://github.com/openzipkin/brave/issues/1243, checked with 5.12.5-SNAPSHOT builds (local), the issue is gone. Thanks to  @dkulp and @adriancole .