### PR TITLE
Set JUL loggerName

### DIFF
--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -14,6 +14,8 @@
 package brave.internal;
 
 import brave.Clock;
+import brave.Tracer;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
@@ -81,7 +83,8 @@ public abstract class Platform {
 
   // Use nested class to ensure logger isn't initialized unless it is accessed once.
   private static final class LoggerHolder {
-    static final Logger LOG = Logger.getLogger(brave.Tracer.class.getName());
+    static final String LOGGER_NAME = Tracer.class.getName();
+    static final Logger LOG = Logger.getLogger(LOGGER_NAME);
   }
 
   /** Like {@link Logger#log(Level, String) */
@@ -96,6 +99,7 @@ public abstract class Platform {
     Logger logger = LoggerHolder.LOG;
     if (!logger.isLoggable(Level.FINE)) return; // fine level to not fill logs
     LogRecord lr = new LogRecord(Level.FINE, msg);
+    lr.setLoggerName(LoggerHolder.LOGGER_NAME);
     Object[] params = {param1};
     lr.setParameters(params);
     if (thrown != null) lr.setThrown(thrown);

--- a/instrumentation/jms-jakarta/src/main/java/brave/jakarta/jms/JmsTracing.java
+++ b/instrumentation/jms-jakarta/src/main/java/brave/jakarta/jms/JmsTracing.java
@@ -67,7 +67,8 @@ public final class JmsTracing {
 
   // Use nested class to ensure logger isn't initialized unless it is accessed once.
   private static final class LoggerHolder {
-    static final Logger LOG = Logger.getLogger(JmsTracing.class.getName());
+    static final String LOGGER_NAME = JmsTracing.class.getName();
+    static final Logger LOG = Logger.getLogger(LOGGER_NAME);
   }
 
   // Use nested class to ensure we only check once per classloader
@@ -307,6 +308,7 @@ public final class JmsTracing {
     Logger logger = LoggerHolder.LOG;
     if (!logger.isLoggable(Level.FINE)) return; // fine level to not fill logs
     LogRecord lr = new LogRecord(Level.FINE, msg);
+    lr.setLoggerName(LoggerHolder.LOGGER_NAME);
     Object[] params = one != null ? new Object[] {zero, one} : new Object[] {zero};
     lr.setParameters(params);
     lr.setThrown(thrown);

--- a/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
+++ b/instrumentation/jms/src/main/java/brave/jms/JmsTracing.java
@@ -66,7 +66,8 @@ public final class JmsTracing {
 
   // Use nested class to ensure logger isn't initialized unless it is accessed once.
   private static final class LoggerHolder {
-    static final Logger LOG = Logger.getLogger(JmsTracing.class.getName());
+    static final String LOGGER_NAME = JmsTracing.class.getName();
+    static final Logger LOG = Logger.getLogger(LOGGER_NAME);
   }
 
   // Use nested class to ensure we only check once per classloader
@@ -308,6 +309,7 @@ public final class JmsTracing {
     Logger logger = LoggerHolder.LOG;
     if (!logger.isLoggable(Level.FINE)) return; // fine level to not fill logs
     LogRecord lr = new LogRecord(Level.FINE, msg);
+    lr.setLoggerName(LoggerHolder.LOGGER_NAME);
     Object[] params = one != null ? new Object[] {zero, one} : new Object[] {zero};
     lr.setParameters(params);
     lr.setThrown(thrown);

--- a/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
+++ b/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaTracing.java
@@ -56,7 +56,8 @@ public final class KafkaTracing {
   };
   // Use nested class to ensure logger isn't initialized unless it is accessed once.
   private static final class LoggerHolder {
-    static final Logger LOG = Logger.getLogger(KafkaTracing.class.getName());
+    static final String LOGGER_NAME = KafkaTracing.class.getName();
+    static final Logger LOG = Logger.getLogger(LOGGER_NAME);
   }
 
   public static KafkaTracing create(Tracing tracing) {
@@ -278,6 +279,7 @@ public final class KafkaTracing {
     Logger logger = LoggerHolder.LOG;
     if (!logger.isLoggable(Level.FINE)) return; // fine level to not fill logs
     LogRecord lr = new LogRecord(Level.FINE, msg);
+    lr.setLoggerName(LoggerHolder.LOGGER_NAME);
     Object[] params = one != null ? new Object[] {zero, one} : new Object[] {zero};
     lr.setParameters(params);
     lr.setThrown(thrown);


### PR DESCRIPTION
## Problem:
When using JUL to SLF4J bridge, the logger is misconfigured and logs are detected as being sent from "unknown.jul.logger".
As a result, it is not straightforward to configure logback to filter out brave debug logs.

## Solution:
This is apparently solvable but setting a logger name to each LogRecord produced, like in https://github.com/asciidoctor/asciidoctorj/pull/834

## Drawbacks
For people using JUL directly with the default format, this will change the log output slightly.

Before: 
```
Jan 01, 1970 9:00:00 AM null
FINE: Some message
```

After:

```
Jan 01, 1970 9:00:00 AM brave.Tracer
FINE: Some message
```