### PR TITLE
Adds BaggagePropagation benchmarks for decorate

### DIFF
--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -43,6 +43,13 @@
       <version>${jmh.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- IntelliJ doesn't know to use annotation processing on tests without this -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/instrumentation/benchmarks/src/test/java/brave/baggage/BaggagePropagationBenchmarks.java
+++ b/instrumentation/benchmarks/src/test/java/brave/baggage/BaggagePropagationBenchmarks.java
@@ -14,6 +14,7 @@
 package brave.baggage;
 
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
+import brave.internal.InternalPropagation;
 import brave.internal.codec.HexCodec;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
@@ -65,6 +66,8 @@ public class BaggagePropagationBenchmarks {
     }
   };
 
+  static final TraceContext contextWithBaggage = extractor.extract(incoming).context();
+
   static final Map<String, String> incomingNoBaggage = new LinkedHashMap<String, String>() {
     {
       injector.inject(context, this);
@@ -72,6 +75,14 @@ public class BaggagePropagationBenchmarks {
   };
 
   static final Map<String, String> nothingIncoming = Collections.emptyMap();
+
+  @Benchmark public TraceContext decorate() {
+    return factory.decorate(InternalPropagation.instance.shallowCopy(context));
+  }
+
+  @Benchmark public TraceContext decorate_withBaggage() {
+    return factory.decorate(InternalPropagation.instance.shallowCopy(contextWithBaggage));
+  }
 
   @Benchmark public void inject() {
     Map<String, String> request = new LinkedHashMap<>();


### PR DESCRIPTION
I tried a couple ways to optimize ExtraFactory with regards to supplying the extraList directly, including some special casing of singleton list and using `InternalPropagation.instance.withExtra(context, unmodifiableList(newExtra));` on a pre-sized list. The results of routine case always ended up with more allocation than now.

This adds a benchmark, so people don't think like I did and feel there is a quick change that won't hurt others. It is possible that the bench isn't representative, or more angles need to be looked at, but this should help people understand where to start, and know if something becomes worse as a result!

See #1421

```
Benchmark                                                               Mode     Cnt     Score     Error   Units
BaggagePropagationBenchmarks.decorate:gc.alloc.rate.norm              sample      15   160.003 ±   0.001    B/op
BaggagePropagationBenchmarks.decorate:p0.99                           sample             0.042             us/op
BaggagePropagationBenchmarks.decorate_withBaggage:gc.alloc.rate.norm  sample      15    80.002 ±   0.001    B/op
BaggagePropagationBenchmarks.decorate_withBaggage:p0.99               sample             0.042             us/op
```