### PR TITLE
Docs: adds note about explicit reporter dependencies

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -52,9 +52,8 @@ reporter = AsyncReporter.builder(sender)
 zipkinSpanHandler = ZipkinSpanHandler.create(reporter)
 ```
 
-*Note*: `ZipkinSpanHandler` handler requires an explicit dependency on
+*Note*: `ZipkinSpanHandler` requires an explicit dependency on
 [io.zipkin.reporter2:zipkin-reporter](https://github.com/openzipkin/zipkin-reporter-java/tree/master/core)
-
 
 ## Tracing
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -52,6 +52,10 @@ reporter = AsyncReporter.builder(sender)
 zipkinSpanHandler = ZipkinSpanHandler.create(reporter)
 ```
 
+*Note*: `ZipkinSpanHandler` handler requires an explicit dependency on
+[io.zipkin.reporter2:zipkin-reporter](https://github.com/openzipkin/zipkin-reporter-java/tree/master/core)
+
+
 ## Tracing
 
 The tracer creates and joins spans that model the latency of potentially

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -1,10 +1,12 @@
 # brave-spring-beans
 This module contains Spring Factory Beans that allow you to configure
-tracing with only XML
+tracing with only XML.
+
+*Note*: zipkin2.reporter beans require a dependency on
+[io.zipkin.reporter2:zipkin-reporter-spring-beans](https://github.com/openzipkin/zipkin-reporter-java/tree/master/spring-beans)
 
 ## Configuration
 Bean Factories exist for the following types:
-* EndpointFactoryBean - for configuring the service name, IP etc representing this host
 * TracingFactoryBean - wires most together, like reporter and log integration
 * RpcTracingFactoryBean - for RPC tagging and sampling policy
 * HttpTracingFactoryBean - for HTTP tagging and sampling policy


### PR DESCRIPTION
Brave v6 avoids conflicts by not managing the zipkin-reporter deps. This means users need to, either via the bom or otherwise.