### PR TITLE
fix(sec): upgrade io.undertow:undertow-servlet to 2.2.4.Final

### DIFF
--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright 2013-2022 The OpenZipkin Authors
@@ -12,8 +13,7 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.brave</groupId>
@@ -29,7 +29,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <jmh.version>1.27</jmh.version>
-    <undertow-servlet.version>2.2.3.Final</undertow-servlet.version>
+    <undertow-servlet.version>2.2.4.Final</undertow-servlet.version>
   </properties>
 
   <!-- can't import brave-bom due to build-support/go-offline.sh -->
@@ -291,7 +291,7 @@
               <!-- instead of javac-with-errorprone -->
               <compilerId>javac</compilerId>
               <!-- scrub errorprone compiler args -->
-              <compilerArgs />
+              <compilerArgs/>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.undertow:undertow-servlet 2.2.3.Final
- [MPS-2022-12530](https://www.oscs1024.com/hd/MPS-2022-12530)


### What did I do？
Upgrade io.undertow:undertow-servlet from 2.2.3.Final to 2.2.4.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS