### PR TITLE
Updates for Kafka clients/streams 3.0

### DIFF
--- a/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
@@ -122,7 +122,7 @@ public class TracingProducerBenchmarks {
     @Override
     public Future<RecordMetadata> send(ProducerRecord<String, String> record, Callback callback) {
       TopicPartition tp = new TopicPartition(record.topic(), 0);
-      RecordMetadata rm = new RecordMetadata(tp, -1L, -1L, 1L, 2L, 3, 4);
+      RecordMetadata rm = new RecordMetadata(tp, -1L, -1, 1L, 3, 4);
       if (callback != null) callback.onCompletion(rm, null);
       return Futures.immediateFuture(rm);
     }
@@ -139,9 +139,6 @@ public class TracingProducerBenchmarks {
     }
 
     @Override public void close() {
-    }
-
-    @Override public void close(long l, TimeUnit timeUnit) {
     }
 
     @Override public void close(Duration duration) {

--- a/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/kafka/clients/TracingProducerBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/kafka-clients/README.md
+++ b/instrumentation/kafka-clients/README.md
@@ -4,6 +4,11 @@ Add decorators for Kafka producer and consumer to enable tracing.
 * `TracingProducer` completes a producer span per record and propagates it via headers.
 * `TracingConsumer` completes a consumer span on `poll`, resuming a trace in headers if present.
 
+## Notes
+* This tracer is only compatible with Kafka versions including headers support ( > 0.11.0).
+* More information about "Message Tracing" [here](https://github.com/openzipkin/openzipkin.github.io/wiki/Messaging-instrumentation-abstraction)
+* `Consumer#timeout(long, TimeUnit)` is deprecated and removed in > 3.x. When using this method, Brave will fall-back to `Consumer#timeout()`.
+
 ## Setup
 First, setup the generic Kafka component like this:
 ```java
@@ -133,6 +138,3 @@ poll
 +- processing N
 ```
 
-## Notes
-* This tracer is only compatible with Kafka versions including headers support ( > 0.11.0).
-* More information about "Message Tracing" [here](https://github.com/openzipkin/openzipkin.github.io/wiki/Messaging-instrumentation-abstraction)

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2021 The OpenZipkin Authors
+    Copyright 2013-2022 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -15,12 +15,12 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
     <version>5.13.8-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>brave-instrumentation-kafka-clients</artifactId>
   <name>Brave Instrumentation: Kafka Clients</name>

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -330,6 +330,10 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
     delegate.close();
   }
 
+  /**
+   * This operation is deprecated and removed in Kafka v3.
+   * For backward-compatibility, it is kept on this instrumentation, though the message will fall-back to {@link Consumer#close()}
+   */
   // Do not use @Override annotation to avoid compatibility on deprecated methods
   @Deprecated public void close(long timeout, TimeUnit unit) {
     LOG.warning("Falling back to Consumer#close() as #close(long, TimeUnit) is deprecated in v3.0");

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
@@ -47,6 +48,8 @@ import org.apache.kafka.common.TopicPartition;
  * producers span if possible.
  */
 final class TracingConsumer<K, V> implements Consumer<K, V> {
+  static final Logger LOG = Logger.getLogger(TracingConsumer.class.getName());
+
   final Consumer<K, V> delegate;
   final KafkaTracing kafkaTracing;
   final Tracing tracing;
@@ -328,8 +331,9 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   }
 
   // Do not use @Override annotation to avoid compatibility on deprecated methods
-  public void close(long timeout, TimeUnit unit) {
-    delegate.close(Duration.ofMillis(unit.convert(timeout, TimeUnit.MILLISECONDS)));
+  @Deprecated public void close(long timeout, TimeUnit unit) {
+    LOG.warning("Falling back to Consumer#close() as #close(long, TimeUnit) is deprecated in v3.0");
+    delegate.close();
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -303,9 +304,13 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0
-  public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions,
-    Duration timeout) {
+  public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
     return delegate.endOffsets(partitions, timeout);
+  }
+
+  // Do not use @Override annotation to avoid compatibility issue version < 3.0
+  public OptionalLong currentLag(TopicPartition topicPartition) {
+    return delegate.currentLag(topicPartition);
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.5
@@ -324,7 +329,7 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
 
   // Do not use @Override annotation to avoid compatibility on deprecated methods
   public void close(long timeout, TimeUnit unit) {
-    delegate.close(timeout, unit);
+    delegate.close(Duration.ofMillis(unit.convert(timeout, TimeUnit.MILLISECONDS)));
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -155,7 +155,7 @@ final class TracingProducer<K, V> implements Producer<K, V> {
 
   // Do not use @Override annotation to avoid compatibility on deprecated methods
   public void close(long timeout, TimeUnit unit) {
-    delegate.close(timeout, unit);
+    delegate.close(Duration.ofMillis(unit.convert(timeout, TimeUnit.MILLISECONDS)));
   }
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTest.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -64,7 +64,7 @@ public class KafkaTest {
 
   ConsumerRecord<String, String>
       consumerRecord = new ConsumerRecord<>(TEST_TOPIC, 0, 1L, TEST_KEY, TEST_VALUE);
-  ProducerRecord<Object, String>
+  ProducerRecord<String, String>
       producerRecord = new ProducerRecord<>(TEST_TOPIC, TEST_KEY, TEST_VALUE);
   RuntimeException error = new RuntimeException("Test exception");
 
@@ -98,10 +98,10 @@ public class KafkaTest {
     return result.entrySet();
   }
 
-  static Map<String, String> lastHeaders(MockProducer<Object, String> mockProducer) {
+  static Map<String, String> lastHeaders(MockProducer<String, String> mockProducer) {
     Map<String, String> headers = new LinkedHashMap<>();
-    List<ProducerRecord<Object, String>> history = mockProducer.history();
-    ProducerRecord<Object, String> lastRecord = history.get(history.size() - 1);
+    List<ProducerRecord<String, String>> history = mockProducer.history();
+    ProducerRecord<String, String> lastRecord = history.get(history.size() - 1);
     for (Header header : lastRecord.headers()) {
       headers.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
     }

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/TracingKafkaClientSupplierTests.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/TracingKafkaClientSupplierTests.java
@@ -39,7 +39,7 @@ class TracingKafkaClientSupplierTests {
   void shouldThrowException() {
     assertThrows(UnsupportedOperationException.class, () -> {
       FakeKafkaClientSupplier fake = new FakeKafkaClientSupplier();
-      fake.getAdminClient(props);
+      fake.getAdmin(props);
     });
   }
 

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/TracingKafkaClientSupplierTests.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/TracingKafkaClientSupplierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2021 The OpenZipkin Authors
+    Copyright 2013-2022 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -97,7 +97,7 @@
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
     <resteasy.version>3.14.0.Final</resteasy.version>
 
-    <kafka.version>2.6.0</kafka.version>
+    <kafka.version>3.0.0</kafka.version>
     <activemq.version>5.16.0</activemq.version>
     <spring-rabbit.version>2.3.2</spring-rabbit.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <mockito.version>3.6.28</mockito.version>
     <jersey.version>2.33</jersey.version>
     <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.1.11</kafka-junit.version>
+    <kafka-junit.version>4.2.1</kafka-junit.version>
     <testcontainers.version>1.15.1</testcontainers.version>
 
     <license.skip>${skipTests}</license.skip>


### PR DESCRIPTION
Fixes #1316

Changes:

- Upgrade `kafka-junit`
- Upgrade kafka clients/streams dependency
- Forward `close(long,  TimeUnit)` to `close()` for backward compatibililty