### PR TITLE
Expose builder for apache http5

### DIFF
--- a/instrumentation/httpclient5/src/main/java/brave/httpclient5/HttpClient5Tracing.java
+++ b/instrumentation/httpclient5/src/main/java/brave/httpclient5/HttpClient5Tracing.java
@@ -43,15 +43,19 @@ public class HttpClient5Tracing {
     return new HttpClient5Tracing(httpTracing);
   }
 
+  public HttpClientBuilder addTracingToBuilder(HttpClientBuilder builder) {
+      if (builder == null) throw new NullPointerException("HttpClientBuilder == null");
+      builder.addExecInterceptorBefore(ChainElement.MAIN_TRANSPORT.name(),
+          HandleSendHandler.class.getName(),
+          new HandleSendHandler(httpTracing));
+      builder.addExecInterceptorBefore(ChainElement.PROTOCOL.name(),
+          HandleReceiveHandler.class.getName(),
+          new HandleReceiveHandler(httpTracing));
+      return builder;
+  }
+
   public CloseableHttpClient build(HttpClientBuilder builder) {
-    if (builder == null) throw new NullPointerException("HttpClientBuilder == null");
-    builder.addExecInterceptorBefore(ChainElement.MAIN_TRANSPORT.name(),
-      HandleSendHandler.class.getName(),
-      new HandleSendHandler(httpTracing));
-    builder.addExecInterceptorBefore(ChainElement.PROTOCOL.name(),
-      HandleReceiveHandler.class.getName(),
-      new HandleReceiveHandler(httpTracing));
-    return builder.build();
+    return addTracingToBuilder(builder).build();
   }
 
   public CloseableHttpAsyncClient build(HttpAsyncClientBuilder builder) {


### PR DESCRIPTION
This relates to #1443 

In additon to the `build` method, I've added a new public method which adds the http tracing to the builder. This new method can be called instead of the `build` method in the builder is required in order to add additional options before building. The functionality should be identical for current users.