### PR TITLE
Adds MessagingTracing.propagation()

### DIFF
--- a/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
+++ b/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
@@ -144,7 +144,7 @@ public final class JmsTracing {
   JmsTracing(Builder builder) { // intentionally hidden constructor
     this.tracing = builder.messagingTracing.tracing();
     this.tracer = tracing.tracer();
-    Propagation<String> propagation = tracing.propagation();
+    Propagation<String> propagation = builder.messagingTracing.propagation();
     if (JmsTypes.HAS_JMS_PRODUCER) {
       this.jmsProducerExtractor = propagation.extractor(JMSProducerRequest.GETTER);
       this.jmsProducerInjector = propagation.injector(JMSProducerRequest.SETTER);
@@ -156,11 +156,11 @@ public final class JmsTracing {
     this.messageProducerInjector = propagation.injector(MessageProducerRequest.SETTER);
     this.messageConsumerExtractor = propagation.extractor(MessageConsumerRequest.GETTER);
     this.messageConsumerInjector = propagation.injector(MessageConsumerRequest.SETTER);
-    this.processorExtractor = tracing.propagation().extractor(GETTER);
+    this.processorExtractor = propagation.extractor(GETTER);
     this.producerSampler = builder.messagingTracing.producerSampler();
     this.consumerSampler = builder.messagingTracing.consumerSampler();
     this.remoteServiceName = builder.remoteServiceName;
-    this.traceIdProperties = new LinkedHashSet<>(tracing.propagation().keys());
+    this.traceIdProperties = new LinkedHashSet<>(propagation.keys());
   }
 
   public Connection connection(Connection connection) {

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -141,7 +141,7 @@ public final class KafkaTracing {
   KafkaTracing(Builder builder) { // intentionally hidden constructor
     this.messagingTracing = builder.messagingTracing;
     this.tracer = builder.messagingTracing.tracing().tracer();
-    Propagation<String> propagation = messagingTracing.tracing().propagation();
+    Propagation<String> propagation = messagingTracing.propagation();
     this.producerExtractor = propagation.extractor(KafkaProducerRequest.GETTER);
     this.consumerExtractor = propagation.extractor(KafkaConsumerRequest.GETTER);
     this.processorExtractor = propagation.extractor(GETTER);

--- a/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
+++ b/instrumentation/kafka-streams/src/main/java/brave/kafka/streams/KafkaStreamsTracing.java
@@ -61,7 +61,7 @@ public final class KafkaStreamsTracing {
       .singleRootSpanOnReceiveBatch(builder.singleRootSpanOnReceiveBatch)
       .build();
     this.tracer = kafkaTracing.messagingTracing().tracing().tracer();
-    Propagation<String> propagation = kafkaTracing.messagingTracing().tracing().propagation();
+    Propagation<String> propagation = kafkaTracing.messagingTracing().propagation();
     this.extractor = propagation.extractor(KafkaStreamsPropagation.GETTER);
     this.injector = propagation.injector(KafkaStreamsPropagation.SETTER);
     this.propagationKeys = new LinkedHashSet<>(propagation.keys());
@@ -96,7 +96,7 @@ public final class KafkaStreamsTracing {
   /**
    * Provides a {@link KafkaClientSupplier} with tracing enabled, hence Producer and Consumer
    * operations will be traced.
-   *
+   * <p>
    * This is mean to be used in scenarios {@link KafkaStreams} creation is not controlled by the
    * user but framework (e.g. Spring Kafka Streams) creates it, and {@link KafkaClientSupplier} is
    * accepted.
@@ -109,7 +109,7 @@ public final class KafkaStreamsTracing {
    * Creates a {@link KafkaStreams} instance with a tracing-enabled {@link KafkaClientSupplier}. All
    * Topology Sources and Sinks (including internal Topics) will create Spans on records processed
    * (i.e. send or consumed).
-   *
+   * <p>
    * Use this instead of {@link KafkaStreams} constructor.
    *
    * <p>Simple example:
@@ -237,7 +237,7 @@ public final class KafkaStreamsTracing {
   /**
    * Create a mark transformer, similar to {@link KStream#peek(ForeachAction)}, but no action is
    * executed. Instead, only a span is created to represent an event as part of the stream process.
-   *
+   * <p>
    * A common scenario for this transformer is to mark the beginning and end of a step (or set of
    * steps) in a stream process.
    *
@@ -309,11 +309,11 @@ public final class KafkaStreamsTracing {
 
   /**
    * Create a filter transformer.
-   *
+   * <p>
    * WARNING: this filter implementation uses the Streams transform API, meaning that
    * re-partitioning can occur if a key modifying operation like grouping or joining operation is
    * applied after this filter.
-   *
+   * <p>
    * In that case, consider using {@link #markAsFiltered(String, Predicate)} instead which uses
    * {@link ValueTransformerWithKey} API instead.
    *
@@ -332,7 +332,7 @@ public final class KafkaStreamsTracing {
 
   /**
    * Create a filterNot transformer.
-   *
+   * <p>
    * WARNING: this filter implementation uses the Streams transform API, meaning that
    * re-partitioning can occur if a key modifying operation like grouping or joining operation is
    * applied after this filter. In that case, consider using {@link #markAsNotFiltered(String,
@@ -353,12 +353,12 @@ public final class KafkaStreamsTracing {
 
   /**
    * Create a markAsFiltered valueTransformer.
-   *
+   * <p>
    * Instead of filtering, and not emitting values downstream as {@code filter} does; {@code
    * markAsFiltered} creates a span, marking it as filtered or not. If filtered, value returned will
    * be {@code null} and will require an additional non-null value filter to complete the
    * filtering.
-   *
+   * <p>
    * This operation is offered as lack of a processor that allows to continue conditionally with the
    * processing without risk of accidental re-partitioning.
    *
@@ -378,12 +378,12 @@ public final class KafkaStreamsTracing {
 
   /**
    * Create a markAsNotFiltered valueTransformer.
-   *
+   * <p>
    * Instead of filtering, and not emitting values downstream as {@code filterNot} does; {@code
    * markAsNotFiltered} creates a span, marking it as filtered or not. If filtered, value returned
    * will be {@code null} and will require an additional non-null value filter to complete the
    * filtering.
-   *
+   * <p>
    * This operation is offered as lack of a processor that allows to continue conditionally with the
    * processing without risk of accidental re-partitioning.
    *

--- a/instrumentation/messaging/src/main/java/brave/messaging/MessagingTracing.java
+++ b/instrumentation/messaging/src/main/java/brave/messaging/MessagingTracing.java
@@ -13,8 +13,12 @@
  */
 package brave.messaging;
 
+import brave.Span;
 import brave.Tracing;
+import brave.baggage.BaggagePropagation;
 import brave.internal.Nullable;
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
 import brave.sampler.SamplerFunction;
 import brave.sampler.SamplerFunctions;
 import java.io.Closeable;
@@ -77,6 +81,62 @@ public class MessagingTracing implements Closeable {
     return consumerSampler;
   }
 
+  /**
+   * Returns the propagation component used by messaging instrumentation.
+   *
+   * <p>Typically, this is the same as {@link Tracing#propagation()}. Overrides will apply to all
+   * messaging instrumentation in use. For example, Kafka and also AMQP. If only trying to change B3
+   * related headers, use the more efficient {@link B3Propagation.FactoryBuilder#injectFormat(Span.Kind,
+   * B3Propagation.Format)} instead.
+   *
+   * <h3>Use caution when overriding</h3>
+   * If overriding this via {@link Builder#propagation(Propagation)}, take care to also delegate to
+   * {@link Tracing#propagation()}. Otherwise, you can break features something else may have set,
+   * such as {@link BaggagePropagation}.
+   *
+   * <h3>Library-specific formats</h3>
+   * Messaging instrumentation can localize propagation changes by calling {@link #toBuilder()},
+   * then {@link Builder#propagation(Propagation)}. This allows library-specific formats.
+   *
+   * <h4>Example 1: Apache Camel</h4>
+   * Apache Camel has multiple trace instrumentation. Instead of using a single header like "b3" to
+   * avoid JMS propagation problems, their OpenTracing implementation replaces hyphens with
+   * <a href="https://github.com/apache/camel/blob/992a6b9685f4db49236e540af2546548cf99a7d3/components/camel-tracing/src/main/java/org/apache/camel/tracing/propagation/CamelMessagingHeadersInjectAdapter.java">"_$dash$_"</a>.
+   *
+   * <p>For example, this would cause "X-B3-TraceId" to become "X_$dash$_B3_$dash$_TraceId". When
+   * normal instrumentation is on the other side, it would not guess to use this convention, and
+   * fail to resume the opentracing created trace.
+   *
+   * <p>A custom propagation component used only for camel could tolerantly read this replacement
+   * format and write down the safe and more efficient {@link B3Propagation.Format#SINGLE_NO_PARENT}
+   * instead. It could do this with configuration, such as "opentracing compatibility" and not add
+   * the same overhead to other libraries.
+   *
+   * <h4>Example 2: Spring Messaging</h4>
+   * Spring Messaging is used for both in-memory and remote channels. Transports such as STOMP may
+   * require speculatively duplicating propagation fields as <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/messaging/support/NativeMessageHeaderAccessor.html#NATIVE_HEADERS">Native
+   * Headers</a>.
+   *
+   * <p>You could make a custom {@link Propagation.RemoteSetter} that takes into consideration if
+   * a message has native support or not, and add "native headers" only when needed by the message
+   * in use instead of adding headers to all messaging libraries.
+   *
+   * <pre>{@code
+   * SimpMessageHeaderAccessor accessor =
+   *     MessageHeaderAccessor.getAccessor(message, SimpMessageHeaderAccessor.class);
+   *
+   * if (accessor != null) {
+   *   // Add native headers..
+   * }
+   * }</pre>
+   *
+   * @see Tracing#propagation()
+   * @since 5.13
+   */
+  public Propagation<String> propagation() {
+    return propagation;
+  }
+
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -84,11 +144,13 @@ public class MessagingTracing implements Closeable {
   final Tracing tracing;
   final SamplerFunction<MessagingRequest> producerSampler;
   final SamplerFunction<MessagingRequest> consumerSampler;
+  final Propagation<String> propagation;
 
   MessagingTracing(Builder builder) {
     this.tracing = builder.tracing;
     this.producerSampler = builder.producerSampler;
     this.consumerSampler = builder.consumerSampler;
+    this.propagation = builder.propagation;
     // assign current IFF there's no instance already current
     CURRENT.compareAndSet(null, this);
   }
@@ -97,10 +159,12 @@ public class MessagingTracing implements Closeable {
     Tracing tracing;
     SamplerFunction<MessagingRequest> producerSampler;
     SamplerFunction<MessagingRequest> consumerSampler;
+    Propagation<String> propagation;
 
     Builder(Tracing tracing) {
       if (tracing == null) throw new NullPointerException("tracing == null");
       this.tracing = tracing;
+      this.propagation = tracing.propagation();
       this.producerSampler = SamplerFunctions.deferDecision();
       this.consumerSampler = SamplerFunctions.deferDecision();
     }
@@ -109,6 +173,7 @@ public class MessagingTracing implements Closeable {
       this.tracing = source.tracing;
       this.producerSampler = source.producerSampler;
       this.consumerSampler = source.consumerSampler;
+      this.propagation = source.propagation;
     }
 
     /** @see MessagingTracing#tracing() */
@@ -129,6 +194,13 @@ public class MessagingTracing implements Closeable {
     public Builder consumerSampler(SamplerFunction<MessagingRequest> consumerSampler) {
       if (consumerSampler == null) throw new NullPointerException("consumerSampler == null");
       this.consumerSampler = consumerSampler;
+      return this;
+    }
+
+    /** @see MessagingTracing#propagation() */
+    public Builder propagation(Propagation<String> propagation) {
+      if (propagation == null) throw new NullPointerException("propagation == null");
+      this.propagation = propagation;
       return this;
     }
 

--- a/instrumentation/messaging/src/test/java/brave/messaging/MessagingTracingTest.java
+++ b/instrumentation/messaging/src/test/java/brave/messaging/MessagingTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,8 @@
 package brave.messaging;
 
 import brave.Tracing;
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
 import org.junit.Test;
 
 import static brave.sampler.SamplerFunctions.deferDecision;
@@ -43,5 +45,25 @@ public class MessagingTracingTest {
     assertThat(messagingTracing.toBuilder().producerSampler(neverSample()).build())
       .usingRecursiveComparison()
       .isEqualTo(MessagingTracing.newBuilder(tracing).producerSampler(neverSample()).build());
+  }
+
+  @Test public void canOverridePropagation() {
+    Propagation<String> propagation = B3Propagation.newFactoryBuilder()
+      .injectFormat(B3Propagation.Format.SINGLE)
+      .build().get();
+
+    MessagingTracing messagingTracing = MessagingTracing.newBuilder(tracing)
+      .propagation(propagation)
+      .build();
+
+    assertThat(messagingTracing.propagation())
+      .isSameAs(propagation);
+
+    messagingTracing = MessagingTracing.create(tracing).toBuilder()
+      .propagation(propagation)
+      .build();
+
+    assertThat(messagingTracing.propagation())
+      .isSameAs(propagation);
   }
 }

--- a/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
+++ b/instrumentation/rpc/src/main/java/brave/rpc/RpcTracing.java
@@ -286,7 +286,7 @@ public class RpcTracing implements Closeable {
       return this;
     }
 
-    /** @see RpcTracing#serverSampler() */
+    /** @see RpcTracing#propagation() */
     public Builder propagation(Propagation<String> propagation) {
       if (propagation == null) throw new NullPointerException("propagation == null");
       this.propagation = propagation;

--- a/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
+++ b/instrumentation/spring-rabbit/src/main/java/brave/spring/rabbit/SpringRabbitTracing.java
@@ -113,7 +113,7 @@ public final class SpringRabbitTracing {
     this.tracing = builder.messagingTracing.tracing();
     this.tracer = tracing.tracer();
     MessagingTracing messagingTracing = builder.messagingTracing;
-    Propagation<String> propagation = tracing.propagation();
+    Propagation<String> propagation = messagingTracing.propagation();
     this.producerExtractor = propagation.extractor(MessageProducerRequest.GETTER);
     this.consumerExtractor = propagation.extractor(MessageConsumerRequest.GETTER);
     this.producerInjector = propagation.injector(MessageProducerRequest.SETTER);


### PR DESCRIPTION
This allows messaging-specific, and messaging library-specific
propagation, similar to what was done in #1262 for RPC.