### PR TITLE
Deprecates tracing support for dependencies not released in 1.5-3.5+ years

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>io.zipkin.brave</groupId>
   <artifactId>brave-bom</artifactId>
-  <version>5.17.2-SNAPSHOT</version>
+  <version>5.18.0-SNAPSHOT</version>
   <name>Brave BOM</name>
   <description>Bill Of Materials POM for all Brave artifacts</description>
   <packaging>pom</packaging>

--- a/brave-tests/pom.xml
+++ b/brave-tests/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave</artifactId>

--- a/context/jfr/pom.xml
+++ b/context/jfr/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/context/log4j12/pom.xml
+++ b/context/log4j12/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/context/log4j2/pom.xml
+++ b/context/log4j2/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-context-parent</artifactId>

--- a/context/rxjava2/README.md
+++ b/context/rxjava2/README.md
@@ -1,4 +1,12 @@
 # brave-context-rxjava2
+
+## Deprecated
+
+RxJava 2 hasn't been released since Feb 2021. Tracing support will be removed
+in Brave v6.
+
+## Overview
+
 `CurrentTraceContextAssemblyTracking` prevents traces from breaking
 during RxJava operations by scoping trace context that existed
 at assembly time around callbacks or computation of new values.

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/context/rxjava2/src/main/java/brave/context/rxjava2/CurrentTraceContextAssemblyTracking.java
+++ b/context/rxjava2/src/main/java/brave/context/rxjava2/CurrentTraceContextAssemblyTracking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,11 @@ import io.reactivex.plugins.RxJavaPlugins;
  *
  * <p>The design of this library borrows heavily from https://github.com/akaita/RxJava2Debug and
  * https://github.com/akarnokd/RxJava2Extensions
+ *
+ * @deprecated RxJava 2 hasn't been released since Feb 2021. Tracing support will be removed in
+ * Brave v6.
  */
