### PR TITLE
deps: manages io.zipkin.zipkin2:zipkin as reporter will soon remove it

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>zipkin-reporter-brave</artifactId>
       <version>${zipkin-reporter.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${zipkin.version}</version>
+    </dependency>
 
     <!-- To show off SpanHandler -->
     <dependency>

--- a/brave/src/it/no_deps/pom.xml
+++ b/brave/src/it/no_deps/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2023 The OpenZipkin Authors
+    Copyright 2013-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,12 @@
       <groupId>@project.groupId@</groupId>
       <artifactId>brave</artifactId>
       <version>@project.version@</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
zipkin-reporter will soon be zipkin free, yet until Brave 6.0, we still need the types for deprecated methods.