### PR TITLE
Undeprecates propagation symbols for v6 interop

### DIFF
--- a/brave/src/main/java/brave/baggage/BaggagePropagation.java
+++ b/brave/src/main/java/brave/baggage/BaggagePropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,7 +18,6 @@ import brave.internal.Nullable;
 import brave.internal.baggage.BaggageCodec;
 import brave.internal.baggage.BaggageFields;
 import brave.internal.collect.Lists;
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
@@ -196,10 +195,6 @@ public final class BaggagePropagation<K> implements Propagation<K> {
       }
       this.baggageFactory = BaggageFields.newFactory(fields, maxDynamicFields);
       this.localFieldNames = localFieldNames.toArray(new String[0]);
-    }
-
-    @Deprecated @Override public <K1> BaggagePropagation<K1> create(KeyFactory<K1> keyFactory) {
-      return new BaggagePropagation<K1>(StringPropagationAdapter.create(get(), keyFactory));
     }
 
     @Override public BaggagePropagation<String> get() {

--- a/brave/src/main/java/brave/internal/propagation/StringPropagationAdapter.java
+++ b/brave/src/main/java/brave/internal/propagation/StringPropagationAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -70,7 +70,10 @@ import java.util.Map;
  * }</pre>
  *
  * @since 5.12
+ * @deprecated As of Brave 5.18, throw an {@link UnsupportedOperationException} in
+ * {@link #create(Propagation, KeyFactory)} instead of implementing it.
  */
+@Deprecated
 public final class StringPropagationAdapter<K> implements Propagation<K> {
   public static <K> Propagation<K> create(Propagation<String> delegate, KeyFactory<K> keyFactory) {
     if (delegate == null) throw new NullPointerException("delegate == null");

--- a/brave/src/main/java/brave/propagation/B3SinglePropagation.java
+++ b/brave/src/main/java/brave/propagation/B3SinglePropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,9 +18,9 @@ import brave.Span;
 /**
  * Implements the propagation format described in {@link B3SingleFormat}.
  *
- * @deprecated Since 5.9, use {@link B3Propagation#newFactoryBuilder()} to control inject formats.
+ * <p>Use {@link B3Propagation#newFactoryBuilder()} to control inject formats.
  */
-@Deprecated public final class B3SinglePropagation {
+public final class B3SinglePropagation {
   public static final Propagation.Factory FACTORY = B3Propagation.newFactoryBuilder()
     .injectFormat(B3Propagation.Format.SINGLE)
     .injectFormat(Span.Kind.CLIENT, B3Propagation.Format.SINGLE)

--- a/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
+++ b/brave/src/main/java/brave/propagation/ExtraFieldPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext.Extractor;
 import brave.propagation.TraceContext.Injector;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -190,24 +189,16 @@ import static java.util.Collections.unmodifiableList;
   /** @deprecated Since 5.11 use {@link Propagation.Factory} */
   public static class Factory extends Propagation.Factory {
     final Propagation.Factory delegate;
-    final String[] extraKeyNames;
+    final List<String> extraKeyNames;
 
     Factory(Propagation.Factory delegate, String[] extraKeyNames) {
       this.delegate = delegate;
-      this.extraKeyNames = extraKeyNames;
+      this.extraKeyNames = unmodifiableList(Arrays.asList(extraKeyNames));
     }
 
     /** {@inheritDoc} */
     @Override public ExtraFieldPropagation<String> get() {
-      return create(KeyFactory.STRING);
-    }
-
-    /** {@inheritDoc} */
-    @Deprecated @Override
-    public <K> ExtraFieldPropagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-      List<K> extraKeys = new ArrayList<K>();
-      for (String extraKeyName : extraKeyNames) extraKeys.add(keyFactory.create(extraKeyName));
-      return new ExtraFieldPropagation<K>(delegate.create(keyFactory), unmodifiableList(extraKeys));
+      return new ExtraFieldPropagation<String>(delegate.get(), extraKeyNames);
     }
 
     @Override public boolean supportsJoin() {

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,8 +19,6 @@ import brave.baggage.BaggagePropagation;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
-import brave.internal.Platform;
-import brave.internal.handler.OrphanTracker;
 import brave.propagation.B3Propagation;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
@@ -42,7 +40,6 @@ import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import zipkin2.Endpoint;
 import zipkin2.reporter.Reporter;
 
@@ -68,8 +65,8 @@ public class TracerTest {
     .addSpanHandler(spans)
     .trackOrphans()
     .propagationFactory(new Propagation.Factory() {
-      @Deprecated @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-        return propagationFactory.create(keyFactory);
+      @Override public Propagation<String> get() {
+        return propagationFactory.get();
       }
 
       @Override public boolean supportsJoin() {
@@ -229,9 +226,8 @@ public class TracerTest {
   @Test void join_createsChildWhenUnsupportedByPropagation() {
     tracer = Tracing.newBuilder()
       .propagationFactory(new Propagation.Factory() {
-        @Override
-        @Deprecated public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-          return B3Propagation.FACTORY.create(keyFactory);
+        @Override public Propagation<String> get() {
+          return B3Propagation.FACTORY.get();
         }
       })
       .addSpanHandler(spans).build().tracer();

--- a/brave/src/test/java/brave/TracingTest.java
+++ b/brave/src/test/java/brave/TracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -243,8 +243,8 @@ class TracingTest {
     AtomicBoolean sampledLocal = new AtomicBoolean();
     try (Tracing tracing = Tracing.newBuilder()
       .propagationFactory(new Propagation.Factory() {
-        @Deprecated public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-          return B3SinglePropagation.FACTORY.create(keyFactory);
+        @Override public Propagation<String> get() {
+          return B3SinglePropagation.FACTORY.get();
         }
 
         @Override public TraceContext decorate(TraceContext context) {

--- a/brave/src/test/java/brave/features/propagation/CustomTraceIdPropagation.java
+++ b/brave/src/test/java/brave/features/propagation/CustomTraceIdPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,7 +41,7 @@ public final class CustomTraceIdPropagation extends Propagation.Factory
   public static Propagation.Factory create(Propagation.Factory delegate, String customTraceIdName) {
     if (delegate == null) throw new NullPointerException("delegate == null");
     if (customTraceIdName == null) throw new NullPointerException("customTraceIdName == null");
-    if (!delegate.create(KeyFactory.STRING).keys().contains("b3")) {
+    if (!delegate.get().keys().contains("b3")) {
       throw new IllegalArgumentException("delegate must implement B3 propagation");
     }
     return new CustomTraceIdPropagation(delegate, customTraceIdName);

--- a/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
+++ b/brave/src/test/java/brave/features/propagation/NonStringPropagationKeysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** This shows propagation keys don't need to be Strings. For example, we can propagate over gRPC */
 class NonStringPropagationKeysTest {
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+
+  // Note: This class will be removed in Brave 6.0, but B3Propagation implements create meanwhile.
   Propagation<Metadata.Key<String>> grpcPropagation = B3Propagation.FACTORY.create(
     name -> Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER)
   );
@@ -31,7 +33,6 @@ class NonStringPropagationKeysTest {
   TraceContext.Injector<Metadata> injector = grpcPropagation.injector(Metadata::put);
 
   @Test void injectExtractTraceContext() {
-
     Metadata metadata = new Metadata();
     injector.inject(context, metadata);
 

--- a/brave/src/test/java/brave/internal/extra/ExtraFactoryTest.java
+++ b/brave/src/test/java/brave/internal/extra/ExtraFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,8 +30,8 @@ class ExtraFactoryTest {
       .build();
 
   Propagation.Factory propagationFactory = new Propagation.Factory() {
-    @Deprecated @Override public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-      return B3Propagation.FACTORY.create(keyFactory);
+    @Override public Propagation<String> get() {
+      return B3Propagation.FACTORY.get();
     }
 
     @Override public TraceContext decorate(TraceContext context) {

--- a/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
+++ b/instrumentation/kafka-clients/src/test/java/brave/kafka/clients/ITKafkaTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package brave.kafka.clients;
 import brave.Span.Kind;
 import brave.handler.MutableSpan;
 import brave.internal.codec.HexCodec;
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.messaging.MessagingRuleSampler;
 import brave.messaging.MessagingTracing;
 import brave.propagation.Propagation;
@@ -212,10 +211,6 @@ public class ITKafkaTracing extends ITKafka { // public for src/it
 
     @Override public Propagation<String> get() {
       return this;
-    }
-
-    @Override public <K1> Propagation<K1> create(KeyFactory<K1> keyFactory) {
-      return StringPropagationAdapter.create(this, keyFactory);
     }
   }
 


### PR DESCRIPTION
This undeprecates B3SinglePropagation and enforces at runtime that `Propagation.Factory#get()` must be implemented. I spot checked all the implementations on GitHub already do.