+@Deprecated
 public final class CurrentTraceContextAssemblyTracking {
   public interface SavedHooks {
 

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-context-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-instrumentation-benchmarks</artifactId>

--- a/instrumentation/dubbo-rpc/README.md
+++ b/instrumentation/dubbo-rpc/README.md
@@ -1,4 +1,13 @@
 # brave-instrumentation-dubbo-rpc
+
+## Deprecated
+
+Please use [brave-instrumentation-dubbo](../brave-instrumentation-dubbo) with
+Apache Dubbo, as Alibaba Dubbo is no longer maintained. This module will be
+removed in Brave v6.
+
+## Overview
+
 This is a tracing filter for RPC providers and consumers in [Dubbo 2.6+](http://dubbo.apache.org/en-us/docs/dev/impls/filter.html)
 
 When used on a consumer, `TracingFilter` adds trace state as attachments

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/main/java/brave/dubbo/rpc/TracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -43,6 +43,11 @@ import java.util.concurrent.Future;
 
 import static brave.internal.Throwables.propagateIfFatal;
 
+/**
+ * @deprecated please use io.zipkin.brave:brave-instrumentation-dubbo with Apache Dubbo, as Alibaba
+ * Dubbo is no longer maintained. Tracing support for Alibaba Dubbo will be removed in Brave v6.
+ */
+@Deprecated
 @Activate(group = {Constants.PROVIDER, Constants.CONSUMER}, value = "tracing")
 // http://dubbo.apache.org/en-us/docs/dev/impls/filter.html
 // public constructor permitted to allow dubbo to instantiate this

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
  */
 package brave.dubbo.rpc;
 
+import brave.rpc.RpcTracing;
 import brave.test.ITRemote;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
 import com.alibaba.dubbo.config.ReferenceConfig;
@@ -32,7 +33,7 @@ public abstract class ITTracingFilter extends ITRemote {
   TracingFilter init() {
     TracingFilter filter = (TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
       .getExtension("tracing");
-    filter.setTracing(tracing);
+    filter.setRpcTracing(RpcTracing.create(tracing));
     return filter;
   }
 }

--- a/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo-rpc/src/test/java/brave/dubbo/rpc/ITTracingFilter_Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -205,7 +205,7 @@ class ITTracingFilter_Consumer extends ITTracingFilter {
     MutableSpan span =
         testSpanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*Not found exported service.*");
     assertThat(span.tags())
-        .containsEntry("dubbo.error_code", "1");
+        .containsEntry("rpc.error_code", "NETWORK_EXCEPTION");
   }
 
   /** Shows if you aren't using RpcTracing, the old "dubbo.error_code" works */

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -30,7 +30,7 @@
 
     <main.basedir>${project.basedir}/../..</main.basedir>
 
-    <dubbo.version>3.2.9</dubbo.version>
+    <dubbo.version>3.3.0-beta.1</dubbo.version>
     <!-- add opens to avoid below in JRE 21:
          com.alibaba.com.caucho.hessian.io.JavaSerializer -->
     <maven-failsafe-plugin.argLine>

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
  */
 package brave.dubbo;
 
+import brave.rpc.RpcTracing;
 import brave.test.ITRemote;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.config.ApplicationConfig;
@@ -44,7 +45,7 @@ public abstract class ITTracingFilter extends ITRemote {
   TracingFilter init() {
     TracingFilter filter = (TracingFilter) ExtensionLoader.getExtensionLoader(Filter.class)
       .getExtension("tracing");
-    filter.setTracing(tracing);
+    filter.setRpcTracing(RpcTracing.create(tracing));
     return filter;
   }
 }

--- a/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
+++ b/instrumentation/dubbo/src/test/java/brave/dubbo/ITTracingFilter_Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -236,7 +236,7 @@ class ITTracingFilter_Consumer extends ITTracingFilter {
         testSpanHandler.takeRemoteSpanWithErrorMessage(CLIENT, ".*Fail to decode request.*");
 
     assertThat(span.tags())
-        .containsEntry("dubbo.error_code", "1");
+        .containsEntry("rpc.error_code", "NETWORK_EXCEPTION");
   }
 
   /** Shows if you aren't using RpcTracing, the old "dubbo.error_code" works */

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/http-tests-jakarta/pom.xml
+++ b/instrumentation/http-tests-jakarta/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/httpclient5/pom.xml
+++ b/instrumentation/httpclient5/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-instrumentation-httpclient5</artifactId>

--- a/instrumentation/jakarta-jms/pom.xml
+++ b/instrumentation/jakarta-jms/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/jms-jakarta/pom.xml
+++ b/instrumentation/jms-jakarta/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-instrumentation-kafka-clients</artifactId>

--- a/instrumentation/kafka-streams/pom.xml
+++ b/instrumentation/kafka-streams/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/messaging/pom.xml
+++ b/instrumentation/messaging/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/mongodb/pom.xml
+++ b/instrumentation/mongodb/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/mysql/pom.xml
+++ b/instrumentation/mysql/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/mysql6/pom.xml
+++ b/instrumentation/mysql6/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/netty-codec-http/pom.xml
+++ b/instrumentation/netty-codec-http/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -1,4 +1,12 @@
 # brave-instrumentation-p6spy
+
+## Deprecated
+
+P6Spy hasn't been released since July 2020. This module will be removed in
+Brave v6.
+
+## Overview
+
 This includes a tracing event listener for [P6Spy](https://github.com/p6spy/p6spy) (a proxy for calls to your JDBC driver).
 It reports to Zipkin how long each statement takes, along with relevant tags like the query.
 

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,7 +18,13 @@ import com.p6spy.engine.spy.P6Factory;
 import com.p6spy.engine.spy.P6LoadableOptions;
 import com.p6spy.engine.spy.option.P6OptionsRepository;
 
-/** Add this class name to the "moduleslist" in spy.properties */
+/**
+ * Add this class name to the "moduleslist" in spy.properties
+ *
+ * @deprecated P6Spy hasn't been released since July 2020. Tracing support will be removed in Brave
+ * v6.
+ */
+@Deprecated
 public final class TracingP6Factory implements P6Factory {
 
   TracingP6SpyOptions options;

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-instrumentation-parent</artifactId>

--- a/instrumentation/rpc/pom.xml
+++ b/instrumentation/rpc/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/servlet-jakarta/pom.xml
+++ b/instrumentation/servlet-jakarta/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/sparkjava/README.md
+++ b/instrumentation/sparkjava/README.md
@@ -1,5 +1,12 @@
 # brave-instrumentation-sparkjava
 
+## Deprecated
+
+sparkjava hasn't been released since July 2022. This module will be removed in
+Brave v6.
+
+## Overview
+
 This module contains tracing filters and exception handlers for [SparkJava](http://sparkjava.com/)
 The filters extract trace state from incoming requests. Then, they
 reports Zipkin how long each request takes, along with relevant tags

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
+++ b/instrumentation/sparkjava/src/main/java/brave/sparkjava/SparkTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +26,11 @@ import brave.servlet.HttpServletResponseWrapper;
 import spark.ExceptionHandler;
 import spark.Filter;
 
+/**
+ * @deprecated sparkjava hasn't been released since July 2022. Tracing support will be removed in
+ * Brave v6.
+ */
+@Deprecated
 public final class SparkTracing {
   public static SparkTracing create(Tracing tracing) {
     return new SparkTracing(HttpTracing.create(tracing));

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-instrumentation-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.brave</groupId>
   <artifactId>brave-parent</artifactId>
-  <version>5.17.2-SNAPSHOT</version>
+  <version>5.18.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Brave (parent)</name>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave</groupId>
     <artifactId>brave-parent</artifactId>
-    <version>5.17.2-SNAPSHOT</version>
+    <version>5.18.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This deprecates for removal the following, as they have not been updated in a long time. The exception to this rule is log4j context, which is widely used even if not updated recently.

* context/rxjava2 - last released Feb 2021
  * replaced by RxJava3, but unlikely this module will be ported as it wasn't used widely.
* instrumentation/dubbo-rpc - (alibaba) last released Dec 2021
  * replaced by Apache Dubbo instrumentation/dubbo
* instrumentation/p6spy - last released July 2020
  * project dormant
* instrumentation/sparkjava - last released July 2022
  * project dormant

These will be removed in Brave 6 and can be re-introduced if something changes.