### PR TITLE
Fixes and backfills missing test of localEndpoint IP default

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -475,6 +475,10 @@ public abstract class Tracing implements Closeable {
       this.noop = new AtomicBoolean();
 
       MutableSpan defaultSpan = new MutableSpan(builder.defaultSpan); // safe copy
+      // Lazy add localEndpoint.ip if not yet set
+      if (defaultSpan.localIp() == null) {
+        defaultSpan.localIp(Platform.get().linkLocalIp());
+      }
 
       Set<SpanHandler> spanHandlers = new LinkedHashSet<>(builder.spanHandlers);
       // When present, the Zipkin handler is invoked after the user-supplied ones.

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -16,6 +16,7 @@ package brave;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
+import brave.internal.Platform;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.Propagation;
 import brave.propagation.StrictCurrentTraceContext;
@@ -68,6 +69,14 @@ public class TracingTest {
     }
 
     assertThat(spans).isEmpty();
+  }
+
+  @Test public void localEndpointDefaults() {
+    Tracing tracing = Tracing.newBuilder().build();
+    assertThat(tracing).extracting("tracer.pendingSpans.defaultSpan.localServiceName")
+      .isEqualTo("unknown");
+    assertThat(tracing).extracting("tracer.pendingSpans.defaultSpan.localIp")
+      .isEqualTo(Platform.get().linkLocalIp());
   }
 
   @Test public void localServiceNamePreservesCase() {


### PR DESCRIPTION
When we switched to use zipkin-reporter-brave, we goofed IP defaults. It
happened because we never tested existence of local IP all these years!

Thanks to @heesuk-ahn for reporting