### PR TITLE
deps: bumps all main versions that compile

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -34,8 +34,8 @@
     <main.basedir>${project.basedir}/..</main.basedir>
 
     <!-- use the same values in ../pom.xml -->
-    <zipkin.version>2.23.2</zipkin.version>
-    <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
+    <zipkin.version>2.25.2</zipkin.version>
+    <zipkin-reporter.version>2.17.0</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/brave-tests/src/main/java/brave/test/ITRemote.java
+++ b/brave-tests/src/main/java/brave/test/ITRemote.java
@@ -66,7 +66,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // ^-- TODO: verify if this value is per method.
 public abstract class ITRemote {
   static {
-    SamplingFlags.NOT_SAMPLED.toString(); // ensure InternalPropagation is wired for tests
+    String unused = SamplingFlags.NOT_SAMPLED.toString(); // ensure InternalPropagation is wired for tests
   }
 
   public static final BaggageField BAGGAGE_FIELD = BaggageField.create("userId");

--- a/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
+++ b/brave-tests/src/test/java/brave/internal/recorder/PendingSpansClassLoaderTest.java
@@ -33,7 +33,7 @@ import static brave.test.util.ClassLoaders.assertRunIsUnloadable;
 
 class PendingSpansClassLoaderTest {
   static {
-    SamplingFlags.NOT_SAMPLED.toString(); // ensure InternalPropagation is wired for tests
+    String unused = SamplingFlags.DEBUG.toString(); // ensure InternalPropagation is wired for tests
   }
 
   // PendingSpans should always be passed a trace context instantiated by the Tracer. This fakes

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.6.2</version>
+      <version>1.12.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjweaver</artifactId>
-      <version>1.9.6</version>
+      <version>1.9.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/brave/src/main/java/brave/propagation/CurrentTraceContext.java
+++ b/brave/src/main/java/brave/propagation/CurrentTraceContext.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutorService;
 public abstract class CurrentTraceContext {
   static {
     // ensure a reference to InternalPropagation exists
-    SamplingFlags.DEBUG.toString();
+    String unused = SamplingFlags.DEBUG.toString();
   }
 
   /** Implementations of this allow standardized configuration, for example scope decoration. */

--- a/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
+++ b/brave/src/test/java/brave/internal/recorder/PendingSpansTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PendingSpansTest {
   static {
-    SamplingFlags.NOT_SAMPLED.toString(); // ensure InternalPropagation is wired for tests
+    String unused = SamplingFlags.DEBUG.toString(); // ensure InternalPropagation is wired for tests
   }
 
   List<TraceContext> contexts = new ArrayList<>();

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.2.20</version>
+      <version>2.2.21</version>
       <scope>provided</scope>
     </dependency>
 

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.36</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -28,7 +28,7 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
-    <jmh.version>1.27</jmh.version>
+    <jmh.version>1.37</jmh.version>
     <!-- Note: versions above 2.2 move to jakarta package -->
     <undertow-servlet.version>2.2.28.Final</undertow-servlet.version>
   </properties>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-xray-recorder-sdk-core</artifactId>
-      <version>2.8.0</version>
+      <version>2.15.0</version>
     </dependency>
 
     <dependency>

--- a/instrumentation/benchmarks/src/main/java/brave/jms/JmsMessageProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/jms/JmsMessageProducerBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package brave.jms;
 
 import brave.Tracing;
 import java.util.concurrent.TimeUnit;
+import javax.jms.CompletionListener;
 import javax.jms.Destination;
 import javax.jms.Message;
 import javax.jms.MessageNotWriteableException;
@@ -115,6 +116,13 @@ public class JmsMessageProducerBenchmarks {
       return 0;
     }
 
+    @Override public void setDeliveryDelay(long l) {
+    }
+
+    @Override public long getDeliveryDelay() {
+      return 0;
+    }
+
     @Override public Destination getDestination() {
       return null;
     }
@@ -131,9 +139,23 @@ public class JmsMessageProducerBenchmarks {
     @Override public void send(Destination destination, Message message) {
     }
 
-    @Override
-    public void send(Destination destination, Message message, int deliveryMode, int priority,
-      long timeToLive) {
+    @Override public void send(Destination destination, Message message, int deliveryMode,
+      int priority, long timeToLive) {
+    }
+
+    @Override public void send(Message message, CompletionListener completionListener) {
+    }
+
+    @Override public void send(Message message, int i, int i1, long l,
+      CompletionListener completionListener) {
+    }
+
+    @Override public void send(Destination destination, Message message,
+      CompletionListener completionListener) {
+    }
+
+    @Override public void send(Destination destination, Message message, int i, int i1, long l,
+      CompletionListener completionListener) {
     }
   }
 }

--- a/instrumentation/httpclient5/pom.xml
+++ b/instrumentation/httpclient5/pom.xml
@@ -33,7 +33,7 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
 
     <!-- To obey the integration tests, we need to use the version >= 5.2 -->
-    <httpclient5.version>5.2</httpclient5.version>
+    <httpclient5.version>5.3</httpclient5.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -69,7 +69,7 @@
          -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>artemis-jms-server</artifactId>
+        <artifactId>artemis-jms-server</artifactId>
       <version>${activemq.artemis.version}</version>
       <scope>test</scope>
     </dependency>

--- a/instrumentation/mongodb/pom.xml
+++ b/instrumentation/mongodb/pom.xml
@@ -31,7 +31,7 @@
 
     <main.basedir>${project.basedir}/../..</main.basedir>
 
-    <mongodb-driver.version>3.12.7</mongodb-driver.version>
+    <mongodb-driver.version>3.12.14</mongodb-driver.version>
   </properties>
 
   <dependencies>

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.22</version>
+      <version>8.0.33</version>
       <scope>provided</scope>
     </dependency>
 

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -30,9 +30,7 @@
     <module.name>brave.vertx.web</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <vertx.version>3.9.5</vertx.version>
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
+    <vertx.version>3.9.16</vertx.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -76,48 +76,53 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.4.0</errorprone.version>
+    <errorprone.version>2.23.0</errorprone.version>
 
     <!-- use the same values in bom/pom.xml -->
-    <zipkin.version>2.24.2</zipkin.version>
-    <zipkin-reporter.version>2.16.4</zipkin-reporter.version>
+    <zipkin.version>2.25.2</zipkin.version>
+    <zipkin-reporter.version>2.17.0</zipkin-reporter.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
-    <!-- to test @Inject annotations -->
-    <guice.version>5.0.0-BETA-1</guice.version>
+    <!-- to test @Inject annotations. Note 7.x is for jakarta annotations! -->
+    <guice.version>6.0.0</guice.version>
 
     <!-- Ensure older versions of spring still work -->
-    <spring5.version>5.3.14</spring5.version>
+    <spring5.version>5.3.31</spring5.version>
     <spring.version>3.2.18.RELEASE</spring.version>
 
     <!-- Apis used, but not in Jetty 7.6* imply duplication in servlet25 test fixtures -->
     <!-- prefer sparkjava's jetty to reduce downloads -->
-    <jetty.version>9.4.35.v20201120</jetty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
     <jetty-servlet25.version>7.6.21.v20160908</jetty-servlet25.version>
-    <resteasy.version>3.14.0.Final</resteasy.version>
+    <resteasy.version>3.15.6.Final</resteasy.version>
 
     <!-- Jakarta -->
-    <jetty11.version>11.0.11</jetty11.version>
+    <jetty11.version>11.0.18</jetty11.version>
     <jakarta.servlet>5.0.0</jakarta.servlet>
 
-    <kafka.version>3.4.0</kafka.version>
-    <activemq.version>5.16.0</activemq.version>
-    <activemq.artemis.version>2.26.0</activemq.artemis.version>
-    <spring-rabbit.version>2.3.2</spring-rabbit.version>
+    <kafka.version>3.6.1</kafka.version>
+    <activemq.version>5.18.3</activemq.version>
+    <activemq.artemis.version>2.31.2</activemq.artemis.version>
+    <!-- TODO: reflection drift after this version -->
+    <spring-rabbit.version>2.3.6</spring-rabbit.version>
 
+    <!-- TODO: update and fix drift or remove the FinagleContextInteropTest -->
     <finagle.version>20.12.0</finagle.version>
-    <log4j.version>2.17.1</log4j.version>
-    <okhttp.version>4.9.0</okhttp.version>
-    <httpclient.version>4.5.13</httpclient.version>
+    <log4j.version>2.22.0</log4j.version>
+    <okhttp.version>4.12.0</okhttp.version>
+    <httpclient.version>4.5.14</httpclient.version>
 
-    <grpc.version>1.54.0</grpc.version>
-    <protobuf.version>3.21.7</protobuf.version>
+    <!-- TODO: grpc removed code we use in tests saying is wasn't used.
+         Port the attachHeaders code from here.
+         https://github.com/grpc/grpc-java/commit/a589eacc8f83c80bb44c8fae0b0b173b5ff51e61 -->
+    <grpc.version>1.57.2</grpc.version>
+    <protobuf.version>3.22.3</protobuf.version>
     <!-- prefer grpc's version of netty -->
-    <netty.version>4.1.87.Final</netty.version>
+    <netty.version>4.1.93.Final</netty.version>
 
-    <httpasyncclient.version>4.1.4</httpasyncclient.version>
-    <sparkjava.version>2.9.3</sparkjava.version>
+    <httpasyncclient.version>4.1.5</httpasyncclient.version>
+    <sparkjava.version>2.9.4</sparkjava.version>
 
     <!-- Test only dependencies -->
     <junit-jupiter.version>5.10.1</junit-jupiter.version>


### PR DESCRIPTION
This bumps all main versions to current, except a few TODOs noted where there is drift. As this generally gets things years ahead and I'm out of time, good enough for now!