### PR TITLE
Dubbo3 support

### DIFF
--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -32,7 +32,7 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
 
-    <dubbo.version>2.7.8</dubbo.version>
+    <dubbo.version>3.1.7</dubbo.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
+++ b/instrumentation/dubbo/src/main/java/brave/dubbo/TracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,18 +26,19 @@ import brave.rpc.RpcResponse;
 import brave.rpc.RpcResponseParser;
 import brave.rpc.RpcServerHandler;
 import brave.rpc.RpcTracing;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import org.apache.dubbo.common.Version;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.common.extension.ExtensionLoader;
-import org.apache.dubbo.config.spring.extension.SpringExtensionFactory;
 import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcContext;
 import org.apache.dubbo.rpc.RpcException;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static brave.internal.Throwables.propagateIfFatal;
 
@@ -64,7 +65,7 @@ public final class TracingFilter implements Filter {
 
   /**
    * {@link ExtensionLoader} supplies the tracing implementation which must be named "tracing". For
-   * example, if using the {@link SpringExtensionFactory}, only a bean named "tracing" will be
+   * example, if using the {@link org.apache.dubbo.config.spring.extension.SpringExtensionInjector}, only a bean named "tracing" will be
    * injected.
    *
    * @deprecated Since 5.12 only use {@link #setRpcTracing(RpcTracing)}
@@ -79,7 +80,7 @@ public final class TracingFilter implements Filter {
 
   /**
    * {@link ExtensionLoader} supplies the tracing implementation which must be named "rpcTracing".
-   * For example, if using the {@link SpringExtensionFactory}, only a bean named "rpcTracing" will
+   * For example, if using the {@link org.apache.dubbo.config.spring.extension.SpringExtensionInjector}, only a bean named "rpcTracing" will
    * be injected.
    *
    * <h3>Custom parsing</h3>
@@ -106,11 +107,7 @@ public final class TracingFilter implements Filter {
     Span span;
     DubboRequest request;
     if (kind.equals(Kind.CLIENT)) {
-      // When A service invoke B service, then B service then invoke C service, the parentId of the
-      // C service span is A when read from invocation.getAttachments(). This is because
-      // AbstractInvoker adds attachments via RpcContext.getContext(), not the invocation.
-      // See org.apache.dubbo.rpc.protocol.AbstractInvoker(line 141) from v2.7.3
-      Map<String, String> attachments = RpcContext.getContext().getAttachments();
+      Map<String, String> attachments = getVersion() >= 3000000 ? invocation.getAttachments():RpcContext.getContext().getAttachments();
       DubboClientRequest clientRequest = new DubboClientRequest(invoker, invocation, attachments);
       request = clientRequest;
       span = clientHandler.handleSendWithParent(clientRequest, invocationContext);
@@ -144,5 +141,9 @@ public final class TracingFilter implements Filter {
       if (isSynchronous) FinishSpan.finish(this, request, result, error, span);
       scope.close();
     }
+  }
+
+  private int getVersion(){
+    return Version.getIntVersion(Version.getVersion());
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
@@ -122,6 +122,14 @@ public class DubboParserTest {
     assertThat(DubboParser.errorCode(new RpcException(8)))
         .isEqualTo("TIMEOUT_TERMINATE");
     assertThat(DubboParser.errorCode(new RpcException(9)))
-        .isNull(); // This test will drift with a new error code name if Dubbo adds one.
+      .isEqualTo("REGISTRY_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(10)))
+      .isEqualTo("ROUTER_CACHE_NOT_BUILD");
+    assertThat(DubboParser.errorCode(new RpcException(11)))
+      .isEqualTo("METHOD_NOT_FOUND");
+    assertThat(DubboParser.errorCode(new RpcException(12)))
+      .isEqualTo("VALIDATION_EXCEPTION");
+    assertThat(DubboParser.errorCode(new RpcException(13)))
+      .isNull();// This test will drift with a new error code name if Dubbo adds one
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/DubboParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -47,7 +47,11 @@ class TestServer {
     service = new ServiceConfig<>();
     service.setApplication(application);
     service.setRegistry(new RegistryConfig(RegistryConfig.NO_AVAILABLE));
-    service.setProtocol(new ProtocolConfig("dubbo", PickUnusedPort.get()));
+    service.setProtocol(new ProtocolConfig("dubbo",PickUnusedPort.get()));
+  }
+
+  public void initService() {
+
     service.setInterface(GreeterService.class);
     service.setRef((method, parameterTypes, args) -> {
       requestQueue.add(extractor.extract(RpcContext.getContext().getAttachments()));
@@ -55,9 +59,6 @@ class TestServer {
     });
   }
 
-  ApplicationConfig application() {
-    return service.getApplication();
-  }
 
   void start() {
     service.export();

--- a/instrumentation/httpclient5/pom.xml
+++ b/instrumentation/httpclient5/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.15.1-SNAPSHOT</version>
+    <version>5.15.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Hello! Due to Dubbo 2.7 no longer being maintained and an increasing number of users reporting that Brave cannot run on Dubbo 3, we have decided to upgrade the version of Dubbo. This version has smaller changes compared to the previous PR and is compatible with the features of Dubbo 2.7.