### PR TITLE
Makes entry splitter work with CharSequence

### DIFF
--- a/brave/src/main/java/brave/internal/codec/CharSequences.java
+++ b/brave/src/main/java/brave/internal/codec/CharSequences.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+/**
+ * Most of our parsing tools accept {@link CharSequence} instead of {@link String} to avoid
+ * unnecessary allocation. This contains common functions available on {@link String}, preferring
+ * signatures that match our utilities such as {@link EntrySplitter}.
+ */
+public final class CharSequences {
+
+  /**
+   * Joins two character sequences together. Inputs must be immutable. This is useful when the
+   * result is only scanned. It does not implement {@link #toString()} or {@link #equals(Object)}.
+   */
+  public static CharSequence concat(CharSequence left, CharSequence right) {
+    if (left == null) throw new NullPointerException("left == null");
+    if (right == null) throw new NullPointerException("right == null");
+    if (left.length() == 0) return right; // isEmpty is Java 15+
+    if (right.length() == 0) return left;
+    return new ConcatCharSequence(left, right);
+  }
+
+  static final class ConcatCharSequence implements CharSequence {
+    final CharSequence left, right;
+    final int length;
+
+    ConcatCharSequence(CharSequence left, CharSequence right) {
+      this.left = left;
+      this.right = right;
+      this.length = left.length() + right.length();
+    }
+
+    @Override public int length() {
+      return length;
+    }
+
+    @Override public char charAt(int index) {
+      if (index < 0) throw new IndexOutOfBoundsException("index < 0");
+      if (index >= length) throw new IndexOutOfBoundsException("index >= length");
+      int leftLength = left.length();
+      if (index < leftLength) return left.charAt(index);
+      return right.charAt(index - leftLength);
+    }
+
+    @Override public CharSequence subSequence(int beginIndex, int endIndex) {
+      if (regionLength(length, beginIndex, endIndex) == 0) return "";
+      if (beginIndex == 0 && endIndex == length) return this;
+
+      int leftLength = left.length();
+      // Exit early if the subSequence is only left or right
+      if (beginIndex == 0 && endIndex == leftLength) return left;
+      if (beginIndex == leftLength && endIndex == length) return right;
+
+      // Exit early if the subSequence is contained by left or right
+      if (endIndex <= leftLength) {
+        return left.subSequence(beginIndex, endIndex);
+      } else if (beginIndex > leftLength) {
+        return right.subSequence(beginIndex - leftLength, endIndex - leftLength);
+      }
+
+      return new ConcatCharSequence( // we are in the middle
+        left.subSequence(beginIndex, leftLength),
+        right.subSequence(0, endIndex - leftLength)
+      );
+    }
+
+    @Override public String toString() {
+      return String.valueOf(left) + right;
+    }
+  }
+
+  /**
+   * Returns true if the input range contains only the expected characters.
+   *
+   * @param expected   characters to search for in the input
+   * @param input      charSequence to search for {@code expected}
+   * @param beginIndex begin index of the {@code input}, inclusive
+   * @param endIndex   end index of the {@code input}, exclusive
+   * @return true if we reached the {@code endIndex} without failures.
+   * @see String#regionMatches(int, String, int, int) similar, except for {@link String}
+   */
+  public static boolean regionMatches(
+    CharSequence expected, CharSequence input, int beginIndex, int endIndex) {
+    if (expected == null) throw new NullPointerException("expected == null");
+    if (input == null) throw new NullPointerException("input == null");
+    int regionLength = regionLength(input.length(), beginIndex, endIndex);
+    if (expected.length() > regionLength) return false;
+    for (int i = 0, inputIndex = beginIndex; i < regionLength; i++, inputIndex++) {
+      if (expected.charAt(i) != input.charAt(inputIndex)) return false;
+    }
+    return true;
+  }
+
+  /** Opposite of {@link CharSequence#subSequence(int, int)} */
+  public static CharSequence withoutSubSequence(CharSequence input, int beginIndex, int endIndex) {
+    if (input == null) throw new NullPointerException("input == null");
+    int length = input.length();
+
+    // Exit early if the region is empty or the entire input
+    if (regionLength(length, beginIndex, endIndex) == 0) return input;
+    if (beginIndex == 0 && endIndex == length) return "";
+
+    // Exit early if the region ends on a boundary.
+    if (beginIndex == 0) return input.subSequence(endIndex, length);
+    if (endIndex == length) return input.subSequence(0, beginIndex);
+
+    // Otherwise, the region to skip in the middle
+    return new ConcatCharSequence(
+      input.subSequence(0, beginIndex),
+      input.subSequence(endIndex, length)
+    );
+  }
+
+  static int regionLength(int inputLength, int beginIndex, int endIndex) {
+    if (beginIndex < 0) throw new IndexOutOfBoundsException("beginIndex < 0");
+    if (endIndex < 0) throw new IndexOutOfBoundsException("endIndex < 0");
+    if (beginIndex > endIndex) throw new IndexOutOfBoundsException("beginIndex > endIndex");
+    int regionLength = endIndex - beginIndex;
+    if (endIndex > inputLength) throw new IndexOutOfBoundsException("endIndex > input");
+    return regionLength;
+  }
+}

--- a/brave/src/main/java/brave/internal/codec/CharSequences.java
+++ b/brave/src/main/java/brave/internal/codec/CharSequences.java
@@ -19,68 +19,6 @@ package brave.internal.codec;
  * signatures that match our utilities such as {@link EntrySplitter}.
  */
 public final class CharSequences {
-
-  /**
-   * Joins two character sequences together. Inputs must be immutable. This is useful when the
-   * result is only scanned. It does not implement {@link #toString()} or {@link #equals(Object)}.
-   */
-  public static CharSequence concat(CharSequence left, CharSequence right) {
-    if (left == null) throw new NullPointerException("left == null");
-    if (right == null) throw new NullPointerException("right == null");
-    if (left.length() == 0) return right; // isEmpty is Java 15+
-    if (right.length() == 0) return left;
-    return new ConcatCharSequence(left, right);
-  }
-
-  static final class ConcatCharSequence implements CharSequence {
-    final CharSequence left, right;
-    final int length;
-
-    ConcatCharSequence(CharSequence left, CharSequence right) {
-      this.left = left;
-      this.right = right;
-      this.length = left.length() + right.length();
-    }
-
-    @Override public int length() {
-      return length;
-    }
-
-    @Override public char charAt(int index) {
-      if (index < 0) throw new IndexOutOfBoundsException("index < 0");
-      if (index >= length) throw new IndexOutOfBoundsException("index >= length");
-      int leftLength = left.length();
-      if (index < leftLength) return left.charAt(index);
-      return right.charAt(index - leftLength);
-    }
-
-    @Override public CharSequence subSequence(int beginIndex, int endIndex) {
-      if (regionLength(length, beginIndex, endIndex) == 0) return "";
-      if (beginIndex == 0 && endIndex == length) return this;
-
-      int leftLength = left.length();
-      // Exit early if the subSequence is only left or right
-      if (beginIndex == 0 && endIndex == leftLength) return left;
-      if (beginIndex == leftLength && endIndex == length) return right;
-
-      // Exit early if the subSequence is contained by left or right
-      if (endIndex <= leftLength) {
-        return left.subSequence(beginIndex, endIndex);
-      } else if (beginIndex > leftLength) {
-        return right.subSequence(beginIndex - leftLength, endIndex - leftLength);
-      }
-
-      return new ConcatCharSequence( // we are in the middle
-        left.subSequence(beginIndex, leftLength),
-        right.subSequence(0, endIndex - leftLength)
-      );
-    }
-
-    @Override public String toString() {
-      return String.valueOf(left) + right;
-    }
-  }
-
   /**
    * Returns true if the input range contains only the expected characters.
    *
@@ -130,5 +68,58 @@ public final class CharSequences {
     int regionLength = endIndex - beginIndex;
     if (endIndex > inputLength) throw new IndexOutOfBoundsException("endIndex > input");
     return regionLength;
+  }
+
+  /**
+   * Joins two character sequences together. Inputs must be immutable. This is useful when the
+   * result is only scanned. It does not implement {@link #toString()} or {@link #equals(Object)}.
+   */
+  static final class ConcatCharSequence implements CharSequence {
+    final CharSequence left, right;
+    final int length;
+
+    ConcatCharSequence(CharSequence left, CharSequence right) {
+      this.left = left;
+      this.right = right;
+      this.length = left.length() + right.length();
+    }
+
+    @Override public int length() {
+      return length;
+    }
+
+    @Override public char charAt(int index) {
+      if (index < 0) throw new IndexOutOfBoundsException("index < 0");
+      if (index >= length) throw new IndexOutOfBoundsException("index >= length");
+      int leftLength = left.length();
+      if (index < leftLength) return left.charAt(index);
+      return right.charAt(index - leftLength);
+    }
+
+    @Override public CharSequence subSequence(int beginIndex, int endIndex) {
+      if (regionLength(length, beginIndex, endIndex) == 0) return "";
+      if (beginIndex == 0 && endIndex == length) return this;
+
+      int leftLength = left.length();
+      // Exit early if the subSequence is only left or right
+      if (beginIndex == 0 && endIndex == leftLength) return left;
+      if (beginIndex == leftLength && endIndex == length) return right;
+
+      // Exit early if the subSequence is contained by left or right
+      if (endIndex <= leftLength) {
+        return left.subSequence(beginIndex, endIndex);
+      } else if (beginIndex > leftLength) {
+        return right.subSequence(beginIndex - leftLength, endIndex - leftLength);
+      }
+
+      return new ConcatCharSequence( // we are in the middle
+        left.subSequence(beginIndex, leftLength),
+        right.subSequence(0, endIndex - leftLength)
+      );
+    }
+
+    @Override public String toString() {
+      return String.valueOf(left) + right;
+    }
   }
 }

--- a/brave/src/main/java/brave/internal/codec/IpLiteral.java
+++ b/brave/src/main/java/brave/internal/codec/IpLiteral.java
@@ -30,7 +30,7 @@ public final class IpLiteral {
     return ip;
   }
 
