### PR TITLE
Support for Jakarta servlet specification

### DIFF
--- a/instrumentation/http-tests-jakarta/README.md
+++ b/instrumentation/http-tests-jakarta/README.md
@@ -1,0 +1,4 @@
+# brave-instrumentation-http-tests-jakarta
+
+This module contains test base classes used to ensure instrumentation
+work portably.

--- a/instrumentation/http-tests-jakarta/pom.xml
+++ b/instrumentation/http-tests-jakarta/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2013-2022 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>5.13.12-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-http-tests-jakarta</artifactId>
+  <name>Brave Instrumentation: Http Interop Tests (Jakarta)</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>11</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+    <!-- disable errorprone warning that "return this" is not synchronized! -->
+    <errorprone.args>-Xep:UnsynchronizedOverridesSynchronized:OFF</errorprone.args>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-tests</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+    </dependency>
+    <!-- Only subclasses of ITServlet5Container need Jetty. -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty11.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <!-- Only subclasses of ITServlet5Container need Jakarta Servlet. -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet}</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>brave.test.jakarta.http</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrumentation/http-tests-jakarta/src/main/java/brave/test/jakarta/http/ITServlet5Container.java
+++ b/instrumentation/http-tests-jakarta/src/main/java/brave/test/jakarta/http/ITServlet5Container.java
@@ -11,44 +11,87 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package brave.test.http;
+package brave.test.jakarta.http;
 
 import brave.Tracer;
+import brave.Tracing;
 import brave.http.HttpTracing;
 import brave.propagation.TraceContext;
+import brave.test.http.ITServletContainer;
+
 import java.io.IOException;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.UnavailableException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.log.Log;
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import static brave.Span.Kind.SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class ITServlet25Container extends ITServletContainer {
-  public static final UnavailableException NOT_READY_UE =
-    new UnavailableException(NOT_READY_ISE.getMessage(), 1 /* temporary implies 503 */) {
-      @Override public Throwable fillInStackTrace() {
-        return this; // don't fill logs as we are only testing
-      }
-    };
+public abstract class ITServlet5Container extends ITServletContainer {
+  static ExecutorService executor = Executors.newCachedThreadPool();
 
-  protected ITServlet25Container(ServletContainer.ServerController serverController) {
-    super(serverController);
+  public ITServlet5Container() {
+    super(new Jetty11ServerController(), Log.getLogger("org.eclipse.jetty.util.log"));
   }
 
+  @AfterClass public static void shutdownExecutor() {
+    executor.shutdownNow();
+  }
+
+  @Test public void forward() throws Exception {
+    get("/forward");
+
+    testSpanHandler.takeRemoteSpan(SERVER);
+  }
+
+  @Test public void forwardAsync() throws Exception {
+    get("/forwardAsync");
+
+    testSpanHandler.takeRemoteSpan(SERVER);
+  }
+
+  Filter delegate;
+
+  class DelegatingFilter implements Filter {
+
+    @Override public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+      if (delegate == null) {
+        chain.doFilter(request, response);
+      } else {
+        delegate.doFilter(request, response, chain);
+      }
+    }
+
+    @Override public void destroy() {
+    }
+  }
+  
   static class StatusServlet extends HttpServlet {
     final int status;
 
@@ -88,49 +131,104 @@ public abstract class ITServlet25Container extends ITServletContainer {
       throw NOT_READY_ISE;
     }
   }
-
-  Filter delegate;
-
-  class DelegatingFilter implements Filter {
-
-    @Override public void init(FilterConfig filterConfig) {
-    }
-
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-      throws IOException, ServletException {
-      if (delegate == null) {
-        chain.doFilter(request, response);
-      } else {
-        delegate.doFilter(request, response, chain);
-      }
-    }
-
-    @Override public void destroy() {
+    
+  static class ForwardServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+      req.getServletContext().getRequestDispatcher("/foo").forward(req, resp);
     }
   }
 
-  // copies the header to the response
+  static class AsyncForwardServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      AsyncContext asyncContext = req.startAsync(req, resp);
+      executor.execute(() -> asyncContext.dispatch("/async"));
+    }
+  }
+
+  static class AsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (Tracing.currentTracer().currentSpan() == null) {
+        throw new IllegalStateException("couldn't read current span!");
+      }
+      AsyncContext ctx = req.startAsync();
+      ctx.start(ctx::complete);
+    }
+  }
+
+  static class ExceptionAsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
+
+      AsyncContext async = req.startAsync();
+      // unless we add a listener, the onError hook will never occur
+      async.addListener(new AsyncListener() {
+        @Override public void onComplete(AsyncEvent event) {
+        }
+
+        @Override public void onTimeout(AsyncEvent event) {
+        }
+
+        @Override public void onError(AsyncEvent event) {
+          // Change the status from 500 to 503
+          req.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 503);
+        }
+
+        @Override public void onStartAsync(AsyncEvent event) {
+        }
+      });
+      throw NOT_READY_ISE;
+    }
+  }
+
+  @Test public void errorTag_onException_asyncTimeout() throws Exception {
+    Response response =
+        httpStatusCodeTagMatchesResponse_onUncaughtException("/exceptionAsyncTimeout", "Timed out after 1ms");
+
+    assertThat(response.code()).isIn(500, 504); // Jetty is inconsistent
+  }
+
+  static class TimeoutExceptionAsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
+
+      AsyncContext ctx = req.startAsync();
+      ctx.setTimeout(1 /* ms */);
+      ctx.start(
+        () -> {
+          resp.setStatus(504);
+          try {
+            Thread.sleep(10L);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            ctx.complete();
+          }
+        });
+    }
+  }
+
+  //copies the header to the response
   Filter userFilter = new Filter() {
     @Override public void init(FilterConfig filterConfig) {
     }
-
+    
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
       ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD_KEY, BAGGAGE_FIELD.getValue());
       chain.doFilter(request, response);
     }
