### PR TITLE
More accurate OkHttp3 / Okio version management for OSGi deployments

### DIFF
--- a/instrumentation/okhttp3/bnd.bnd
+++ b/instrumentation/okhttp3/bnd.bnd
@@ -1,4 +1,6 @@
 Import-Package: \
+  okhttp3;version="[3.11, 5)",\
+  okio;version="[1.15,3)",\
   *
 Export-Package: \
   brave.okhttp3


### PR DESCRIPTION
At the moment, the OkHttp3 and Okio versions are unspecified in OSGI manifests.

```
Import-Package: brave;version="[5.12,6)",brave.http;version="[5.12,6)",brave.internal;braveinternal=true;version="[5.12,6)",brave.propagation;version="[5.12,6)",okhttp3,okio
```

Since Zipkin OkHttp3 instrumentation supports OkHttp3 `3.x` and `4.x`, more accurate version management would be helpful. 

```
Import-Package: brave;version="[5.12,6)",brave.http;version="[5.12,6)",brave.internal;braveinternal=true;version="[5.12,6)",brave.propagation;version="[5.12,6)",okhttp3;version="[3.11,5)",okio;version="[1.15,3)"
```

Relates to https://github.com/openzipkin/zipkin-reporter-java/pull/195
CC @adriancole 