### PR TITLE
Adds RpcTracing.propagation() and fixes grpc-trace-bin propagation

### DIFF
--- a/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/GrpcPropagation.java
@@ -100,9 +100,9 @@ final class GrpcPropagation implements Propagation<String> {
     }
 
     @Override public void inject(TraceContext context, R request) {
-      if (request instanceof GrpcClientRequest) {
+      if (request instanceof GrpcRequest) {
         byte[] serialized = TraceContextBinaryFormat.toBytes(context);
-        Metadata metadata = ((GrpcClientRequest) request).headers;
+        Metadata metadata = ((GrpcRequest) request).headers();
         metadata.removeAll(GRPC_TRACE_BIN);
         metadata.put(GRPC_TRACE_BIN, serialized);
         TagsBin tags = context.findExtra(TagsBin.class);
@@ -125,9 +125,9 @@ final class GrpcPropagation implements Propagation<String> {
     }
 
     @Override public TraceContextOrSamplingFlags extract(R request) {
-      if (!(request instanceof GrpcServerRequest)) return delegate.extract(request);
+      if (!(request instanceof GrpcRequest)) return delegate.extract(request);
 
-      Metadata metadata = ((GrpcClientRequest) request).headers;
+      Metadata metadata = ((GrpcRequest) request).headers();
 
       // First, check if we are propagating gRPC tags.
       TagsBin tagsBin = metadata.get(GRPC_TAGS_BIN);

--- a/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
+++ b/instrumentation/grpc/src/test/java/brave/grpc/TestServer.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 class TestServer {
   static final Key<String> CUSTOM_KEY = Key.of("custom", Metadata.ASCII_STRING_MARSHALLER);
   final BlockingQueue<Long> delayQueue = new LinkedBlockingQueue<>();
+  final BlockingQueue<Metadata> headers = new LinkedBlockingQueue<>();
   final BlockingQueue<TraceContextOrSamplingFlags> requests = new LinkedBlockingQueue<>();
   final Extractor<GrpcServerRequest> extractor;
   final Server server;
@@ -57,6 +58,7 @@ class TestServer {
                     throw new AssertionError("interrupted sleeping " + delay);
                   }
                 }
+                TestServer.this.headers.add(headers);
                 requests.add(extractor.extract(new GrpcServerRequest(nameToKey, call, headers)));
                 return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
                   @Override public void sendHeaders(Metadata headers) {

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcClientHandler.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcClientHandler.java
@@ -69,7 +69,7 @@ public final class RpcClientHandler extends RpcHandler<RpcClientRequest, RpcClie
   RpcClientHandler(RpcTracing rpcTracing) {
     super(rpcTracing.clientRequestParser(), rpcTracing.clientResponseParser());
     this.tracer = rpcTracing.tracing().tracer();
-    this.injector = rpcTracing.tracing.propagation().injector(RpcClientRequest.SETTER);
+    this.injector = rpcTracing.propagation().injector(RpcClientRequest.SETTER);
     this.sampler = rpcTracing.clientSampler();
   }
 

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcServerHandler.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcServerHandler.java
@@ -68,7 +68,7 @@ public final class RpcServerHandler extends RpcHandler<RpcServerRequest, RpcServ
   RpcServerHandler(RpcTracing rpcTracing) {
     super(rpcTracing.serverRequestParser(), rpcTracing.serverResponseParser());
     this.tracer = rpcTracing.tracing().tracer();
-    this.extractor = rpcTracing.tracing().propagation().extractor(RpcServerRequest.GETTER);
+    this.extractor = rpcTracing.propagation().extractor(RpcServerRequest.GETTER);
     this.sampler = rpcTracing.serverSampler();
   }
 

--- a/instrumentation/rpc/src/test/java/brave/rpc/RpcTracingTest.java
+++ b/instrumentation/rpc/src/test/java/brave/rpc/RpcTracingTest.java
@@ -14,6 +14,8 @@
 package brave.rpc;
 
 import brave.Tracing;
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
 import org.junit.Test;
 
 import static brave.sampler.SamplerFunctions.deferDecision;
@@ -43,5 +45,25 @@ public class RpcTracingTest {
     assertThat(rpcTracing.toBuilder().clientSampler(neverSample()).build())
         .usingRecursiveComparison()
         .isEqualTo(RpcTracing.newBuilder(tracing).clientSampler(neverSample()).build());
+  }
+
+  @Test public void canOverridePropagation() {
+    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+      .injectFormat(B3Propagation.Format.SINGLE)
+      .build().get();
+
+    RpcTracing rpcTracing = RpcTracing.newBuilder(tracing)
+      .propagation(propagation)
+      .build();
+
+    assertThat(rpcTracing.propagation())
+      .isSameAs(propagation);
+
+    rpcTracing = RpcTracing.create(tracing).toBuilder()
+      .propagation(propagation)
+      .build();
+
+    assertThat(rpcTracing.propagation())
+      .isSameAs(propagation);
   }
 }


### PR DESCRIPTION
When gRPC dropped census, it broke our integration tests. We removed
them, and in doing so lost coverage of the deprecated `grpc-trace-bin`
format, which drifted and broke.

@dimi-nk's company are still using that format. The cleanest way to
support it is to allow overriding of `RpcTracing.propagation()`. This
allows us the most flexibility including backporting the feature
without breaking API.

While I've done this only for RpcTracing, it might make sense for
HTTP and Messaging, as some library specific formats might exist
elsewhere. If no one asks for that, I'll leave it to just RpcTracing.

cc @anuraaga @jeqo @jorgheymans @jcchavezs @saturnism