### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <spring-rabbit.version>2.3.2</spring-rabbit.version>
 
     <finagle.version>20.12.0</finagle.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <okhttp.version>4.9.0</okhttp.version>
     <httpclient.version>4.5.13</httpclient.version>
 


### PR DESCRIPTION
This fixes https://nvd.nist.gov/vuln/detail/CVE-2021-44832