### PR TITLE
Increase Sonatype OSS staging timeout.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -711,9 +711,10 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- Double the normal timeout even though we haven't had a problem in this project.
-                   The only outcome of timing out client side is trying again. -->
-              <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+              <!-- Recent slowdowns with Sonatype staging have pushed latencies over 10-20 minutes.
+                   Increasing the timeout avoids failures and retries, which still often fail when
+                   Sonatype servers are overloaded. -->
+              <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>


### PR DESCRIPTION
Staging servers have had an increased latency for days which
makes it impossible to do releases. This increases the timeout
above the average latency.