### PR TITLE
Remove outdated BOM warning from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,14 +186,6 @@
     <url>https://github.com/openzipkin/brave/issues</url>
   </issueManagement>
 
-  <dependencyManagement>
-    <!-- Be careful here, especially to not import BOMs as io.zipkin.brave:brave has this parent.
-
-         For example, if you imported Netty's BOM here, using Brave would also download that BOM. As
-         Brave is indirectly used, this can be extremely confusing when people are troubleshooting
-         library version assignments. -->
-  </dependencyManagement>
-
   <dependencies>
     <!-- Do not add compile dependencies here. This can cause problems for libraries that depend on
          io.zipkin.brave:brave difficult to unravel. -->


### PR DESCRIPTION
flattenMode=ossrh strips dependencyManagement from published poms, so end users never inherit BOMs declared here.

See: https://github.com/mojohaus/flatten-maven-plugin/blob/master/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
Signed-off-by: Adrian Cole <adrian@tetrate.io>

