### PR TITLE
Consolidates notes on "extra" data

### DIFF
--- a/brave/src/main/java/brave/baggage/BaggageFields.java
+++ b/brave/src/main/java/brave/baggage/BaggageFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The OpenZipkin Authors
+ * Copyright 2013-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,7 +25,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
  * <h3>Built-in fields</h3>
  * The following are fields that dispatch to methods on the {@link TraceContext}. They are available
  * regardless of {@link BaggagePropagation}. None will return in lookups such as {@link
- * BaggageField#getAll(TraceContext)} or {@link BaggageField#getByName(TraceContext, String)}
+ * BaggageField#getAllValues(TraceContext)} or {@link BaggageField#getByName(TraceContext, String)}.
  *
  * <p><ol>
  * <li>{@link #TRACE_ID}</li>

--- a/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
+++ b/brave/src/main/java/brave/propagation/TraceContextOrSamplingFlags.java
@@ -14,6 +14,7 @@
 package brave.propagation;
 
 import brave.Tracer;
+import brave.baggage.BaggagePropagation;
 import brave.internal.InternalPropagation;
 import brave.internal.Nullable;
 import brave.propagation.TraceContext.Extractor;
@@ -245,9 +246,10 @@ public final class TraceContextOrSamplingFlags {
    * #context()} is {@code null}.
    *
    * @see TraceContext#extra()
+   * @see Builder#addExtra(Object) for notes on extra values.
    * @since 4.9
    */
-  public final List<Object> extra() {
+  public List<Object> extra() {
     return extraList;
   }
 
@@ -309,7 +311,16 @@ public final class TraceContextOrSamplingFlags {
     }
 
     /**
+     * This is an advanced function used for {@link Propagation} plugins, such as
+     * {@link BaggagePropagation}, to add an internal object to hold state before extracting a
+     * remote request.
+     *
+     * <p>Implications of data are the same as {@link TraceContext.Builder#addExtra(Object)}. The
+     * main difference here is that {@link Extractor#extract(Object)} may not result in a trace
+     * context. For example, baggage fields can exist without an incoming trace.
+     *
      * @see TraceContextOrSamplingFlags#extra()
+     * @see TraceContext.Builder#addExtra(Object)
      * @since 4.9
      */
     public Builder addExtra(Object extra) {


### PR DESCRIPTION
Before this change, notes about state, particularly the "one instance per plugin" rule were not consolidated on the method that can cause problems `addExtra`. This migrates notes together with additional warnings that when we talk about this being used for propagation plugins, we also mean not for ad-hoc usage, as that can lead to excessive overhead.

See #1421