### PR TITLE
deps: updates to zipkin-reporter 2.17.1

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -35,7 +35,7 @@
 
     <!-- use the same values in ../pom.xml -->
     <zipkin.version>2.25.2</zipkin.version>
-    <zipkin-reporter.version>2.17.0</zipkin-reporter.version>
+    <zipkin-reporter.version>2.17.1</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 
     <!-- use the same values in bom/pom.xml -->
     <zipkin.version>2.25.2</zipkin.version>
-    <zipkin-reporter.version>2.17.0</zipkin-reporter.version>
+    <zipkin-reporter.version>2.17.1</zipkin-reporter.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>


### PR DESCRIPTION
only to align deps before second attempt at release