### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <jetty11.version>11.0.11</jetty11.version>
     <jakarta.servlet>5.0.0</jakarta.servlet>
 
-    <kafka.version>3.4.0</kafka.version>
+    <kafka.version>3.2.3</kafka.version>
     <activemq.version>5.16.0</activemq.version>
     <activemq.artemis.version>2.26.0</activemq.artemis.version>
     <spring-rabbit.version>2.3.2</spring-rabbit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <jetty11.version>11.0.11</jetty11.version>
     <jakarta.servlet>5.0.0</jakarta.servlet>
 
-    <kafka.version>3.2.1</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
     <activemq.version>5.16.0</activemq.version>
     <activemq.artemis.version>2.26.0</activemq.artemis.version>
     <spring-rabbit.version>2.3.2</spring-rabbit.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 3.2.1
- [CVE-2023-25194](https://www.oscs1024.com/hd/CVE-2023-25194)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 3.2.1 to 3.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS