### PR TITLE
fix(sec): upgrade netty-codec-http to 4.1.71.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <grpc.version>1.34.1</grpc.version>
     <protobuf.version>3.12.0</protobuf.version>
     <!-- prefer grpc's version of netty -->
-    <netty.version>4.1.51.Final</netty.version>
+    <netty.version>4.1.71.Final</netty.version>
 
     <httpasyncclient.version>4.1.4</httpasyncclient.version>
     <sparkjava.version>2.9.3</sparkjava.version>


### PR DESCRIPTION
Upgrade netty-codec-http 4.1.51.Final to 4.1.71.Final for vulnerability fix:
 - [CVE-2021-21290](https://www.oscs1024.com/hd/MPS-2021-1580)
 - [CVE-2021-21295](https://www.oscs1024.com/hd/MPS-2021-2435)
 - [CVE-2021-43797](https://www.oscs1024.com/hd/MPS-2021-36922)