### PR TITLE
Bumps library versions to latest

### DIFF
--- a/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
+++ b/brave-tests/src/main/java/brave/test/propagation/PropagationTest.java
@@ -180,8 +180,9 @@ public abstract class PropagationTest {
       Map<Object, String> map = new LinkedHashMap<>();
       injector.inject(ctx, map);
 
-      assertThat(extractor.extract(map).context())
-        .isEqualToIgnoringGivenFields(ctx, "traceIdString", "spanIdString");
+      TraceContext extracted = extractor.extract(map).context();
+      assertThat(extracted.traceIdString()).isEqualTo(ctx.traceIdString());
+      assertThat(extracted.spanIdString()).isEqualTo(ctx.spanIdString());
     }
   }
 }

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -18,6 +18,7 @@ import brave.internal.InternalPropagation;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -578,7 +579,7 @@ public class MutableSpanTest {
         MutableSpan other = otherConstructor.get();
         assertThat(span).isNotSameAs(other); // sanity
         assertNeitherEqualNorShareHashCode(span, other);
-        assertThat(span).usingRecursiveComparison().isNotEqualTo(other); // double check our impl
+        assertThat(Objects.deepEquals(span, other)).isFalse(); // double check our impl
       }
     }
   }

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -28,7 +28,8 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
-    <undertow.version>2.1.3.Final</undertow.version>
+    <jmh.version>1.25.2</jmh.version>
+    <undertow.version>2.2.0.Final</undertow.version>
     <spring.version>${spring5.version}</spring.version>
   </properties>
 

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -32,7 +32,7 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
     <!-- Use brave-instrumentation-dubbo for Apache Dubbo 2.7+, not this module. -->
-    <dubbo.version>2.6.8</dubbo.version>
+    <dubbo.version>2.6.9</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -32,7 +32,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
 
-    <dubbo.version>2.7.7</dubbo.version>
+    <dubbo.version>2.7.8</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -33,7 +33,6 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
 
-    <protobuf.version>3.12.0</protobuf.version>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -313,6 +313,11 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
     return delegate.groupMetadata();
   }
 
+  // Do not use @Override annotation to avoid compatibility issue version < 2.6
+  public void enforceRebalance() {
+    delegate.enforceRebalance();
+  }
+
   @Override public void close() {
     delegate.close();
   }

--- a/instrumentation/mongodb/pom.xml
+++ b/instrumentation/mongodb/pom.xml
@@ -34,7 +34,7 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
 
