### PR TITLE
fix: http5 parent version

### DIFF
--- a/instrumentation/httpclient5/pom.xml
+++ b/instrumentation/httpclient5/pom.xml
@@ -15,12 +15,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.15.1-SNAPSHOT</version>
+    <version>5.15.2-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>brave-instrumentation-httpclient5</artifactId>
   <name>Brave Instrumentation: Apache HttpClient v5.2+</name>


### PR DESCRIPTION
With the headers version reported and fixed on #1372, seems http5 module got stuck on a previous version of the parent module when merging #1274 .

This fix should unblock the main workflows that are complaining about this issue.