### PR TITLE
Update zipkin to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
     <errorprone.version>2.4.0</errorprone.version>
 
     <!-- use the same values in bom/pom.xml -->
-    <zipkin.version>2.23.2</zipkin.version>
-    <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
+    <zipkin.version>2.24.2</zipkin.version>
+    <zipkin-reporter.version>2.16.4</zipkin-reporter.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>


### PR DESCRIPTION
zipkin includes gson code internally but outdated version Bluckduck reports CVE-2022-25647