### PR TITLE
Have StrictScopeDecorator also detect leaked to GC scopes.

### DIFF
--- a/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
+++ b/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ConcurrentMap;
  * <p>See https://github.com/raphw/weak-lock-free
  */
 public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Iterable<Map.Entry<K, V>> {
-  protected final ConcurrentMap<WeakKey<K>, V> target = new ConcurrentHashMap<>();
+  final ConcurrentMap<WeakKey<K>, V> target = new ConcurrentHashMap<>();
 
   @Nullable public V getIfPresent(K key) {
     if (key == null) throw new NullPointerException("key == null");

--- a/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
+++ b/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
@@ -17,6 +17,10 @@ import brave.internal.Nullable;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -32,14 +36,13 @@ import java.util.concurrent.ConcurrentMap;
  * <p>Other changes mostly remove features (to reduce the bytecode size) and address style:
  * <ul>
  *   <li>Inline expunction only as we have no thread to use anyway</li>
- *   <li>Removes methods we don't need such as iteration</li>
  *   <li>Stylistic changes including different javadoc and removal of private modifiers</li>
  *   <li>toString: derived only from keys</li>
  * </ul>
  *
  * <p>See https://github.com/raphw/weak-lock-free
  */
-public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> {
+public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> implements Iterable<Map.Entry<K, V>> {
   protected final ConcurrentMap<WeakKey<K>, V> target = new ConcurrentHashMap<>();
 
   @Nullable public V getIfPresent(K key) {
@@ -64,6 +67,12 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> {
     expungeStaleEntries();
 
     return target.remove(key);
+  }
+
+  /** Iterates over the entries in this map. */
+  @Override
+  public Iterator<Map.Entry<K, V>> iterator() {
+    return new EntryIterator(target.entrySet().iterator());
   }
 
   /** Cleans all unused references. */
@@ -148,5 +157,53 @@ public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> {
 
   static boolean equal(@Nullable Object a, @Nullable Object b) {
     return a == null ? b == null : a.equals(b); // Java 6 can't use Objects.equals()
+  }
+
+  class EntryIterator implements Iterator<Map.Entry<K, V>> {
+
+    private final Iterator<Map.Entry<WeakKey<K>, V>> iterator;
+
+    private Map.Entry<WeakKey<K>, V> nextEntry;
+
+    private K nextKey;
+
+    private EntryIterator(Iterator<Map.Entry<WeakKey<K>, V>> iterator) {
+      this.iterator = iterator;
+      findNext();
+    }
+
+    private void findNext() {
+      while (iterator.hasNext()) {
+        nextEntry = iterator.next();
+        nextKey = nextEntry.getKey().get();
+        if (nextKey != null) {
+          return;
+        }
+      }
+      nextEntry = null;
+      nextKey = null;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return nextKey != null;
+    }
+
+    @Override
+    public Map.Entry<K, V> next() {
+      if (nextKey == null) {
+        throw new NoSuchElementException();
+      }
+      try {
+        return new AbstractMap.SimpleImmutableEntry<K, V>(nextKey, nextEntry.getValue());
+      } finally {
+        findNext();
+      }
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
+++ b/brave/src/main/java/brave/internal/collect/WeakConcurrentMap.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentMap;
  * <p>See https://github.com/raphw/weak-lock-free
  */
 public class WeakConcurrentMap<K, V> extends ReferenceQueue<K> {
-  final ConcurrentMap<WeakKey<K>, V> target = new ConcurrentHashMap<>();
+  protected final ConcurrentMap<WeakKey<K>, V> target = new ConcurrentHashMap<>();
 
   @Nullable public V getIfPresent(K key) {
     if (key == null) throw new NullPointerException("key == null");

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -92,7 +92,7 @@ public class TracerTest {
   @Test public void handler_hasNiceToString() {
     tracer = Tracing.newBuilder().build().tracer();
 
-    assertThat(tracer.pendingSpans).extracting("spanHandler")
+    assertThat((Object) tracer.pendingSpans).extracting("spanHandler")
       .hasToString("LogSpanHandler{name=brave.Tracer}");
   }
 

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -112,7 +112,7 @@ public class TracingTest {
 
   @Test public void spanHandler_loggingByDefault() {
     try (Tracing tracing = Tracing.newBuilder().build()) {
-      assertThat(tracing.tracer().pendingSpans).extracting("spanHandler.delegate")
+      assertThat((Object) tracing.tracer().pendingSpans).extracting("spanHandler.delegate")
         .isInstanceOf(Tracing.LogSpanHandler.class);
     }
   }
@@ -121,7 +121,7 @@ public class TracingTest {
     try (Tracing tracing = Tracing.newBuilder()
       .addSpanHandler(SpanHandler.NOOP)
       .build()) {
-      assertThat(tracing.tracer().pendingSpans).extracting("spanHandler.delegate")
+      assertThat((Object) tracing.tracer().pendingSpans).extracting("spanHandler.delegate")
         .isInstanceOf(Tracing.LogSpanHandler.class);
     }
   }
@@ -141,7 +141,7 @@ public class TracingTest {
       .addSpanHandler(one)
       .addSpanHandler(two)
       .build()) {
-      assertThat(tracing.tracer().pendingSpans).extracting("spanHandler.delegate.handlers")
+      assertThat((Object) tracing.tracer().pendingSpans).extracting("spanHandler.delegate.handlers")
         .asInstanceOf(InstanceOfAssertFactories.array(SpanHandler[].class))
         .containsExactly(one, two);
     }
@@ -159,7 +159,7 @@ public class TracingTest {
       .addSpanHandler(spanHandler)
       .addSpanHandler(spanHandler) // dupe
       .build()) {
-      assertThat(tracing.tracer().pendingSpans).extracting("spanHandler.delegate")
+      assertThat((Object) tracing.tracer().pendingSpans).extracting("spanHandler.delegate")
         .isEqualTo(spanHandler);
     }
   }


### PR DESCRIPTION
With all the thought I've had to put into context leakage lately, I thought it could be nice to have `StrictScopeDecorator` detect GC leaked scopes too, for enabling on a staging server. What do you think?