### PR TITLE
Removes root dependency management

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,8 +83,9 @@ VERSION=xx-version-to-release-xx
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION
 
+# -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy -DskipBenchmarks -pl -:brave-bom
 # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy -pl -:brave-bom
 ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy -f brave-bom/pom.xml
 
 # if all the above worked, clean up stuff and push the local changes.

--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -34,8 +34,8 @@
     <main.basedir>${project.basedir}/..</main.basedir>
 
     <!-- use the same values in ../pom.xml -->
-    <zipkin.version>2.22.1</zipkin.version>
-    <zipkin-reporter.version>2.15.4</zipkin-reporter.version>
+    <zipkin.version>2.22.2</zipkin.version>
+    <zipkin-reporter.version>2.16.0</zipkin-reporter.version>
 
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
   </properties>
@@ -97,16 +97,6 @@
       <dependency>
         <groupId>io.zipkin.zipkin2</groupId>
         <artifactId>zipkin</artifactId>
-        <version>${zipkin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin-tests</artifactId>
-        <version>${zipkin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin-junit</artifactId>
         <version>${zipkin.version}</version>
       </dependency>
       <dependency>
@@ -302,6 +292,11 @@
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>3.0.0-M1</version>
           </plugin>
 
           <plugin>

--- a/brave-tests/pom.xml
+++ b/brave-tests/pom.xml
@@ -35,14 +35,17 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
     </dependency>
   </dependencies>
 

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.blogspot.mydailyjava</groupId>
       <artifactId>weak-lock-free</artifactId>
-      <version>0.16</version>
+      <version>0.17</version>
       <scope>test</scope>
     </dependency>
     <!-- to mock Platform calls -->
@@ -83,6 +83,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -100,35 +101,31 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.5.2</version>
+      <version>1.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
+      <version>${spring5.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjweaver</artifactId>
-      <version>1.9.5</version>
+      <version>1.9.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+      <version>${spring5.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-sender-okhttp3</artifactId>
       <version>${zipkin-reporter.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin-junit</artifactId>
-      <version>${zipkin.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/brave/src/test/java/brave/features/handler/MutableSpanAsyncReporterTest.java
+++ b/brave/src/test/java/brave/features/handler/MutableSpanAsyncReporterTest.java
@@ -20,16 +20,11 @@ import brave.handler.MutableSpanBytesEncoder;
 import brave.handler.SpanHandler;
 import brave.propagation.B3SingleFormat;
 import brave.propagation.TraceContext;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import zipkin2.codec.BytesEncoder;
-import zipkin2.codec.Encoding;
-import zipkin2.junit.ZipkinRule;
-import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.okhttp3.OkHttpSender;
+import zipkin2.codec.SpanBytesDecoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,79 +33,54 @@ import static org.assertj.core.api.Assertions.assertThat;
  * direct encoding from {@link MutableSpan} into JSON without converting to Zipkin model first.
  */
 public class MutableSpanAsyncReporterTest {
-  @Rule public ZipkinRule zipkin = new ZipkinRule();
+  MutableSpanBytesEncoder mutableSpanBytesEncoder =
+    MutableSpanBytesEncoder.zipkinJsonV2(Tags.ERROR);
 
-  MutableSpanBytesEncoder mutableSpanBytesEncoder = MutableSpanBytesEncoder.zipkinJsonV2(Tags.ERROR);
-  BytesEncoder<MutableSpan> zipkinBytesEncoderAdapter = new BytesEncoder<MutableSpan>() {
-
-    @Override public Encoding encoding() {
-      return Encoding.JSON;
-    }
-
-    @Override public int sizeInBytes(MutableSpan span) {
-      return mutableSpanBytesEncoder.sizeInBytes(span);
-    }
-
-    @Override public byte[] encode(MutableSpan span) {
-      return mutableSpanBytesEncoder.encode(span);
-    }
-
-    @Override public byte[] encodeList(List<MutableSpan> spans) {
-      return mutableSpanBytesEncoder.encodeList(spans);
-    }
-  };
-
-  OkHttpSender sender = OkHttpSender.create(zipkin.httpUrl() + "/api/v2/spans");
-
-  AsyncReporter<MutableSpan> reporter = AsyncReporter.builder(sender)
-      .messageTimeout(0, TimeUnit.MILLISECONDS) // don't spawn a thread
-      .build(zipkinBytesEncoderAdapter);
+  List<byte[]> messages = new ArrayList<>();
 
   SpanHandler spanHandlerAdapter = new SpanHandler() {
     @Override public boolean end(TraceContext context, MutableSpan span, SpanHandler.Cause cause) {
       if (!Boolean.TRUE.equals(context.sampled())) return true;
-      reporter.report(span);
+      messages.add(mutableSpanBytesEncoder.encode(span));
       return true;
     }
   };
 
   Tracing tracing = Tracing.newBuilder()
-      .localServiceName("Aa")
-      .localIp("1.2.3.4")
-      .localPort(80)
-      .addSpanHandler(spanHandlerAdapter)
-      .build();
+    .localServiceName("Aa")
+    .localIp("1.2.3.4")
+    .localPort(80)
+    .addSpanHandler(spanHandlerAdapter)
+    .build();
 
   @After public void close() {
     tracing.close();
-    reporter.close();
-    sender.close();
   }
 
   /** This mainly shows endpoints are taken from Brave, and error is back-filled. */
   @Test public void basicSpan() {
     TraceContext context = B3SingleFormat.parseB3SingleFormat(
-        "50d980fffa300f29-86154a4ba6e91385-1"
+      "50d980fffa300f29-86154a4ba6e91385-1"
     ).context();
 
     tracing.tracer().toSpan(context).name("test")
-        .start(1L)
-        .error(new RuntimeException("this cake is a lie"))
-        .finish(3L);
+      .start(1L)
+      .error(new RuntimeException("this cake is a lie"))
+      .finish(3L);
 
-    reporter.flush();
-
-    assertThat(zipkin.getTraces()).hasSize(1).first().hasToString(
-        "[{\"traceId\":\"50d980fffa300f29\","
-            + "\"id\":\"86154a4ba6e91385\","
-            + "\"name\":\"test\","
-            + "\"timestamp\":1,"
-            + "\"duration\":2,"
-            + "\"localEndpoint\":{"
-            + "\"serviceName\":\"aa\","
-            + "\"ipv4\":\"1.2.3.4\","
-            + "\"port\":80},"
-            + "\"tags\":{\"error\":\"this cake is a lie\"}}]"
-    );
+    assertThat(messages).hasSize(1).first()
+      .extracting(SpanBytesDecoder.JSON_V2::decodeOne)
+      .hasToString(
+        "{\"traceId\":\"50d980fffa300f29\","
+          + "\"id\":\"86154a4ba6e91385\","
+          + "\"name\":\"test\","
+          + "\"timestamp\":1,"
+          + "\"duration\":2,"
+          + "\"localEndpoint\":{"
+          + "\"serviceName\":\"aa\","
+          + "\"ipv4\":\"1.2.3.4\","
+          + "\"port\":80},"
+          + "\"tags\":{\"error\":\"this cake is a lie\"}}"
+      );
   }
 }

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -43,10 +43,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.2.19</version>
+      <version>2.2.20</version>
       <scope>provided</scope>
     </dependency>
 
@@ -58,6 +58,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -30,7 +30,6 @@
     <main.signature.artifact>java18</main.signature.artifact>
     <jmh.version>1.25.2</jmh.version>
     <undertow.version>2.2.0.Final</undertow.version>
-    <spring.version>${spring5.version}</spring.version>
   </properties>
 
   <!-- can't import brave-bom due to build-support/go-offline.sh -->
@@ -51,12 +50,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-xray-recorder-sdk-core</artifactId>
-      <version>2.6.1</version>
+      <version>2.7.1</version>
     </dependency>
 
     <dependency>
@@ -78,6 +78,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpasyncclient</artifactId>
+      <version>${httpasyncclient.version}</version>
     </dependency>
 
     <dependency>
@@ -88,6 +89,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
+      <version>${spring5.version}</version>
     </dependency>
 
     <dependency>
@@ -98,6 +100,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
     </dependency>
 
     <dependency>
@@ -125,6 +128,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
+      <version>${spring5.version}</version>
     </dependency>
 
     <dependency>
@@ -162,6 +166,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>
@@ -244,26 +249,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <configuration>
-          <skipStaging>true</skipStaging>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-rpc</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.alibaba</groupId>
@@ -57,6 +58,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-rpc</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.dubbo</groupId>
@@ -50,6 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-rpc</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -60,17 +61,20 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-context-log4j2</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- for Generated annotation in tests -->
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
+      <version>${javax-annotation-api.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -37,26 +37,32 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
     </dependency>
     <!-- Only subclasses of ITServletContainer need Jetty. -->
     <dependency>

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -38,21 +38,19 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpasyncclient</artifactId>
+      <version>${httpasyncclient.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>brave-tests</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -38,26 +38,25 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
+      <version>${httpclient.version}</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>brave-tests</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -38,10 +38,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
       <scope>provided</scope>
     </dependency>
     <!-- For Priority -->
@@ -49,7 +51,7 @@
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <scope>provided</scope>
-      <version>1.3.2</version>
+      <version>${javax-annotation-api.version}</version>
     </dependency>
     <!-- For Inject -->
     <dependency>
@@ -61,17 +63,14 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>brave-tests</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-servlet</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -83,6 +82,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
+      <version>${resteasy.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -91,11 +91,11 @@
       <version>${resteasy.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- to test the inject annotations -->
+    <!-- to test @Inject annotations -->
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.2.3</version>
+      <version>${guice.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -45,16 +45,19 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-servlet</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -77,11 +80,11 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- to test the inject annotations -->
+    <!-- to test @Inject annotations -->
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.2.3</version>
+      <version>${guice.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -89,6 +92,7 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/instrumentation/jersey-server/src/test/resources/log4j2.properties
+++ b/instrumentation/jersey-server/src/test/resources/log4j2.properties
@@ -1,0 +1,14 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT
+
+# mute logs that do not effect our tests
+logger.wadl.name=org.glassfish.jersey.server.wadl.WadlFeature
+logger.wadl.level=off
+logger.model.name=org.glassfish.jersey.internal.inject.Providers
+logger.model.level=off

--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-messaging</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <!-- Provided at 2.0.1 eventhough 1.1 is supported via invoker tests -->
     <dependency>
@@ -53,6 +54,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-messaging</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -56,16 +57,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
       <scope>test</scope>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.charithe</groupId>

--- a/instrumentation/kafka-streams/pom.xml
+++ b/instrumentation/kafka-streams/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-messaging</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -58,15 +59,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/messaging/pom.xml
+++ b/instrumentation/messaging/pom.xml
@@ -35,6 +35,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/mongodb/pom.xml
+++ b/instrumentation/mongodb/pom.xml
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/mysql/pom.xml
+++ b/instrumentation/mysql/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/mysql6/pom.xml
+++ b/instrumentation/mysql6/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -37,21 +37,19 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>brave-tests</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -68,6 +68,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -32,7 +32,6 @@
   </properties>
 
   <modules>
-    <module>benchmarks</module>
     <module>http</module>
     <module>http-tests</module>
     <module>dubbo</module>
@@ -88,6 +87,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/instrumentation/rpc/pom.xml
+++ b/instrumentation/rpc/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <!-- compile dep on 3.1.0 runtime on 2.5 -->
     <dependency>
@@ -50,6 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-servlet</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sparkjava</groupId>
@@ -49,6 +50,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-messaging</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <!-- spring-aop is required for the consumer side instrumentation point -->
     <dependency>
@@ -65,6 +66,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -64,12 +65,8 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>brave-tests</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -81,11 +78,13 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpasyncclient</artifactId>
+      <version>${httpasyncclient.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -38,11 +38,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-servlet</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <!-- implicitly servlet 3.1.0 -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
+      <version>${spring5.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -55,6 +57,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -49,12 +50,8 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>brave-tests</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-@Ignore("Run manually until openzipkin/brave#1270")
 public class ITVertxWebTracing extends ITHttpServer {
   Vertx vertx;
   HttpServer server;

--- a/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
+++ b/instrumentation/vertx-web/src/test/java/brave/vertx/web/ITVertxWebTracing.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
+@Ignore("Run manually until openzipkin/brave#1270")
 public class ITVertxWebTracing extends ITHttpServer {
   Vertx vertx;
   HttpServer server;

--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,16 @@
     <errorprone.version>2.4.0</errorprone.version>
 
     <!-- use the same values in bom/pom.xml -->
-    <zipkin.version>2.22.1</zipkin.version>
-    <zipkin-reporter.version>2.15.4</zipkin-reporter.version>
+    <zipkin.version>2.22.2</zipkin.version>
+    <zipkin-reporter.version>2.16.0</zipkin-reporter.version>
+
+    <!-- Used for Generated annotations -->
+    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
+    <!-- to test @Inject annotations -->
+    <guice.version>5.0.0-BETA-1</guice.version>
 
     <!-- Ensure older versions of spring still work -->
-    <spring5.version>5.2.9.RELEASE</spring5.version>
+    <spring5.version>5.3.0</spring5.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
     <!-- Apis used, but not in Jetty 7.6* imply duplication in servlet25 test fixtures -->
@@ -102,11 +107,12 @@
     <okhttp.version>4.9.0</okhttp.version>
     <httpclient.version>4.5.13</httpclient.version>
 
-    <grpc.version>1.32.2</grpc.version>
+    <grpc.version>1.33.1</grpc.version>
     <protobuf.version>3.12.0</protobuf.version>
     <!-- prefer grpc's version of netty -->
     <netty.version>4.1.51.Final</netty.version>
 
+    <httpasyncclient.version>4.1.4</httpasyncclient.version>
     <sparkjava.version>2.9.3</sparkjava.version>
 
     <!-- Test only dependencies -->
@@ -114,7 +120,7 @@
     <junit-jupiter.version>5.7.0</junit-jupiter.version>
     <assertj.version>3.18.0</assertj.version>
     <powermock.version>2.0.7</powermock.version>
-    <mockito.version>3.5.13</mockito.version>
+    <mockito.version>3.6.0</mockito.version>
     <jersey.version>2.32</jersey.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
     <kafka-junit.version>4.1.10</kafka-junit.version>
@@ -164,245 +170,61 @@
   </issueManagement>
 
   <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-context-log4j2</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-instrumentation-http</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-instrumentation-http-tests</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-instrumentation-messaging</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-instrumentation-rpc</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-instrumentation-servlet</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>brave-tests</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin</artifactId>
-        <version>${zipkin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-webmvc</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <!-- The httpcomponents group do not share versions within it -->
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>4.4.13</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${httpclient.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient-cache</artifactId>
-        <version>${httpclient.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpasyncclient</artifactId>
-        <version>4.1.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-client</artifactId>
-        <version>${resteasy.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-spring</artifactId>
-        <version>${resteasy.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-jul</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-1.2-api</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <!--
-      Current versions of JUnit5 provide the above junit-jupiter artifact for convenience but we may
-      still have transitive dependencies on these older artifacts and have to make sure they're all
-      using the same version.
-      -->
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${assertj.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.0</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>1.3.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito.version}</version>
-      </dependency>
-    </dependencies>
+    <!-- Be careful here, especially to not import BOMs as io.zipkin.brave:brave has this parent.
+
+         For example, if you imported Netty's BOM here, using Brave would also download that BOM. As
+         Brave is indirectly used, this can be extremely confusing when people are troubleshooting
+         library version assignments. -->
   </dependencyManagement>
 
   <dependencies>
+    <!-- Do not add compile dependencies here. This can cause problems for libraries that depend on
+         io.zipkin.brave:brave difficult to unravel. -->
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Main code uses jul and tests log with log4j -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- route jul over log4j2 during tests -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jul</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- route log4j over log4j2 during tests -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- route slf4j over log4j2 during tests -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -670,14 +492,6 @@
       </plugin>
 
       <plugin>
-        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
-        <artifactId>centralsync-maven-plugin</artifactId>
-        <version>0.1.1</version>
-        <configuration>
-          <packageName>brave</packageName>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>${maven-enforcer-plugin.version}</version>
         <executions>
@@ -788,6 +602,18 @@
         </plugins>
       </build>
     </profile>
+    <!-- -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central -->
+    <profile>
+      <id>include-benchmarks</id>
+      <activation>
+        <property>
+          <name>!skipBenchmarks</name>
+        </property>
+      </activation>
+      <modules>
+        <module>instrumentation/benchmarks</module>
+      </modules>
+    </profile>
     <profile>
       <id>release</id>
       <build>
@@ -799,6 +625,9 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- Double the normal timeout even though we haven't had a problem in this project.
+                   The only outcome of timing out client side is trying again. -->
+              <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -48,10 +49,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-messaging</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>brave-instrumentation-rpc</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -177,8 +177,9 @@ elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
   DEPLOY="./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy"
 
+  # -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central
+  $DEPLOY -DskipBenchmarks -pl -:brave-bom
   # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
-  $DEPLOY -pl -:brave-bom
   $DEPLOY -f brave-bom/pom.xml
 
   if is_release_version; then


### PR DESCRIPTION
This removes root dependency management for same rationale as
https://github.com/openzipkin/zipkin/pull/3284

Notably, to prevent interference or confusion in downstream projects.

This also forcibly prevents benchmarks from the deploy phase as the
prior config resulted in orphaned staging repos. See
https://github.com/openzipkin/zipkin/pull/3286