### PR TITLE
Capture row counts for plain statements and batch

### DIFF
--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -38,8 +38,10 @@ excludebinary=true
 
 ### Affected rows count
 When the `includeAffectedRowsCount` option is set to `true`, the tag `sql.affected_rows` of traces
-for SQL insert and update commands will include the number of rows that were inserted/updated, if
-the database and driver supports that. No row count is included for select statements.
+for SQL insert and update statements performed using `executeUpdate` and `executeBatch` (but not
+`execute`, as it does not report the update count) will include the number of rows that were
+inserted/updated (comma separated in the case of `executebatch`), if the database and driver
+supports that. No row count is included for calls to `executeQuery` (e.g. select statements).
 
 ## Service name as URL query parameter
 `spy.properties` applies globally to any instrumented jdbc connection. To override this, add the


### PR DESCRIPTION
Previously, only row counts for executeUpdate on prepared statements was
included as sql.affected_rows. With this change, row counts are also
included for executeUpdate on plain statements, and for executeBatch on
prepared and plain statements.

Capturing row counts on plain execute is a lot trickier, since it´s not
safe to call getUpdateCount behind the application´s back, as it is not
idempotent - we´d unexpectedly change state.