### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.3.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <guice.version>5.0.0-BETA-1</guice.version>
 
     <!-- Ensure older versions of spring still work -->
-    <spring5.version>5.3.2</spring5.version>
+    <spring5.version>5.3.14</spring5.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
     <!-- Apis used, but not in Jetty 7.6* imply duplication in servlet25 test fixtures -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-core 5.3.2
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)


### What did I do？
Upgrade org.springframework:spring-core from 5.3.2 to 5.3.14 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS