### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 5.3.7

### DIFF
--- a/instrumentation/spring-web/src/it/spring3/pom.xml
+++ b/instrumentation/spring-web/src/it/spring3/pom.xml
@@ -13,10 +13,7 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>@project.groupId@</groupId>
@@ -36,7 +33,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>@spring.version@</version>
+      <version>5.3.7</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-web 5.3.2
- [CVE-2021-22118](https://www.oscs1024.com/hd/CVE-2021-22118)


### What did I do？
Upgrade org.springframework:spring-web from 5.3.2 to 5.3.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS