### PR TITLE
json: fixes incorrect handling of error tag

### DIFF
--- a/brave/src/main/java/brave/handler/MutableSpanBytesEncoder.java
+++ b/brave/src/main/java/brave/handler/MutableSpanBytesEncoder.java
@@ -22,6 +22,12 @@ import java.util.List;
 /** Similar to {@code zipkin2.MutableSpan.SpanBytesEncoder} except no Zipkin dependency. */
 public abstract class MutableSpanBytesEncoder {
 
+  /**
+   * Encodes a {@linkplain MutableSpan} into Zipkin's V2 json format.
+   *
+   * @param errorTag sets the tag for a {@linkplain MutableSpan#error()}, if the corresponding key
+   *                 doesn't already exist.
+   */
   public static MutableSpanBytesEncoder zipkinJsonV2(Tag<Throwable> errorTag) {
     if (errorTag == null) throw new NullPointerException("errorTag == null");
     return new ZipkinJsonV2(errorTag);

--- a/instrumentation/benchmarks/src/main/java/brave/handler/MutableSpanBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/handler/MutableSpanBenchmarks.java
@@ -76,9 +76,11 @@ public class MutableSpanBenchmarks {
     span.tag("http.path", "/thrift/shopForTalk");
     span.tag("http.status_code", "200");
     span.tag("http.url", "tbinary+h2c://abasdasgad.hsadas.ism/thrift/shopForTalk");
+    span.tag("error", "true");
     span.tag("instanceId", "line-wallet-api");
     span.tag("phase", "beta");
     span.tag("siteId", "shop");
+    span.error(new RuntimeException("ice cream"));
     return span;
   }
 

--- a/instrumentation/benchmarks/src/main/java/brave/handler/MutableSpanBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/handler/MutableSpanBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/ZipkinV2JsonWriterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/ZipkinV2JsonWriterBenchmarks.java
@@ -70,7 +70,7 @@ public class ZipkinV2JsonWriterBenchmarks {
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
       .addProfiler("gc")
-      .include(".*" + ZipkinV2JsonWriter.class.getSimpleName() + ".*")
+      .include(".*" + ZipkinV2JsonWriter.class.getSimpleName() + ".*bigClientSpan")
       .build();
 
     new Runner(opt).run();

--- a/instrumentation/benchmarks/src/main/java/brave/internal/codec/ZipkinV2JsonWriterBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/internal/codec/ZipkinV2JsonWriterBenchmarks.java
@@ -70,7 +70,7 @@ public class ZipkinV2JsonWriterBenchmarks {
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
       .addProfiler("gc")
-      .include(".*" + ZipkinV2JsonWriter.class.getSimpleName() + ".*bigClientSpan")
+      .include(".*" + ZipkinV2JsonWriter.class.getSimpleName())
       .build();
 
     new Runner(opt).run();


### PR DESCRIPTION
Before, we didn't document that an existing tag with the same name as the `errorTag` parameter of the JSON writer would be retained. This documents it. It also fixes a bug where that key is not literally "error", for example, adding a tag named "exception".

I backfilled tests and adjusted benchmarks to make sure the result isn't worse than before.

Before
```
Benchmark                                                          Mode     Cnt    Score   Error   Units
ZipkinV2JsonWriterBenchmarks.sizeInBytes_bigClientSpan:gc.alloc.rate.norm  sample      15   0.042 ± 0.007    B/op
ZipkinV2JsonWriterBenchmarks.sizeInBytes_bigClientSpan:p0.99               sample           0.334           us/op
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:gc.alloc.rate.norm        sample      15  24.105 ± 0.008    B/op
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:p0.99                     sample           0.791           us/op
```

After
```
Benchmark                                                                    Mode     Cnt    Score   Error   Units
ZipkinV2JsonWriterBenchmarks.sizeInBytes_bigClientSpan:gc.alloc.rate.norm  sample      15    0.041 ± 0.006    B/op
ZipkinV2JsonWriterBenchmarks.sizeInBytes_bigClientSpan:p0.99               sample            0.334           us/op
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:gc.alloc.rate.norm        sample      15   24.101 ± 0.017    B/op
ZipkinV2JsonWriterBenchmarks.write_bigClientSpan:p0.99                     sample            0.750           us/op
```