### PR TITLE
removes IpLiteral dependency from ZipkinV2JsonWriter

### DIFF
--- a/brave/src/main/java/brave/internal/codec/ZipkinV2JsonWriter.java
+++ b/brave/src/main/java/brave/internal/codec/ZipkinV2JsonWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -263,7 +263,8 @@ public final class ZipkinV2JsonWriter implements WriteBuffer.Writer<MutableSpan>
     }
     if (ip != null) {
       if (wroteField) b.writeByte(',');
-      if (IpLiteral.detectFamily(ip) == IpLiteral.IpFamily.IPv4) {
+      // MutableSpan forces IPs to be an IPv4, IPv6 (coerces embedded to IPv4) or null.
+      if (ip.indexOf('.') != -1) {
         b.writeAscii("\"ipv4\":\"");
       } else {
         b.writeAscii("\"ipv6\":\"");

--- a/brave/src/main/java/brave/internal/codec/ZipkinV2JsonWriter.java
+++ b/brave/src/main/java/brave/internal/codec/ZipkinV2JsonWriter.java
@@ -263,7 +263,7 @@ public final class ZipkinV2JsonWriter implements WriteBuffer.Writer<MutableSpan>
     }
     if (ip != null) {
       if (wroteField) b.writeByte(',');
-      // MutableSpan forces IPs to be an IPv4, IPv6 (coerces embedded to IPv4) or null.
+      // MutableSpan unwraps any Ipv4 from a mapped or compatability mode IPv6.
       if (ip.indexOf('.') != -1) {
         b.writeAscii("\"ipv4\":\"");
       } else {

--- a/brave/src/test/java/brave/handler/MutableSpanTest.java
+++ b/brave/src/test/java/brave/handler/MutableSpanTest.java
@@ -652,6 +652,15 @@ public class MutableSpanTest {
       .isEqualTo(new MutableSpan(context, null));
   }
 
+  @Test void unwrapsIpv4() {
+    MutableSpan span = new MutableSpan();
+    span.localIp("::FFFF:43.0.192.2"); // mapped
+    span.remoteIp("::0000:43.0.192.2"); // compat
+
+    assertThat(span.localIp()).isEqualTo("43.0.192.2");
+    assertThat(span.remoteIp()).isEqualTo("43.0.192.2");
+  }
+
   @Test void tags() {
     MutableSpan span = new MutableSpan();
     assertThat(span.tagCount()).isZero();

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/ZipkinV2JsonWriterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/ZipkinV2JsonWriterBenchmarks.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.internal.codec;
+
+import brave.Tags;
+import brave.handler.MutableSpan;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static brave.handler.MutableSpanBenchmarks.newBigClientMutableSpan;
+import static brave.handler.MutableSpanBenchmarks.newServerMutableSpan;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class ZipkinV2JsonWriterBenchmarks {
+
+  static final ZipkinV2JsonWriter writer = new ZipkinV2JsonWriter(Tags.ERROR);
+  static final MutableSpan serverSpan = newServerMutableSpan();
+  static final MutableSpan bigClientSpan = newBigClientMutableSpan();
+  static final byte[] buffer = new byte[1024];
+
+  @Benchmark public int sizeInBytes_serverSpan() {
+    return writer.sizeInBytes(serverSpan);
+  }
+
+  @Benchmark public void write_serverSpan() {
+    writer.write(serverSpan, new WriteBuffer(buffer, 0));
+  }
+
+  @Benchmark public int sizeInBytes_bigClientSpan() {
+    return writer.sizeInBytes(bigClientSpan);
+  }
+
+  @Benchmark public void write_bigClientSpan() {
+    writer.write(bigClientSpan, new WriteBuffer(buffer, 0));
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+      .addProfiler("gc")
+      .include(".*" + ZipkinV2JsonWriter.class.getSimpleName() + ".*")
+      .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
This removes a dependency on `IpLiteral.detectFamily` from json writing, and adds a benchmark to make sure it doesn't hurt performance. While a nit, this clarifies that it has already happened, so that a proto encoder port will not think it needs to re-detect also.

Before
```
Benchmark                                                              Mode     Cnt    Score   Error   Units
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:gc.alloc.rate.norm  sample      15   24.104 ± 0.011    B/op
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:p0.99               sample            0.791           us/op
ZipkinV2JsonWriterBenchmarks.write_serverSpan:gc.alloc.rate.norm     sample      15   24.040 ± 0.006    B/op
ZipkinV2JsonWriterBenchmarks.write_serverSpan:p0.99                  sample            0.333           us/op

```

After
```
Benchmark                                                              Mode     Cnt    Score   Error   Units
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:gc.alloc.rate.norm  sample      15   24.101 ± 0.011    B/op
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:p0.99               sample            0.750           us/op
ZipkinV2JsonWriterBenchmarks.write_serverSpan:gc.alloc.rate.norm     sample      15   24.039 ± 0.007    B/op
ZipkinV2JsonWriterBenchmarks.write_serverSpan:p0.99                  sample            0.333           us/op
```