### PR TITLE
Adds HttpTracing.propagation()

### DIFF
--- a/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpClientHandler.java
@@ -100,7 +100,7 @@ public final class HttpClientHandler<Req, Resp> extends HttpHandler {
     this.serverName = !"".equals(httpTracing.serverName()) ? httpTracing.serverName() : null;
     // The following allows us to add the method: handleSend(HttpClientRequest request) without
     // duplicating logic from the superclass or deprecated handleReceive methods.
-    this.defaultInjector = httpTracing.tracing().propagation().injector(HttpClientRequest.SETTER);
+    this.defaultInjector = httpTracing.propagation().injector(HttpClientRequest.SETTER);
   }
 
   /**

--- a/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
+++ b/instrumentation/http/src/main/java/brave/http/HttpServerHandler.java
@@ -94,7 +94,7 @@ public final class HttpServerHandler<Req, Resp> extends HttpHandler {
     this.sampler = httpTracing.serverRequestSampler();
     // The following allows us to add the method: handleReceive(HttpServerRequest request) without
     // duplicating logic from the superclass or deprecated handleReceive methods.
-    this.defaultExtractor = httpTracing.tracing().propagation().extractor(HttpServerRequest.GETTER);
+    this.defaultExtractor = httpTracing.propagation().extractor(HttpServerRequest.GETTER);
   }
 
   /**


### PR DESCRIPTION
This allows HTTP-specific, and HTTP library-specific
propagation, similar to what was done in #1262 for RPC.