### PR TITLE
Adds RocketMQ plugin

### DIFF
--- a/brave-bom/pom.xml
+++ b/brave-bom/pom.xml
@@ -252,6 +252,11 @@
         <artifactId>brave-spring-beans</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>brave-instrumentation-rocketmq-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -25,6 +25,7 @@ Here's a brief overview of what's packaged here:
 * [spring-web](spring-web/README.md) - Tracing interceptor for [Spring RestTemplate](https://spring.io/guides/gs/consuming-rest/)
 * [spring-webmvc](spring-webmvc/README.md) - Tracing filter and span customizing interceptors for [Spring WebMVC](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html)
 * [vertx-web](vertx-web/README.md) - Tracing routing context handler for [Vert.x Web](http://vertx.io/docs/vertx-web/js/)
+* [rocketmq-client](rocketmq-client/README.md) - Tracing Producer, MessageListenerConcurrently and MessageListenerOrderly for [Apache RocketMQ](https://github.com/apache/rocketmq/)
 
 Here are other tools we provide for configuring or testing instrumentation:
 * [http](http/README.md) - `HttpTracing` that allows portable configuration of HTTP instrumentation

--- a/instrumentation/benchmarks/pom.xml
+++ b/instrumentation/benchmarks/pom.xml
@@ -240,6 +240,18 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-rocketmq-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.rocketmq</groupId>
+      <artifactId>rocketmq-client</artifactId>
+      <version>${rocketmq-client.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/instrumentation/benchmarks/src/test/java/brave/rocketmq/client/RocketMQProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/test/java/brave/rocketmq/client/RocketMQProducerBenchmarks.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.Tracing;
+import brave.kafka.clients.TracingProducerBenchmarks;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.rocketmq.client.producer.SendStatus.SEND_OK;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class RocketMQProducerBenchmarks {
+  Message message;
+  DefaultMQProducer producer, tracingProducer;
+
+  @Setup(Level.Trial) public void init() {
+    message = new Message("zipkin", "zipkin".getBytes());
+    Tracing tracing = Tracing.newBuilder().build();
+    producer = new FakeProducer();
+    tracingProducer = new FakeProducer();
+    tracingProducer.getDefaultMQProducerImpl().registerSendMessageHook(
+        new TracingSendMessage(RocketMQTracing.newBuilder(tracing).build())
+    );
+  }
+
+  @TearDown(Level.Trial) public void close() {
+    Tracing.current().close();
+  }
+
+  @Benchmark public SendResult send_baseCase() throws Exception {
+    return producer.send(message);
+  }
+
+  @Benchmark public void send_traced() throws Exception {
+    tracingProducer.send(message);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + TracingProducerBenchmarks.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+
+  static final class FakeProducer extends DefaultMQProducer {
+    @Override public SendResult send(Message msg) {
+      SendResult sendResult = new SendResult();
+      sendResult.setMsgId("zipkin");
+      sendResult.setSendStatus(SEND_OK);
+      return sendResult;
+    }
+  }
+}

--- a/instrumentation/benchmarks/src/test/java/brave/rocketmq/client/RocketMQProducerBenchmarks.java
+++ b/instrumentation/benchmarks/src/test/java/brave/rocketmq/client/RocketMQProducerBenchmarks.java
@@ -46,7 +46,7 @@ public class RocketMQProducerBenchmarks {
     producer = new FakeProducer();
     tracingProducer = new FakeProducer();
     tracingProducer.getDefaultMQProducerImpl().registerSendMessageHook(
-        new TracingSendMessage(RocketMQTracing.newBuilder(tracing).build())
+        new TracingSendMessageHook(RocketMQTracing.newBuilder(tracing).build())
     );
   }
 

--- a/instrumentation/pom.xml
+++ b/instrumentation/pom.xml
@@ -52,6 +52,7 @@
     <module>kafka-streams</module>
     <module>netty-codec-http</module>
     <module>vertx-web</module>
+    <module>rocketmq-client</module>
   </modules>
 
   <!-- ${project.groupId}:brave version is set in the root pom.

--- a/instrumentation/rocketmq-client/README.md
+++ b/instrumentation/rocketmq-client/README.md
@@ -8,7 +8,7 @@ This module provides instrumentation for RocketMQ based services.
 
 ### producer
 
-The key is to register our hook to the producer, use `registerSendMessageHook(new TracingSendMessage())`.
+Register `brave.rocketmq.client.RocketMQTracing.newSendMessageHook()` to trace the message.
 
 ```java
 package brave.rocketmq.client;
@@ -32,7 +32,7 @@ public class ProducerExample {
     Message message = new Message(topic, "zipkin", "zipkin".getBytes());
     DefaultMQProducer producer = new DefaultMQProducer("testSend");
     producer.getDefaultMQProducerImpl()
-        .registerSendMessageHook(new TracingSendMessage());
+        .registerSendMessageHook(producerTracing.newSendMessageHook());
     producer.setNamesrvAddr("127.0.0.1:9876");
     producer.start();
     producer.send(message);
@@ -44,7 +44,7 @@ public class ProducerExample {
 
 ### consumer
 
-wrap `org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly`
+Wrap `org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly`
 using `brave.rocketmq.client.RocketMQTracing.messageListenerOrderly(org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly)`,
 or alternatively, wrap `org.apache.rocketmq.client.consumer.listener.messageListenerConcurrently`
 using `brave.rocketmq.client.RocketMQTracing.messageListenerConcurrently(org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently)`;

--- a/instrumentation/rocketmq-client/README.md
+++ b/instrumentation/rocketmq-client/README.md
@@ -1,0 +1,98 @@
+# brave-instrumentation-rocketmq-client
+
+## Tracing for RocketMQ Client
+
+This module provides instrumentation for RocketMQ based services.
+
+## example
+
+### producer
+
+The key is to register our hook to the producer, use `registerSendMessageHook(new TracingSendMessage())`.
+
+```java
+package brave.rocketmq.client;
+
+import brave.Tracing;
+import brave.messaging.MessagingRequest;
+import brave.messaging.MessagingTracing;
+import brave.sampler.SamplerFunction;
+import brave.sampler.SamplerFunctions;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.common.message.Message;
+
+public class ProducerExample {
+  public static void main(String[] args) throws Exception {
+    Tracing tracing = Tracing.newBuilder().build();
+    SamplerFunction<MessagingRequest> producerSampler = SamplerFunctions.deferDecision();
+    RocketMQTracing producerTracing = RocketMQTracing.create(
+        MessagingTracing.newBuilder(tracing).producerSampler(producerSampler).build());
+
+    String topic = "testSend";
+    Message message = new Message(topic, "zipkin", "zipkin".getBytes());
+    DefaultMQProducer producer = new DefaultMQProducer("testSend");
+    producer.getDefaultMQProducerImpl()
+        .registerSendMessageHook(new TracingSendMessage());
+    producer.setNamesrvAddr("127.0.0.1:9876");
+    producer.start();
+    producer.send(message);
+
+    producer.shutdown();
+  }
+}
+```
+
+### consumer
+
+wrap `org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly`
+using `brave.rocketmq.client.RocketMQTracing.messageListenerOrderly(org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly)`,
+or alternatively, wrap `org.apache.rocketmq.client.consumer.listener.messageListenerConcurrently`
+using `brave.rocketmq.client.RocketMQTracing.messageListenerConcurrently(org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently)`;
+
+```java
+package brave.rocketmq.client;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.common.message.MessageExt;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.messaging.MessagingRequest;
+import brave.messaging.MessagingTracing;
+import brave.rocketmq.client.RocketMQTracing;
+import brave.sampler.SamplerFunction;
+import brave.sampler.SamplerFunctions;
+
+public class ProducerExample {
+  public static void main(String[] args) throws Exception {
+    Tracing tracing = Tracing.newBuilder().build();
+    SamplerFunction<MessagingRequest> producerSampler = SamplerFunctions.deferDecision();
+    RocketMQTracing rocketMQTracing = RocketMQTracing.create(
+        MessagingTracing.newBuilder(tracing).producerSampler(producerSampler).build());
+
+    String topic = "testPushConsumer";
+    String nameserverAddr = "127.0.0.1:9876";
+
+    DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("testPushConsumer");
+    consumer.setNamesrvAddr(nameserverAddr);
+    consumer.subscribe(topic, "*");
+    MessageListenerConcurrently messageListenerConcurrently = rocketMQTracing.messageListenerConcurrently(
+        new MessageListenerConcurrently() {
+          @Override public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> list, ConsumeConcurrentlyContext context) {
+            // do something
+            return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+          }
+        });
+    consumer.registerMessageListener(messageListenerConcurrently);
+
+    consumer.start();
+  }
+}
+```

--- a/instrumentation/rocketmq-client/bnd.bnd
+++ b/instrumentation/rocketmq-client/bnd.bnd
@@ -1,0 +1,6 @@
+# We use brave.internal.Nullable, but it is not used at runtime.
+Import-Package: \
+  !brave.internal*,\
+  *
+Export-Package: \
+  brave.rocketmq.client

--- a/instrumentation/rocketmq-client/pom.xml
+++ b/instrumentation/rocketmq-client/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.zipkin.brave</groupId>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <version>6.0.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>brave-instrumentation-rocketmq-client</artifactId>
+  <name>Brave Instrumentation: RocketMQ Client</name>
+
+  <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>brave.rocketmq.client</module.name>
+
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-instrumentation-messaging</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.rocketmq</groupId>
+      <artifactId>rocketmq-client</artifactId>
+      <version>${rocketmq-client.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-tests</artifactId>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/AbstractMessageListener.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/AbstractMessageListener.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.internal.Nullable;
+import brave.messaging.MessagingRequest;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.SamplerFunction;
+import org.apache.rocketmq.common.message.MessageExt;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static brave.Span.Kind.CONSUMER;
+import static brave.internal.Throwables.propagateIfFatal;
+import static brave.rocketmq.client.RocketMQTracing.ROCKETMQ_TOPIC;
+
+/**
+ * Read records headers to create and complete a child of the incoming
+ * producers span if possible.
+ * The spans are modeled as a duration 1 {@link Span.Kind#CONSUMER} span to represent consuming the
+ * message from the rocketmq broker with a child span representing the processing of the message.
+ */
+abstract class AbstractMessageListener {
+  final RocketMQTracing rocketMQTracing;
+  final Tracing tracing;
+  final Tracer tracer;
+  final TraceContext.Extractor<MessageConsumerRequest> extractor;
+  final SamplerFunction<MessagingRequest> sampler;
+  @Nullable final String remoteServiceName;
+
+  AbstractMessageListener(RocketMQTracing rocketMQTracing) {
+    this.rocketMQTracing = rocketMQTracing;
+    this.tracing = rocketMQTracing.messagingTracing.tracing();
+    this.tracer = tracing.tracer();
+    this.extractor = rocketMQTracing.consumerExtractor;
+    this.sampler = rocketMQTracing.consumerSampler;
+    this.remoteServiceName = rocketMQTracing.remoteServiceName;
+  }
+
+  <T> T processConsumeMessage(
+      List<MessageExt> msgs,
+      Function<List<MessageExt>, T> consumerFunc,
+      BiFunction<T, T, Boolean> successFunc,
+      T successStatus
+  ) {
+    for (MessageExt message : msgs) {
+      MessageConsumerRequest request = new MessageConsumerRequest(message);
+      TraceContextOrSamplingFlags extracted =
+          rocketMQTracing.extractAndClearTraceIdHeaders(extractor, request, message.getProperties());
+      Span consumerSpan = rocketMQTracing.nextMessagingSpan(sampler, request, extracted);
+      Span listenerSpan = tracer.newChild(consumerSpan.context());
+
+      if (!consumerSpan.isNoop()) {
+        setConsumerSpan(consumerSpan, message.getTopic());
+        // incur timestamp overhead only once
+        long timestamp = tracing.clock(consumerSpan.context()).currentTimeMicroseconds();
+        consumerSpan.start(timestamp);
+        long consumerFinish = timestamp + 1L; // save a clock reading
+        consumerSpan.finish(consumerFinish);
+        // not using scoped span as we want to start with a pre-configured time
+        listenerSpan.name("on-message").start(consumerFinish);
+      }
+
+      Tracer.SpanInScope scope = tracer.withSpanInScope(listenerSpan);
+      Throwable error = null;
+      T result;
+
+      try {
+        result = consumerFunc.apply(msgs);
+      } catch (Throwable t) {
+        propagateIfFatal(t);
+        error = t;
+        throw t;
+      } finally {
+        if (error != null) listenerSpan.error(error);
+        listenerSpan.finish();
+        scope.close();
+      }
+
+      if (!successFunc.apply(result, successStatus)) {
+        return result;
+      }
+    }
+    return successStatus;
+  }
+
+  void setConsumerSpan(Span span, String topic) {
+    span.name("receive").kind(CONSUMER);
+    span.tag(ROCKETMQ_TOPIC, topic);
+    if (remoteServiceName != null) span.remoteServiceName(remoteServiceName);
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/MessageConsumerRequest.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/MessageConsumerRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.Span;
+import brave.messaging.ConsumerRequest;
+import brave.propagation.Propagation.RemoteGetter;
+import brave.propagation.Propagation.RemoteSetter;
+import org.apache.rocketmq.common.message.MessageExt;
+
+// intentionally not yet public until we add tag parsing functionality
+final class MessageConsumerRequest extends ConsumerRequest {
+  static final RemoteGetter<MessageConsumerRequest> GETTER =
+    new RemoteGetter<MessageConsumerRequest>() {
+      @Override public Span.Kind spanKind() {
+        return Span.Kind.CONSUMER;
+      }
+
+      @Override public String get(MessageConsumerRequest request, String name) {
+        return request.delegate.getUserProperty(name);
+      }
+
+      @Override public String toString() {
+        return "MessageExt::getUserProperty";
+      }
+    };
+
+  static final RemoteSetter<MessageConsumerRequest> SETTER =
+    new RemoteSetter<MessageConsumerRequest>() {
+      @Override public Span.Kind spanKind() {
+        return Span.Kind.CONSUMER;
+      }
+
+      @Override public void put(MessageConsumerRequest request, String name, String value) {
+        request.delegate.putUserProperty(name, value);
+      }
+
+      @Override public String toString() {
+        return "MessageExt::putUserProperty";
+      }
+    };
+
+  final MessageExt delegate;
+
+  MessageConsumerRequest(MessageExt delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  @Override public MessageExt unwrap() {
+    return delegate;
+  }
+
+  @Override public String operation() {
+    return "receive";
+  }
+
+  @Override public String channelKind() {
+    return "topic";
+  }
+
+  @Override public String channelName() {
+    return delegate.getTopic();
+  }
+
+  @Override public String messageId() {
+    return delegate.getMsgId();
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/MessageProducerRequest.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/MessageProducerRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.Span.Kind;
+import brave.messaging.ProducerRequest;
+import brave.propagation.Propagation.RemoteGetter;
+import brave.propagation.Propagation.RemoteSetter;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageConst;
+
+// intentionally not yet public until we add tag parsing functionality
+final class MessageProducerRequest extends ProducerRequest {
+  static final RemoteGetter<MessageProducerRequest> GETTER =
+      new RemoteGetter<MessageProducerRequest>() {
+        @Override public Kind spanKind() {
+          return Kind.PRODUCER;
+        }
+
+        @Override public String get(MessageProducerRequest request, String name) {
+          return request.delegate.getUserProperty(name);
+        }
+
+        @Override public String toString() {
+          return "Message::getUserProperty";
+        }
+      };
+
+  static final RemoteSetter<MessageProducerRequest> SETTER =
+      new RemoteSetter<MessageProducerRequest>() {
+        @Override public Kind spanKind() {
+          return Kind.PRODUCER;
+        }
+
+        @Override public void put(MessageProducerRequest request, String name, String value) {
+          request.delegate.putUserProperty(name, value);
+        }
+
+        @Override public String toString() {
+          return "Message::putUserProperty";
+        }
+      };
+
+  final Message delegate;
+
+  MessageProducerRequest(Message delegate) {
+    if (delegate == null) throw new NullPointerException("delegate == null");
+    this.delegate = delegate;
+  }
+
+  @Override public Message unwrap() {
+    return delegate;
+  }
+
+  @Override public String operation() {
+    return "send";
+  }
+
+  @Override public String channelKind() {
+    return "topic";
+  }
+
+  @Override public String channelName() {
+    return delegate.getTopic();
+  }
+
+  @Override public String messageId() {
+    return delegate.getProperty(MessageConst.PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX);
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/RocketMQTracing.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/RocketMQTracing.java
@@ -34,12 +34,12 @@ public final class RocketMQTracing {
     return newBuilder(MessagingTracing.create(tracing));
   }
 
-  /** @since 5.9 */
+  /** @since 6.1 */
   public static RocketMQTracing create(MessagingTracing messagingTracing) {
     return newBuilder(messagingTracing).build();
   }
 
-  /** @since 5.9 */
+  /** @since 6.1 */
   public static Builder newBuilder(MessagingTracing messagingTracing) {
     return new Builder(messagingTracing);
   }
@@ -134,7 +134,7 @@ public final class RocketMQTracing {
    * Implements a hook that creates a {@link Span.Kind#PRODUCER} span when a message is sent.
    */
   public SendMessageHook newSendMessageHook() {
-    return new TracingSendMessage(this);
+    return new TracingSendMessageHook(this);
   }
 
   /**

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/RocketMQTracing.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/RocketMQTracing.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.messaging.MessagingRequest;
+import brave.messaging.MessagingTracing;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext.Extractor;
+import brave.propagation.TraceContext.Injector;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.SamplerFunction;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
+
+import java.util.Map;
+
+/** Use this class to decorate your RocketMQ consumer / producer and enable Tracing. */
+public final class RocketMQTracing {
+  static final String
+      ROCKETMQ_TOPIC = "rocketmq.topic",
+      ROCKETMQ_TAGS = "rocketmq.tags";
+
+  public static RocketMQTracing create(Tracing tracing) {
+    return newBuilder(tracing).build();
+  }
+
+  public static Builder newBuilder(Tracing tracing) {
+    return newBuilder(MessagingTracing.create(tracing));
+  }
+
+  /** @since 5.9 */
+  public static RocketMQTracing create(MessagingTracing messagingTracing) {
+    return newBuilder(messagingTracing).build();
+  }
+
+  /** @since 5.9 */
+  public static Builder newBuilder(MessagingTracing messagingTracing) {
+    return new Builder(messagingTracing);
+  }
+
+  public static final class Builder {
+    final MessagingTracing messagingTracing;
+    String remoteServiceName = "rocketmq";
+
+    Builder(MessagingTracing messagingTracing) {
+      if (messagingTracing == null) throw new NullPointerException("messagingTracing == null");
+      this.messagingTracing = messagingTracing;
+    }
+
+    /** The remote service name that describes the broker in the dependency graph. Defaults to "rocketmq". */
+    public Builder remoteServiceName(String remoteServiceName) {
+      this.remoteServiceName = remoteServiceName;
+      return this;
+    }
+
+    public RocketMQTracing build() {
+      return new RocketMQTracing(this);
+    }
+  }
+
+  final MessagingTracing messagingTracing;
+  final Tracer tracer;
+  final String remoteServiceName;
+  final Extractor<MessageProducerRequest> producerExtractor;
+  final Extractor<MessageConsumerRequest> consumerExtractor;
+  final Injector<MessageProducerRequest> producerInjector;
+  final Injector<MessageConsumerRequest> consumerInjector;
+  final SamplerFunction<MessagingRequest> producerSampler, consumerSampler;
+  final String[] traceIdHeaders;
+  final TraceContextOrSamplingFlags emptyExtraction;
+
+  RocketMQTracing(Builder builder) { // intentionally hidden constructor
+    this.messagingTracing = builder.messagingTracing;
+    this.tracer = builder.messagingTracing.tracing().tracer();
+    this.remoteServiceName = builder.remoteServiceName;
+    Propagation<String> propagation = messagingTracing.propagation();
+    this.producerExtractor = propagation.extractor(MessageProducerRequest.GETTER);
+    this.consumerExtractor = propagation.extractor(MessageConsumerRequest.GETTER);
+    this.producerInjector = propagation.injector(MessageProducerRequest.SETTER);
+    this.consumerInjector = propagation.injector(MessageConsumerRequest.SETTER);
+    this.producerSampler = messagingTracing.producerSampler();
+    this.consumerSampler = messagingTracing.consumerSampler();
+
+    // We clear the trace ID headers, so that a stale consumer span is not preferred over current
+    // listener. We intentionally don't clear BaggagePropagation.allKeyNames as doing so will
+    // application fields "user_id" or "country_code"
+    this.traceIdHeaders = propagation.keys().toArray(new String[0]);
+
+    // When baggage or similar is in use, the result != TraceContextOrSamplingFlags.EMPTY
+    this.emptyExtraction = propagation.extractor((c, k) -> null).extract(Boolean.TRUE);
+  }
+
+  <R> TraceContextOrSamplingFlags extractAndClearTraceIdHeaders(
+      Extractor<R> extractor, R request, Map<String, String> properties
+  ) {
+    TraceContextOrSamplingFlags extracted = extractor.extract(request);
+    // Clear any propagation keys present in the headers
+    if (extracted.samplingFlags() == null) { // then trace IDs were extracted
+      if (properties != null) {
+        clearTraceIdHeaders(properties);
+      }
+    }
+    return extracted;
+  }
+
+  // We can't just skip clearing headers we use because we might inject B3 single, yet have stale B3
+  // multi, or vice versa.
+  void clearTraceIdHeaders(Map<String, String> headers) {
+    for (String traceIDHeader : traceIdHeaders)
+      headers.remove(traceIDHeader);
+  }
+
+  /** Creates a potential noop remote span representing this request */
+  Span nextMessagingSpan(
+      SamplerFunction<MessagingRequest> sampler,
+      MessagingRequest request,
+      TraceContextOrSamplingFlags extracted
+  ) {
+    Boolean sampled = extracted.sampled();
+    // only recreate the context if the messaging sampler made a decision
+    if (sampled == null && (sampled = sampler.trySample(request)) != null) {
+      extracted = extracted.sampled(sampled);
+    }
+    return tracer.nextSpan(extracted);
+  }
+
+  /**
+   * Extracts or creates a {@link Span.Kind#CONSUMER} span for each message received. This span is
+   * injected onto each message so it becomes the parent when a processor later calls {@link Tracer#nextSpan(TraceContextOrSamplingFlags)}.
+   */
+  public MessageListenerOrderly messageListenerOrderly(MessageListenerOrderly messageListenerOrderly) {
+    return new TracingMessageListenerOrderly(this, messageListenerOrderly);
+  }
+
+  /**
+   * Extracts or creates a {@link Span.Kind#CONSUMER} span for each message received. This span is
+   * injected onto each message so it becomes the parent when a processor later calls {@link Tracer#nextSpan(TraceContextOrSamplingFlags)}.
+   */
+  public MessageListenerConcurrently messageListenerConcurrently(MessageListenerConcurrently messageListenerConcurrently) {
+    return new TracingMessageListenerConcurrently(this, messageListenerConcurrently);
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingMessageListenerConcurrently.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingMessageListenerConcurrently.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.common.message.MessageExt;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * RocketMQ Consumer decorator for concurrent message processing with tracing support.
+ */
+final class TracingMessageListenerConcurrently extends AbstractMessageListener implements MessageListenerConcurrently {
+  final MessageListenerConcurrently messageListenerConcurrently;
+  final BiFunction<ConsumeConcurrentlyStatus, ConsumeConcurrentlyStatus, Boolean> CONCURRENT_CHECK =
+      (result, success) -> result == success;
+
+  TracingMessageListenerConcurrently(
+      RocketMQTracing rocketMQTracing,
+      MessageListenerConcurrently messageListenerConcurrently
+  ) {
+    super(rocketMQTracing);
+    this.messageListenerConcurrently = messageListenerConcurrently;
+  }
+
+  @Override
+  public ConsumeConcurrentlyStatus consumeMessage(
+      final List<MessageExt> msgs,
+      final ConsumeConcurrentlyContext context
+  ) {
+    return processConsumeMessage(
+        msgs,
+        list -> messageListenerConcurrently.consumeMessage(list, context),
+        CONCURRENT_CHECK,
+        ConsumeConcurrentlyStatus.CONSUME_SUCCESS
+    );
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingMessageListenerOrderly.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingMessageListenerOrderly.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
+import org.apache.rocketmq.common.message.MessageExt;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * RocketMQ Consumer decorator for orderly message processing with tracing support.
+ */
+final class TracingMessageListenerOrderly extends AbstractMessageListener implements MessageListenerOrderly {
+  final MessageListenerOrderly messageListenerOrderly;
+  final BiFunction<ConsumeOrderlyStatus, ConsumeOrderlyStatus, Boolean> ORDERLY_CHECK =
+      (result, success) -> result == success;
+
+  TracingMessageListenerOrderly(
+      RocketMQTracing rocketMQTracing,
+      MessageListenerOrderly messageListenerOrderly
+  ) {
+    super(rocketMQTracing);
+    this.messageListenerOrderly = messageListenerOrderly;
+  }
+
+  @Override
+  public ConsumeOrderlyStatus consumeMessage(
+      final List<MessageExt> msgs,
+      final ConsumeOrderlyContext context
+  ) {
+    return processConsumeMessage(
+        msgs,
+        list -> messageListenerOrderly.consumeMessage(list, context),
+        ORDERLY_CHECK,
+        ConsumeOrderlyStatus.SUCCESS
+    );
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingSendMessage.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingSendMessage.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.Span;
+import brave.Tracer;
+import brave.internal.Nullable;
+import brave.messaging.MessagingRequest;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.SamplerFunction;
+import io.opentelemetry.api.internal.StringUtils;
+import org.apache.rocketmq.client.hook.SendMessageContext;
+import org.apache.rocketmq.client.hook.SendMessageHook;
+import org.apache.rocketmq.client.impl.CommunicationMode;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+
+import static brave.Span.Kind.PRODUCER;
+import static brave.rocketmq.client.RocketMQTracing.ROCKETMQ_TAGS;
+import static brave.rocketmq.client.RocketMQTracing.ROCKETMQ_TOPIC;
+
+/**
+ * For the user side, there are many overloaded methods for send message in
+ * {@link org.apache.rocketmq.client.producer.MQProducer}, so implementing
+ * {@link org.apache.rocketmq.client.hook.SendMessageHook} might be an efficient approach to enable tracing.
+ * This class is provided to users as one of the sendMessageHookList.
+ */
+public final class TracingSendMessage implements SendMessageHook {
+  final RocketMQTracing rocketMQTracing;
+  final CurrentTraceContext currentTraceContext;
+  final Tracer tracer;
+  final TraceContext.Extractor<MessageProducerRequest> extractor;
+  final SamplerFunction<MessagingRequest> sampler;
+  final TraceContext.Injector<MessageProducerRequest> injector;
+  @Nullable final String remoteServiceName;
+
+  public TracingSendMessage(RocketMQTracing rocketMQTracing) {
+    this.rocketMQTracing = rocketMQTracing;
+    this.currentTraceContext = rocketMQTracing.messagingTracing.tracing().currentTraceContext();
+    this.tracer = rocketMQTracing.messagingTracing.tracing().tracer();
+    this.extractor = rocketMQTracing.producerExtractor;
+    this.sampler = rocketMQTracing.producerSampler;
+    this.injector = rocketMQTracing.producerInjector;
+    this.remoteServiceName = rocketMQTracing.remoteServiceName;
+  }
+
+  @Override public String hookName() {
+    return "brave-tracing-producer";
+  }
+
+  @Override public void sendMessageBefore(SendMessageContext context) {
+    if (context == null || context.getMessage() == null) {
+      return;
+    }
+    Message message = context.getMessage();
+    MessageProducerRequest request = new MessageProducerRequest(message);
+    TraceContext maybeParent = currentTraceContext.get();
+    // Unlike message consumers, we try current span before trying extraction. This is the proper
+    // order because the span in scope should take precedence over a potentially stale header entry.
+    //
+    // NOTE: Brave instrumentation used properly does not result in stale header entries, as we
+    // always clear message headers after reading.
+    Span span;
+    if (maybeParent == null) {
+      TraceContextOrSamplingFlags extracted =
+          rocketMQTracing.extractAndClearTraceIdHeaders(extractor, request, message.getProperties());
+      span = rocketMQTracing.nextMessagingSpan(sampler, request, extracted);
+    } else {
+      span = tracer.newChild(maybeParent);
+    }
+
+    if (!span.isNoop()) {
+      span.kind(PRODUCER).name("send");
+      if (remoteServiceName != null) span.remoteServiceName(remoteServiceName);
+      if (!StringUtils.isNullOrEmpty(message.getTags())) {
+        span.tag(ROCKETMQ_TAGS, message.getTags());
+      }
+      span.tag(ROCKETMQ_TOPIC, message.getTopic());
+      span.start();
+    }
+
+    context.setMqTraceContext(span);
+    injector.inject(span.context(), request);
+  }
+
+  @Override public void sendMessageAfter(SendMessageContext context) {
+    if (context == null || context.getMessage() == null || context.getMqTraceContext() == null) {
+      return;
+    }
+
+    SendResult sendResult = context.getSendResult();
+    Span span = (Span) context.getMqTraceContext();
+    MessageProducerRequest request = new MessageProducerRequest(context.getMessage());
+    if (sendResult == null) {
+      if (context.getCommunicationMode() == CommunicationMode.ASYNC) {
+        return;
+      }
+      span.finish();
+      injector.inject(span.context(), request);
+      return;
+    }
+
+    injector.inject(span.context(), request);
+    span.finish();
+  }
+}

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingSendMessage.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingSendMessage.java
@@ -27,9 +27,8 @@ import static brave.rocketmq.client.RocketMQTracing.ROCKETMQ_TOPIC;
  * For the user side, there are many overloaded methods for send message in
  * {@link org.apache.rocketmq.client.producer.MQProducer}, so implementing
  * {@link org.apache.rocketmq.client.hook.SendMessageHook} might be an efficient approach to enable tracing.
- * This class is provided to users as one of the sendMessageHookList.
  */
-public final class TracingSendMessage implements SendMessageHook {
+final class TracingSendMessage implements SendMessageHook {
   final RocketMQTracing rocketMQTracing;
   final CurrentTraceContext currentTraceContext;
   final Tracer tracer;
@@ -38,7 +37,7 @@ public final class TracingSendMessage implements SendMessageHook {
   final TraceContext.Injector<MessageProducerRequest> injector;
   @Nullable final String remoteServiceName;
 
-  public TracingSendMessage(RocketMQTracing rocketMQTracing) {
+  TracingSendMessage(RocketMQTracing rocketMQTracing) {
     this.rocketMQTracing = rocketMQTracing;
     this.currentTraceContext = rocketMQTracing.messagingTracing.tracing().currentTraceContext();
     this.tracer = rocketMQTracing.messagingTracing.tracing().tracer();
@@ -67,7 +66,7 @@ public final class TracingSendMessage implements SendMessageHook {
     Span span;
     if (maybeParent == null) {
       TraceContextOrSamplingFlags extracted =
-          rocketMQTracing.extractAndClearTraceIdHeaders(extractor, request, message.getProperties());
+        rocketMQTracing.extractAndClearTraceIdHeaders(extractor, request, message.getProperties());
       span = rocketMQTracing.nextMessagingSpan(sampler, request, extracted);
     } else {
       span = tracer.newChild(maybeParent);

--- a/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingSendMessageHook.java
+++ b/instrumentation/rocketmq-client/src/main/java/brave/rocketmq/client/TracingSendMessageHook.java
@@ -12,7 +12,6 @@ import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.SamplerFunction;
-import io.opentelemetry.api.internal.StringUtils;
 import org.apache.rocketmq.client.hook.SendMessageContext;
 import org.apache.rocketmq.client.hook.SendMessageHook;
 import org.apache.rocketmq.client.impl.CommunicationMode;
@@ -28,7 +27,7 @@ import static brave.rocketmq.client.RocketMQTracing.ROCKETMQ_TOPIC;
  * {@link org.apache.rocketmq.client.producer.MQProducer}, so implementing
  * {@link org.apache.rocketmq.client.hook.SendMessageHook} might be an efficient approach to enable tracing.
  */
-final class TracingSendMessage implements SendMessageHook {
+final class TracingSendMessageHook implements SendMessageHook {
   final RocketMQTracing rocketMQTracing;
   final CurrentTraceContext currentTraceContext;
   final Tracer tracer;
@@ -37,7 +36,7 @@ final class TracingSendMessage implements SendMessageHook {
   final TraceContext.Injector<MessageProducerRequest> injector;
   @Nullable final String remoteServiceName;
 
-  TracingSendMessage(RocketMQTracing rocketMQTracing) {
+  TracingSendMessageHook(RocketMQTracing rocketMQTracing) {
     this.rocketMQTracing = rocketMQTracing;
     this.currentTraceContext = rocketMQTracing.messagingTracing.tracing().currentTraceContext();
     this.tracer = rocketMQTracing.messagingTracing.tracing().tracer();
@@ -75,7 +74,7 @@ final class TracingSendMessage implements SendMessageHook {
     if (!span.isNoop()) {
       span.kind(PRODUCER).name("send");
       if (remoteServiceName != null) span.remoteServiceName(remoteServiceName);
-      if (!StringUtils.isNullOrEmpty(message.getTags())) {
+      if (message.getTags() != null && !"".equals(message.getTags())) {
         span.tag(ROCKETMQ_TAGS, message.getTags());
       }
       span.tag(ROCKETMQ_TOPIC, message.getTopic());

--- a/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/ITRocketMQTracing.java
+++ b/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/ITRocketMQTracing.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import brave.handler.MutableSpan;
+import brave.messaging.MessagingRequest;
+import brave.messaging.MessagingTracing;
+import brave.sampler.Sampler;
+import brave.sampler.SamplerFunction;
+import brave.sampler.SamplerFunctions;
+import brave.test.ITRemote;
+import brave.test.IntegrationTestSpanHandler;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendCallback;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static brave.Span.Kind.CONSUMER;
+import static brave.Span.Kind.PRODUCER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("docker")
+@Testcontainers(disabledWithoutDocker = true)
+@Timeout(240)
+class ITRocketMQTracing extends ITRemote {
+  static final Logger LOGGER = LoggerFactory.getLogger(ITRocketMQTracing.class);
+
+  @Container RocketMQContainer rocket = new RocketMQContainer();
+  @RegisterExtension IntegrationTestSpanHandler producerSpanHandler = new IntegrationTestSpanHandler();
+  @RegisterExtension IntegrationTestSpanHandler consumerSpanHandler = new IntegrationTestSpanHandler();
+
+  SamplerFunction<MessagingRequest> producerSampler = SamplerFunctions.deferDecision();
+  SamplerFunction<MessagingRequest> consumerSampler = SamplerFunctions.deferDecision();
+
+  RocketMQTracing producerTracing = RocketMQTracing.create(
+      MessagingTracing.newBuilder(tracingBuilder(Sampler.ALWAYS_SAMPLE).localServiceName("producer")
+              .clearSpanHandlers().addSpanHandler(producerSpanHandler).build())
+          .producerSampler(r -> producerSampler.trySample(r))
+          .build()
+  );
+  RocketMQTracing consumerTracing = RocketMQTracing.create(
+      MessagingTracing.newBuilder(tracingBuilder(Sampler.ALWAYS_SAMPLE).localServiceName("consumer")
+              .clearSpanHandlers().addSpanHandler(consumerSpanHandler).build())
+          .consumerSampler(r -> consumerSampler.trySample(r))
+          .build()
+  );
+
+  DefaultMQProducer producer;
+
+  @BeforeEach void setup() throws Exception {
+    producer = new DefaultMQProducer(testName);
+    producer.setInstanceName(testName);
+    producer.setNamesrvAddr(rocket.getNamesrvAddr());
+    producer.getDefaultMQProducerImpl().registerSendMessageHook(new TracingSendMessage(producerTracing));
+    producer.setSendMsgTimeout(60_000);
+    producer.start();
+    Thread.sleep(5000); // wait for producer to be ready.
+  }
+
+  @Override @AfterEach protected void close() throws Exception {
+    if (producer != null) producer.shutdown();
+    super.close();
+  }
+
+  @Test void send_message() throws Exception {
+    producer.send(new Message(testName, testName.getBytes()));
+    MutableSpan producerSpan = producerSpanHandler.takeRemoteSpan(PRODUCER);
+    assertThat(producerSpan.parentId()).isNull();
+  }
+
+  @Test void send_one_way_message() throws Exception {
+    producer.sendOneway(new Message(testName, testName.getBytes()));
+    MutableSpan producerSpan = producerSpanHandler.takeRemoteSpan(PRODUCER);
+    assertThat(producerSpan.parentId()).isNull();
+  }
+
+  @Test void async_send_message() throws Exception {
+    producer.send(new Message(testName, testName.getBytes()), new SendCallback() {
+      @Override public void onSuccess(SendResult sendResult) {
+        LOGGER.info("Send message success: {}.", sendResult);
+      }
+
+      @Override public void onException(Throwable e) {
+        assertThat(e).isNull();
+      }
+    });
+    MutableSpan producerSpan = producerSpanHandler.takeRemoteSpan(PRODUCER);
+    assertThat(producerSpan.parentId()).isNull();
+  }
+
+  @Test void message_listener_concurrently() throws Exception {
+    producer.send(new Message(testName, testName.getBytes()));
+    DefaultMQPushConsumer consumer = new DefaultMQPushConsumer(testName);
+    consumer.setNamesrvAddr(rocket.getNamesrvAddr());
+    consumer.subscribe(testName, "*");
+    MessageListenerConcurrently messageListenerConcurrently = consumerTracing.messageListenerConcurrently(
+        (list, context) -> ConsumeConcurrentlyStatus.CONSUME_SUCCESS);
+    consumer.registerMessageListener(messageListenerConcurrently);
+    consumer.start();
+
+    MutableSpan producerSpan = producerSpanHandler.takeRemoteSpan(PRODUCER);
+    assertThat(producerSpan.parentId()).isNull();
+    MutableSpan consumerSpan = consumerSpanHandler.takeRemoteSpan(CONSUMER);
+    assertChildOf(consumerSpan, producerSpan);
+    MutableSpan listenerSpan = consumerSpanHandler.takeLocalSpan();
+    assertChildOf(listenerSpan, consumerSpan);
+  }
+
+  @Test void message_listener_orderly() throws Exception {
+    producer.send(new Message(testName, testName.getBytes()));
+    DefaultMQPushConsumer consumer = new DefaultMQPushConsumer(testName);
+    consumer.setNamesrvAddr(rocket.getNamesrvAddr());
+    consumer.subscribe(testName, "*");
+    MessageListenerOrderly messageListenerOrderly = consumerTracing.messageListenerOrderly(
+        (list, context) -> ConsumeOrderlyStatus.SUCCESS);
+    consumer.registerMessageListener(messageListenerOrderly);
+    consumer.start();
+
+    MutableSpan producerSpan = producerSpanHandler.takeRemoteSpan(PRODUCER);
+    assertThat(producerSpan.parentId()).isNull();
+    MutableSpan consumerSpan = consumerSpanHandler.takeRemoteSpan(CONSUMER);
+    assertChildOf(consumerSpan, producerSpan);
+    MutableSpan listenerSpan = consumerSpanHandler.takeLocalSpan();
+    assertChildOf(listenerSpan, consumerSpan);
+  }
+}

--- a/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/ITRocketMQTracing.java
+++ b/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/ITRocketMQTracing.java
@@ -68,7 +68,7 @@ class ITRocketMQTracing extends ITRemote {
     producer = new DefaultMQProducer(testName);
     producer.setInstanceName(testName);
     producer.setNamesrvAddr(rocket.getNamesrvAddr());
-    producer.getDefaultMQProducerImpl().registerSendMessageHook(new TracingSendMessage(producerTracing));
+    producer.getDefaultMQProducerImpl().registerSendMessageHook(producerTracing.newSendMessageHook());
     producer.setSendMsgTimeout(60_000);
     producer.start();
     Thread.sleep(5000); // wait for producer to be ready.

--- a/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/MessagePropertiesTest.java
+++ b/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/MessagePropertiesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import org.apache.rocketmq.common.message.Message;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessagePropertiesTest {
+  Message message = new Message();
+
+  @Test void putUserProperty_noProperties() {
+    message.putUserProperty("b3", "1");
+
+    assertThat(message.getProperty("b3"))
+        .isEqualTo("1");
+  }
+  
+  @Test void putUserProperty_replace() {
+    message.putUserProperty("b3", String.valueOf((byte) 0));
+    message.putUserProperty("b3", "1");
+
+    assertThat(message.getUserProperty("b3"))
+        .isEqualTo("1");
+  }
+
+  @Test void getUserProperty_hasProperties() {
+    message = new Message("topic", new byte[0]);
+    message.putUserProperty("b3", "1");
+
+    assertThat(message.getProperty("b3"))
+        .isEqualTo("1");
+  }
+  
+  @Test void getUserProperty_null() {
+    assertThat(message.getProperty("b3")).isNull();
+  }
+}

--- a/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/RocketMQContainer.java
+++ b/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/RocketMQContainer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.rocketmq.client;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+final class RocketMQContainer extends GenericContainer<RocketMQContainer> {
+  static Logger LOGGER = LoggerFactory.getLogger(RocketMQContainer.class);
+  static final int NAMESERVER_PORT = 9876;
+  static final int BROKER_PORT = 10911;
+
+  RocketMQContainer() {
+    super(DockerImageName.parse("apache/rocketmq:5.3.1"));
+    List<String> portBindings = new ArrayList<>();
+    portBindings.add(String.format("%d:%d", NAMESERVER_PORT, NAMESERVER_PORT));
+    portBindings.add(String.format("%d:%d", BROKER_PORT, BROKER_PORT));
+    setPortBindings(portBindings);
+    setCommand("/bin/sh", "-c", "sh mqnamesrv & sh mqbroker -n localhost:" + NAMESERVER_PORT);
+    this.waitStrategy = Wait.forLogMessage(".*boot success.*", 1)
+        .withStartupTimeout(Duration.ofSeconds(60));
+  }
+
+  @Override
+  protected void containerIsStarted(InspectContainerResponse containerInfo) {
+    followOutput(new Slf4jLogConsumer(LOGGER));
+    List<String> updateBrokerConfigCommands = new ArrayList<>();
+    updateBrokerConfigCommands.add(updateBrokerConfig("brokerIP1", getHost()));
+    updateBrokerConfigCommands.add(updateBrokerConfig("listenPort", BROKER_PORT));
+    updateBrokerConfigCommands.add(updateBrokerConfig("autoCreateTopicEnable", true));
+    final String command = String.join(" && ", updateBrokerConfigCommands);
+    ExecResult result;
+    try {
+      result = execInContainer("/bin/sh", "-c", command);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    if (result != null && result.getExitCode() != 0) {
+      throw new IllegalStateException(result.toString());
+    }
+  }
+
+  String updateBrokerConfig(final String key, final Object val) {
+    return String.format("./mqadmin updateBrokerConfig -b localhost:%s -k %s -v %s", BROKER_PORT, key, val);
+  }
+
+  String getNamesrvAddr() {
+    return getHost() + ":" + NAMESERVER_PORT;
+  }
+}

--- a/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/RocketMQContainer.java
+++ b/instrumentation/rocketmq-client/src/test/java/brave/rocketmq/client/RocketMQContainer.java
@@ -5,20 +5,15 @@
 package brave.rocketmq.client;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
 final class RocketMQContainer extends GenericContainer<RocketMQContainer> {
-  static Logger LOGGER = LoggerFactory.getLogger(RocketMQContainer.class);
   static final int NAMESERVER_PORT = 9876;
   static final int BROKER_PORT = 10911;
 
@@ -30,12 +25,11 @@ final class RocketMQContainer extends GenericContainer<RocketMQContainer> {
     setPortBindings(portBindings);
     setCommand("/bin/sh", "-c", "sh mqnamesrv & sh mqbroker -n localhost:" + NAMESERVER_PORT);
     this.waitStrategy = Wait.forLogMessage(".*boot success.*", 1)
-        .withStartupTimeout(Duration.ofSeconds(60));
+      .withStartupTimeout(Duration.ofSeconds(60));
   }
 
   @Override
   protected void containerIsStarted(InspectContainerResponse containerInfo) {
-    followOutput(new Slf4jLogConsumer(LOGGER));
     List<String> updateBrokerConfigCommands = new ArrayList<>();
     updateBrokerConfigCommands.add(updateBrokerConfig("brokerIP1", getHost()));
     updateBrokerConfigCommands.add(updateBrokerConfig("listenPort", BROKER_PORT));

--- a/instrumentation/rocketmq-client/src/test/resources/log4j2.properties
+++ b/instrumentation/rocketmq-client/src/test/resources/log4j2.properties
@@ -1,0 +1,11 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT
+# stop huge spam
+logger.dockerclient.name=org.testcontainers.dockerclient
+logger.dockerclient.level=off

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
     <mockito.version>5.14.1</mockito.version>
     <jersey.version>2.42</jersey.version>
     <testcontainers.version>1.20.2</testcontainers.version>
+    <rocketmq-client.version>5.3.1</rocketmq-client.version>
 
     <license.skip>${skipTests}</license.skip>
     <maven-surefire-plugin.argLine />


### PR DESCRIPTION
Resolves https://github.com/openzipkin/brave/issues/1043

~~~
Benchmark                                                     Mode     Cnt      Score     Error   Units
TracingProducerBenchmarks.send_baseCase                     sample  362740      0.018 ±   0.001   us/op
TracingProducerBenchmarks.send_baseCase:gc.alloc.rate       sample      15  12041.287 ± 915.439  MB/sec
TracingProducerBenchmarks.send_baseCase:gc.alloc.rate.norm  sample      15     64.000 ±   0.001    B/op
TracingProducerBenchmarks.send_baseCase:gc.count            sample      15    314.000            counts
TracingProducerBenchmarks.send_baseCase:gc.time             sample      15    113.000                ms
TracingProducerBenchmarks.send_baseCase:p0.00               sample                ≈ 0             us/op
TracingProducerBenchmarks.send_baseCase:p0.50               sample                ≈ 0             us/op
TracingProducerBenchmarks.send_baseCase:p0.90               sample              0.042             us/op
TracingProducerBenchmarks.send_baseCase:p0.95               sample              0.042             us/op
TracingProducerBenchmarks.send_baseCase:p0.99               sample              0.042             us/op
TracingProducerBenchmarks.send_baseCase:p0.999              sample              0.084             us/op
TracingProducerBenchmarks.send_baseCase:p0.9999             sample              0.883             us/op
TracingProducerBenchmarks.send_baseCase:p1.00               sample            142.080             us/op
TracingProducerBenchmarks.send_traced                       sample  438551      9.473 ±   0.570   us/op
TracingProducerBenchmarks.send_traced:gc.alloc.rate         sample      15   1321.673 ± 117.872  MB/sec
TracingProducerBenchmarks.send_traced:gc.alloc.rate.norm    sample      15  11941.827 ±  37.758    B/op
TracingProducerBenchmarks.send_traced:gc.count              sample      15     59.000            counts
TracingProducerBenchmarks.send_traced:gc.time               sample      15     24.000                ms
TracingProducerBenchmarks.send_traced:p0.00                 sample              5.536             us/op
TracingProducerBenchmarks.send_traced:p0.50                 sample              7.832             us/op
TracingProducerBenchmarks.send_traced:p0.90                 sample              8.912             us/op
TracingProducerBenchmarks.send_traced:p0.95                 sample             10.160             us/op
TracingProducerBenchmarks.send_traced:p0.99                 sample             24.832             us/op
TracingProducerBenchmarks.send_traced:p0.999                sample             88.505             us/op
TracingProducerBenchmarks.send_traced:p0.9999               sample           5059.209             us/op
TracingProducerBenchmarks.send_traced:p1.00                 sample          25296.896             us/op
~~~