### PR TITLE
Re-enables license plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ arch: amd64           # arm64 is LXD containers which we can't use because we ru
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution
 
-# Don't do a shallow clone to allow license plugin to correctly read git history.
+# license-maven-plugin needs the full history to generate copyright year range. Ex. 2013-2020
+# Don't do a shallow clone, as it interferes with this.
 git:
   depth: false
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
    Release automation invokes [`travis/publish.sh`](travis/publish.sh), which does the following:
      * Creates commits, N.N.N tag, and increments the version (maven-release-plugin)
      * Publishes jars to https://oss.sonatype.org/service/local/staging/deploy/maven2 (maven-deploy-plugin)
-       * Upon close, this synchronizes jars to Maven Central
+       * Upon close, this synchronizes jars to Maven Central (nexus-staging-maven-plugin)
      * Publishes Javadoc to https://zipkin.io/zipkin into a versioned subdirectory
 
    Notes:
@@ -78,7 +78,7 @@ export SONATYPE_PASSWORD=your_sonatype_password
 VERSION=xx-version-to-release-xx
 
 # now from latest master, prepare the release. We are intentionally deferring pushing commits
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests -Dlicense.skip=true" release:prepare  -DpushChanges=false
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests" release:prepare -DpushChanges=false
 
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -163,8 +163,7 @@ if is_release_version; then
 else
   # verify runs both tests and integration tests (Docker tests included)
   # MYSQL_USER=travis because MySQL tests currently use OS managed mysql
-  # -Dlicense.skip=true skips license on Travis due to #1512
-  MYSQL_USER=travis ./mvnw verify -nsu -Dlicense.skip=true
+  MYSQL_USER=travis ./mvnw verify -nsu
 fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
@@ -176,7 +175,7 @@ if is_pull_request; then
 #    Sonatype and try again: https://oss.sonatype.org/#stagingRepositories
 elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
-  DEPLOY="./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -Dlicense.skip=true deploy"
+  DEPLOY="./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy"
 
   # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
   $DEPLOY -pl -:brave-bom
@@ -192,5 +191,5 @@ elif is_travis_branch_master; then
 elif build_started_by_tag; then
   safe_checkout_master
   # skip license on travis due to #1512
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests -Dlicense.skip=true" release:prepare
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -190,6 +190,5 @@ elif is_travis_branch_master; then
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
   safe_checkout_master
-  # skip license on travis due to #1512
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi


### PR DESCRIPTION
We've long since gotten to the bottom of this. Rather than always skipping the license plugin in CI, causing a poor experience for people who have local builds fail over it, this re-enables after underscoring the CI config needed to make it work.

After this change, pull requests won't be green unless the headers are correct.