### PR TITLE
modify logger class name for locating easily

### DIFF
--- a/brave/src/main/java/brave/Tracing.java
+++ b/brave/src/main/java/brave/Tracing.java
@@ -343,7 +343,7 @@ public abstract class Tracing implements Closeable {
   }
 
   static final class LogSpanHandler extends SpanHandler {
-    final Logger logger = Logger.getLogger(Tracer.class.getName());
+    final Logger logger = Logger.getLogger(LogSpanHandler.class.getName());
 
     @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
       if (!logger.isLoggable(Level.INFO)) return false;


### PR DESCRIPTION
modify logger class name for locating easily, it's helpful for locating the specific code with log.