### PR TITLE
fix(sec): upgrade io.netty:netty-codec-http to 4.1.86.final

### DIFF
--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
+++ b/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -111,10 +111,10 @@
     <okhttp.version>4.9.0</okhttp.version>
     <httpclient.version>4.5.13</httpclient.version>
 
-    <grpc.version>1.34.1</grpc.version>
-    <protobuf.version>3.12.0</protobuf.version>
+    <grpc.version>1.54.0</grpc.version>
+    <protobuf.version>3.21.7</protobuf.version>
     <!-- prefer grpc's version of netty -->
-    <netty.version>4.1.86.final</netty.version>
+    <netty.version>4.1.87.Final</netty.version>
 
     <httpasyncclient.version>4.1.4</httpasyncclient.version>
     <sparkjava.version>2.9.3</sparkjava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <grpc.version>1.34.1</grpc.version>
     <protobuf.version>3.12.0</protobuf.version>
     <!-- prefer grpc's version of netty -->
-    <netty.version>4.1.71.Final</netty.version>
+    <netty.version>4.1.86.final</netty.version>
 
     <httpasyncclient.version>4.1.4</httpasyncclient.version>
     <sparkjava.version>2.9.3</sparkjava.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec-http 4.1.71.Final
- [CVE-2022-41915](https://www.oscs1024.com/hd/CVE-2022-41915)


### What did I do？
Upgrade io.netty:netty-codec-http from 4.1.71.Final to 4.1.86.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS