### PR TITLE
fix(kafka-clients): avoid using deprecated poll to get records

### DIFF
--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -84,13 +84,16 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
 
   // Do not use @Override annotation to avoid compatibility issue version < 2.0
   public ConsumerRecords<K, V> poll(Duration timeout) {
-    return poll(timeout.toMillis());
+    return poll(delegate.poll(timeout));
+  }
+
+  @Deprecated public ConsumerRecords<K, V> poll(long timeout) {
+    return poll(delegate.poll(timeout));
   }
 
   /** This uses a single timestamp for all records polled, to reduce overhead. */
   // Do not use @Override annotation to avoid compatibility on deprecated methods
-  public ConsumerRecords<K, V> poll(long timeout) {
-    ConsumerRecords<K, V> records = delegate.poll(timeout);
+  private ConsumerRecords<K, V> poll(ConsumerRecords<K, V> records) {
     if (records.isEmpty() || tracing.isNoop()) return records;
     long timestamp = 0L;
     Map<String, Span> consumerSpansForTopic = new LinkedHashMap<>();

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -87,12 +87,12 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
     return poll(delegate.poll(timeout));
   }
 
+  // Do not use @Override annotation to avoid compatibility on deprecated methods
   @Deprecated public ConsumerRecords<K, V> poll(long timeout) {
     return poll(delegate.poll(timeout));
   }
 
   /** This uses a single timestamp for all records polled, to reduce overhead. */
-  // Do not use @Override annotation to avoid compatibility on deprecated methods
   private ConsumerRecords<K, V> poll(ConsumerRecords<K, V> records) {
     if (records.isEmpty() || tracing.isNoop()) return records;
     long timestamp = 0L;

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/TracingConsumer.java
@@ -92,7 +92,11 @@ final class TracingConsumer<K, V> implements Consumer<K, V> {
     return poll(delegate.poll(timeout));
   }
 
-  /** This uses a single timestamp for all records polled, to reduce overhead. */
+  /** This uses a single timestamp for all records polled, to reduce overhead.
+   * poll internal implementation changes between {@code #poll(long)} and {@code #poll(Duration)}.
+   * <p/>
+   * To avoid forcing the old behavior, the wrapping methods call themselves first to obtain records.
+   */
   private ConsumerRecords<K, V> poll(ConsumerRecords<K, V> records) {
     if (records.isEmpty() || tracing.isNoop()) return records;
     long timestamp = 0L;


### PR DESCRIPTION
Fix #1334 

Kafka Consumer `#poll` has a different behavior depending on the timeout type to fetch assignment metadata. 

https://github.com/apache/kafka/blob/cf5e714a8bea8bb1de75201d0769bb1c246b9334/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L1238-L1245

Using the old poll(long) API will block on the timer, causing issues on the client application. 

@frosiere proposed this fix to avoid calling the deprecated API.