-
+    
     @Override public void destroy() {
     }
   };
-
+    
   @Test public void currentSpanVisibleToOtherFilters() throws Exception {
     delegate = userFilter;
-
+    
     String path = "/foo";
-
+    
     Request request = new Request.Builder().url(url(path))
       .header(BAGGAGE_FIELD_KEY, "abcdefg").build();
     try (Response response = client.newCall(request).execute()) {
@@ -138,103 +236,119 @@ public abstract class ITServlet25Container extends ITServletContainer {
       assertThat(response.header(BAGGAGE_FIELD_KEY))
         .isEqualTo("abcdefg");
     }
-
+    
     testSpanHandler.takeRemoteSpan(SERVER);
-  }
-
-  // copies the header to the response
-  Filter traceContextFilter = new Filter() {
+    }
+    
+    // copies the header to the response
+    Filter traceContextFilter = new Filter() {
     @Override public void init(FilterConfig filterConfig) {
     }
-
+    
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
       TraceContext context = (TraceContext) request.getAttribute("brave.propagation.TraceContext");
       String value = BAGGAGE_FIELD.getValue(context);
-      ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD_KEY, value);
-      chain.doFilter(request, response);
+        ((HttpServletResponse) response).setHeader(BAGGAGE_FIELD_KEY, value);
+        chain.doFilter(request, response);
     }
-
+    
     @Override public void destroy() {
     }
   };
-
+    
   @Test public void traceContextVisibleToOtherFilters() throws Exception {
     delegate = traceContextFilter;
-
+    
     String path = "/foo";
-
+    
     Request request = new Request.Builder().url(url(path))
       .header(BAGGAGE_FIELD_KEY, "abcdefg").build();
     try (Response response = client.newCall(request).execute()) {
       assertThat(response.isSuccessful()).isTrue();
       assertThat(response.header(BAGGAGE_FIELD_KEY))
-          .isEqualTo("abcdefg");
+         .isEqualTo("abcdefg");
     }
-
+    
     testSpanHandler.takeRemoteSpan(SERVER);
   }
-
+  
   // Shows how a framework can layer on "http.route" logic
   Filter customHttpRoute = new Filter() {
     @Override public void init(FilterConfig filterConfig) {
     }
-
+    
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
       request.setAttribute("http.route", ((HttpServletRequest) request).getRequestURI());
       chain.doFilter(request, response);
     }
-
+    
     @Override public void destroy() {
     }
   };
-
+    
   /**
    * Shows that by adding the request attribute "http.route" a layered framework can influence any
    * derived from the route, including the span name.
    */
   @Test public void canSetCustomRoute() throws Exception {
     delegate = customHttpRoute;
-
+    
     get("/foo");
-
+    
     assertThat(testSpanHandler.takeRemoteSpan(SERVER).name())
       .isEqualTo("GET /foo");
   }
-
+  
   Filter customHook = new Filter() {
     @Override public void init(FilterConfig filterConfig) {
-    }
-
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-      throws IOException, ServletException {
+  }
+  
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+    throws IOException, ServletException {
       ((brave.SpanCustomizer) request.getAttribute("brave.SpanCustomizer")).tag("foo", "bar");
       chain.doFilter(request, response);
     }
-
+    
     @Override public void destroy() {
     }
   };
-
+    
   /**
    * Shows that a framework can directly use the "brave.Span" rather than relying on the current
    * span.
    */
   @Test public void canUseSpanAttribute() throws Exception {
     delegate = customHook;
-
+  
     get("/foo");
-
+  
     assertThat(testSpanHandler.takeRemoteSpan(SERVER).tags())
       .containsEntry("foo", "bar");
   }
+   
+  @Test public void errorTag_onException_asyncDispatch() throws Exception {
+    httpStatusCodeTagMatchesResponse_onUncaughtException("/exceptionAsyncDispatch", "not ready");
+  }
 
-  @Override
-  public void init(ServletContextHandler handler) {
+  static class DispatchExceptionAsyncServlet extends HttpServlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+      if (DispatcherType.ERROR.equals(req.getDispatcherType())) return; // don't loop
+
+      if (req.getAttribute("dispatched") != null) {
+        throw NOT_READY_ISE;
+      }
+
+      req.setAttribute("dispatched", Boolean.TRUE);
+      req.startAsync().dispatch();
+    }
+  }
+
+  @Override public void init(ServletContextHandler handler) {
     // add servlets for the test resource
     handler.addServlet(new ServletHolder(new StatusServlet(404)), "/*");
     handler.addServlet(new ServletHolder(new StatusServlet(200)), "/foo");
@@ -247,10 +361,21 @@ public abstract class ITServlet25Container extends ITServletContainer {
     addFilter(handler, newTracingFilter());
     // add a holder for test filters
     addFilter(handler, new DelegatingFilter());
-  }
 
+    // add servlet 3.0+
+    handler.addServlet(new ServletHolder(new AsyncServlet()), "/async");
+    handler.addServlet(new ServletHolder(new ForwardServlet()), "/forward");
+    handler.addServlet(new ServletHolder(new AsyncForwardServlet()), "/forwardAsync");
+    handler.addServlet(new ServletHolder(new ExceptionAsyncServlet()), "/exceptionAsync");
+    handler.addServlet(new ServletHolder(new TimeoutExceptionAsyncServlet()),
+      "/exceptionAsyncTimeout");
+    handler.addServlet(new ServletHolder(new DispatchExceptionAsyncServlet()),
+      "/exceptionAsyncDispatch");
+  }
+  
   protected abstract Filter newTracingFilter();
 
   // abstract because filter registration types were not introduced until servlet 3.0
   protected abstract void addFilter(ServletContextHandler handler, Filter filter);
+
 }

--- a/instrumentation/http-tests-jakarta/src/main/java/brave/test/jakarta/http/Jetty11ServerController.java
+++ b/instrumentation/http-tests-jakarta/src/main/java/brave/test/jakarta/http/Jetty11ServerController.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.test.jakarta.http;
+
+import brave.test.http.ServletContainer;
+import brave.test.http.ServletContainer.ServerController;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+public final class Jetty11ServerController implements ServerController {
+  @Override public Server newServer(int port) {
+    Server result = new Server();
+    ServerConnector connector = new ServerConnector(result);
+    connector.setPort(port);
+    connector.setIdleTimeout(1000 * 60 * 60);
+    result.setConnectors(new Connector[] {connector});
+    return result;
+  }
+
+  @Override public int getLocalPort(Server server) {
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+}

--- a/instrumentation/http-tests-jakarta/src/main/resources/jetty-logging.properties
+++ b/instrumentation/http-tests-jakarta/src/main/resources/jetty-logging.properties
@@ -1,0 +1,1 @@
+org.eclipse.jetty.LEVEL=WARN

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,7 +38,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.UnavailableException;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -60,7 +59,7 @@ public abstract class ITHttpServer extends ITRemote {
     }
   };
 
-  OkHttpClient client = new OkHttpClient();
+  protected OkHttpClient client = new OkHttpClient();
   protected HttpTracing httpTracing = HttpTracing.create(tracing);
 
   @Before public void setup() throws IOException {
@@ -481,7 +480,7 @@ public abstract class ITHttpServer extends ITRemote {
         .isEqualTo(503);
   }
 
-  Response httpStatusCodeTagMatchesResponse_onUncaughtException(String path, String errorMessage)
+  protected Response httpStatusCodeTagMatchesResponse_onUncaughtException(String path, String errorMessage)
       throws IOException {
     Response response = get(path);
 
@@ -491,7 +490,7 @@ public abstract class ITHttpServer extends ITRemote {
     return response;
   }
 
-  Response httpStatusCodeTagMatchesResponse_onUncaughtException(String path) throws IOException {
+  protected Response httpStatusCodeTagMatchesResponse_onUncaughtException(String path) throws IOException {
     Response response = get(path);
     MutableSpan span = testSpanHandler.takeRemoteSpanWithError(SERVER);
     assertThat(span.tags()).containsEntry("http.status_code", String.valueOf(response.code()));

--- a/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
+++ b/instrumentation/http-tests/src/main/java/brave/test/http/ITServletContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,24 +14,21 @@
 package brave.test.http;
 
 import brave.test.http.ServletContainer.ServerController;
-import javax.servlet.UnavailableException;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 import org.junit.After;
 
 /** Starts a jetty server which runs a servlet container */
 public abstract class ITServletContainer extends ITHttpServer {
-  public static final UnavailableException NOT_READY_UE =
-    new UnavailableException(NOT_READY_ISE.getMessage(), 1 /* temporary implies 503 */) {
-      @Override public Throwable fillInStackTrace() {
-        return this; // don't fill logs as we are only testing
-      }
-    };
-
   final ServerController serverController;
 
   protected ITServletContainer(ServerController serverController) {
-    Log.setLog(new Log4J2Log());
+      this(serverController, new Log4J2Log());
+  }
+  
+  protected ITServletContainer(ServerController serverController, Logger logger) {
+    Log.setLog(logger);
     this.serverController = serverController;
   }
 

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -34,6 +34,7 @@
   <modules>
     <module>http</module>
     <module>http-tests</module>
+    <module>http-tests-jakarta</module>
     <module>dubbo</module>
     <module>dubbo-rpc</module>
     <module>grpc</module>
@@ -51,6 +52,7 @@
     <module>p6spy</module>
     <module>rpc</module>
     <module>servlet</module>
+    <module>servlet-jakarta</module>
     <module>sparkjava</module>
     <module>spring-rabbit</module>
     <module>spring-web</module>

--- a/instrumentation/servlet-jakarta/README.md
+++ b/instrumentation/servlet-jakarta/README.md
@@ -1,0 +1,81 @@
+# brave-instrumentation-servlet-jakarta
+This module contains a tracing filter for Jakarta Servlet 5+ (including Async).
+`TracingFilter` extracts trace state from incoming requests. Then, it
+reports Zipkin how long each request takes, along with relevant tags
+like the http url.
+
+## Configuration
+To enable tracing, you need to add the `TracingFilter`. If using Spring,
+we provide a [built-in delegate](../spring-webmvc) to configure it.
+Otherwise, use a different framework or look at one of the manually
+configured examples below.
+
+### Servlet 5+ (Jakarta)
+When configuring, make sure this is set for all paths, all dispatcher
+types and matches after other filters. Otherwise, you may miss spans or
+leak unfinished asynchronous spans.
+
+Here's an example Servlet 5+ listener
+```java
+public class TracingServletContextListener implements ServletContextListener {
+  // Configure an async span handler, which controls how often spans are sent
+  //   (this dependency is io.zipkin.reporter2:zipkin-sender-okhttp3)
+  Sender sender = OkHttpSender.create("http://127.0.0.1:9411/api/v2/spans");
+  //   (this dependency is io.zipkin.reporter2:zipkin-reporter-brave)
+  ZipkinSpanHandler zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender);
+  Tracing tracing = Tracing.newBuilder()
+                   .localServiceName("my-service")
+                   .addSpanHandler(zipkinSpanHandler)
+                   .build();
+
+  @Override
+  public void contextInitialized(ServletContextEvent servletContextEvent) {
+    servletContextEvent
+        .getServletContext()
+        .addFilter("tracingFilter", TracingFilter.create(tracing))
+        .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    try {
+      tracing.close(); // disables Tracing.current()
+      zipkinSpanHandler.close(); // stops reporting thread and flushes data
+      sender.close(); // closes any transport resources
+    } catch (IOException e) {
+      // do something real
+    }
+  }
+}
+```
+
+
+## Collaborating with `TracingFilter`
+
+`TracingFilter` adds some utilities as request attributes, so that you
+can read the trace context or write span data with less coupling. These
+attributes have the same name as their corresponding Java types:
+* `brave.SpanCustomizer` - add tags or rename the span without a tracer
+* `brave.propagation.TraceContext` - shows trace IDs and any extra data
+
+Ex: The following
+```java
+SpanCustomizer customizer = (SpanCustomizer) request.getAttribute(SpanCustomizer.class.getName());
+if (customizer != null) customizer.tag("platform", "XX");
+```
+
+`TracingFilter` looks for request attributes when completing a span.
+When integrating higher level frameworks, set the following attributes:
+
+* "http.route" - A string representing the route which this request matched or
+                 "" (empty string), if there was no match. Ex "/users/{userId}"
+                 Only set "http.route" when routing is supported!
+* "error" - An instance of `Throwable` raised when processing a user handler.
+            This is only necessary when the error is not propagated to the
+            Servlet layer.
+
+Ex. To copy the Spring match pattern as the "http.route":
+```java
+Object httpRoute = request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
+request.setAttribute("http.route", httpRoute != null ? httpRoute.toString() : "");
+```

--- a/instrumentation/servlet-jakarta/bnd.bnd
+++ b/instrumentation/servlet-jakarta/bnd.bnd
@@ -1,0 +1,7 @@
+# We use need to import to support brave.internal.Throwables
+# brave.internal.Nullable is not used at runtime.
+Import-Package: \
+  brave.internal;braveinternal=true,\
+  *
+Export-Package: \
+  brave.jakarta.servlet

--- a/instrumentation/servlet-jakarta/pom.xml
+++ b/instrumentation/servlet-jakarta/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2013-2022 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>5.13.12-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>brave-instrumentation-servlet-jakarta</artifactId>
+  <name>Brave Instrumentation: Servlet (Jakarta)</name>
+
+  <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.jakarta.servlet</module.name>
+
+    <main.basedir>${project.basedir}/../..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-http-tests-jakarta</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${jetty11.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty11.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <version>${jetty11.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/HttpServletRequestWrapper.java
+++ b/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/HttpServletRequestWrapper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet;
+
+import brave.Span;
+import brave.http.HttpServerRequest;
+import brave.internal.Nullable;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Besides delegating to {@link HttpServletRequest} methods, this also parses the remote IP of the
+ * client.
+ *
+ * @since 5.10
+ */
+// Public for use in sparkjava or other frameworks that re-use servlet types
+public final class HttpServletRequestWrapper extends HttpServerRequest {
+  /** @since 5.10 */
+  public static HttpServerRequest create(HttpServletRequest request) {
+    return new HttpServletRequestWrapper(request);
+  }
+
+  final HttpServletRequest delegate;
+
+  HttpServletRequestWrapper(HttpServletRequest delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  @Override public final Object unwrap() {
+    return delegate;
+  }
+
+  /**
+   * This sets the client IP:port to the {@linkplain HttpServletRequest#getRemoteAddr() remote
+   * address} if the {@link #parseClientIpFromXForwardedFor default parsing} fails.
+   */
+  @Override public boolean parseClientIpAndPort(Span span) {
+    if (parseClientIpFromXForwardedFor(span)) return true;
+    return span.remoteIpAndPort(delegate.getRemoteAddr(), delegate.getRemotePort());
+  }
+
+  @Override public final String method() {
+    return delegate.getMethod();
+  }
+
+  @Override public String route() {
+    Object maybeRoute = delegate.getAttribute("http.route");
+    return maybeRoute instanceof String ? (String) maybeRoute : null;
+  }
+
+  @Override public final String path() {
+    return delegate.getRequestURI();
+  }
+
+  // not final as some implementations may be able to do this more efficiently
+  @Override public String url() {
+    StringBuffer url = delegate.getRequestURL();
+    if (delegate.getQueryString() != null && !delegate.getQueryString().isEmpty()) {
+      url.append('?').append(delegate.getQueryString());
+    }
+    return url.toString();
+  }
+
+  @Override public final String header(String name) {
+    return delegate.getHeader(name);
+  }
+
+  /** Looks for a valid request attribute "error" */
+  @Nullable Throwable maybeError() {
+    Object maybeError = delegate.getAttribute("error");
+    if (maybeError instanceof Throwable) return (Throwable) maybeError;
+    maybeError = delegate.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+    if (maybeError instanceof Throwable) return (Throwable) maybeError;
+    return null;
+  }
+}

--- a/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/HttpServletResponseWrapper.java
+++ b/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/HttpServletResponseWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet;
+
+import brave.http.HttpServerResponse;
+import brave.internal.Nullable;
+import brave.jakarta.servlet.internal.ServletRuntime;
+import jakarta.servlet.UnavailableException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * This delegates to {@link HttpServletResponse} methods, taking care to portably handle {@link
+ * #statusCode()}.
+ *
+ * @since 5.10
+ */
+// Public for use in sparkjava or other frameworks that re-use servlet types
+public class HttpServletResponseWrapper extends HttpServerResponse { // not final for inner subtype
+  /**
+   * @param caught an exception caught serving the request.
+   * @since 5.10
+   */
+  public static HttpServerResponse create(@Nullable HttpServletRequest request,
+    HttpServletResponse response, @Nullable Throwable caught) {
+    return new HttpServletResponseWrapper(request, response, caught);
+  }
+
+  @Nullable final HttpServletRequestWrapper request;
+  final HttpServletResponse response;
+  @Nullable final Throwable caught;
+
+  HttpServletResponseWrapper(@Nullable HttpServletRequest request, HttpServletResponse response,
+    @Nullable Throwable caught) {
+    if (response == null) throw new NullPointerException("response == null");
+    this.request = request != null ? new HttpServletRequestWrapper(request) : null;
+    this.response = response;
+    this.caught = caught;
+  }
+
+  @Override public final Object unwrap() {
+    return response;
+  }
+
+  @Override @Nullable public HttpServletRequestWrapper request() {
+    return request;
+  }
+
+  @Override public Throwable error() {
+    if (caught != null) return caught;
+    if (request == null) return null;
+    return request.maybeError();
+  }
+
+  @Override public int statusCode() {
+    int result = ServletRuntime.get().status(response);
+    if (caught != null && result == 200) { // We may have a potentially bad status due to defaults
+      // Servlet only seems to define one exception that has a built-in code. Logic in Jetty
+      // defaults the status to 500 otherwise.
+      if (caught instanceof UnavailableException) {
+        return ((UnavailableException) caught).isPermanent() ? 404 : 503;
+      }
+      return 500;
+    }
+    return result;
+  }
+}

--- a/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/TracingFilter.java
+++ b/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/TracingFilter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet;
+
+import brave.Span;
+import brave.SpanCustomizer;
+import brave.Tracing;
+import brave.http.HttpServerHandler;
+import brave.http.HttpServerRequest;
+import brave.http.HttpServerResponse;
+import brave.http.HttpTracing;
+import brave.jakarta.servlet.internal.ServletRuntime;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.TraceContext;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public final class TracingFilter implements Filter {
+  public static Filter create(Tracing tracing) {
+    return new TracingFilter(HttpTracing.create(tracing));
+  }
+
+  public static Filter create(HttpTracing httpTracing) {
+    return new TracingFilter(httpTracing);
+  }
+
+  final ServletRuntime servlet = ServletRuntime.get();
+  final CurrentTraceContext currentTraceContext;
+  final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
+
+  TracingFilter(HttpTracing httpTracing) {
+    currentTraceContext = httpTracing.tracing().currentTraceContext();
+    handler = HttpServerHandler.create(httpTracing);
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+    throws IOException, ServletException {
+    HttpServletRequest req = (HttpServletRequest) request;
+    HttpServletResponse res = servlet.httpServletResponse(response);
+
+    // Prevent duplicate spans for the same request
+    TraceContext context = (TraceContext) request.getAttribute(TraceContext.class.getName());
+    if (context != null) {
+      // A forwarded request might end up on another thread, so make sure it is scoped
+      Scope scope = currentTraceContext.maybeScope(context);
+      try {
+        chain.doFilter(request, response);
+      } finally {
+        scope.close();
+      }
+      return;
+    }
+
+    Span span = handler.handleReceive(new HttpServletRequestWrapper(req));
+
+    // Add attributes for explicit access to customization or span context
+    request.setAttribute(SpanCustomizer.class.getName(), span.customizer());
+    request.setAttribute(TraceContext.class.getName(), span.context());
+    SendHandled sendHandled = new SendHandled();
+    request.setAttribute(SendHandled.class.getName(), sendHandled);
+
+    Throwable error = null;
+    Scope scope = currentTraceContext.newScope(span.context());
+    try {
+      // any downstream code can see Tracer.currentSpan() or use Tracer.currentSpanCustomizer()
+      chain.doFilter(req, res);
+    } catch (Throwable e) {
+      error = e;
+      throw e;
+    } finally {
+      // When async, even if we caught an exception, we don't have the final response: defer
+      if (servlet.isAsync(req)) {
+        servlet.handleAsync(handler, req, res, span);
+      } else if (sendHandled.compareAndSet(false, true)){
+        // we have a synchronous response or error: finish the span
+        HttpServerResponse responseWrapper = HttpServletResponseWrapper.create(req, res, error);
+        handler.handleSend(responseWrapper, span);
+      }
+      scope.close();
+    }
+  }
+
+  // Special type used to ensure handleSend is only called once
+  static final class SendHandled extends AtomicBoolean {
+  }
+
+  @Override public void destroy() {
+  }
+
+  @Override public void init(FilterConfig filterConfig) {
+  }
+}

--- a/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/internal/ServletRuntime.java
+++ b/instrumentation/servlet-jakarta/src/main/java/brave/jakarta/servlet/internal/ServletRuntime.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet.internal;
+
+import brave.Span;
+import brave.http.HttpServerHandler;
+import brave.http.HttpServerRequest;
+import brave.http.HttpServerResponse;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Access to servlet version-specific features
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.platform.Platform}
+ */
+public abstract class ServletRuntime {
+  private static final ServletRuntime SERVLET_RUNTIME = new Servlet5();
+
+  public HttpServletResponse httpServletResponse(ServletResponse response) {
+    return (HttpServletResponse) response;
+  }
+
+  /** public for {@link brave.jakarta.servlet.HttpServletResponseWrapper}. */
+  public abstract int status(HttpServletResponse response);
+
+  public abstract boolean isAsync(HttpServletRequest request);
+
+  public abstract void handleAsync(
+    HttpServerHandler<HttpServerRequest, HttpServerResponse> handler,
+    HttpServletRequest request, HttpServletResponse response, Span span);
+
+  ServletRuntime() {
+  }
+
+  public static ServletRuntime get() {
+    return SERVLET_RUNTIME;
+  }
+
+  static final class Servlet5 extends ServletRuntime {
+    @Override public boolean isAsync(HttpServletRequest request) {
+      return request.isAsyncStarted();
+    }
+
+    @Override public int status(HttpServletResponse response) {
+      return response.getStatus();
+    }
+
+    @Override public void handleAsync(
+      HttpServerHandler<HttpServerRequest, HttpServerResponse> handler,
+      HttpServletRequest request, HttpServletResponse response, Span span) {
+      if (span.isNoop()) return; // don't add overhead when we aren't httpTracing
+      TracingAsyncListener listener = new TracingAsyncListener(handler, span);
+      request.getAsyncContext().addListener(listener, request, response);
+    }
+
+    static final class TracingAsyncListener implements AsyncListener {
+      final HttpServerHandler<HttpServerRequest, HttpServerResponse> handler;
+      final Span span;
+
+      TracingAsyncListener(HttpServerHandler<HttpServerRequest, HttpServerResponse> handler,
+        Span span
+      ) {
+        this.handler = handler;
+        this.span = span;
+      }
+
+      @Override public void onComplete(AsyncEvent e) {
+        HttpServletRequest req = (HttpServletRequest) e.getSuppliedRequest();
+        // Use package-private attribute to check if this hook was called redundantly
+        Object sendHandled = req.getAttribute("brave.jakarta.servlet.TracingFilter$SendHandled");
+        if (sendHandled instanceof AtomicBoolean
+            && ((AtomicBoolean) sendHandled).compareAndSet(false, true)) {
+          HttpServletResponse res = (HttpServletResponse) e.getSuppliedResponse();
+
+          HttpServerResponse response =
+              brave.jakarta.servlet.HttpServletResponseWrapper.create(req, res, e.getThrowable());
+          handler.handleSend(response, span);
+        } else {
+          // TODO: None of our tests reach this condition. Make a concrete case that re-enters the
+          // onComplete hook or remove the special case
+        }
+      }
+
+      // Per Servlet 3 section 2.3.3.3, we can't see the final HTTP status, yet. defer to onComplete
+      // https://download.oracle.com/otndocs/jcp/servlet-3.0-mrel-eval-oth-JSpec/
+      @Override public void onTimeout(AsyncEvent e) {
+        // Propagate the timeout so that the onComplete hook can see it.
+        ServletRequest request = e.getSuppliedRequest();
+        if (request.getAttribute("error") == null) {
+          request.setAttribute("error", new AsyncTimeoutException(e));
+        }
+      }
+
+      // Per Servlet 3 section 2.3.3.3, we can't see the final HTTP status, yet. defer to onComplete
+      // https://download.oracle.com/otndocs/jcp/servlet-3.0-mrel-eval-oth-JSpec/
+      @Override public void onError(AsyncEvent e) {
+        ServletRequest request = e.getSuppliedRequest();
+        if (request.getAttribute("error") == null) {
+          request.setAttribute("error", e.getThrowable());
+        }
+      }
+
+      /** If another async is created (ex via asyncContext.dispatch), this needs to be re-attached */
+      @Override public void onStartAsync(AsyncEvent e) {
+        AsyncContext eventAsyncContext = e.getAsyncContext();
+        if (eventAsyncContext != null) {
+          eventAsyncContext.addListener(this, e.getSuppliedRequest(), e.getSuppliedResponse());
+        }
+      }
+
+      @Override public String toString() {
+        return "TracingAsyncListener{" + span + "}";
+      }
+    }
+
+    static final class AsyncTimeoutException extends TimeoutException {
+      AsyncTimeoutException(AsyncEvent e) {
+        super("Timed out after " + e.getAsyncContext().getTimeout() + "ms");
+      }
+
+      @Override
+      public Throwable fillInStackTrace() {
+        return this; // stack trace doesn't add value as this is used in a callback
+      }
+    }
+  }
+}

--- a/instrumentation/servlet-jakarta/src/test/java/brave/jakarta/servlet/HttpServletRequestWrapperTest.java
+++ b/instrumentation/servlet-jakarta/src/test/java/brave/jakarta/servlet/HttpServletRequestWrapperTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet;
+
+import brave.Span;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class HttpServletRequestWrapperTest {
+  HttpServletRequest request = mock(HttpServletRequest.class);
+  HttpServletRequestWrapper wrapper =
+    (HttpServletRequestWrapper) HttpServletRequestWrapper.create(request);
+  Span span = mock(Span.class);
+
+  @Test public void unwrap() {
+    assertThat(wrapper.unwrap())
+      .isEqualTo(request);
+  }
+
+  @Test public void method() {
+    when(request.getMethod()).thenReturn("POST");
+
+    assertThat(wrapper.method())
+      .isEqualTo("POST");
+  }
+
+  @Test public void path_doesntCrashOnNullUrl() {
+    assertThat(wrapper.path())
+      .isNull();
+  }
+
+  @Test public void path_getRequestURI() {
+    when(request.getRequestURI()).thenReturn("/bar");
+
+    assertThat(wrapper.path())
+      .isEqualTo("/bar");
+  }
+
+  @Test public void url_derivedFromUrlAndQueryString() {
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://foo:8080/bar"));
+    when(request.getQueryString()).thenReturn("hello=world");
+
+    assertThat(wrapper.url())
+      .isEqualTo("http://foo:8080/bar?hello=world");
+  }
+
+  @Test public void parseClientIpAndPort_prefersXForwardedFor() {
+    when(span.remoteIpAndPort("1.2.3.4", 0)).thenReturn(true);
+    when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
+
+    wrapper.parseClientIpAndPort(span);
+
+    verify(span).remoteIpAndPort("1.2.3.4", 0);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void parseClientIpAndPort_skipsRemotePortOnXForwardedFor() {
+    when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
+    when(span.remoteIpAndPort("1.2.3.4", 0)).thenReturn(true);
+
+    wrapper.parseClientIpAndPort(span);
+
+    verify(span).remoteIpAndPort("1.2.3.4", 0);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void parseClientIpAndPort_acceptsRemoteAddr() {
+    when(request.getRemoteAddr()).thenReturn("1.2.3.4");
+    when(request.getRemotePort()).thenReturn(61687);
+
+    wrapper.parseClientIpAndPort(span);
+
+    verify(span).remoteIpAndPort("1.2.3.4", 61687);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test public void maybeError_fromRequestAttribute() {
+    Exception requestError = new Exception();
+    when(request.getAttribute("error")).thenReturn(requestError);
+
+    assertThat(wrapper.maybeError()).isSameAs(requestError);
+  }
+
+  @Test public void maybeError_badRequestAttribute() {
+    when(request.getAttribute("error")).thenReturn(new Object());
+
+    assertThat(wrapper.maybeError()).isNull();
+  }
+
+  @Test public void maybeError_dispatcher() {
+    Exception error = new Exception();
+    when(request.getAttribute(RequestDispatcher.ERROR_EXCEPTION)).thenReturn(error);
+
+    assertThat(wrapper.maybeError()).isSameAs(error);
+  }
+
+  @Test public void maybeError_dispatcher_badAttribute() {
+    when(request.getAttribute(RequestDispatcher.ERROR_EXCEPTION)).thenReturn(new Object());
+
+    assertThat(wrapper.maybeError()).isNull();
+  }
+}

--- a/instrumentation/servlet-jakarta/src/test/java/brave/jakarta/servlet/HttpServletResponseWrapperTest.java
+++ b/instrumentation/servlet-jakarta/src/test/java/brave/jakarta/servlet/HttpServletResponseWrapperTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet;
+
+import brave.http.HttpServerResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HttpServletResponseWrapperTest {
+  HttpServletRequest request = mock(HttpServletRequest.class);
+  HttpServletResponse response = mock(HttpServletResponse.class);
+
+  @Test public void unwrap() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    assertThat(wrapper.unwrap())
+      .isEqualTo(response);
+  }
+
+  @Test public void statusCode() {
+    when(response.getStatus()).thenReturn(200);
+
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    assertThat(wrapper.statusCode()).isEqualTo(200);
+  }
+
+  @Test public void statusCode_zeroNoResponse() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    assertThat(wrapper.statusCode()).isZero();
+  }
+
+  @Test public void nullRequestOk() {
+    HttpServletResponseWrapper.create(null, response, null);
+  }
+
+  @Test public void method_isRequestMethod() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    when(request.getMethod()).thenReturn("POST");
+
+    assertThat(wrapper.method()).isEqualTo("POST");
+  }
+
+  @Test public void error_noRequest() {
+    Exception error = new Exception();
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(null, response, error);
+
+    assertThat(wrapper.error()).isSameAs(error);
+  }
+
+  @Test public void error_fromRequestAttribute() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    Exception requestError = new Exception();
+    when(request.getAttribute("error")).thenReturn(requestError);
+
+    assertThat(wrapper.error()).isSameAs(requestError);
+  }
+
+  @Test public void error_badRequestAttribute() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    when(request.getAttribute("error")).thenReturn(new Object());
+
+    assertThat(wrapper.error()).isNull();
+  }
+
+  @Test public void error_overridesRequestAttribute() {
+    Exception error = new Exception();
+
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, error);
+
+    Exception requestError = new Exception();
+    when(request.getAttribute("error")).thenReturn(requestError);
+
+    assertThat(wrapper.error()).isSameAs(error);
+  }
+
+  @Test public void route_okOnBadAttribute() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    when(request.getAttribute("http.route")).thenReturn(new Object());
+
+    assertThat(wrapper.route()).isNull();
+  }
+
+  @Test public void route_isHttpRouteAttribute() {
+    HttpServerResponse wrapper = HttpServletResponseWrapper.create(request, response, null);
+
+    when(request.getAttribute("http.route")).thenReturn("/users/{userId}");
+
+    assertThat(wrapper.route()).isEqualTo("/users/{userId}");
+  }
+}

--- a/instrumentation/servlet-jakarta/src/test/java/brave/jakarta/servlet/ITTracingFilter.java
+++ b/instrumentation/servlet-jakarta/src/test/java/brave/jakarta/servlet/ITTracingFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.jakarta.servlet;
+
+import java.util.EnumSet;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.UnavailableException;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Ignore;
+
+import brave.test.jakarta.http.ITServlet5Container;
+
+public class ITTracingFilter extends ITServlet5Container {
+
+  @Override protected Filter newTracingFilter() {
+    return TracingFilter.create(httpTracing);
+  }
+
+  @Override protected void addFilter(ServletContextHandler handler, Filter filter) {
+    FilterRegistration.Dynamic filterRegistration =
+        handler.getServletContext().addFilter(filter.getClass().getSimpleName(), filter);
+    filterRegistration.setAsyncSupported(true);
+    // isMatchAfter=true is required for async tests to pass!
+    filterRegistration.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+  }
+
+  /**
+   * Jetty 9.4.28.v20200408 {@link HttpChannelState} {@code #sendError(Throwable)} ignores the
+   * attribute {@link RequestDispatcher#ERROR_STATUS_CODE}.
+   *
+   * <p>It might seem we should use {@link #NOT_READY_UE} instead, but Jetty {@link
+   * ServletHolder#handle(Request, ServletRequest, ServletResponse)} catches {@link
+   * UnavailableException} and swaps internally to a servlet instance that doesn't set the exception
+   * cause.
+   */
+  @Ignore("We can't set the error code for an uncaught exception with jetty-servlet")
+  @Override public void httpStatusCodeSettable_onUncaughtException() {
+  }
+
+  @Ignore("We can't set the error code for an uncaught exception with jetty-servlet")
+  @Override public void httpStatusCodeSettable_onUncaughtException_async() {
+  }
+}

--- a/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
+++ b/instrumentation/spring-webmvc/src/it/spring25/src/test/java/brave/spring/webmvc/ITSpanCustomizingHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package brave.spring.webmvc;
 import brave.Tracer;
 import brave.http.HttpTracing;
 import brave.test.http.ITServletContainer;
+import brave.test.http.ITServlet25Container;
 import brave.test.http.ServletContainer;
 import java.io.IOException;
 import java.util.EnumSet;
@@ -103,7 +104,7 @@ public class ITSpanCustomizingHandlerInterceptor extends ITServletContainer {
 
     @RequestMapping(value = "/exception")
     public void notReady() throws UnavailableException {
-      throw NOT_READY_UE;
+      throw ITServlet25Container.NOT_READY_UE;
     }
   }
 

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet25TestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import static brave.test.ITRemote.BAGGAGE_FIELD;
-import static brave.test.http.ITServletContainer.NOT_READY_UE;
+import static brave.test.http.ITServlet25Container.NOT_READY_UE;
 
 @Controller class Servlet25TestController {
   final Tracer tracer;

--- a/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
+++ b/instrumentation/spring-webmvc/src/test/java/brave/spring/webmvc/Servlet3TestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2022 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import static brave.test.http.ITServletContainer.NOT_READY_UE;
+import static brave.test.http.ITServlet25Container.NOT_READY_UE;
 
 @Controller class Servlet3TestController extends Servlet25TestController {
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
     <resteasy.version>3.14.0.Final</resteasy.version>
 
+    <!-- Jakarta -->
+    <jetty11.version>11.0.11</jetty11.version>
+    <jakarta.servlet>5.0.0</jakarta.servlet>
+
     <kafka.version>3.2.1</kafka.version>
     <activemq.version>5.16.0</activemq.version>
     <spring-rabbit.version>2.3.2</spring-rabbit.version>
@@ -547,6 +551,7 @@
             <maven_release>SCRIPT_STYLE</maven_release>
           </mapping>
           <excludes>
+            <exclude>**/jetty-logging.properties</exclude>
             <exclude>**/log4j2.properties</exclude>
             <exclude>.editorconfig</exclude>
             <exclude>.gitattributes</exclude>


### PR DESCRIPTION
Support for Jakarta servlet specification. Added 2 new modules:

- `instrumentation/http-tests-jakarta`: HTTP tests based on Jakarta Servlet 5+ and Jetty 11
-  `instrumentation/servlet-jakarta`: Jakarta Servlet 5+ instrumentation

Closes https://github.com/openzipkin/brave/issues/1337