-  // All the below code is from zipkin2.Endpoint, copy/pasted here to prevent a depedency.
+  // All the below code is from zipkin2.Endpoint, copy/pasted here to prevent a dependency.
   public enum IpFamily {
     Unknown,
     IPv4,

--- a/brave/src/main/java/brave/internal/codec/WriteBuffer.java
+++ b/brave/src/main/java/brave/internal/codec/WriteBuffer.java
@@ -68,7 +68,7 @@ public final class WriteBuffer {
     return pos;
   }
 
-  public void writeAscii(String v) {
+  public void writeAscii(CharSequence v) {
     for (int i = 0, length = v.length(); i < length; i++) {
       writeByte(v.charAt(i) & 0xff);
     }

--- a/brave/src/main/java/brave/internal/extra/Extra.java
+++ b/brave/src/main/java/brave/internal/extra/Extra.java
@@ -21,11 +21,11 @@ import java.util.Arrays;
 /**
  * Holds extended state in {@link TraceContext#extra()} or {@link TraceContextOrSamplingFlags#extra()}.
  *
- * <p>The implementation of this type uses copy-on-write semantics to prevent changes in a
- * child context from affecting its parent.
+ * <p>Implementations copy-on-write when changing {@linkplain #state} to prevent a child context
+ * from affecting its parent.
  *
  * @param <E> Use a final type as otherwise tools like {@link TraceContext#findExtra(Class)} will
- * not work. In most cases, the type should be package private.
+ *            not work. In most cases, the type should be package private.
  * @param <F> The factory that {@link ExtraFactory#create() creates} this instance.
  */
 // We handle dynamic vs fixed state internally as it..
@@ -66,7 +66,9 @@ public abstract class Extra<E extends Extra<E, F>, F extends ExtraFactory<E, F>>
    * <p>Ex 1: If state is a map, and ours includes {@code A -> 1, B -> 2} and theirs
    * includes {@code A -> 2, D -> 1}, create a new state of {@code A -> 1, B -> 2, D -> 1}.
    *
-   * <p><em>Note</em>: This operation does not need to {@linkplain #lock lock}.
+   * <p><em>Note</em>: This operation does not need to {@linkplain #lock lock} as long as changes
+   * happen before updating {@link #state}. See <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/package-summary.html#MemoryVisibility">MemoryVisibility</a>
+   * for details on "happens before" and volatile fields.
    */
   protected abstract void mergeStateKeepingOursOnConflict(E that);
 

--- a/brave/src/test/java/brave/features/baggage/SingleHeaderCodec.java
+++ b/brave/src/test/java/brave/features/baggage/SingleHeaderCodec.java
@@ -50,10 +50,10 @@ final class SingleHeaderCodec implements BaggageCodec, EntrySplitter.Handler<Val
     return ENTRY_SPLITTER.parse(this, valueUpdater, value);
   }
 
-  @Override public boolean onEntry(
-      ValueUpdater target, String buffer, int beginKey, int endKey, int beginValue, int endValue) {
-    BaggageField field = BaggageField.create(buffer.substring(beginKey, endKey));
-    String value = buffer.substring(beginValue, endValue);
+  @Override public boolean onEntry(ValueUpdater target,
+    CharSequence buffer, int beginKey, int endKey, int beginValue, int endValue) {
+    BaggageField field = BaggageField.create(buffer.subSequence(beginKey, endKey).toString());
+    String value = buffer.subSequence(beginValue, endValue).toString();
     return target.updateValue(field, value);
   }
 

--- a/brave/src/test/java/brave/internal/codec/CharSequencesTest.java
+++ b/brave/src/test/java/brave/internal/codec/CharSequencesTest.java
@@ -13,6 +13,7 @@
  */
 package brave.internal.codec;
 
+import brave.internal.codec.CharSequences.ConcatCharSequence;
 import java.nio.CharBuffer;
 import org.junit.Test;
 
@@ -60,16 +61,16 @@ public class CharSequencesTest {
   }
 
   @Test public void concat() {
-    assertThat(CharSequences.concat("a", "b")).hasToString("ab");
-    assertThat(CharSequences.concat("a", ",b")).hasToString("a,b");
+    assertThat(new ConcatCharSequence("a", "b")).hasToString("ab");
+    assertThat(new ConcatCharSequence("a", ",b")).hasToString("a,b");
 
-    assertThat(CharSequences.concat(CharBuffer.wrap("a"), "b")).hasToString("ab");
-    assertThat(CharSequences.concat("a", CharBuffer.wrap("b"))).hasToString("ab");
+    assertThat(new ConcatCharSequence(CharBuffer.wrap("a"), "b")).hasToString("ab");
+    assertThat(new ConcatCharSequence("a", CharBuffer.wrap("b"))).hasToString("ab");
   }
 
   @Test public void concat_charAt() {
     String left = "b3=1", right = "azure=b";
-    CharSequence concated = new CharSequences.ConcatCharSequence(left, right);
+    CharSequence concated = new ConcatCharSequence(left, right);
     String normalConcated = left + right;
     for (int i = 0; i < normalConcated.length(); i++) {
       assertThat(concated.charAt(i)).isEqualTo(normalConcated.charAt(i));
@@ -77,40 +78,14 @@ public class CharSequencesTest {
   }
 
   @Test public void concat_empties() {
-    assertThat(CharSequences.concat("", "")).isEmpty();
-    assertThat(CharSequences.concat("a", "")).isEqualTo("a");
-    assertThat(CharSequences.concat("", "b")).isEqualTo("b");
-  }
-
-  @Test public void concat_badParameters() {
-    assertThatThrownBy(() -> CharSequences.concat(null, ""))
-      .isInstanceOf(NullPointerException.class)
-      .hasMessage("left == null");
-    assertThatThrownBy(() -> CharSequences.concat("", null))
-      .isInstanceOf(NullPointerException.class)
-      .hasMessage("right == null");
-
-    CharSequence concated = CharSequences.concat("1", "2");
-    assertThatThrownBy(() -> concated.subSequence(-1, 1))
-      .isInstanceOf(IndexOutOfBoundsException.class)
-      .hasMessage("beginIndex < 0");
-
-    assertThatThrownBy(() -> concated.subSequence(0, -1))
-      .isInstanceOf(IndexOutOfBoundsException.class)
-      .hasMessage("endIndex < 0");
-
-    assertThatThrownBy(() -> concated.subSequence(1, 0))
-      .isInstanceOf(IndexOutOfBoundsException.class)
-      .hasMessage("beginIndex > endIndex");
-
-    assertThatThrownBy(() -> concated.subSequence(0, 5))
-      .isInstanceOf(IndexOutOfBoundsException.class)
-      .hasMessage("endIndex > input");
+    assertThat(new ConcatCharSequence("", "")).isEmpty();
+    assertThat(new ConcatCharSequence("a", "")).hasToString("a");
+    assertThat(new ConcatCharSequence("", "b")).hasToString("b");
   }
 
   @Test public void concat_subSequence() {
     String left = "b3=1,", right = "es=2";
-    CharSequence concat = new CharSequences.ConcatCharSequence(left, right);
+    CharSequence concat = new ConcatCharSequence(left, right);
     assertThat(concat.subSequence(0, 0)).isEmpty();
     assertThat(concat.subSequence(0, concat.length())).isSameAs(concat);
 

--- a/brave/src/test/java/brave/internal/codec/CharSequencesTest.java
+++ b/brave/src/test/java/brave/internal/codec/CharSequencesTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import java.nio.CharBuffer;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CharSequencesTest {
+  @Test public void regionMatches() {
+    assertThat(CharSequences.regionMatches("b3", "b3=1", 0, 2)).isTrue();
+    assertThat(CharSequences.regionMatches("b3", "b3=1", 1, 3)).isFalse();
+    assertThat(CharSequences.regionMatches("1", "b3=1", 3, 4)).isTrue();
+
+    assertThat(CharSequences.regionMatches(CharBuffer.wrap("b3"), "b3=1", 0, 2)).isTrue();
+    assertThat(CharSequences.regionMatches(CharBuffer.wrap("b3"), "b3=1", 1, 3)).isFalse();
+    assertThat(CharSequences.regionMatches(CharBuffer.wrap("1"), "b3=1", 3, 4)).isTrue();
+
+    assertThat(CharSequences.regionMatches("b3", CharBuffer.wrap("b3=1"), 0, 2)).isTrue();
+    assertThat(CharSequences.regionMatches("b3", CharBuffer.wrap("b3=1"), 1, 3)).isFalse();
+    assertThat(CharSequences.regionMatches("1", CharBuffer.wrap("b3=1"), 3, 4)).isTrue();
+  }
+
+  @Test public void regionMatches_badParameters() {
+    assertThatThrownBy(() -> CharSequences.regionMatches(null, "b3", 0, 0))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("expected == null");
+    assertThatThrownBy(() -> CharSequences.regionMatches("b3", null, 0, 0))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("input == null");
+
+    assertThatThrownBy(() -> CharSequences.regionMatches("b3", "a", -1, 1))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("beginIndex < 0");
+
+    assertThatThrownBy(() -> CharSequences.regionMatches("b3", "a", 0, -1))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("endIndex < 0");
+
+    assertThatThrownBy(() -> CharSequences.regionMatches("b3", "a", 1, 0))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("beginIndex > endIndex");
+
+    assertThatThrownBy(() -> CharSequences.regionMatches("b3", "a", 0, 2))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("endIndex > input");
+  }
+
+  @Test public void concat() {
+    assertThat(CharSequences.concat("a", "b")).hasToString("ab");
+    assertThat(CharSequences.concat("a", ",b")).hasToString("a,b");
+
+    assertThat(CharSequences.concat(CharBuffer.wrap("a"), "b")).hasToString("ab");
+    assertThat(CharSequences.concat("a", CharBuffer.wrap("b"))).hasToString("ab");
+  }
+
+  @Test public void concat_charAt() {
+    String left = "b3=1", right = "azure=b";
+    CharSequence concated = new CharSequences.ConcatCharSequence(left, right);
+    String normalConcated = left + right;
+    for (int i = 0; i < normalConcated.length(); i++) {
+      assertThat(concated.charAt(i)).isEqualTo(normalConcated.charAt(i));
+    }
+  }
+
+  @Test public void concat_empties() {
+    assertThat(CharSequences.concat("", "")).isEmpty();
+    assertThat(CharSequences.concat("a", "")).isEqualTo("a");
+    assertThat(CharSequences.concat("", "b")).isEqualTo("b");
+  }
+
+  @Test public void concat_badParameters() {
+    assertThatThrownBy(() -> CharSequences.concat(null, ""))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("left == null");
+    assertThatThrownBy(() -> CharSequences.concat("", null))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("right == null");
+
+    CharSequence concated = CharSequences.concat("1", "2");
+    assertThatThrownBy(() -> concated.subSequence(-1, 1))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("beginIndex < 0");
+
+    assertThatThrownBy(() -> concated.subSequence(0, -1))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("endIndex < 0");
+
+    assertThatThrownBy(() -> concated.subSequence(1, 0))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("beginIndex > endIndex");
+
+    assertThatThrownBy(() -> concated.subSequence(0, 5))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("endIndex > input");
+  }
+
+  @Test public void concat_subSequence() {
+    String left = "b3=1,", right = "es=2";
+    CharSequence concat = new CharSequences.ConcatCharSequence(left, right);
+    assertThat(concat.subSequence(0, 0)).isEmpty();
+    assertThat(concat.subSequence(0, concat.length())).isSameAs(concat);
+
+    assertThat(concat.subSequence(0, left.length())).isSameAs(left);
+    assertThat(concat.subSequence(left.length(), concat.length())).isSameAs(right);
+
+    assertThat(concat.subSequence(0, 2)).hasToString("b3");
+    assertThat(concat.subSequence(2, 4)).hasToString("=1");
+    assertThat(concat.subSequence(4, 6)).hasToString(",e");
+    assertThat(concat.subSequence(6, 8)).hasToString("s=");
+
+    assertThat(concat.subSequence(1, 9)).hasToString("3=1,es=2");
+    assertThat(concat.subSequence(0, 8)).hasToString("b3=1,es=");
+  }
+
+  @Test public void withoutSubSequence() {
+    String input = "b3=1,es=2";
+    assertThat(CharSequences.withoutSubSequence(input, 0, 0)).isSameAs(input);
+    assertThat(CharSequences.withoutSubSequence(input, 0, input.length())).isEmpty();
+
+    assertThat(CharSequences.withoutSubSequence(input, 0, 2)).hasToString("=1,es=2");
+    assertThat(CharSequences.withoutSubSequence(input, 2, 4)).hasToString("b3,es=2");
+    assertThat(CharSequences.withoutSubSequence(input, 4, 6)).hasToString("b3=1s=2");
+    assertThat(CharSequences.withoutSubSequence(input, 6, 8)).hasToString("b3=1,e2");
+
+    assertThat(CharSequences.withoutSubSequence(input, 1, 9)).hasToString("b");
+    assertThat(CharSequences.withoutSubSequence(input, 0, 8)).hasToString("2");
+  }
+
+  @Test public void withoutSubSequence_badParameters() {
+    assertThatThrownBy(() -> CharSequences.withoutSubSequence(null, 0, 0))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("input == null");
+
+    assertThatThrownBy(() -> CharSequences.withoutSubSequence("b3", -1, 1))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("beginIndex < 0");
+
+    assertThatThrownBy(() -> CharSequences.withoutSubSequence("b3", 0, -1))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("endIndex < 0");
+
+    assertThatThrownBy(() -> CharSequences.withoutSubSequence("b3", 1, 0))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("beginIndex > endIndex");
+
+    assertThatThrownBy(() -> CharSequences.withoutSubSequence("b3", 0, 3))
+      .isInstanceOf(IndexOutOfBoundsException.class)
+      .hasMessage("endIndex > input");
+  }
+}

--- a/brave/src/test/java/brave/internal/codec/EntrySplitterTest.java
+++ b/brave/src/test/java/brave/internal/codec/EntrySplitterTest.java
@@ -21,6 +21,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
+import static brave.internal.codec.CharSequences.regionMatches;
+import static brave.internal.codec.HexCodec.lenientLowerHexToUnsignedLong;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -29,19 +31,19 @@ public class EntrySplitterTest {
   EntrySplitter entrySplitter = EntrySplitter.newBuilder().shouldThrow(true).build();
   Map<String, String> map = new LinkedHashMap<>();
   Handler<Map<String, String>> parseIntoMap =
-      (target, input, beginKey, endKey, beginValue, endValue) -> {
-        String key = input.substring(beginKey, endKey);
-        String value = input.substring(beginValue, endValue);
-        target.put(key, value);
-        return true;
-      };
+    (target, input, beginKey, endKey, beginValue, endValue) -> {
+      String key = input.subSequence(beginKey, endKey).toString();
+      String value = input.subSequence(beginValue, endValue).toString();
+      target.put(key, value);
+      return true;
+    };
 
   @Test public void parse() {
     entrySplitter.parse(parseIntoMap, map, "k1=v1,k2=v2");
 
     assertThat(map).containsExactly(
-        entry("k1", "v1"),
-        entry("k2", "v2")
+      entry("k1", "v1"),
+      entry("k2", "v2")
     );
   }
 
@@ -49,16 +51,16 @@ public class EntrySplitterTest {
     entrySplitter.parse(parseIntoMap, map, "k=v,a=b");
 
     assertThat(map).containsExactly(
-        entry("k", "v"),
-        entry("a", "b")
+      entry("k", "v"),
+      entry("a", "b")
     );
   }
 
   @Test public void parse_valuesAreRequired() {
     for (String missingValue : Arrays.asList("k1", "k1  ", "k1=v1,k2", "k1   ,k2=v1")) {
       assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, map, missingValue))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Invalid input: missing key value separator '='");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid input: missing key value separator '='");
     }
     assertThat(map.isEmpty());
   }
@@ -74,59 +76,59 @@ public class EntrySplitterTest {
     entrySplitter.parse(parseIntoMap, map, "k1=v1,k2=");
 
     assertThat(map).containsExactly(
-        entry("k1", "v1"),
-        entry("k2", "")
+      entry("k1", "v1"),
+      entry("k2", "")
     );
   }
 
   @Test public void keyValueSeparatorRequired_false() {
     entrySplitter = EntrySplitter.newBuilder()
-        .keyValueSeparatorRequired(false)
-        .shouldThrow(true)
-        .build();
+      .keyValueSeparatorRequired(false)
+      .shouldThrow(true)
+      .build();
 
     entrySplitter.parse(parseIntoMap, map, " authcache , gateway ");
 
     assertThat(map).containsExactly(
-        entry("authcache", ""),
-        entry("gateway", "")
+      entry("authcache", ""),
+      entry("gateway", "")
     );
   }
 
   /** Parse Accept header style encoding as used in secondary sampling */
   @Test public void parse_onlyFirstKeyValueSeparator() {
     entrySplitter = EntrySplitter.newBuilder()
-        .keyValueSeparator(';')
-        .keyValueSeparatorRequired(false)
-        .shouldThrow(true)
-        .build();
+      .keyValueSeparator(';')
+      .keyValueSeparatorRequired(false)
+      .shouldThrow(true)
+      .build();
 
     entrySplitter.parse(parseIntoMap, map, "authcache;ttl=1;spanId=19f84f102048e047,gateway");
 
     assertThat(map).containsExactly(
-        entry("authcache", "ttl=1;spanId=19f84f102048e047"),
-        entry("gateway", "")
+      entry("authcache", "ttl=1;spanId=19f84f102048e047"),
+      entry("gateway", "")
     );
   }
 
   /** This shows you can nest parsers without unnecessary string allocation between stages. */
   @Test public void parse_nested() {
     EntrySplitter outerSplitter = EntrySplitter.newBuilder()
-        .keyValueSeparator(';')
-        .keyValueSeparatorRequired(false)
-        .shouldThrow(true)
-        .build();
+      .keyValueSeparator(';')
+      .keyValueSeparatorRequired(false)
+      .shouldThrow(true)
+      .build();
 
     EntrySplitter innerSplitter = EntrySplitter.newBuilder()
-        .entrySeparator(';')
-        .keyValueSeparator('=')
-        .shouldThrow(true)
-        .build();
+      .entrySeparator(';')
+      .keyValueSeparator('=')
+      .shouldThrow(true)
+      .build();
 
     Map<String, Map<String, String>> keyToAttributes = new LinkedHashMap<>();
 
     outerSplitter.parse((target, input, beginKey, endKey, beginValue, endValue) -> {
-      String key = input.substring(beginKey, endKey);
+      String key = input.subSequence(beginKey, endKey).toString();
       Map<String, String> attributes = new LinkedHashMap<>();
       if (beginValue == endValue) { // no string allocation at all
         attributes = Collections.emptyMap();
@@ -142,16 +144,16 @@ public class EntrySplitterTest {
     expectedAttributes.put("ttl", "1");
     expectedAttributes.put("spanId", "19f84f102048e047");
     assertThat(keyToAttributes).containsExactly(
-        entry("authcache", expectedAttributes),
-        entry("gateway", Collections.emptyMap())
+      entry("authcache", expectedAttributes),
+      entry("gateway", Collections.emptyMap())
     );
   }
 
   @Test public void parse_emptyKeysNotOk() {
     for (String missingKey : Arrays.asList("=", "=v1", ",=", ",=v2")) {
       assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, map, missingKey))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Invalid input: no key before '='");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid input: no key before '='");
     }
   }
 
@@ -163,59 +165,58 @@ public class EntrySplitterTest {
     entrySplitter = EntrySplitter.newBuilder().entrySeparator(';').build();
 
     String awsTraceId =
-        "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1";
+      "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1";
 
     Handler<TraceContext.Builder> parseIntoMap =
-        (target, input, beginKey, endKey, beginValue, endValue) -> {
-          int keyLength = endKey - beginKey;
-          if (input.regionMatches(beginKey, "Root", 0, keyLength)) {
-            int valueLength = endValue - beginValue;
-            int i = beginValue;
-            if (valueLength != 35 // length of 1-67891233-abcdef012345678912345678
-                || input.charAt(i++) != '1'
-                || input.charAt(i++) != '-') {
-              return false; // invalid version or format
-            }
-            long high32 = HexCodec.lenientLowerHexToUnsignedLong(input, i, i + 8);
-            i += 9; // skip the hyphen
-            long low32 = HexCodec.lenientLowerHexToUnsignedLong(input, i, i + 8);
-            i += 8;
-            long traceIdHigh = high32 << 32;
-            traceIdHigh = traceIdHigh | low32;
-            long traceId = HexCodec.lenientLowerHexToUnsignedLong(input, i, i + 16);
-            if (traceIdHigh == 0L || traceId == 0L) return false;
-            target.traceIdHigh(traceIdHigh).traceId(traceId);
-            return true;
-          } else if (input.regionMatches(beginKey, "Parent", 0, keyLength)) {
-            long spanId = HexCodec.lenientLowerHexToUnsignedLong(input, beginValue, endValue);
-            if (spanId == 0L) return false;
-            target.spanId(spanId);
-            return true;
-          } else if (input.regionMatches(beginKey, "Sampled", 0, keyLength)) {
-            switch (input.charAt(beginValue)) {
-              case '0':
-                target.sampled(false);
-                break;
-              case '1':
-                target.sampled(true);
-                break;
-              default:
-                return false;
-            }
+      (target, input, beginKey, endKey, beginValue, endValue) -> {
+        if (regionMatches("Root", input, beginKey, endKey)) {
+          int valueLength = endValue - beginValue;
+          int i = beginValue;
+          if (valueLength != 35 // length of 1-67891233-abcdef012345678912345678
+            || input.charAt(i++) != '1'
+            || input.charAt(i++) != '-') {
+            return false; // invalid version or format
           }
+          long high32 = lenientLowerHexToUnsignedLong(input, i, i + 8);
+          i += 9; // skip the hyphen
+          long low32 = lenientLowerHexToUnsignedLong(input, i, i + 8);
+          i += 8;
+          long traceIdHigh = high32 << 32;
+          traceIdHigh = traceIdHigh | low32;
+          long traceId = lenientLowerHexToUnsignedLong(input, i, i + 16);
+          if (traceIdHigh == 0L || traceId == 0L) return false;
+          target.traceIdHigh(traceIdHigh).traceId(traceId);
           return true;
-        };
+        } else if (regionMatches("Parent", input, beginKey, endKey)) {
+          long spanId = lenientLowerHexToUnsignedLong(input, beginValue, endValue);
+          if (spanId == 0L) return false;
+          target.spanId(spanId);
+          return true;
+        } else if (regionMatches("Sampled", input, beginKey, endKey)) {
+          switch (input.charAt(beginValue)) {
+            case '0':
+              target.sampled(false);
+              break;
+            case '1':
+              target.sampled(true);
+              break;
+            default:
+              return false;
+          }
+        }
+        return true;
+      };
 
     TraceContext.Builder builder = TraceContext.newBuilder();
     assertThat(entrySplitter.parse(parseIntoMap, builder, awsTraceId)).isTrue();
     TraceContext context = builder.build();
 
     assertThat(context).usingRecursiveComparison().isEqualTo(
-        TraceContext.newBuilder()
-            .traceIdHigh(0x67891233abcdef01L).traceId(0x2345678912345678L)
-            .spanId(0x463ac35c9f6413adL)
-            .sampled(true)
-            .build()
+      TraceContext.newBuilder()
+        .traceIdHigh(0x67891233abcdef01L).traceId(0x2345678912345678L)
+        .spanId(0x463ac35c9f6413adL)
+        .sampled(true)
+        .build()
     );
   }
 
@@ -223,9 +224,8 @@ public class EntrySplitterTest {
     entrySplitter = EntrySplitter.newBuilder().maxEntries(2).shouldThrow(true).build();
 
     entrySplitter.parse((target, input, beginKey, endKey, beginValue, endValue) -> {
-      String key = input.substring(beginKey, endKey);
-      if (key.equals("k1")) {
-        target.put(key, input.substring(beginValue, endValue));
+      if (regionMatches("k1", input, beginKey, endKey)) {
+        target.put("k1", input.subSequence(beginValue, endValue).toString());
         return true;
       }
       return false;
@@ -240,77 +240,77 @@ public class EntrySplitterTest {
     entrySplitter.parse(parseIntoMap, map, "k1=v1,k2=v2");
 
     assertThat(map).containsExactly(
-        entry("k1", "v1"),
-        entry("k2", "v2")
+      entry("k1", "v1"),
+      entry("k2", "v2")
     );
 
     assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, map, "k1=v1,k2=v2,k3=v3"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid input: over 2 entries");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid input: over 2 entries");
   }
 
   @Test public void parse_whitespaceInKeyValue() {
     entrySplitter.parse(parseIntoMap, map, "k 1=v 1,k 2=v 2");
 
     assertThat(map).containsExactly(
-        entry("k 1", "v 1"),
-        entry("k 2", "v 2")
+      entry("k 1", "v 1"),
+      entry("k 2", "v 2")
     );
   }
 
   @Test public void trimOWSAroundEntrySeparator() {
     entrySplitter = EntrySplitter.newBuilder()
-        .trimOWSAroundEntrySeparator(true)
-        .trimOWSAroundKeyValueSeparator(false)
-        .shouldThrow(true).build();
+      .trimOWSAroundEntrySeparator(true)
+      .trimOWSAroundKeyValueSeparator(false)
+      .shouldThrow(true).build();
 
     entrySplitter.parse(parseIntoMap, map, "  k1   =   v1  ,  k2   =   v2  ");
 
     assertThat(map).containsExactly(
-        entry("k1   ", "   v1"),
-        entry("k2   ", "   v2")
+      entry("k1   ", "   v1"),
+      entry("k2   ", "   v2")
     );
   }
 
   @Test public void trimOWSAroundKeyValueSeparator() {
     entrySplitter = EntrySplitter.newBuilder()
-        .trimOWSAroundEntrySeparator(false)
-        .trimOWSAroundKeyValueSeparator(true)
-        .shouldThrow(true).build();
+      .trimOWSAroundEntrySeparator(false)
+      .trimOWSAroundKeyValueSeparator(true)
+      .shouldThrow(true).build();
 
     entrySplitter.parse(parseIntoMap, map, "  k1   =   v1  ,  k2   =   v2  ");
 
     assertThat(map).containsExactly(
-        entry("  k1", "v1  "),
-        entry("  k2", "v2  ")
+      entry("  k1", "v1  "),
+      entry("  k2", "v2  ")
     );
   }
 
   @Test public void trimOWSAroundSeparators() {
     entrySplitter = EntrySplitter.newBuilder()
-        .trimOWSAroundEntrySeparator(true)
-        .trimOWSAroundKeyValueSeparator(true)
-        .shouldThrow(true).build();
+      .trimOWSAroundEntrySeparator(true)
+      .trimOWSAroundKeyValueSeparator(true)
+      .shouldThrow(true).build();
 
     entrySplitter.parse(parseIntoMap, map, "  k1   =   v1  ,  k2   =   v2  ");
 
     assertThat(map).containsExactly(
-        entry("k1", "v1"),
-        entry("k2", "v2")
+      entry("k1", "v1"),
+      entry("k2", "v2")
     );
   }
 
   @Test public void trimOWSAroundNothing() {
     entrySplitter = EntrySplitter.newBuilder()
-        .trimOWSAroundEntrySeparator(false)
-        .trimOWSAroundKeyValueSeparator(false)
-        .shouldThrow(true).build();
+      .trimOWSAroundEntrySeparator(false)
+      .trimOWSAroundKeyValueSeparator(false)
+      .shouldThrow(true).build();
 
     entrySplitter.parse(parseIntoMap, map, "  k1   =   v1  ,  k2   =   v2  ");
 
     assertThat(map).containsExactly(
-        entry("  k1   ", "   v1  "),
-        entry("  k2   ", "   v2  ")
+      entry("  k1   ", "   v1  "),
+      entry("  k2   ", "   v2  ")
     );
   }
 
@@ -346,43 +346,43 @@ public class EntrySplitterTest {
     EntrySplitter.Builder builder = EntrySplitter.newBuilder();
 
     assertThatThrownBy(() -> builder.maxEntries(-1))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("maxEntries <= 0");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("maxEntries <= 0");
     assertThatThrownBy(() -> builder.maxEntries(0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("maxEntries <= 0");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("maxEntries <= 0");
 
     assertThatThrownBy(() -> builder.entrySeparator((char) 0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("entrySeparator == 0");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("entrySeparator == 0");
 
     assertThatThrownBy(() -> builder.keyValueSeparator((char) 0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("keyValueSeparator == 0");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("keyValueSeparator == 0");
 
     builder.keyValueSeparator(';').entrySeparator(';');
     assertThatThrownBy(builder::build)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("entrySeparator == keyValueSeparator");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("entrySeparator == keyValueSeparator");
   }
 
   @Test public void parse_badParameters() {
     assertThatThrownBy(() -> entrySplitter.parse(null, map, ""))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("handler == null");
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("handler == null");
     assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, null, ""))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("target == null");
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("target == null");
     assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, map, null))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("input == null");
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("input == null");
 
     assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, map, "", -1, 1))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("beginIndex < 0");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("beginIndex < 0");
 
     assertThatThrownBy(() -> entrySplitter.parse(parseIntoMap, map, "", 0, 2))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("endIndex > input.length()");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("endIndex > input.length()");
   }
 }

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/CharSequencesBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/CharSequencesBenchmarks.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static brave.internal.codec.CharSequences.regionMatches;
+import static brave.internal.codec.CharSequences.withoutSubSequence;
+
+/**
+ * For {@link CharSequences#withoutSubSequence(CharSequence, int, int)}, this only benchmarks the
+ * interesting case, which is when the substring to exclude is in the middle of the input. This
+ * shows how it helps reduce GC pressure vs concatenating strings.
+ *
+ * <p>The use case for this is we are writing down a "tracestate" header, and overwriting only the
+ * "b3" entry of it. We write this header using {@link StringBuilder#append(CharSequence)}, which
+ * implies the input does not necessarily need to be a String. This flexibility allows us to avoid
+ * the allocation implied when otherwise concatenating ranges to exclude a middle part of a string.
+ */
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class CharSequencesBenchmarks {
+  static final String B3_128 = "67891233abcdef012345678912345678-463ac35c9f6413ad-1";
+  static final String TRACESTATE_B3_ONLY = "b3=" + B3_128;
+  static final String TRACESTATE_B3_MIDDLE =
+    "other=28167db2-2de7-4c63-ae3f-f56e7a0eca65,b3=" + B3_128 + ",another=               a";
+  static final String TRACESTATE_B3_MIDDLE_MAX_ENTRIES;
+
+  static {
+    StringBuilder builder = new StringBuilder().append(0).append('=').append(B3_128);
+    for (int i = 1; i < 32; i++) {
+      builder.append(',').append(i == 15 ? "b3" : i).append('=').append(B3_128);
+    }
+    TRACESTATE_B3_MIDDLE_MAX_ENTRIES = builder.toString();
+  }
+
+  static final int INDEX_OF_TRACESTATE_B3_MIDDLE = TRACESTATE_B3_MIDDLE.indexOf(TRACESTATE_B3_ONLY);
+  static final int INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES =
+    TRACESTATE_B3_MIDDLE_MAX_ENTRIES.indexOf(TRACESTATE_B3_ONLY);
+
+  @Benchmark public boolean regionMatches_hit() {
+    return regionMatches(TRACESTATE_B3_ONLY, TRACESTATE_B3_MIDDLE, INDEX_OF_TRACESTATE_B3_MIDDLE,
+      INDEX_OF_TRACESTATE_B3_MIDDLE + TRACESTATE_B3_ONLY.length());
+  }
+
+  @Benchmark public boolean regionMatches_miss() {
+    return regionMatches(TRACESTATE_B3_ONLY, TRACESTATE_B3_MIDDLE, 0, TRACESTATE_B3_ONLY.length());
+  }
+
+  @Benchmark public CharSequence withoutSubSequence_middle_normal() {
+    return withoutSubSequence(TRACESTATE_B3_MIDDLE, INDEX_OF_TRACESTATE_B3_MIDDLE,
+      INDEX_OF_TRACESTATE_B3_MIDDLE + TRACESTATE_B3_ONLY.length());
+  }
+
+  @Benchmark public CharSequence withoutSubSequence_middle_normal_string() {
+    return withoutSubSequence_string(TRACESTATE_B3_MIDDLE, INDEX_OF_TRACESTATE_B3_MIDDLE,
+      INDEX_OF_TRACESTATE_B3_MIDDLE + TRACESTATE_B3_ONLY.length());
+  }
+
+  @Benchmark public CharSequence withoutSubSequence_middle_max() {
+    return withoutSubSequence(TRACESTATE_B3_MIDDLE_MAX_ENTRIES,
+      INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES,
+      INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES + TRACESTATE_B3_ONLY.length()).toString();
+  }
+
+  @Benchmark public CharSequence withoutSubSequence_middle_max_string() {
+    return withoutSubSequence_string(TRACESTATE_B3_MIDDLE_MAX_ENTRIES,
+      INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES,
+      INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES + TRACESTATE_B3_ONLY.length());
+  }
+
+  static CharSequence withoutSubSequence_string(String input, int beginIndex, int endIndex) {
+    // String.subSequence is the same as String.substring!
+    return input.substring(0, beginIndex) + input.substring(endIndex);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .addProfiler("gc")
+      .include(".*" + CharSequencesBenchmarks.class.getSimpleName())
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/CharSequencesBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/CharSequencesBenchmarks.java
@@ -85,7 +85,7 @@ public class CharSequencesBenchmarks {
   @Benchmark public CharSequence withoutSubSequence_middle_max() {
     return withoutSubSequence(TRACESTATE_B3_MIDDLE_MAX_ENTRIES,
       INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES,
-      INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES + TRACESTATE_B3_ONLY.length()).toString();
+      INDEX_OF_TRACESTATE_B3_MIDDLE_MAX_ENTRIES + TRACESTATE_B3_ONLY.length());
   }
 
   @Benchmark public CharSequence withoutSubSequence_middle_max_string() {

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/EntrySplitterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/EntrySplitterBenchmarks.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static brave.internal.codec.CharSequencesBenchmarks.TRACESTATE_B3_MIDDLE;
+import static brave.internal.codec.CharSequencesBenchmarks.TRACESTATE_B3_MIDDLE_MAX_ENTRIES;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class EntrySplitterBenchmarks {
+  // covers pattern used in https://github.com/openzipkin-contrib/brave-propagation-w3c
+  static final EntrySplitter ENTRY_SPLITTER = EntrySplitter.newBuilder()
+    .maxEntries(32) // https://www.w3.org/TR/trace-context/#list
+    .entrySeparator(',')
+    .trimOWSAroundEntrySeparator(true) // https://www.w3.org/TR/trace-context/#list
+    .keyValueSeparator('=')
+    .trimOWSAroundKeyValueSeparator(false) // https://github.com/w3c/trace-context/pull/411
+    .shouldThrow(false)
+    .build();
+
+  static final EntrySplitter.Handler<Boolean> NOOP_HANDLER =
+    (target, input, beginKey, endKey, beginValue, endValue) -> true;
+
+  @Benchmark public boolean parse_middle_normal() {
+    return ENTRY_SPLITTER.parse(NOOP_HANDLER, false, TRACESTATE_B3_MIDDLE);
+  }
+
+  @Benchmark public boolean parse_middle_normal_string() {
+    return parse_string(TRACESTATE_B3_MIDDLE);
+  }
+
+  @Benchmark public boolean parse_middle_max() {
+    return ENTRY_SPLITTER.parse(NOOP_HANDLER, false, TRACESTATE_B3_MIDDLE_MAX_ENTRIES);
+  }
+
+  @Benchmark public boolean parse_middle_max_string() {
+    return parse_string(TRACESTATE_B3_MIDDLE_MAX_ENTRIES);
+  }
+
+  static boolean parse_string(String input) {
+    boolean result = true;
+    for (String entry : input.split(",", 32)) {
+      result = entry.trim().split(",", 2).length == 2;
+    }
+    return result;
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .addProfiler("gc")
+      .include(".*" + EntrySplitterBenchmarks.class.getSimpleName())
+      .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/EntrySplitterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/EntrySplitterBenchmarks.java
@@ -48,26 +48,26 @@ public class EntrySplitterBenchmarks {
   static final EntrySplitter.Handler<Boolean> NOOP_HANDLER =
     (target, input, beginKey, endKey, beginValue, endValue) -> true;
 
-  @Benchmark public boolean parse_middle_normal() {
+  @Benchmark public boolean parse_normal() {
     return ENTRY_SPLITTER.parse(NOOP_HANDLER, false, TRACESTATE_B3_MIDDLE);
   }
 
-  @Benchmark public boolean parse_middle_normal_string() {
+  @Benchmark public boolean parse_normal_string() {
     return parse_string(TRACESTATE_B3_MIDDLE);
   }
 
-  @Benchmark public boolean parse_middle_max() {
+  @Benchmark public boolean parse_max() {
     return ENTRY_SPLITTER.parse(NOOP_HANDLER, false, TRACESTATE_B3_MIDDLE_MAX_ENTRIES);
   }
 
-  @Benchmark public boolean parse_middle_max_string() {
+  @Benchmark public boolean parse_max_string() {
     return parse_string(TRACESTATE_B3_MIDDLE_MAX_ENTRIES);
   }
 
   static boolean parse_string(String input) {
     boolean result = true;
     for (String entry : input.split(",", 32)) {
-      result = entry.trim().split(",", 2).length == 2;
+      result = entry.trim().split("=", 2).length == 2;
     }
     return result;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
 
     <!-- Test only dependencies -->
     <junit.version>4.13.1</junit.version>
-    <junit-jupiter.version>5.7.0</junit-jupiter.version>
     <assertj.version>3.18.1</assertj.version>
     <powermock.version>2.0.9</powermock.version>
     <mockito.version>3.6.0</mockito.version>
@@ -138,6 +137,8 @@
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <!-- Use same version as https://github.com/openzipkin/docker-java -->
+    <maven-help-plugin.version>3.2.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
     <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
@@ -255,13 +256,6 @@
           <configuration>
             <!-- Add dependencies indirectly referenced by build plugins -->
             <dynamicDependencies>
-              <!-- animal sniffer implicitly uses this -->
-              <DynamicDependency>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
-                <repositoryType>PLUGIN</repositoryType>
-              </DynamicDependency>
               <DynamicDependency>
                 <groupId>org.codehaus.mojo.signature</groupId>
                 <artifactId>${main.signature.artifact}</artifactId>
@@ -303,11 +297,6 @@
             <fork>true</fork>
             <showWarnings>true</showWarnings>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>${maven-dependency-plugin.version}</version>
         </plugin>
 
         <!-- Uploads occur as a last step (which also adds checksums) -->
@@ -420,6 +409,16 @@
     </pluginManagement>
 
     <plugins>
+      <!-- Ensure common utility commands use coherent versions (avoid lazy downloads) -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>${maven-help-plugin.version}</version>
+      </plugin>
+
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>


### PR DESCRIPTION
This allows us to split and parse CharSequence instead of String, which
reduces allocations when parsing W3C tracestate.

This adds a utility `CharSequences` to help with tasks.