### PR TITLE
Tries to hone OSGi imports according to use

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -35,7 +35,7 @@
 
     <!-- use the same values in ../pom.xml -->
     <zipkin.version>2.21.7</zipkin.version>
-    <zipkin-reporter.version>2.15.1</zipkin-reporter.version>
+    <zipkin-reporter.version>2.15.2</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/context/jfr/bnd.bnd
+++ b/context/jfr/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/context/log4j12/bnd.bnd
+++ b/context/log4j12/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.CorrelationContext
+# We use need to import to support brave.internal.CorrelationContext
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.context.log4j12

--- a/context/log4j2/bnd.bnd
+++ b/context/log4j2/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.CorrelationContext
+# We use need to import to support brave.internal.CorrelationContext
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.context.log4j2

--- a/context/slf4j/bnd.bnd
+++ b/context/slf4j/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.CorrelationContext
+# We use need to import to support brave.internal.CorrelationContext
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.context.slf4j

--- a/instrumentation/dubbo-rpc/bnd.bnd
+++ b/instrumentation/dubbo-rpc/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.Platform
+# We use need to import to support brave.internal.Platform
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.dubbo.rpc

--- a/instrumentation/dubbo/bnd.bnd
+++ b/instrumentation/dubbo/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.Platform
+# We use need to import to support brave.internal.Platform
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.dubbo

--- a/instrumentation/grpc/bnd.bnd
+++ b/instrumentation/grpc/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable,Platform,MapPropagationFields,PropagationFieldsFactory
+# We use need to import to support brave.internal.Platform,MapPropagationFields,PropagationFieldsFactory
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.grpc

--- a/instrumentation/http/bnd.bnd
+++ b/instrumentation/http/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/httpasyncclient/bnd.bnd
+++ b/instrumentation/httpasyncclient/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/httpclient/bnd.bnd
+++ b/instrumentation/httpclient/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/jersey-server/bnd.bnd
+++ b/instrumentation/jersey-server/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/jms/bnd.bnd
+++ b/instrumentation/jms/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.Throwables
+# We use need to import to support brave.internal.Throwables
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.jms

--- a/instrumentation/kafka-clients/bnd.bnd
+++ b/instrumentation/kafka-clients/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/messaging/bnd.bnd
+++ b/instrumentation/messaging/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/netty-codec-http/bnd.bnd
+++ b/instrumentation/netty-codec-http/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.Platform
+# We use need to import to support brave.internal.Platform
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.netty.http

--- a/instrumentation/p6spy/bnd.bnd
+++ b/instrumentation/p6spy/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/rpc/bnd.bnd
+++ b/instrumentation/rpc/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/instrumentation/servlet/bnd.bnd
+++ b/instrumentation/servlet/bnd.bnd
@@ -1,6 +1,7 @@
-# We use brave.internal.Nullable and brave.internal.Throwables
+# We use need to import to support brave.internal.Throwables
+# brave.internal.Nullable is not used at runtime.
 Import-Package: \
-  !brave.internal*,\
+  brave.internal;braveinternal=true,\
   *
 Export-Package: \
   brave.servlet

--- a/instrumentation/spring-rabbit/bnd.bnd
+++ b/instrumentation/spring-rabbit/bnd.bnd
@@ -1,4 +1,4 @@
-# We use brave.internal.Nullable, but nothing else internal.
+# We use brave.internal.Nullable, but it is not used at runtime.
 Import-Package: \
   !brave.internal*,\
   *

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
     <!-- use the same values in bom/pom.xml -->
     <zipkin.version>2.21.7</zipkin.version>
-    <zipkin-reporter.version>2.15.1</zipkin-reporter.version>
+    <zipkin-reporter.version>2.15.2</zipkin-reporter.version>
 
     <!-- Ensure older versions of spring still work -->
     <spring5.version>5.2.7.RELEASE</spring5.version>


### PR DESCRIPTION
It is my understanding that unless we shade something, we have to add
internal import for the few utilities we use.

Fixes #1248