### PR TITLE
Accept any string as zipkinServiceName parameter.

### DIFF
--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -66,6 +66,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
       <scope>test</scope>

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -29,8 +29,9 @@ import static brave.Span.Kind.CLIENT;
 
 final class TracingJdbcEventListener extends SimpleJdbcEventListener {
 
+  // Captures all the characters between = and either the next & or the end of the string.
   private static final Pattern URL_SERVICE_NAME_FINDER =
-    Pattern.compile("zipkinServiceName=(\\w*)");
+    Pattern.compile("zipkinServiceName=(.*?)(?:&|$)");
 
   @Nullable final String remoteServiceName;
   final boolean includeParameterValues;


### PR DESCRIPTION
While `remoteServiceName` accepts any string, the jdbc url parameter which provides a way to override it only accepts characters from the word group `[a-zA-Z0-9_]` this change remove that assumption and capture the complete value of the parameter and it solves a problem that I'm experiencing where in my naming convention (kebab case) is not possible to have the correct value due the presence of dash (`-`), for example `my-database-override` results in `my` as the `remoteServiceName`.