### PR TITLE
Compatible with versions after dubbo-2.7.14

### DIFF
--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2021 The OpenZipkin Authors
+    Copyright 2013-2022 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -32,7 +32,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
 
-    <dubbo.version>2.7.8</dubbo.version>
+    <dubbo.version>2.7.15</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/DubboClientRequest.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/DubboClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,22 +15,20 @@ package brave.dubbo;
 
 import brave.Span;
 import brave.rpc.RpcClientRequest;
-import java.util.Map;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcContext;
 
 final class DubboClientRequest extends RpcClientRequest implements DubboRequest {
   final Invoker<?> invoker;
   final Invocation invocation;
-  final Map<String, String> attachments;
 
-  DubboClientRequest(Invoker<?> invoker, Invocation invocation, Map<String, String> attachments) {
+  DubboClientRequest(Invoker<?> invoker, Invocation invocation) {
     if (invoker == null) throw new NullPointerException("invoker == null");
     if (invocation == null) throw new NullPointerException("invocation == null");
     this.invoker = invoker;
     this.invocation = invocation;
-    this.attachments = attachments;
   }
 
   @Override public Invoker<?> invoker() {
@@ -66,6 +64,6 @@ final class DubboClientRequest extends RpcClientRequest implements DubboRequest 
   }
 
   @Override protected void propagationField(String keyName, String value) {
-    attachments.put(keyName, value);
+    RpcContext.getContext().setAttachment(keyName, value);
   }
 }

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,7 +26,6 @@ import brave.rpc.RpcResponse;
 import brave.rpc.RpcResponseParser;
 import brave.rpc.RpcServerHandler;
 import brave.rpc.RpcTracing;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.Activate;
@@ -110,8 +109,7 @@ public final class TracingFilter implements Filter {
       // C service span is A when read from invocation.getAttachments(). This is because
       // AbstractInvoker adds attachments via RpcContext.getContext(), not the invocation.
       // See org.apache.dubbo.rpc.protocol.AbstractInvoker(line 141) from v2.7.3
-      Map<String, String> attachments = RpcContext.getContext().getAttachments();
-      DubboClientRequest clientRequest = new DubboClientRequest(invoker, invocation, attachments);
+      DubboClientRequest clientRequest = new DubboClientRequest(invoker, invocation);
       request = clientRequest;
       span = clientHandler.handleSendWithParent(clientRequest, invocationContext);
     } else {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientRequestTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,11 +13,10 @@
  */
 package brave.dubbo;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcContext;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,8 +27,7 @@ public class DubboClientRequestTest {
   Invoker invoker = mock(Invoker.class);
   Invocation invocation = mock(Invocation.class);
   URL url = URL.valueOf("dubbo://localhost:6666?scope=remote&interface=brave.dubbo.GreeterService");
-  Map<String, String> attachments = new LinkedHashMap<>();
-  DubboClientRequest request = new DubboClientRequest(invoker, invocation, attachments);
+  DubboClientRequest request = new DubboClientRequest(invoker, invocation);
 
   @Test public void service() {
     when(invocation.getInvoker()).thenReturn(invoker);
@@ -60,6 +58,6 @@ public class DubboClientRequestTest {
   @Test public void propagationField() {
     request.propagationField("b3", "d");
 
-    assertThat(attachments).containsEntry("b3", "d");
+    assertThat(RpcContext.getContext().getObjectAttachments()).containsEntry("b3", "d");
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientResponseTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboClientResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,8 +13,6 @@
  */
 package brave.dubbo;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
@@ -30,8 +28,7 @@ public class DubboClientResponseTest {
   Invocation invocation = mock(Invocation.class);
   Result result = mock(Result.class);
   RpcException error = new RpcException(TIMEOUT_EXCEPTION);
-  Map<String, String> attachments = new LinkedHashMap<>();
-  DubboClientRequest request = new DubboClientRequest(invoker, invocation, attachments);
+  DubboClientRequest request = new DubboClientRequest(invoker, invocation);
   DubboClientResponse response = new DubboClientResponse(request, result, error);
 
   @Test public void request() {

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/FinishSpanTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/FinishSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package brave.dubbo;
 
 import brave.Span;
-import java.util.Collections;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
@@ -27,7 +26,7 @@ import static org.mockito.Mockito.mock;
 
 public class FinishSpanTest extends ITTracingFilter {
   DubboClientRequest clientRequest =
-      new DubboClientRequest(mock(Invoker.class), mock(Invocation.class), Collections.emptyMap());
+      new DubboClientRequest(mock(Invoker.class), mock(Invocation.class));
   DubboServerRequest serverRequest =
       new DubboServerRequest(mock(Invoker.class), mock(Invocation.class));
   TracingFilter filter;

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -48,7 +48,7 @@ public class ITTracingFilter_Consumer extends ITTracingFilter {
   @Before public void setup() {
     server.start();
 
-    String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean";
+    String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote";
     client = new ReferenceConfig<>();
     client.setGeneric("true");
     client.setFilter("tracing");

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,7 +51,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
     init();
     server.start();
 
-    String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote&generic=bean";
+    String url = "dubbo://" + server.ip() + ":" + server.port() + "?scope=remote";
     client = new ReferenceConfig<>();
     client.setGeneric("true");
     client.setInterface(GreeterService.class);
@@ -70,7 +70,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
   @Test public void reusesPropagatedSpanId() {
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
 
-    RpcContext.getContext().getAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
+    RpcContext.getContext().getObjectAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
     client.get().sayHello("jorge");
 
     assertSameIds(testSpanHandler.takeRemoteSpan(SERVER), parent);
@@ -82,7 +82,7 @@ public class ITTracingFilter_Provider extends ITTracingFilter {
 
     TraceContext parent = newTraceContext(SamplingFlags.SAMPLED);
 
-    RpcContext.getContext().getAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
+    RpcContext.getContext().getObjectAttachments().put("b3", B3SingleFormat.writeB3SingleFormat(parent));
     client.get().sayHello("jorge");
 
     MutableSpan span = testSpanHandler.takeRemoteSpan(SERVER);


### PR DESCRIPTION
Since version dubbo-2.7.14, the ```RpcContext.getContext().getAttachments()```  a copy map is returned,
so the put data will be lost.

https://github.com/apache/dubbo/blob/8240ea26cb00a52dd000d99e3997fe554134b9c3/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcContext.java#L557

https://github.com/apache/dubbo/blob/8240ea26cb00a52dd000d99e3997fe554134b9c3/dubbo-common/src/main/java/org/apache/dubbo/common/utils/MapUtils.java#L35




