### PR TITLE
Fixes race condition with toSpan and flush

### DIFF
--- a/brave/src/main/java/brave/Tracer.java
+++ b/brave/src/main/java/brave/Tracer.java
@@ -192,11 +192,6 @@ public class Tracer {
     }
   }
 
-  /** Returns an equivalent context if exists in the pending map */
-  PendingSpan getPendingSpan(TraceContext context) {
-    return pendingSpans.get(context);
-  }
-
   /**
    * Explicitly creates a child within an existing trace. The result will be have its parent ID set
    * to the input's span ID. If a sampling decision has not yet been made, one will happen here.
@@ -377,7 +372,7 @@ public class Tracer {
 
   Span toSpan(@Nullable TraceContext parent, TraceContext context) {
     // Re-use a pending span if present: This ensures reference consistency on Span.context()
-    PendingSpan pendingSpan = getPendingSpan(context);
+    PendingSpan pendingSpan = pendingSpans.get(context);
     if (pendingSpan != null) {
       if (isNoop(context)) return new NoopSpan(context);
       return _toSpan(context, pendingSpan);

--- a/brave/src/main/java/brave/baggage/BaggagePropagationConfig.java
+++ b/brave/src/main/java/brave/baggage/BaggagePropagationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/main/java/brave/handler/SpanHandler.java
+++ b/brave/src/main/java/brave/handler/SpanHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,9 +37,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
+
 import zipkin2.Endpoint;
 import zipkin2.reporter.Reporter;
 
@@ -226,6 +229,7 @@ public class TracerTest {
   @Test public void join_createsChildWhenUnsupportedByPropagation() {
     tracer = Tracing.newBuilder()
       .propagationFactory(new Propagation.Factory() {
+        @Override
         @Deprecated public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
           return B3Propagation.FACTORY.create(keyFactory);
         }
@@ -1090,6 +1094,22 @@ public class TracerTest {
     TraceContext toSpan = tracer.toSpan(incoming).context();
     assertThat(toSpan).isNotSameAs(incoming);
     assertThat(toSpan.extra()).isNotEmpty();
+  }
+
+  @Test public void toSpan_flushedAfterFetch() throws InterruptedException, ExecutionException {
+    propagationFactory = baggageFactory;
+    TraceContext parent = TraceContext.newBuilder().traceId(1L).spanId(2L).sampled(true).build();
+    TraceContext incoming = TraceContext.newBuilder().traceId(1L).spanId(3L).parentId(2L).sampled(true).build();
+
+    tracer.pendingSpans.getOrCreate(parent, incoming, false);
+    Tracer spiedTracer = Mockito.spy(tracer);
+    Mockito.doAnswer(i -> {
+      //Simulate a concurrent call flushing the span at the beginning of this method's execution
+      tracer.pendingSpans.flush(incoming);
+      return i.callRealMethod();
+    }).when(spiedTracer)._toSpan(Mockito.any(TraceContext.class), Mockito.any(TraceContext.class));
+
+    spiedTracer.toSpan(incoming);
   }
 
   @Test public void currentSpan_sameContextReference() {


### PR DESCRIPTION
Fixes #1295
Previous to this fix, a call to Tracer::toSpan concurrent with a call
to flush the span from pendingSpans could result in an assertion error.

We now only fetch the pendingSpan once for a single call to toSpan.