### PR TITLE
trivy: adds maven-invoker-plugin ignoring config

### DIFF
--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -12,6 +12,10 @@ On deploy:
 On deploy_bom:
 * The artifact `brave-bom` is deployed. Intentionally separate to allow a retry.
 
+We also include a [Trivy configuration](trivy.yaml) which works around its lack
+of support for maven-invoker-plugin. Run `./build-bin/trivy` from the project
+root to get a vulnerability assessment.
+
 [//]: # (Below here should be standard for all projects)
 
 ## Build Overview

--- a/build-bin/trivy
+++ b/build-bin/trivy
@@ -1,0 +1,6 @@
+#!/bin/sh -ue
+
+# This script deploys a master or release version.
+#
+# See [README.md] for an explanation of this and how CI should use it.
+trivy -c $(dirname "$0")/trivy.yaml repo .

--- a/build-bin/trivy.yaml
+++ b/build-bin/trivy.yaml
@@ -1,0 +1,7 @@
+# As of Feb 2024, Trivy has no plans to handle maven-invoker-plugin.
+# Skip to reduce noise about intentional tests against old versions.
+# https://github.com/aquasecurity/trivy/discussions/5787
+image:
+  skip-files:
+    - "**/src/it/*/pom.xml"
+    - "**/target/it/*/pom.xml"


### PR DESCRIPTION
I've given up trying to convince trivy to consider maven-invoker-plugin a test vs a deployment. This adds a config and a helper script to run it ad-hoc.