### PR TITLE
build: fixes bytecode level and updates build versions (#236)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,10 +62,10 @@ project has a bom.
 $ mvn=$PWD/mvnw
 $ for p in ./brave-bom .; do
  (cd $p
- $mvn versions:set -DnewVersion=2.17.1-SNAPSHOT -DgenerateBackupPoms=false
+ $mvn versions:set -DnewVersion=5.17.2-SNAPSHOT -DgenerateBackupPoms=false
  $mvn -o clean install -DskipTests
  $mvn com.mycila:license-maven-plugin:format
- $mvn versions:set -DnewVersion=5.17.0-SNAPSHOT -DgenerateBackupPoms=false)
+ $mvn versions:set -DnewVersion=5.17.1-SNAPSHOT -DgenerateBackupPoms=false)
  done
 $ git commit -asm"Adjusts copyright headers for this year"
 ```

--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -34,8 +34,8 @@
     <main.basedir>${project.basedir}/..</main.basedir>
 
     <!-- use the same values in ../pom.xml -->
-    <zipkin.version>2.25.2</zipkin.version>
-    <zipkin-reporter.version>2.17.1</zipkin-reporter.version>
+    <zipkin.version>2.27.0</zipkin.version>
+    <zipkin-reporter.version>2.17.2</zipkin-reporter.version>
   </properties>
 
   <organization>

--- a/brave-tests/pom.xml
+++ b/brave-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -34,9 +34,6 @@
 
     <!-- disable errorprone cast warning as PendingSpans internally hacks equals -->
     <errorprone.args>-Xep:EqualsUnsafeCast:OFF</errorprone.args>
-
-    <!-- The brave jar needs to be Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -46,13 +43,6 @@
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-reporter-brave</artifactId>
       <version>${zipkin-reporter.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet</groupId>
-      <artifactId>animal-sniffer-annotation</artifactId>
-      <version>1.0</version>
-      <!-- annotations are not runtime retention, so don't need a runtime dep -->
-      <scope>provided</scope>
     </dependency>
 
     <!-- To show off SpanHandler -->
@@ -136,7 +126,11 @@
       <id>release</id>
       <properties>
         <!-- The brave jar needs to be Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <!-- Clear the release tag, so that we can compile Platform without
+             errors and without changing the end bytecode to 1.8 -->
+        <maven.compiler.release />
       </properties>
       <build>
         <plugins>

--- a/brave/src/main/java/brave/internal/Platform.java
+++ b/brave/src/main/java/brave/internal/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,7 +25,6 @@ import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * Access to platform-specific features.
@@ -167,12 +166,12 @@ public abstract class Platform implements Clock {
   }
 
   static class Jre9 extends Jre7 {
-    @IgnoreJRERequirement @Override public long currentTimeMicroseconds() {
+    @Override public long currentTimeMicroseconds() {
       java.time.Instant instant = java.time.Clock.systemUTC().instant();
       return (instant.getEpochSecond() * 1000000) + (instant.getNano() / 1000);
     }
 
-    @IgnoreJRERequirement @Override public Clock clock() {
+    @Override public Clock clock() {
       return new Clock() {
         // we could use jdk.internal.misc.VM to do this more efficiently, but it is internal
         @Override public long currentTimeMicroseconds() {
@@ -199,19 +198,19 @@ public abstract class Platform implements Clock {
       return System.nanoTime();
     }
 
-    @IgnoreJRERequirement @Override public String getHostString(InetSocketAddress socket) {
+    @Override public String getHostString(InetSocketAddress socket) {
       return socket.getHostString();
     }
 
-    @IgnoreJRERequirement @Override public long randomLong() {
+    @Override public long randomLong() {
       return java.util.concurrent.ThreadLocalRandom.current().nextLong();
     }
 
-    @IgnoreJRERequirement @Override public long nextTraceIdHigh() {
+    @Override public long nextTraceIdHigh() {
       return nextTraceIdHigh(currentTimeMicroseconds(), java.util.concurrent.ThreadLocalRandom.current().nextInt());
     }
 
-    @IgnoreJRERequirement @Override
+    @Override
     public AssertionError assertionError(String message, Throwable cause) {
       return new AssertionError(message, cause);
     }

--- a/context/jfr/pom.xml
+++ b/context/jfr/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -29,22 +29,13 @@
     <!-- Matches Export-Package in bnd.bnd -->
     <module.name>brave.context.jfr</module.name>
 
-    <main.basedir>${project.basedir}/../..</main.basedir>
-    <!-- for add-modules -->
-    <main.java.version>11</main.java.version>
-    <!-- 12 not 11 as there is no java11 published -->
-    <main.signature.artifact>java12</main.signature.artifact>
-  </properties>
+    <!-- JFR is JDK11+ -->
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.jvnet</groupId>
-      <artifactId>animal-sniffer-annotation</artifactId>
-      <version>1.0</version>
-      <!-- annotations are not runtime retention, so don't need a runtime dep -->
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
 
   <build>
     <plugins>

--- a/context/jfr/src/main/java/brave/context/jfr/JfrScopeDecorator.java
+++ b/context/jfr/src/main/java/brave/context/jfr/JfrScopeDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,7 +22,6 @@ import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Event;
 import jdk.jfr.Label;
-import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * Adds {@linkplain Event} properties "traceId", "parentId" and "spanId" when a {@link
@@ -56,7 +55,6 @@ public final class JfrScopeDecorator implements ScopeDecorator {
   @Category("Zipkin")
   @Label("Scope")
   @Description("Zipkin event representing a span being placed in scope")
-  @IgnoreJRERequirement
   static final class ScopeEvent extends Event {
     @Label("Trace Id") String traceId;
     @Label("Parent Id") String parentId;

--- a/context/log4j12/pom.xml
+++ b/context/log4j12/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.context.log4j12</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- log4j is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -48,8 +45,10 @@
     <profile>
       <id>release</id>
       <properties>
-        <!-- log4j is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <!-- log4j is 1.6 bytecode -->
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/context/log4j2/pom.xml
+++ b/context/log4j2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -31,8 +31,6 @@
 
     <main.basedir>${project.basedir}/../..</main.basedir>
 
-    <!-- log4j2 <= 2.3.2 is 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -49,7 +47,9 @@
       <id>release</id>
       <properties>
         <!-- log4j2 <= 2.3.2 is 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/context/rxjava2/pom.xml
+++ b/context/rxjava2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.context.rxjava2</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- RxJava 2.x continues support for Java 1.6 and Android 2.3+ -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -68,7 +65,9 @@
       <id>release</id>
       <properties>
         <!-- RxJava 2.x continues support for Java 1.6 and Android 2.3+ -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/context/slf4j/pom.xml
+++ b/context/slf4j/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.context.slf4j</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- SLF4J is 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -49,7 +46,9 @@
       <id>release</id>
       <properties>
         <!-- SLF4J is 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/dubbo-rpc/pom.xml
+++ b/instrumentation/dubbo-rpc/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -45,9 +45,6 @@
       --add-opens java.base/java.lang.reflect=ALL-UNNAMED
       --add-opens java.base/java.math=ALL-UNNAMED
     </maven-failsafe-plugin.argLine>
-
-    <!-- Dubbo is 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -83,7 +80,9 @@
       <id>release</id>
       <properties>
         <!-- Dubbo is 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/dubbo/pom.xml
+++ b/instrumentation/dubbo/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/grpc/pom.xml
+++ b/instrumentation/grpc/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,7 @@
 
     <main.basedir>${project.basedir}/../..</main.basedir>
 
-    <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
+    <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 
     <old-grpc.version>1.2.0</old-grpc.version>
@@ -39,10 +39,7 @@
     <!-- disable mutability warning as TagContextBinaryMarshaller intentionally returns mixed -->
     <errorprone.args>-Xep:MixedMutabilityReturnType:OFF</errorprone.args>
 
-    <!-- grpc-java < 1.15 supports Java 6 https://github.com/grpc/grpc-java/issues/3961 Current versions support Java 7 even though TLS typically implies Java 8+ -->
-    <main.signature.artifact>java16</main.signature.artifact>
-
-    <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
   </properties>
 
   <dependencies>
@@ -126,7 +123,9 @@
       <id>release</id>
       <properties>
         <!-- grpc-java < 1.15 supports Java 6 https://github.com/grpc/grpc-java/issues/3961 Current versions support Java 7 even though TLS typically implies Java 8+ -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/http-tests-jakarta/pom.xml
+++ b/instrumentation/http-tests-jakarta/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/http-tests/pom.xml
+++ b/instrumentation/http-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/http/pom.xml
+++ b/instrumentation/http/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.http</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- The brave jar needs to be Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -57,7 +54,9 @@
       <id>release</id>
       <properties>
         <!-- The brave jar needs to be Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/httpasyncclient/pom.xml
+++ b/instrumentation/httpasyncclient/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.httpasyncclient</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- httpasyncclient Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -61,7 +58,9 @@
       <id>release</id>
       <properties>
         <!-- httpasyncclient Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/httpclient/pom.xml
+++ b/instrumentation/httpclient/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -32,9 +32,6 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
 
     <old-httpclient.version>4.3.6</old-httpclient.version>
-
-    <!-- httpclient is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -106,8 +103,10 @@
     <profile>
       <id>release</id>
       <properties>
-        <!-- httpclient is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <!-- httpclient Java 1.6 bytecode -->
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/httpclient5/pom.xml
+++ b/instrumentation/httpclient5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -34,9 +34,6 @@
 
     <!-- To obey the integration tests, we need to use the version >= 5.2 -->
     <httpclient5.version>5.3</httpclient5.version>
-
-    <!-- HttpClient 5 is Java 1.7 bytecode -->
-    <main.signature.artifact>java17</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -70,7 +67,9 @@
       <id>release</id>
       <properties>
         <!-- HttpClient 5 is Java 1.7 bytecode -->
-        <main.java.version>1.7</main.java.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.release>7</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/jaxrs2/pom.xml
+++ b/instrumentation/jaxrs2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.jaxrs2</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- JAXRS2 is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -106,7 +103,9 @@
       <id>release</id>
       <properties>
         <!-- JAXRS2 is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/jersey-server/pom.xml
+++ b/instrumentation/jersey-server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.jersey.server</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-    <!-- Jersey 2.7 -> 2.25 are Java 7. We don't currently compile against Jersey 2.26+
-         https://jersey.github.io/documentation/latest/modules-and-dependencies.html#d0e560
-         -->
   </properties>
 
   <dependencies>
@@ -103,4 +100,43 @@
       <version>1.1.1</version>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+        <!-- Jersey 2.7 -> 2.25 are Java 7. We don't currently compile against Jersey 2.26+
+         https://jersey.github.io/documentation/latest/modules-and-dependencies.html#d0e560
+         -->
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.release>7</maven.compiler.release>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>${maven-enforcer-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <!-- The only LTS JDK we support that can compile 1.6 bytecode is 11.
+                         https://www.oracle.com/java/technologies/javase/12-relnote-issues.html -->
+                    <requireJavaVersion>
+                      <version>[11,12)</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/instrumentation/jms-jakarta/pom.xml
+++ b/instrumentation/jms-jakarta/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/jms-jakarta/src/main/java/brave/jakarta/jms/TracingMessageProducer.java
+++ b/instrumentation/jms-jakarta/src/main/java/brave/jakarta/jms/TracingMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -132,7 +132,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
   @Override public void send(Message message, int deliveryMode, int priority, long timeToLive)
     throws JMSException {
     Span span = createAndStartProducerSpan(message, destination(message));
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       delegate.send(message, deliveryMode, priority, timeToLive);
@@ -178,7 +178,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
   void send(SendDestination sendDestination, Destination destination, Message message)
     throws JMSException {
     Span span = createAndStartProducerSpan(message, destination);
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       sendDestination.apply(delegate, destination, message);
@@ -216,7 +216,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
   public void send(Message message, CompletionListener completionListener) throws JMSException {
     Destination destination = destination(message);
     Span span = createAndStartProducerSpan(message, destination);
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       delegate.send(message, TracingCompletionListener.create(completionListener, destination, span, current));
@@ -235,7 +235,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
     Destination destination = destination(message);
     Span span = createAndStartProducerSpan(message, destination);
     completionListener = TracingCompletionListener.create(completionListener, destination, span, current);
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       delegate.send(message, deliveryMode, priority, timeToLive, completionListener);

--- a/instrumentation/jms/pom.xml
+++ b/instrumentation/jms/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -33,9 +33,6 @@
 
     <!-- disable errorprone override warning as we do this intentionally to allow JMS 1.1 -->
     <errorprone.args>-Xep:MissingOverride:OFF</errorprone.args>
-
-    <!-- JMS is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -115,7 +112,9 @@
       <id>release</id>
       <properties>
         <!-- JMS is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/jms/src/main/java/brave/jms/TracingMessageProducer.java
+++ b/instrumentation/jms/src/main/java/brave/jms/TracingMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -140,7 +140,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
   @Override public void send(Message message, int deliveryMode, int priority, long timeToLive)
     throws JMSException {
     Span span = createAndStartProducerSpan(message, destination(message));
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       delegate.send(message, deliveryMode, priority, timeToLive);
@@ -192,7 +192,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
   void send(SendDestination sendDestination, Destination destination, Message message)
     throws JMSException {
     Span span = createAndStartProducerSpan(message, destination);
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       sendDestination.apply(delegate, destination, message);
@@ -243,7 +243,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
   public void send(Message message, CompletionListener completionListener) throws JMSException {
     Destination destination = destination(message);
     Span span = createAndStartProducerSpan(message, destination);
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       delegate.send(message, TracingCompletionListener.create(completionListener, destination, span, current));
@@ -269,7 +269,7 @@ final class TracingMessageProducer extends TracingProducer<MessageProducerReques
     Destination destination = destination(message);
     Span span = createAndStartProducerSpan(message, destination);
     completionListener = TracingCompletionListener.create(completionListener, destination, span, current);
-    SpanInScope ws = tracer.withSpanInScope(span); // animal-sniffer mistakes this for AutoCloseable
+    SpanInScope ws = tracer.withSpanInScope(span);
     Throwable error = null;
     try {
       delegate.send(message, deliveryMode, priority, timeToLive, completionListener);

--- a/instrumentation/kafka-clients/pom.xml
+++ b/instrumentation/kafka-clients/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -32,7 +32,6 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
 
     <old-kafka-clients.version>1.0.0</old-kafka-clients.version>
-    <old-kafka-junit.version>4.0.0</old-kafka-junit.version>
 
     <!-- disable errorprone override warning as we do this intentionally to allow old clients -->
     <errorprone.args>-Xep:MissingOverride:OFF</errorprone.args>
@@ -94,13 +93,6 @@
               <groupId>org.apache.kafka</groupId>
               <artifactId>kafka-clients</artifactId>
               <version>${old-kafka-clients.version}</version>
-              <repositoryType>MAIN</repositoryType>
-              <type>jar</type>
-            </DynamicDependency>
-            <DynamicDependency>
-              <groupId>com.github.charithe</groupId>
-              <artifactId>kafka-junit</artifactId>
-              <version>${old-kafka-junit.version}</version>
               <repositoryType>MAIN</repositoryType>
               <type>jar</type>
             </DynamicDependency>

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaExtension.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/KafkaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -95,7 +95,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.27.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/instrumentation/kafka-streams/pom.xml
+++ b/instrumentation/kafka-streams/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/KafkaExtension.java
+++ b/instrumentation/kafka-streams/src/test/java/brave/kafka/streams/KafkaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -95,7 +95,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.27.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/instrumentation/messaging/pom.xml
+++ b/instrumentation/messaging/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -27,9 +27,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- The brave jar needs to be Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -74,7 +71,9 @@
       <id>release</id>
       <properties>
         <!-- The brave jar needs to be Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/mongodb/pom.xml
+++ b/instrumentation/mongodb/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -32,9 +32,6 @@
     <main.basedir>${project.basedir}/../..</main.basedir>
 
     <mongodb-driver.version>3.12.14</mongodb-driver.version>
-
-    <!-- mongodb-driver 3.x requires Java 6 -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -63,7 +60,9 @@
       <id>release</id>
       <properties>
         <!-- mongodb-driver 3.x requires Java 6 -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/mysql/pom.xml
+++ b/instrumentation/mysql/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.mysql</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- mysql-connector-java < v6 requires Java 6 -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -56,7 +53,9 @@
       <id>release</id>
       <properties>
         <!-- mysql-connector-java < v6 requires Java 6 -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/mysql6/pom.xml
+++ b/instrumentation/mysql6/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/mysql8/pom.xml
+++ b/instrumentation/mysql8/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/netty-codec-http/pom.xml
+++ b/instrumentation/netty-codec-http/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.netty.http</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- Netty 4.x requires Java 6+ https://netty.io/wiki/requirements-for-4.x.html -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -60,7 +57,9 @@
       <id>release</id>
       <properties>
         <!-- Netty 4.x requires Java 6+ https://netty.io/wiki/requirements-for-4.x.html -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/okhttp3/pom.xml
+++ b/instrumentation/okhttp3/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -33,9 +33,6 @@
     <!-- Last version before Call.timeout was added -->
     <old-okhttp.version>3.11.0</old-okhttp.version>
     <retrofit.version>2.9.0</retrofit.version>
-
-    <!-- OkHttp 3.x is Java 1.7 bytecode -->
-    <main.signature.artifact>java17</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -101,7 +98,9 @@
       <id>release</id>
       <properties>
         <!-- OkHttp 3.x is Java 1.7 bytecode -->
-        <main.java.version>1.7</main.java.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.release>7</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/p6spy/pom.xml
+++ b/instrumentation/p6spy/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -33,9 +33,6 @@
 
     <p6spy.version>3.9.1</p6spy.version>
     <derby.version>10.15.2.0</derby.version>
-
-    <!-- p6spy is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -79,7 +76,9 @@
       <id>release</id>
       <properties>
         <!-- p6spy is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/rpc/pom.xml
+++ b/instrumentation/rpc/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.rpc</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- The brave jar needs to be Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -49,7 +46,9 @@
       <id>release</id>
       <properties>
         <!-- The brave jar needs to be Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/servlet-jakarta/pom.xml
+++ b/instrumentation/servlet-jakarta/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/servlet/pom.xml
+++ b/instrumentation/servlet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.servlet</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- servlet is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -107,7 +104,9 @@
       <id>release</id>
       <properties>
         <!-- servlet is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/sparkjava/pom.xml
+++ b/instrumentation/sparkjava/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -52,5 +52,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/instrumentation/spring-rabbit/pom.xml
+++ b/instrumentation/spring-rabbit/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.spring.rabbit</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- Spring is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -89,7 +86,9 @@
       <id>release</id>
       <properties>
         <!-- Spring is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.spring.web</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- Spring is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -127,7 +124,9 @@
       <id>release</id>
       <properties>
         <!-- Spring is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/spring-web/pom.xml
+++ b/instrumentation/spring-web/pom.xml
@@ -126,7 +126,10 @@
         <!-- Spring is Java 1.6 bytecode -->
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.release>6</maven.compiler.release>
+        <!-- Clear the release tag, so that we can compile ListenableFuture
+             instrumentation, without errors and without changing the end
+             bytecode to 1.8 -->
+        <maven.compiler.release />
       </properties>
       <build>
         <plugins>

--- a/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
+++ b/instrumentation/spring-web/src/main/java/brave/spring/web/TraceContextListenableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import brave.propagation.TraceContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import org.jvnet.animal_sniffer.IgnoreJRERequirement;
 import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -64,7 +63,7 @@ final class TraceContextListenableFuture<T> implements ListenableFuture<T> {
 
   // Do not use @Override annotation to avoid compatibility issue version < 5.0
   // Only called when in JRE 1.8+
-  @IgnoreJRERequirement public CompletableFuture<T> completable() {
+  public CompletableFuture<T> completable() {
     return delegate.completable(); // NOTE: trace context is not propagated
   }
 

--- a/instrumentation/spring-webmvc/pom.xml
+++ b/instrumentation/spring-webmvc/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,6 @@
     <module.name>brave.spring.webmvc</module.name>
 
     <main.basedir>${project.basedir}/../..</main.basedir>
-
-    <!-- Spring is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -82,7 +79,9 @@
       <id>release</id>
       <properties>
         <!-- Spring is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/instrumentation/vertx-web/pom.xml
+++ b/instrumentation/vertx-web/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -67,16 +67,24 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- default bytecode version for src/main -->
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- We don't use animal-sniffer anymore as release obviates it.
+         See https://github.com/mojohaus/animal-sniffer/issues/62 -->
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- Tests use the floor Java version (used in release) -->
+    <maven.compiler.testSource>11</maven.compiler.testSource>
+    <maven.compiler.testTarget>11</maven.compiler.testTarget>
+    <maven.compiler.testRelease>11</maven.compiler.testRelease>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.23.0</errorprone.version>
+    <errorprone.version>2.24.1</errorprone.version>
 
     <!-- use the same values in bom/pom.xml -->
-    <zipkin.version>2.25.2</zipkin.version>
-    <zipkin-reporter.version>2.17.1</zipkin-reporter.version>
+    <zipkin.version>2.27.0</zipkin.version>
+    <zipkin-reporter.version>2.17.2</zipkin-reporter.version>
 
     <!-- Used for Generated annotations -->
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
@@ -94,7 +102,7 @@
     <resteasy.version>3.15.6.Final</resteasy.version>
 
     <!-- Jakarta -->
-    <jetty11.version>11.0.18</jetty11.version>
+    <jetty11.version>11.0.19</jetty11.version>
     <jakarta.servlet>5.0.0</jakarta.servlet>
 
     <kafka.version>3.6.1</kafka.version>
@@ -105,7 +113,7 @@
 
     <!-- TODO: update and fix drift or remove the FinagleContextInteropTest -->
     <finagle.version>20.12.0</finagle.version>
-    <log4j.version>2.22.0</log4j.version>
+    <log4j.version>2.22.1</log4j.version>
     <okhttp.version>4.12.0</okhttp.version>
     <httpclient.version>4.5.14</httpclient.version>
 
@@ -122,23 +130,20 @@
 
     <!-- Test only dependencies -->
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
-    <assertj.version>3.24.2</assertj.version>
+    <assertj.version>3.25.1</assertj.version>
     <mockito.version>5.8.0</mockito.version>
-    <jersey.version>2.33</jersey.version>
-    <!-- must align with kafka version https://github.com/charithe/kafka-junit -->
-    <kafka-junit.version>4.2.10</kafka-junit.version>
+    <jersey.version>2.41</jersey.version>
     <testcontainers.version>1.19.3</testcontainers.version>
 
     <license.skip>${skipTests}</license.skip>
     <maven-surefire-plugin.argLine />
     <maven-failsafe-plugin.argLine />
 
-    <animal-sniffer-maven-plugin.version>1.23</animal-sniffer-maven-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.3</license-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -147,12 +152,12 @@
     <maven-help-plugin.version>3.4.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     <maven-invoker-plugin.version>3.6.0</maven-invoker-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>
 
@@ -260,13 +265,6 @@
             <!-- Add dependencies indirectly referenced by build plugins -->
             <dynamicDependencies>
               <DynamicDependency>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>${main.signature.artifact}</artifactId>
-                <version>1.0</version>
-                <type>signature</type>
-                <repositoryType>MAIN</repositoryType>
-              </DynamicDependency>
-              <DynamicDependency>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin-git</artifactId>
                 <version>${license-maven-plugin.version}</version>
@@ -294,10 +292,7 @@
           <version>${maven-compiler-plugin.version}</version>
           <inherited>true</inherited>
           <configuration>
-            <source>${main.java.version}</source>
-            <target>${main.java.version}</target>
             <fork>true</fork>
-            <release>8</release>
             <showWarnings>true</showWarnings>
           </configuration>
         </plugin>
@@ -421,29 +416,6 @@
       <plugin>
         <artifactId>maven-help-plugin</artifactId>
         <version>${maven-help-plugin.version}</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer-maven-plugin.version}</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>${main.signature.artifact}</artifactId>
-            <version>1.0</version>
-          </signature>
-          <checkTestClasses>false</checkTestClasses>
-        </configuration>
-        <executions>
-          <execution>
-            <id>animal-sniffer</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -651,8 +623,6 @@
             <version>${maven-compiler-plugin.version}</version>
             <inherited>true</inherited>
             <configuration>
-              <source>${main.java.version}</source>
-              <target>${main.java.version}</target>
               <fork>true</fork>
               <showWarnings>true</showWarnings>
             </configuration>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -31,9 +31,6 @@
     <module.name>brave.spring.beans</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- Spring is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -81,7 +78,9 @@
       <id>release</id>
       <properties>
         <!-- Spring is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
This fixes a problem where we weren't releasing jars with the right bytecode level, due to a constant release=8. As we no longer can rely on RetroLambda to rewrite code, I've had to port things to the appropriate bytecode level manually. I also updated build deps that could be.

Special note: Projects that optionally use types above their bytecode level *unset* maven.compiler.release in the release profile. This allows the project to compile classes not at the source level. This is used in brave core and okhttp, for example.