-    <mongodb-driver.version>3.12.5</mongodb-driver.version>
+    <mongodb-driver.version>3.12.7</mongodb-driver.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/mongodb/src/main/java/brave/mongodb/TraceMongoCommandListener.java
+++ b/instrumentation/mongodb/src/main/java/brave/mongodb/TraceMongoCommandListener.java
@@ -61,11 +61,13 @@ final class TraceMongoCommandListener implements CommandListener {
    * all callbacks happen on the same thread.
    */
   @Override public void commandStarted(CommandStartedEvent event) {
+    String databaseName = event.getDatabaseName();
+    if ("admin".equals(databaseName)) return; // don't trace commands like "endSessions"
+
     Span span = threadLocalSpan.next();
     if (span == null || span.isNoop()) return;
 
     String commandName = event.getCommandName();
-    String databaseName = event.getDatabaseName();
     BsonDocument command = event.getCommand();
     String collectionName = getCollectionName(command, commandName);
 

--- a/instrumentation/mongodb/src/test/java/brave/mongodb/ITMongoDB.java
+++ b/instrumentation/mongodb/src/test/java/brave/mongodb/ITMongoDB.java
@@ -35,7 +35,7 @@ public abstract class ITMongoDB extends ITRemote { // public because of ClassRul
   static final int MONGODB_PORT = 27017;
 
   @ClassRule
-  public static GenericContainer<?> mongo = new GenericContainer<>("mongo:4.0")
+  public static GenericContainer<?> mongo = new GenericContainer<>("mongo:4.4")
     .withExposedPorts(MONGODB_PORT);
 
   @BeforeClass public static void initCollection() {

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.20</version>
+      <version>8.0.21</version>
       <scope>provided</scope>
     </dependency>
 

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -33,7 +33,7 @@
     <main.java.version>1.6</main.java.version>
     <main.signature.artifact>java16</main.signature.artifact>
 
-    <p6spy.version>3.9.0</p6spy.version>
+    <p6spy.version>3.9.1</p6spy.version>
     <derby.version>10.15.2.0</derby.version>
   </properties>
 

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -30,7 +30,7 @@
     <module.name>brave.vertx.web</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>3.9.2</vertx.version>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,12 @@
   </developers>
 
   <properties>
+    <main.basedir>${project.basedir}</main.basedir>
+
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <main.basedir>${project.basedir}</main.basedir>
 
     <!-- default bytecode version for src/main -->
     <main.java.version>1.7</main.java.version>
@@ -82,7 +83,7 @@
     <zipkin-reporter.version>2.15.2</zipkin-reporter.version>
 
     <!-- Ensure older versions of spring still work -->
-    <spring5.version>5.2.7.RELEASE</spring5.version>
+    <spring5.version>5.2.8.RELEASE</spring5.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
     <!-- Apis used, but not in Jetty 7.6* imply duplication in servlet25 test fixtures -->
@@ -90,47 +91,50 @@
     <jetty.version>9.4.30.v20200611</jetty.version>
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
     <!-- Note: 3.1.x requires Java 8; 3.0.20.Final is broken -->
-    <resteasy.version>3.12.1.Final</resteasy.version>
+    <resteasy.version>3.13.1.Final</resteasy.version>
 
-    <kafka.version>2.5.0</kafka.version>
-    <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.1.9</kafka-junit.version>
+    <kafka.version>2.6.0</kafka.version>
     <activemq.version>5.16.0</activemq.version>
-    <spring-rabbit.version>2.2.8.RELEASE</spring-rabbit.version>
+    <spring-rabbit.version>2.2.10.RELEASE</spring-rabbit.version>
 
-    <finagle.version>20.6.0</finagle.version>
+    <finagle.version>20.8.1</finagle.version>
     <log4j.version>2.13.3</log4j.version>
-    <okhttp.version>4.7.2</okhttp.version>
+    <okhttp.version>4.9.0</okhttp.version>
     <httpclient.version>4.5.12</httpclient.version>
 
-    <grpc.version>1.30.2</grpc.version>
+    <grpc.version>1.32.1</grpc.version>
+    <protobuf.version>3.12.0</protobuf.version>
     <!-- prefer grpc's version of netty -->
-    <netty.version>4.1.48.Final</netty.version>
+    <netty.version>4.1.51.Final</netty.version>
 
     <sparkjava.version>2.9.2</sparkjava.version>
+
+    <!-- Test only dependencies -->
     <junit.version>4.13</junit.version>
-    <assertj.version>3.16.1</assertj.version>
+    <assertj.version>3.17.2</assertj.version>
     <powermock.version>2.0.7</powermock.version>
-    <mockito.version>3.3.3</mockito.version>
+    <mockito.version>3.5.10</mockito.version>
     <jersey.version>2.31</jersey.version>
-    <jmh.version>1.23</jmh.version>
+    <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
+    <kafka-junit.version>4.1.10</kafka-junit.version>
     <testcontainers.version>1.14.3</testcontainers.version>
 
+    <animal-sniffer-maven-plugin.version>1.19</animal-sniffer-maven-plugin.version>
+    <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
+    <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
+    <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-    <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <!-- 3.0.0-M5 breaks the build: https://github.com/openzipkin/zipkin/issues/3159 -->
+    <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
+    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+    <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
     <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <!-- 3.0.0-M5 breaks running brave-tests ITRemoteTest.tracer_includesClassName:26
-          NoClassDefFound brave/propagation/CurrentTraceContext$Builder -->
-    <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
-    <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-    <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
-    <license-maven-plugin.version>3.0</license-maven-plugin.version>
+    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
   </properties>
 
   <modules>
@@ -475,7 +479,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.18</version>
+          <version>${animal-sniffer-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -549,6 +553,7 @@
             <artifactId>${main.signature.artifact}</artifactId>
             <version>1.0</version>
           </signature>
+          <checkTestClasses>false</checkTestClasses>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
NOTE: mongo in a patch suddenly started leaking [endSessions](https://docs.mongodb.com/manual/reference/command/endSessions/) admin commands into the listener. I've filtered admin commands out similar to how we do in p6spy and how we choose intentionally to not trace admin commands in kafka

https://github.com/mongodb/mongo-java-driver/commit/e0572db771b682f6c50006965f64c5de1f17a1b3