### PR TITLE
fix(sec): upgrade io.undertow:undertow-core to 

### DIFF
--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -29,7 +29,8 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <jmh.version>1.27</jmh.version>
-    <undertow-servlet.version>2.3.0.Alpha2</undertow-servlet.version>
+    <!-- Note: versions above 2.2 move to jakarta package -->
+    <undertow-servlet.version>2.2.28.Final</undertow-servlet.version>
   </properties>
 
   <!-- can't import brave-bom due to build-support/go-offline.sh -->

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -29,7 +29,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
     <jmh.version>1.27</jmh.version>
-    <undertow-servlet.version>2.2.3.Final</undertow-servlet.version>
+    <undertow-servlet.version>2.3.0.Alpha2</undertow-servlet.version>
   </properties>
 
   <!-- can't import brave-bom due to build-support/go-offline.sh -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.undertow:undertow-core 2.2.3.Final
- [CVE-2021-3597](https://www.oscs1024.com/hd/CVE-2021-3597)


### What did I do？
Upgrade io.undertow:undertow-core from 2.2.3.Final to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>