### PR TITLE
Feature/sql rows written

### DIFF
--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -36,6 +36,11 @@ includeParameterValues=true
 excludebinary=true
 ```
 
+### Affected rows count
+When the `includeAffectedRowsCount` option is set to `true`, the tag `sql.affected_rows` of traces
+for SQL insert and update commands will include the number of rows that were inserted/updated, if
+the database and driver supports that. No row count is included for select statements.
+
 ## Service name as URL query parameter
 `spy.properties` applies globally to any instrumented jdbc connection. To override this, add the
 `zipkinServiceName` property to your connection string.

--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -12,28 +12,33 @@ modulelist=brave.p6spy.TracingP6Factory
 url=jdbc:p6spy:derby:memory:p6spy;create=true
 ```
 
-In addition, you can specify the following options in spy.properties
+## Options
+In addition to the required settings above, you can specify additional options to affect what is
+included in the traces.
 
-`remoteServiceName`
-
-By default the zipkin service name for your database is the name of the database. Set this property to override it
+### Remove Service Name
+By default the zipkin service name for your database is the name of the database.
+Set the `remoteServiceName` property to override it:
 
 ```
 remoteServiceName=myProductionDatabase
 ```
 
-`includeParameterValues`
+### Parameter values
+When the `includeParameterValues` option is set to `true`, the tag `sql.query` will also include the
+JDBC parameter values.
 
-When set to to true, the tag `sql.query` will also include the JDBC parameter values.
- 
-**Note**: if you enable this please also consider enabling 'excludebinary' to avoid logging large blob values as hex (see http://p6spy.readthedocs.io/en/latest/configandusage.html#excludebinary).
+**Note**: if you enable this please also consider enabling `excludebinary` to avoid logging large
+blob values as hex (see http://p6spy.readthedocs.io/en/latest/configandusage.html#excludebinary).
 
-```  
+```
 includeParameterValues=true
 excludebinary=true
 ```
 
-`spy.properties` applies globally to any instrumented jdbc connection. To override this, add the `zipkinServiceName` property to your connection string.
+## Service name as URL query parameter
+`spy.properties` applies globally to any instrumented jdbc connection. To override this, add the
+`zipkinServiceName` property to your connection string.
 
 ```
 jdbc:mysql://127.0.0.1:3306/mydatabase?zipkinServiceName=myServiceName
@@ -43,9 +48,9 @@ This will override the `remoteServiceName` set in `spy.properties`.
 
 The current tracing component is used at runtime. Until you have instantiated `brave.Tracing`, no traces will appear.
 
-### Filtering spans
+## Filtering spans
 
-By default, all statements are recorded as client spans. 
+By default, all statements are recorded as client spans.
 You may wish to exclude statements like `set session` from tracing. This library reuses p6spy's log filtering for this purpose.
 Filtering options are picked up from `spy.properties`, so you can blacklist/whitelist what type of statements to record as spans.
 

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,9 @@ package brave.p6spy;
 import brave.Span;
 import brave.internal.Nullable;
 import brave.propagation.ThreadLocalSpan;
+
+import com.p6spy.engine.common.PreparedStatementInformation;
+import com.p6spy.engine.common.ResultSetInformation;
 import com.p6spy.engine.common.StatementInformation;
 import com.p6spy.engine.event.SimpleJdbcEventListener;
 import com.p6spy.engine.logging.P6LogLoadableOptions;
@@ -35,12 +38,19 @@ final class TracingJdbcEventListener extends SimpleJdbcEventListener {
 
   @Nullable final String remoteServiceName;
   final boolean includeParameterValues;
+  final boolean includeAffectedRowsCount;
   final P6LogLoadableOptions logOptions;
 
   TracingJdbcEventListener(@Nullable String remoteServiceName, boolean includeParameterValues,
     P6LogLoadableOptions logOptions) {
+    this(remoteServiceName, includeParameterValues, false, logOptions);
+  }
+
+  TracingJdbcEventListener(@Nullable String remoteServiceName, boolean includeParameterValues,
+    boolean includeAffectedRowsCount, P6LogLoadableOptions logOptions) {
     this.remoteServiceName = remoteServiceName;
     this.includeParameterValues = includeParameterValues;
+    this.includeAffectedRowsCount = includeAffectedRowsCount;
     this.logOptions = logOptions;
   }
 
@@ -66,10 +76,24 @@ final class TracingJdbcEventListener extends SimpleJdbcEventListener {
     span.start();
   }
 
+  @Override public void onAfterExecuteUpdate(
+    PreparedStatementInformation statementInformation, long timeElapsedNanos, int rowCount, SQLException e
+  ) {
+    Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
+    if (span == null || span.isNoop()) return;
+    if (includeAffectedRowsCount) {
+      span.tag("sql.affected_rows", String.valueOf(rowCount));
+    }
+    finishSpan(span, e);
+  }
+
   @Override public void onAfterAnyExecute(StatementInformation info, long elapsed, SQLException e) {
     Span span = ThreadLocalSpan.CURRENT_TRACER.remove();
     if (span == null || span.isNoop()) return;
+    finishSpan(span, e);
+  }
 
+  private void finishSpan(Span span, SQLException e) {
     if (e != null) {
       span.error(e);
       span.tag("error", Integer.toString(e.getErrorCode()));

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ public final class TracingP6Factory implements P6Factory {
 
   @Override public JdbcEventListener getJdbcEventListener() {
     return new TracingJdbcEventListener(options.remoteServiceName(),
-      options.includeParameterValues(), options.getLogOptions());
+      options.includeParameterValues(), options.includeAffectedRowsCount(),
+      options.getLogOptions());
   }
 }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ final class TracingP6SpyOptions extends P6SpyOptions {
 
   static final String REMOTE_SERVICE_NAME = "remoteServiceName";
   static final String INCLUDE_PARAMETER_VALUES = "includeParameterValues";
+  static final String INCLUDE_AFFECTED_ROWS_COUNT = "includeAffectedRowsCount";
 
   private final P6OptionsRepository optionsRepository;
   private final P6LogLoadableOptions logLoadableOptions;
@@ -41,6 +42,8 @@ final class TracingP6SpyOptions extends P6SpyOptions {
     optionsRepository.set(String.class, REMOTE_SERVICE_NAME, options.get(REMOTE_SERVICE_NAME));
     optionsRepository.set(Boolean.class, INCLUDE_PARAMETER_VALUES,
       options.get(INCLUDE_PARAMETER_VALUES));
+    optionsRepository.set(Boolean.class, INCLUDE_AFFECTED_ROWS_COUNT,
+      options.get(INCLUDE_AFFECTED_ROWS_COUNT));
   }
 
   @Override
@@ -48,6 +51,7 @@ final class TracingP6SpyOptions extends P6SpyOptions {
     Map<String, String> allDefaults = new LinkedHashMap<>(super.getDefaults());
     allDefaults.putAll(logLoadableOptions.getDefaults());
     allDefaults.put(INCLUDE_PARAMETER_VALUES, Boolean.FALSE.toString());
+    allDefaults.put(INCLUDE_AFFECTED_ROWS_COUNT, Boolean.FALSE.toString());
     return allDefaults;
   }
 
@@ -61,5 +65,9 @@ final class TracingP6SpyOptions extends P6SpyOptions {
 
   Boolean includeParameterValues() {
     return optionsRepository.get(Boolean.class, INCLUDE_PARAMETER_VALUES);
+  }
+
+  Boolean includeAffectedRowsCount() {
+    return optionsRepository.get(Boolean.class, INCLUDE_AFFECTED_ROWS_COUNT);
   }
 }

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -113,6 +113,15 @@ public class ITTracingP6Factory {
   }
 
   @Test
+  public void addsRowsWrittenTag() throws Exception {
+    prepareExecuteUpdate("update t set c='x' where i=2");
+
+    assertThat(spans)
+      .flatExtracting(s -> s.tags().entrySet())
+      .contains(entry("sql.affected_rows", "2"));
+  }
+
+  @Test
   public void reportsServerAddress() throws Exception {
     prepareExecuteSelect(QUERY);
 
@@ -128,6 +137,12 @@ public class ITTracingP6Factory {
           resultSet.getString(1);
         }
       }
+    }
+  }
+
+  void prepareExecuteUpdate(String sql) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+      ps.executeUpdate();
     }
   }
 }

--- a/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
+++ b/instrumentation/p6spy/src/test/java/brave/p6spy/ITTracingP6Factory.java
@@ -23,16 +23,21 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.sql.SQLException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 public class ITTracingP6Factory {
-  static final String URL = "jdbc:p6spy:derby:memory:p6spy;create=true";
+  @Rule
+  public TestName testName = new TestName();
+
   static final String QUERY = "SELECT 1 FROM SYSIBM.SYSDUMMY1";
 
   //Get rid of annoying derby.log
@@ -49,8 +54,15 @@ public class ITTracingP6Factory {
 
   @Before
   public void setup() throws Exception {
-    DriverManager.getDriver(URL);
-    connection = DriverManager.getConnection(URL, "foo", "bar");
+    String url = String.format("jdbc:p6spy:derby:memory:%s;create=true", testName.getMethodName());
+    connection = DriverManager.getConnection(url, "foo", "bar");
+    Statement statement = connection.createStatement();
+    statement.executeUpdate("create table t (i integer, c char )");
+    statement.executeUpdate("insert into t (i, c) values (1, 'a')");
+    statement.executeUpdate("insert into t (i, c) values (2, 'b')");
+    statement.executeUpdate("insert into t (i, c) values (2, 'c')");
+    statement.close();
+    spans.clear();
   }
 
   @After

--- a/instrumentation/p6spy/src/test/resources/spy.properties
+++ b/instrumentation/p6spy/src/test/resources/spy.properties
@@ -1,3 +1,4 @@
 modulelist=brave.p6spy.TracingP6Factory
 remoteServiceName=myservice
 #includeParameterValues=true
+includeAffectedRowsCount=true


### PR DESCRIPTION
Adds a tag specifying the number of rows written in an update, for correlating time spent versus rows written on SQLs and finding traces that performed large writes.

Having the corresponding tag for rows read would be very useful, but seems to be a lot more difficult, since you´d then have to count the number of .next calls on the result set - but P6Spy does not pass the ResultSetInformation to `onAfterExecuteQuery`.